### PR TITLE
BHBC-2179: DWC spatial transform

### DIFF
--- a/database/package.json
+++ b/database/package.json
@@ -22,6 +22,7 @@
     "format-fix": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,json,css,scss}\""
   },
   "dependencies": {
+    "@types/csv-parse": "^1.2.2",
     "knex": "~1.0.1",
     "pg": "~8.3.0",
     "typescript": "~4.1.6"

--- a/database/package.json
+++ b/database/package.json
@@ -22,7 +22,6 @@
     "format-fix": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,json,css,scss}\""
   },
   "dependencies": {
-    "@types/csv-parse": "^1.2.2",
     "knex": "~1.0.1",
     "pg": "~8.3.0",
     "typescript": "~4.1.6"

--- a/database/src/migrations/20220602152017_spatial_transform_eml_dwc_occurrences.ts
+++ b/database/src/migrations/20220602152017_spatial_transform_eml_dwc_occurrences.ts
@@ -15,7 +15,7 @@ export async function up(knex: Knex): Promise<void> {
     SET SCHEMA '${DB_SCHEMA}';
     SET SEARCH_PATH = ${DB_SCHEMA}, ${DB_SCHEMA_DAPI_V1};
 
-    INSERT into spatial_transform
+    INSERT into source_transform
       (name, description, record_effective_date, transform)
     VALUES (
       'DwC Occurrences', 'Extracts occurrences and properties from DwC JSON source.', now(),

--- a/database/src/migrations/20220602152017_spatial_transform_eml_dwc_occurrences.ts
+++ b/database/src/migrations/20220602152017_spatial_transform_eml_dwc_occurrences.ts
@@ -15,7 +15,7 @@ export async function up(knex: Knex): Promise<void> {
     SET SCHEMA '${DB_SCHEMA}';
     SET SEARCH_PATH = ${DB_SCHEMA}, ${DB_SCHEMA_DAPI_V1};
 
-    INSERT into source_transform
+    INSERT into spatial_transform
       (name, description, record_effective_date, transform)
     VALUES (
       'DwC Occurrences', 'Extracts occurrences and properties from DwC JSON source.', now(),

--- a/database/src/migrations/20220602152017_spatial_transform_eml_dwc_occurrences.ts
+++ b/database/src/migrations/20220602152017_spatial_transform_eml_dwc_occurrences.ts
@@ -20,27 +20,57 @@ export async function up(knex: Knex): Promise<void> {
     VALUES (
       'DwC Occurrences', 'Extracts occurrences and properties from DwC JSON source.', now(),
       $transform$
-        WITH submission as (SELECT * from submission where submission_id = ?)
-          , occurrences as (SELECT uuid, occs from submission, jsonb_path_query(darwin_core_source, '$.occurrence') occs)
-          , occurrence as (SELECT uuid, jsonb_array_elements(occs) occ from occurrences)
-          , events as (SELECT evns from submission, jsonb_path_query(darwin_core_source, '$.event') evns)
-          , event as (SELECT jsonb_array_elements(evns) evn from events)
-          , event_coord as (SELECT st_x(pt) x, st_y(pt) y, evn from event, ST_Transform(ST_SetSRID(ST_MakePoint(split_part(evn->>'verbatimCoordinates', ' ', 2)::integer, split_part(evn->>'verbatimCoordinates', ' ', 3)::integer), split_part(evn->>'verbatimCoordinates', ' ', 1)::integer+32600), 4326) pt)
-          , taxons as (SELECT taxns from submission, jsonb_path_query(darwin_core_source, '$.taxon') taxns)
-          , taxon as (SELECT jsonb_array_elements(taxns) taxn from taxons)
-          , normal as (SELECT distinct o.uuid, o.occ, e.*, t.taxn from occurrence o
-              LEFT JOIN event_coord e on (e.evn->'id' = o.occ->'id')
-              LEFT OUTER JOIN taxon t on (t.taxn->'occurrenceID' = o.occ->'occurrenceID'))
-              SELECT jsonb_build_object('type', 'FeatureCollection'
-          , 'features', jsonb_build_array(jsonb_build_object('type', 'Feature'
-          , 'geometry', jsonb_build_object('type', 'Point', 'coordinates',
-          json_build_array(n.x, n.y))
-          , 'properties', jsonb_build_object('type', 'Occurrence', 'dwc', jsonb_build_object(
-              'type', 'PhysicalObject', 'basisOfRecord', 'Occurrence', 'datasetID', n.uuid, 'occurrenceID', n.occ->'occurrenceID'
-            , 'sex', n.occ->'sex', 'lifeStage', n.occ->'lifeStage', 'associatedTaxa', n.occ->'associatedTaxa', 'individualCount', n.occ->'individualCount'
-            , 'eventDate', n.evn->'eventDate', 'verbatimSRS', n.evn->'verbatimSRS', 'verbatimCoordinates', n.evn->'verbatimCoordinates'
-            , 'vernacularName', n.taxn->'vernacularName'))))
-        )result_data from normal n;
+      with submission as (select * from submission_observation where submission_observation_id = ?)
+      , occurrences as (select submission_observation_id, occs
+      from submission_observation, jsonb_path_query(darwin_core_source, '$.occurrence') occs)
+      , occurrence as (select submission_observation_id, jsonb_array_elements(occs) occ
+          from occurrences)
+      , events as (select evns
+          from submission_observation, jsonb_path_query(darwin_core_source, '$.event') evns)
+      , event as (select jsonb_array_elements(evns) evn
+          from events)
+      , locations as (select locs
+          from submission_observation, jsonb_path_query(darwin_core_source, '$.location') locs)
+      , location as (select jsonb_array_elements(locs) loc
+          from locations)
+      , location_coord as (select st_x(pt) x, st_y(pt) y, loc  from location
+      , ST_SetSRID(ST_MakePoint((loc->>'decimalLongitude')::float, (loc->>'decimalLatitude')::float), 4326) pt)
+      , normal as (select distinct o.submission_observation_id, o.occ, ec.*, e.evn
+      from occurrence o
+      left outer join location_coord ec on
+                (ec.loc->'eventID' = o.occ->'eventID')
+      left outer join event e on
+            (e.evn->'eventID' = o.occ->'eventID'))
+      select jsonb_build_object(
+        'type', 'FeatureCollection',
+        'features', jsonb_build_array(
+                      jsonb_build_object(
+                        'type', 'Feature'
+                        'geometry',jsonb_build_object(
+                            'type', 'Point',
+                            'coordinates', json_build_array(n.x, n.y)),
+                    'properties', jsonb_build_object(
+                                    'type', 'Occurrence',
+                                    'dwc', jsonb_build_object(
+                                      'type', 'PhysicalObject',
+                                      'basisOfRecord', 'Occurrence',
+                                      'datasetID', n.submission_observation_id,
+                                      'occurrenceID', n.occ->'occurrenceID',
+                                      'sex', n.occ->'sex',
+                                      'lifeStage', n.occ->'lifeStage',
+                                      'taxonID', n.occ->'taxonID',
+                                      'vernacularName', n.occ->'vernacularName',
+                                      'scientificName', n.occ->'scientificName',
+                                      'occurrenceRemarks', n.occ->'occurrenceRemarks',
+                                      'individualCount', n.occ->'individualCount',
+                                      'eventDate', n.evn->'eventDate',
+                                      'verbatimSRS', n.loc->'verbatimSRS',
+                                      'verbatimCoordinates', n.loc->'verbatimCoordinates')
+                                  )
+                      )
+          )
+      )result_data
+      from normal n;
       $transform$
     );
   `);


### PR DESCRIPTION
# Overview

## Links to Jira tickets

-https://quartech.atlassian.net/browse/BHBC-2179

## Description of relevant changes

- the spatial transform uses new tables and has the new fields that come from SIMS

## Independent testing procedure
### Create a submission record and take the resulting submission_id
```INSERT INTO submission(source_transform_id, uuid) VALUES ( 1, 'be929555-59f9-4cac-a96d-89804159a449') returning submission_id;```

### Populate the submission observation table with a valid dwc archive record (use a SIMS output):
```insert into submission_observation(submission_id, darwin_core_source) values(<insert submission_id>, 'insert here a valid occurrence_submission->darwin_core_source record) returning submission_observation_id; ```

### Run the following SQL to see the records generated:
```with submission as (select * from submission_observation where submission_observation_id = <insert submission_observation_id)
  , occurrences as (select submission_observation_id, occs
  from submission_observation, jsonb_path_query(darwin_core_source, '$.occurrence') occs)
  , occurrence as (select submission_observation_id, jsonb_array_elements(occs) occ
      from occurrences)
  , events as (select evns
      from submission_observation, jsonb_path_query(darwin_core_source, '$.event') evns)
  , event as (select jsonb_array_elements(evns) evn
      from events)
  , locations as (select locs
      from submission_observation, jsonb_path_query(darwin_core_source, '$.location') locs)
  , location as (select jsonb_array_elements(locs) loc
      from locations)
  , location_coord as (select st_x(pt) x, st_y(pt) y, loc  from location
  , ST_SetSRID(ST_MakePoint((loc->>'decimalLongitude')::float, (loc->>'decimalLatitude')::float), 4326) pt)
  , normal as (select distinct o.submission_observation_id, o.occ, ec.*,e.evn
  from occurrence o
  left outer join location_coord ec on
            (ec.loc->'eventID' = o.occ->'eventID')
  left outer join event e on
        (e.evn->'eventID' = o.occ->'eventID'))
  select jsonb_build_object('type', 'FeatureCollection'
                , 'features', jsonb_build_array(jsonb_build_object('type', 'Feature'
                , 'geometry'
                ,jsonb_build_object('type', 'Point'
                , 'coordinates', json_build_array(n.x, n.y))
                , 'properties', jsonb_build_object('type', 'Occurrence', 'dwc', jsonb_build_object(
                  'type', 'PhysicalObject', 'basisOfRecord', 'Occurrence', 'datasetID', n.submission_observation_id, 'occurrenceID', n.occ->'occurrenceID'
                  , 'sex', n.occ->'sex', 'lifeStage', n.occ->'lifeStage', 'taxonID', n.occ->'taxonID', 'vernacularName', n.occ->'vernacularName', 
                  'scientificName', n.occ->'scientificName','occurrenceRemarks', n.occ->'occurrenceRemarks',
                  'individualCount', n.occ->'individualCount'
                  , 'eventDate', n.evn->'eventDate', 'verbatimSRS', n.loc->'verbatimSRS', 'verbatimCoordinates', n.loc->'verbatimCoordinates'
                  ))))
          )result_data
      from normal n;```