### PR TITLE
Bug fix: Fix search value for Moose

### DIFF
--- a/app/src/components/map/components/SideSearchBar.tsx
+++ b/app/src/components/map/components/SideSearchBar.tsx
@@ -75,7 +75,7 @@ const SideSearchBar: React.FC<SideSearchBarProps> = (props) => {
             <DatasetSearchForm
               onAreaUpdate={props.onAreaUpdate}
               speciesList={[
-                { value: 'M-ALAM', label: 'Moose (M-ALAM)' },
+                { value: 'M-ALAL', label: 'Moose (M-ALAL)' },
                 { value: 'M-ORAM', label: 'Mountain Goat (M-ORAM)' },
                 { value: 'M-OVDA', label: 'Thinhorn sheep (M-OVDA)' },
                 { value: 'M-OVDA-DA', label: 'Thinhorn sheep (M-OVDA-DA)' },


### PR DESCRIPTION
Reason for this:

When we search for a species, we pass in a species code from app, and the ocde for moose needed to be adjusted.