### PR TITLE
BHBC-2238: See Related Datasets

### DIFF
--- a/api/.pipeline/lib/queue.deploy.js
+++ b/api/.pipeline/lib/queue.deploy.js
@@ -30,6 +30,7 @@ const queueDeploy = async (settings) => {
         VERSION: phases[phase].tag,
         HOST: phases[phase].host,
         CHANGE_ID: phases.build.changeId || changeId,
+        APP_HOST: phases[phase].appHost,
         DB_SERVICE_NAME: `${phases[phase].dbName}-postgresql${phases[phase].suffix}`,
         NODE_ENV: phases[phase].env || 'dev',
         ELASTICSEARCH_URL: phases[phase].elasticsearchURL,

--- a/api/.pipeline/queue.config.js
+++ b/api/.pipeline/queue.config.js
@@ -5,6 +5,7 @@ let options = require('pipeline-cli').Util.parseArguments();
 // The root config for common values
 const config = require('../../.config/config.json');
 
+const appName = config.module.app;
 const name = config.module.queue;
 const dbName = config.module.db;
 
@@ -61,7 +62,6 @@ const phases = {
     version: `${version}-${changeId}`,
     tag: tag,
     env: 'build',
-    s3KeyPrefix: 'biohub',
     tz: config.timezone.api,
     branch: branch,
     queueDockerfilePath: queueDockerfilePath,

--- a/api/.pipeline/queue.config.js
+++ b/api/.pipeline/queue.config.js
@@ -21,6 +21,7 @@ const branch = (isStaticDeployment && options.branch) || null;
 const tag = (branch && `build-${version}-${changeId}-${branch}`) || `build-${version}-${changeId}`;
 
 const staticUrlsAPI = config.staticUrlsAPI;
+const staticUrls = config.staticUrls;
 
 const queueDockerfilePath = './Dockerfile.queue';
 
@@ -80,6 +81,7 @@ const phases = {
     version: `${deployChangeId}-${changeId}`,
     tag: `dev-${version}-${deployChangeId}`,
     host: (isStaticDeployment && staticUrlsAPI.dev) || `${name}-${changeId}-a0ec71-dev.apps.silver.devops.gov.bc.ca`,
+    appHost: (isStaticDeployment && staticUrls.dev) || `${appName}-${changeId}-a0ec71-dev.apps.silver.devops.gov.bc.ca`,
     adminHost: 'https://loginproxy.gov.bc.ca/auth',
     env: 'dev',
     elasticsearchURL: 'http://es01:9200',
@@ -108,6 +110,7 @@ const phases = {
     version: `${version}`,
     tag: `test-${version}`,
     host: staticUrlsAPI.test,
+    appHost: staticUrls.test,
     adminHost: 'https://loginproxy.gov.bc.ca/auth',
     env: 'test',
     elasticsearchURL: 'http://es01.a0ec71-dev:9200', // TODO: Update to test instance (es is not yet deployed to test)
@@ -136,6 +139,7 @@ const phases = {
     version: `${version}`,
     tag: `prod-${version}`,
     host: staticUrlsAPI.prod,
+    appHost: staticUrls.prod,
     adminHost: 'https://loginproxy.gov.bc.ca/auth',
     env: 'prod',
     elasticsearchURL: 'http://es01:9200',

--- a/api/.pipeline/templates/api.dc.yaml
+++ b/api/.pipeline/templates/api.dc.yaml
@@ -23,7 +23,7 @@ parameters:
     required: true
   - name: APP_HOST
     description: APP host for application frontend
-    value: ''
+    required: true
   - name: CHANGE_ID
     description: Change id of the project. This will help to pull image stream
     required: true

--- a/api/.pipeline/templates/queue.dc.yaml
+++ b/api/.pipeline/templates/queue.dc.yaml
@@ -15,6 +15,9 @@ parameters:
   - name: HOST
     description: Host name of the application
     required: true
+  - name: APP_HOST
+    description: APP host for application frontend
+    required: true
   - name: CHANGE_ID
     description: Change id of the project. This will help to pull image stream
     required: true
@@ -140,6 +143,8 @@ objects:
             - env:
                 - name: API_HOST
                   value: ${HOST}
+                - name: APP_HOST
+                  value: ${APP_HOST}
                 - name: DB_HOST
                   value: ${DB_SERVICE_NAME}
                 - name: DB_USER_API

--- a/api/src/paths/dwc/eml/search.test.ts
+++ b/api/src/paths/dwc/eml/search.test.ts
@@ -162,8 +162,8 @@ describe('search', () => {
         .stub(SubmissionService.prototype, 'findSubmissionRecordsWithSpatialCount')
         .onCall(0)
         .resolves([
-          { id: 'test_uuid1', source: 'valid_json_string_1', observation_count: 14 },
-          { id: 'test_uuid2', source: 'valid_json_string_2', observation_count: 23 }
+          { id: 'test_uuid1', source: {}, observation_count: 14 },
+          { id: 'test_uuid2', source: {}, observation_count: 23 }
         ]);
 
       const keywordSearchEmlStub = sinon.stub(ESService.prototype, 'keywordSearchEml').resolves([
@@ -177,8 +177,8 @@ describe('search', () => {
 
       expect(keywordSearchEmlStub).to.have.been.calledOnceWith('search-term');
       expect(mockRes.jsonValue).eql([
-        { id: 'test_uuid1', source: 'valid_json_string_1', observation_count: 14 },
-        { id: 'test_uuid2', source: 'valid_json_string_2', observation_count: 23 }
+        { id: 'test_uuid1', source: {}, observation_count: 14 },
+        { id: 'test_uuid2', source: {}, observation_count: 23 }
       ]);
     });
   });

--- a/api/src/paths/dwc/submission/{datasetId}/artifacts.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/artifacts.ts
@@ -5,7 +5,7 @@ import { defaultErrorResponses } from '../../../../openapi/schemas/http-response
 import { ArtifactService } from '../../../../services/artifact-service';
 import { getLogger } from '../../../../utils/logger';
 
-const defaultLog = getLogger('paths/dwc/eml/get');
+const defaultLog = getLogger('paths/dwc/submission/{datasetId}/artifacts');
 
 export const GET: Operation = [getArtifactsByDatasetId()];
 

--- a/api/src/paths/dwc/submission/{datasetId}/get.test.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/get.test.ts
@@ -20,9 +20,7 @@ describe('get', () => {
       const dbConnectionObj = getMockDBConnection();
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
-      sinon
-        .stub(SubmissionService.prototype, 'getSubmissionRecordEMLJSONByDatasetId')
-        .resolves(`{id: 'a valid json string}`);
+      sinon.stub(SubmissionService.prototype, 'getSubmissionRecordEMLJSONByDatasetId').resolves({});
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 

--- a/api/src/paths/dwc/submission/{datasetId}/related.test.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/related.test.ts
@@ -1,0 +1,308 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import OpenAPIRequestValidator, { OpenAPIRequestValidatorArgs } from 'openapi-request-validator';
+import OpenAPIResponseValidator, { OpenAPIResponseValidatorArgs } from 'openapi-response-validator';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import * as db from '../../../../database/db';
+import { HTTPError } from '../../../../errors/http-error';
+import { Artifact } from '../../../../repositories/artifact-repository';
+import { ArtifactService } from '../../../../services/artifact-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
+import { GET, getRelatedDatasetsByDatasetId } from './related';
+import { SubmissionService } from '../../../../services/submission-service';
+
+chai.use(sinonChai);
+
+describe('getRelatedDatasetsByDatasetId', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('openApiSchema', () => {
+    describe('request validation', () => {
+      const requestValidator = new OpenAPIRequestValidator(GET.apiDoc as unknown as OpenAPIRequestValidatorArgs);
+
+      describe('should throw an error when', () => {
+        describe('datasetId', () => {
+          it('is invalid type', async () => {
+            const request = {
+              params: { datasetId: 123 }
+            };
+
+            const response = requestValidator.validateRequest(request);
+
+            expect(response.status).to.equal(400);
+            expect(response.errors.length).to.equal(1);
+            expect(response.errors[0].message).to.equal('must be string');
+          });
+
+          it('is invalid format', async () => {
+            const request = {
+              params: { datasetId: 'abcdefg' }
+            };
+
+            const response = requestValidator.validateRequest(request);
+
+            expect(response.status).to.equal(400);
+            expect(response.errors.length).to.equal(1);
+            expect(response.errors[0].message).to.equal('must match format "uuid"');
+          });
+        });
+      });
+
+      describe('should succeed when', () => {
+        it('required values are valid', async () => {
+          const request = {
+            params: { datasetId: '374c4d6a-3a04-405b-af6d-b6497800a691' }
+          };
+
+          const response = requestValidator.validateRequest(request);
+
+          expect(response).to.be.undefined;
+        });
+      });
+    });
+
+    describe('response validation', () => {
+      const responseValidator = new OpenAPIResponseValidator(GET.apiDoc as unknown as OpenAPIResponseValidatorArgs);
+      const mockRelatedDataset = {
+        datasetId: '374c4d6a-3a04-405b-af6d-b6497800a691',
+        title: 'Test-Related-Dataset',
+        url: 'https://example.com/374c4d6a-3a04-405b-af6d-b6497800a691'
+      };
+
+      describe('should throw an error when', () => {
+        it('returns a null response', async () => {
+          const apiResponse = null;
+          const response = responseValidator.validateResponse(200, apiResponse);
+
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal('must be object');
+        });
+
+        it('returns a null array', async () => {
+          const apiResponse = { datasets: null };
+          const response = responseValidator.validateResponse(200, apiResponse);
+
+          expect(response.message).to.equal('The response was not valid.');
+          expect(response.errors.length).to.equal(1);
+          expect(response.errors[0].message).to.equal('must be array');
+        });
+
+        describe('dataset', () => {
+          it('returns a null response', async () => {
+            const apiResponse = { datasets: [null] };
+            const response = responseValidator.validateResponse(200, apiResponse);
+
+            expect(response.message).to.equal('The response was not valid.');
+            expect(response.errors.length).to.equal(1);
+            expect(response.errors[0].message).to.equal('must be object');
+          });
+
+          describe('datsetId', () => {
+            it('is undefined', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    datasetId: undefined
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal("must have required property 'datasetId'");
+            });
+
+            it('is null', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    datasetId: null
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal('must be string');
+            });
+
+            it('is wrong type', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    datasetId: 1
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal('must be string');
+            });
+          });
+
+          describe('title', () => {
+            it('is undefined', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    title: undefined
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal("must have required property 'title'");
+            });
+
+            it('is null', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    title: null
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal('must be string');
+            });
+
+            it('is wrong type', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    title: 1
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal('must be string');
+            });
+          });
+
+          describe('url', () => {
+            it('is undefined', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    url: undefined
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal("must have required property 'url'");
+            });
+
+            it('is null', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    url: null
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal('must be string');
+            });
+
+            it('is wrong type', async () => {
+              const apiResponse = {
+                datasets: [
+                  {
+                    ...mockRelatedDataset,
+                    url: 1
+                  }
+                ]
+              };
+              const response = responseValidator.validateResponse(200, apiResponse);
+
+              expect(response.message).to.equal('The response was not valid.');
+              expect(response.errors.length).to.equal(1);
+              expect(response.errors[0].message).to.equal('must be string');
+            });
+          });
+        });
+      });
+
+      describe('should succeed when', () => {
+        it('required values are valid', async () => {
+          const apiResponse = {
+            datasets: [mockRelatedDataset]
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response).to.equal(undefined);
+        });
+
+        it('returns an empty array of related datasets', async () => {
+          const apiResponse = {
+            datasets: []
+          };
+
+          const response = responseValidator.validateResponse(200, apiResponse);
+          expect(response).to.equal(undefined);
+        });
+      });
+      
+    });
+  });
+
+  it('should return an empty array if no related projects could be found', async () => {
+    // @TODO
+  });
+
+  it('should return an empty array if JSON Path fails to return any results', async () => {
+    // @TODO
+  });
+
+  it('catches and re-throws an error', async () => {
+    const dbConnectionObj = getMockDBConnection();
+    sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+
+    sinon.stub(ArtifactService.prototype, 'getArtifactsByDatasetId').rejects(new Error('a test error'));
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.params = {
+      datasetId: 'abcd'
+    };
+
+    try {
+      const requestHandler = getArtifactsByDatasetId();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as HTTPError).message).to.equal('a test error');
+    }
+  });
+});

--- a/api/src/paths/dwc/submission/{datasetId}/related.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/related.ts
@@ -39,7 +39,20 @@ GET.apiDoc = {
               datasets: {
                 type: 'array',
                 items: {
-                    // @TODO
+                  type: 'object',
+                  required: ['datasetId', 'title', 'url'],
+                  properties: {
+                    datasetId: {
+                      type: 'string',
+                      format: 'uuid'
+                    },
+                    title: {
+                      type: 'string'
+                    },
+                    url: {
+                      type: 'string'
+                    }
+                  }
                 }
               }
             }

--- a/api/src/paths/dwc/submission/{datasetId}/related.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/related.ts
@@ -66,7 +66,7 @@ GET.apiDoc = {
 };
 
 /**
- * Retrieves dataset metadata from the submission table.
+ * Retrieves related datasets within elastic search
  *
  * @returns {RequestHandler}
  */

--- a/api/src/paths/dwc/submission/{datasetId}/related.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/related.ts
@@ -34,9 +34,14 @@ GET.apiDoc = {
       content: {
         'application/json': {
           schema: {
-            type: 'array',
-            items: {
-                // @TODO
+            type: 'object',
+            properties: {
+              datasets: {
+                type: 'array',
+                items: {
+                    // @TODO
+                }
+              }
             }
           }
         }
@@ -62,13 +67,11 @@ export function getRelatedDatasetsByDatasetId(): RequestHandler {
 
       const submissionService = new SubmissionService(connection);
 
-      const result = await submissionService.getSubmissionRecordEMLJSONByDatasetId(datasetId);
-
-      // @TODO
+      const datasets = await submissionService.findRelatedDatasetsByDatasetId(datasetId);
 
       await connection.commit();
 
-      res.status(200).json(result);
+      res.status(200).json({ datasets });
     } catch (error) {
       defaultLog.error({ label: 'getRelatedDatasetsByDatasetId', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/dwc/submission/{datasetId}/related.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/related.ts
@@ -23,7 +23,8 @@ GET.apiDoc = {
       in: 'path',
       name: 'datasetId',
       schema: {
-        type: 'string'
+        type: 'string',
+        format: 'uuid'
       },
       required: true
     }

--- a/api/src/paths/dwc/submission/{datasetId}/related.ts
+++ b/api/src/paths/dwc/submission/{datasetId}/related.ts
@@ -1,0 +1,80 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { getAPIUserDBConnection, getDBConnection } from '../../../../database/db';
+import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
+import { SubmissionService } from '../../../../services/submission-service';
+import { getLogger } from '../../../../utils/logger';
+
+const defaultLog = getLogger('paths/dwc/submission/{datasetId}/related');
+
+export const GET: Operation = [getRelatedDatasetsByDatasetId()];
+
+GET.apiDoc = {
+  description: 'retrieves related datasets within elastic search',
+  tags: ['eml'],
+  security: [
+    {
+      OptionalBearer: []
+    }
+  ],
+  parameters: [
+    {
+      description: 'Dataset ID',
+      in: 'path',
+      name: 'datasetId',
+      schema: {
+        type: 'string'
+      },
+      required: true
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Related datasets response object.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+                // @TODO
+            }
+          }
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Retrieves dataset metadata from the submission table.
+ *
+ * @returns {RequestHandler}
+ */
+export function getRelatedDatasetsByDatasetId(): RequestHandler {
+  return async (req, res) => {
+    const connection = req['keycloak_token'] ? getDBConnection(req['keycloak_token']) : getAPIUserDBConnection();
+
+    const datasetId = String(req.params.datasetId);
+
+    try {
+      await connection.open();
+
+      const submissionService = new SubmissionService(connection);
+
+      const result = await submissionService.getSubmissionRecordEMLJSONByDatasetId(datasetId);
+
+      // @TODO
+
+      await connection.commit();
+
+      res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'getRelatedDatasetsByDatasetId', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/repositories/submission-repository.ts
+++ b/api/src/repositories/submission-repository.ts
@@ -28,7 +28,7 @@ export interface ISubmissionRecord {
 
 export interface ISubmissionRecordWithSpatial {
   id: string;
-  source: string;
+  source: Record<string, unknown>;
   observation_count: number;
 }
 
@@ -369,10 +369,12 @@ export class SubmissionRepository extends BaseRepository {
    * Get submission eml json by dataset id.
    *
    * @param {string} datasetId
-   * @return {*}  {Promise<string>}
+   * @return {*}  {Promise<QueryResult<{ eml_json_source: Record<string, unknown> }>>}
    * @memberof SubmissionRepository
    */
-  async getSubmissionRecordEMLJSONByDatasetId(datasetId: string): Promise<QueryResult<{ eml_json_source: string }>> {
+  async getSubmissionRecordEMLJSONByDatasetId(
+    datasetId: string
+  ): Promise<QueryResult<{ eml_json_source: Record<string, unknown> }>> {
     const sqlStatement = SQL`
       SELECT
         sm.eml_json_source
@@ -382,7 +384,7 @@ export class SubmissionRepository extends BaseRepository {
       AND s.uuid = ${datasetId};
     `;
 
-    return this.connection.sql<{ eml_json_source: string }>(sqlStatement);
+    return this.connection.sql<{ eml_json_source: Record<string, unknown> }>(sqlStatement);
   }
 
   /**

--- a/api/src/services/eml-service.test.ts
+++ b/api/src/services/eml-service.test.ts
@@ -135,56 +135,28 @@ describe('EMLService', () => {
   });
 
   describe('getSystemURL', () => {
-    it('returns url string when NODE_ENV=local', () => {
-      process.env.NODE_ENV = 'local';
-      process.env.API_HOST = 'localhost';
-      process.env.API_PORT = '1234';
+    it('returns the system url', () => {
+      process.env.APP_HOST = 'http://localhost:7200';
 
       const mockDBConnection = getMockDBConnection();
       const emlService = new EMLService(mockDBConnection);
 
       const response = emlService.getSystemURL();
 
-      expect(response).to.eql('http://localhost:1234');
-    });
-
-    it('returns url string when NODE_ENV!=local', () => {
-      process.env.NODE_ENV = 'dev';
-      process.env.API_HOST = 'www.host.com';
-
-      const mockDBConnection = getMockDBConnection();
-      const emlService = new EMLService(mockDBConnection);
-
-      const response = emlService.getSystemURL();
-
-      expect(response).to.eql('www.host.com');
+      expect(response).to.eql('http://localhost:7200');
     });
   });
 
   describe('getDatasetSystemURL', () => {
-    it('returns url string when NODE_ENV=local', () => {
-      process.env.NODE_ENV = 'local';
-      process.env.API_HOST = 'localhost';
-      process.env.API_PORT = '1234';
+    it('returns the dataset system url', () => {
+      process.env.APP_HOST = 'https://www.biohub.ca';
 
       const mockDBConnection = getMockDBConnection();
       const emlService = new EMLService(mockDBConnection);
 
       const response = emlService.getDatasetSystemURL();
 
-      expect(response).to.eql('http://localhost:1234/datasets');
-    });
-
-    it('returns url string when NODE_ENV!=local', () => {
-      process.env.NODE_ENV = 'dev';
-      process.env.API_HOST = 'www.host.com';
-
-      const mockDBConnection = getMockDBConnection();
-      const emlService = new EMLService(mockDBConnection);
-
-      const response = emlService.getDatasetSystemURL();
-
-      expect(response).to.eql('www.host.com/datasets');
+      expect(response).to.eql('https://www.biohub.ca/datasets');
     });
   });
 
@@ -242,7 +214,7 @@ describe('EMLService', () => {
 
     it('decorates the eml', async () => {
       process.env.NODE_ENV = 'dev';
-      process.env.API_HOST = 'www.host.com';
+      process.env.APP_HOST = 'www.host.com';
       process.env.ELASTICSEARCH_URL = 'www.elastic.com';
       process.env.ELASTICSEARCH_TAXONOMY_INDEX = 'taxonomy_index';
 

--- a/api/src/services/eml-service.ts
+++ b/api/src/services/eml-service.ts
@@ -76,11 +76,7 @@ export class EMLService extends DBService {
    * @memberof EMLService
    */
   getSystemURL(): string {
-    if (process.env.NODE_ENV === 'local') {
-      return `http://${process.env.API_HOST}:${process.env.API_PORT}`;
-    }
-
-    return process.env.API_HOST || '';
+    return process.env.APP_HOST || '';
   }
 
   /**

--- a/api/src/services/submission-service.test.ts
+++ b/api/src/services/submission-service.test.ts
@@ -1,4 +1,5 @@
 import chai, { expect } from 'chai';
+import * as JSONPathPlus from 'jsonpath-plus';
 import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
@@ -392,9 +393,9 @@ describe('SubmissionService', () => {
       const findSubmissionRecordWithSpatialCountStub = sinon
         .stub(SubmissionService.prototype, 'findSubmissionRecordWithSpatialCount')
         .onCall(0)
-        .resolves({ id: '111-111-111', source: 'source string 1', observation_count: 0 })
+        .resolves({ id: '111-111-111', source: {}, observation_count: 0 })
         .onCall(1)
-        .resolves({ id: '222-222-222', source: 'source string 2', observation_count: 200 })
+        .resolves({ id: '222-222-222', source: {}, observation_count: 200 })
         .onCall(2)
         .resolves(null);
 
@@ -406,8 +407,8 @@ describe('SubmissionService', () => {
 
       expect(findSubmissionRecordWithSpatialCountStub).to.be.calledThrice;
       expect(response).to.be.eql([
-        { id: '111-111-111', source: 'source string 1', observation_count: 0 },
-        { id: '222-222-222', source: 'source string 2', observation_count: 200 },
+        { id: '111-111-111', source: {}, observation_count: 0 },
+        { id: '222-222-222', source: {}, observation_count: 200 },
         null
       ]);
     });
@@ -427,7 +428,7 @@ describe('SubmissionService', () => {
 
         const findSubmissionRecordEMLJSONByDatasetIdStub = sinon
           .stub(SubmissionService.prototype, 'findSubmissionRecordEMLJSONByDatasetId')
-          .resolves('source string 1');
+          .resolves({});
 
         const getSpatialComponentCountByDatasetIdStub = sinon
           .stub(SubmissionRepository.prototype, 'getSpatialComponentCountByDatasetId')
@@ -437,7 +438,7 @@ describe('SubmissionService', () => {
 
         expect(findSubmissionRecordEMLJSONByDatasetIdStub).to.be.calledOnce;
         expect(getSpatialComponentCountByDatasetIdStub).to.be.calledOnce;
-        expect(response).to.be.eql({ id: '111-111-111', source: 'source string 1', observation_count: 0 });
+        expect(response).to.be.eql({ id: '111-111-111', source: {}, observation_count: 0 });
       });
     });
 
@@ -450,8 +451,8 @@ describe('SubmissionService', () => {
 
         const findSubmissionRecordEMLJSONByDatasetIdStub = sinon
           .stub(SubmissionService.prototype, 'findSubmissionRecordEMLJSONByDatasetId')
-          .resolves('source string 1')
-          .resolves('source string 2');
+          .resolves({})
+          .resolves({});
 
         const getSpatialComponentCountByDatasetIdStub = sinon
           .stub(SubmissionRepository.prototype, 'getSpatialComponentCountByDatasetId')
@@ -462,7 +463,7 @@ describe('SubmissionService', () => {
 
         expect(findSubmissionRecordEMLJSONByDatasetIdStub).to.be.calledOnce;
         expect(getSpatialComponentCountByDatasetIdStub).to.be.calledOnce;
-        expect(response).to.be.eql({ id: '222-222-222', source: 'source string 2', observation_count: 200 });
+        expect(response).to.be.eql({ id: '222-222-222', source: {}, observation_count: 200 });
       });
     });
 
@@ -506,28 +507,79 @@ describe('SubmissionService', () => {
     });
   });
 
-  describe('getRelatedDatasetsByDatasetId', () => {
+  describe('findRelatedDatasetsByDatasetId', () => {
     it('should return a valid array of related datasets on success', async () => {
-      const mockEmlString = JSON.stringify({
+      const mockDBConnection = getMockDBConnection();
+      const submissionService = new SubmissionService(mockDBConnection);
+
+      const mockEmlJson = {
         'eml:eml': {
-          //
+          dataset: {
+            project: {
+              relatedProject: [
+                {
+                  '@_id': 'abcde',
+                  title: 'Test-Title',
+                  '@_system': 'http://example.com/datasets'
+                }
+              ]
+            }
+          }
         }
-      });
-    
-      sinon.stub(SubmissionService.prototype, 'getSubmissionRecordEMLJSONByDatasetId')
-        .resolves(mockEmlString);
-  
-      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-  
-      // @TODO
+      };
+
+      const emlStub = sinon
+        .stub(SubmissionService.prototype, 'getSubmissionRecordEMLJSONByDatasetId')
+        .resolves(mockEmlJson);
+
+      const response = await submissionService.findRelatedDatasetsByDatasetId('test-dataset-id');
+
+      expect(response).to.eql([
+        {
+          datasetId: 'abcde',
+          title: 'Test-Title',
+          url: 'http://example.com/datasets/abcde'
+        }
+      ]);
+
+      expect(emlStub).to.be.calledOnce;
+      expect(emlStub).to.be.calledWith('test-dataset-id');
     });
-  
+
     it('should return an empty array if no EML JSON could be found', async () => {
-      // @TODO
+      const mockDBConnection = getMockDBConnection();
+      const submissionService = new SubmissionService(mockDBConnection);
+
+      const emlStub = sinon
+        .stub(SubmissionService.prototype, 'getSubmissionRecordEMLJSONByDatasetId')
+        .resolves(null as unknown as Record<string, unknown>);
+
+      const response = await submissionService.findRelatedDatasetsByDatasetId('test-dataset-id');
+
+      expect(response).to.eql([]);
+      expect(emlStub).to.be.calledOnce;
+      expect(emlStub).to.be.calledWith('test-dataset-id');
     });
-  
+
     it('should return an empty array if JSON Path fails to return any results', async () => {
-      // @TODO
+      const mockDBConnection = getMockDBConnection();
+      const submissionService = new SubmissionService(mockDBConnection);
+
+      const emlStub = sinon.stub(SubmissionService.prototype, 'getSubmissionRecordEMLJSONByDatasetId').resolves({});
+
+      const jsonPathStub = sinon.stub(JSONPathPlus, 'JSONPath').returns([]);
+
+      const response = await submissionService.findRelatedDatasetsByDatasetId('test-dataset-id');
+
+      expect(response).to.eql([]);
+      expect(emlStub).to.be.calledOnce;
+      expect(emlStub).to.be.calledWith('test-dataset-id');
+      expect(jsonPathStub).to.be.calledOnce;
+      expect(jsonPathStub).to.be.calledWith({
+        path: '$..eml:eml..relatedProject',
+        json: {},
+        resultType: 'all'
+      });
     });
-  })
+  });
 });

--- a/api/src/services/submission-service.test.ts
+++ b/api/src/services/submission-service.test.ts
@@ -505,4 +505,29 @@ describe('SubmissionService', () => {
       expect(response).to.be.eql({ test: 'test' });
     });
   });
+
+  describe('getRelatedDatasetsByDatasetId', () => {
+    it('should return a valid array of related datasets on success', async () => {
+      const mockEmlString = JSON.stringify({
+        'eml:eml': {
+          //
+        }
+      });
+    
+      sinon.stub(SubmissionService.prototype, 'getSubmissionRecordEMLJSONByDatasetId')
+        .resolves(mockEmlString);
+  
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+  
+      // @TODO
+    });
+  
+    it('should return an empty array if no EML JSON could be found', async () => {
+      // @TODO
+    });
+  
+    it('should return an empty array if JSON Path fails to return any results', async () => {
+      // @TODO
+    });
+  })
 });

--- a/api/src/services/submission-service.ts
+++ b/api/src/services/submission-service.ts
@@ -404,7 +404,7 @@ export class SubmissionService extends DBService {
     return emlJson?.['eml:eml']?.dataset?.project?.relatedProject?.map((relatedProject: any) => {
       return {
         datasetId: relatedProject['@_id'],
-        title: 'Related Project',
+        title: relatedProject['title'],
         url: [relatedProject['@_system'], relatedProject['@_id']].join('/')
       };
     });

--- a/api/src/services/submission-service.ts
+++ b/api/src/services/submission-service.ts
@@ -1,3 +1,4 @@
+import { JSONPath } from 'jsonpath-plus';
 import { z } from 'zod';
 import { IDBConnection } from '../database/db';
 import { ApiExecuteSQLError } from '../errors/api-error';
@@ -401,7 +402,21 @@ export class SubmissionService extends DBService {
   async findRelatedDatasetsByDatasetId(datasetId: string): Promise<RelatedDataset[]> {
     const emlJson = await this.getSubmissionRecordEMLJSONByDatasetId(datasetId);
 
-    return emlJson?.['eml:eml']?.dataset?.project?.relatedProject?.map((relatedProject: any) => {
+    if (!emlJson) {
+      return [];
+    }
+
+    const result = JSONPath({
+      path: '$..eml:eml..relatedProject',
+      json: emlJson,
+      resultType: 'all'
+    });
+
+    if (!result.length) {
+      return [];
+    }
+
+    return result[0].value.map((relatedProject: any) => {
       return {
         datasetId: relatedProject['@_id'],
         title: relatedProject['title'],

--- a/api/src/services/submission-service.ts
+++ b/api/src/services/submission-service.ts
@@ -17,15 +17,10 @@ import {
 import { EMLFile } from '../utils/media/eml/eml-file';
 import { DBService } from './db-service';
 
-
 export const RelatedDataset = z.object({
   dataset_id: z.string(),
   title: z.string(),
-  source: z.string(),
-  focal_species: z.number(),
-  occurrence_count: z.number(),
-  start_date: z.date(),
-  end_date: z.date()
+  url: z.string()
 });
 
 export type RelatedDataset = z.infer<typeof RelatedDataset>;
@@ -404,8 +399,14 @@ export class SubmissionService extends DBService {
    * @memberof SubmissionService
    */
   async findRelatedDatasetsByDatasetId(datasetId: string): Promise<RelatedDataset[]> {
-    await this.getSubmissionRecordEMLJSONByDatasetId(datasetId);
+    const emlJson = await this.getSubmissionRecordEMLJSONByDatasetId(datasetId);
 
-    return [];
+    return emlJson?.['eml:eml']?.dataset?.project?.relatedProject?.map((relatedProject: any) => {
+      return {
+        datasetId: relatedProject['@_id'],
+        title: 'Related Project',
+        url: [relatedProject['@_system'], relatedProject['@_id']].join('/')
+      };
+    });
   }
 }

--- a/api/src/services/submission-service.ts
+++ b/api/src/services/submission-service.ts
@@ -19,7 +19,7 @@ import { EMLFile } from '../utils/media/eml/eml-file';
 import { DBService } from './db-service';
 
 export const RelatedDataset = z.object({
-  dataset_id: z.string(),
+  datasetId: z.string(),
   title: z.string(),
   url: z.string()
 });
@@ -188,10 +188,10 @@ export class SubmissionService extends DBService {
    * Get json representation of eml source from submission by datasetId.
    *
    * @param {string} datasetId
-   * @return {string}
+   * @return {Promise<Record<string, unknown>>}
    * @memberof SubmissionService
    */
-  async getSubmissionRecordEMLJSONByDatasetId(datasetId: string): Promise<string> {
+  async getSubmissionRecordEMLJSONByDatasetId(datasetId: string): Promise<Record<string, unknown>> {
     const response = await this.submissionRepository.getSubmissionRecordEMLJSONByDatasetId(datasetId);
 
     if (response.rowCount !== 1) {
@@ -209,10 +209,10 @@ export class SubmissionService extends DBService {
    * any existing records.
    *
    * @param {string} datasetId
-   * @return {string | null}
+   * @return {Record<string, unknown> | null}
    * @memberof SubmissionService
    */
-  async findSubmissionRecordEMLJSONByDatasetId(datasetId: string): Promise<string | null> {
+  async findSubmissionRecordEMLJSONByDatasetId(datasetId: string): Promise<Record<string, unknown> | null> {
     const response = await this.submissionRepository.getSubmissionRecordEMLJSONByDatasetId(datasetId);
 
     if (response.rowCount !== 1) {

--- a/api/src/services/submission-service.ts
+++ b/api/src/services/submission-service.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { IDBConnection } from '../database/db';
 import { ApiExecuteSQLError } from '../errors/api-error';
 import {
@@ -15,6 +16,19 @@ import {
 } from '../repositories/submission-repository';
 import { EMLFile } from '../utils/media/eml/eml-file';
 import { DBService } from './db-service';
+
+
+export const RelatedDataset = z.object({
+  dataset_id: z.string(),
+  title: z.string(),
+  source: z.string(),
+  focal_species: z.number(),
+  occurrence_count: z.number(),
+  start_date: z.date(),
+  end_date: z.date()
+});
+
+export type RelatedDataset = z.infer<typeof RelatedDataset>;
 
 export class SubmissionService extends DBService {
   submissionRepository: SubmissionRepository;
@@ -380,5 +394,18 @@ export class SubmissionService extends DBService {
     submissonObservation: ISubmissionObservationRecord
   ): Promise<{ submission_observation_id: number }> {
     return this.submissionRepository.insertSubmissionObservationRecord(submissonObservation);
+  }
+
+  /**
+   * Retrieves an array of datasets related to the given dataset.
+   *
+   * @param {string} datasetId
+   * @return {*}  {Promise<RelatedDataset[]>}
+   * @memberof SubmissionService
+   */
+  async findRelatedDatasetsByDatasetId(datasetId: string): Promise<RelatedDataset[]> {
+    await this.getSubmissionRecordEMLJSONByDatasetId(datasetId);
+
+    return [];
   }
 }

--- a/app/src/features/datasets/DatasetPage.tsx
+++ b/app/src/features/datasets/DatasetPage.tsx
@@ -25,6 +25,7 @@ import { useHistory, useParams } from 'react-router';
 import { parseSpatialDataByType } from 'utils/spatial-utils';
 import DatasetArtifacts from './components/DatasetArtifacts';
 import RenderWithHandlebars from './components/RenderWithHandlebars';
+import RelatedDatasets from './components/RelatedDatasets';
 
 const useStyles = makeStyles((theme: Theme) => ({
   datasetTitleContainer: {
@@ -367,6 +368,13 @@ const DatasetPage: React.FC<React.PropsWithChildren> = () => {
         <Box pt={2}>
           <Paper elevation={0}>
             <DatasetArtifacts datasetId={datasetId} />
+          </Paper>
+        </Box>
+      </Container>
+      <Container maxWidth="xl">
+        <Box pt={2}>
+          <Paper elevation={0}>
+            <RelatedDatasets datasetId={datasetId} />
           </Paper>
         </Box>
       </Container>

--- a/app/src/features/datasets/DatasetPage.tsx
+++ b/app/src/features/datasets/DatasetPage.tsx
@@ -24,8 +24,8 @@ import { useContext, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router';
 import { parseSpatialDataByType } from 'utils/spatial-utils';
 import DatasetArtifacts from './components/DatasetArtifacts';
-import RenderWithHandlebars from './components/RenderWithHandlebars';
 import RelatedDatasets from './components/RelatedDatasets';
+import RenderWithHandlebars from './components/RenderWithHandlebars';
 
 const useStyles = makeStyles((theme: Theme) => ({
   datasetTitleContainer: {

--- a/app/src/features/datasets/DatasetsRouter.tsx
+++ b/app/src/features/datasets/DatasetsRouter.tsx
@@ -7,7 +7,7 @@ import DatasetPage from './DatasetPage';
  *
  * @return {*}
  */
-const datasetsRouter: React.FC<React.PropsWithChildren> = () => {
+const DatasetsRouter: React.FC<React.PropsWithChildren> = () => {
   return (
     <Switch>
       <Redirect exact from="/datasets/:id" to="/datasets/:id/details" />
@@ -24,4 +24,4 @@ const datasetsRouter: React.FC<React.PropsWithChildren> = () => {
   );
 };
 
-export default datasetsRouter;
+export default DatasetsRouter;

--- a/app/src/features/datasets/components/DatasetArtifacts.tsx
+++ b/app/src/features/datasets/components/DatasetArtifacts.tsx
@@ -33,6 +33,23 @@ interface IAttachmentItemMenuButtonProps {
   isPendingReview: boolean;
 }
 
+const NoArtifactRowsOverlay = () => (
+  <Box
+    sx={{
+      p: 2,
+      display: 'flex',
+      flexFlow: 'column',
+      alignItems: 'center',
+      top: '50%',
+      position: 'relative',
+      transform: 'translateY(-50%)'
+    }}>
+    <Typography component="strong" color="textSecondary" variant="body2">
+      No Artifacts
+    </Typography>
+  </Box>
+);
+
 const AttachmentItemMenuButton: React.FC<IAttachmentItemMenuButtonProps> = (props) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -250,22 +267,7 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
               }
             }}
             slots={{
-              noRowsOverlay: () => (
-                <Box
-                  sx={{
-                    p: 2,
-                    display: 'flex',
-                    flexFlow: 'column',
-                    alignItems: 'center',
-                    top: '50%',
-                    position: 'relative',
-                    transform: 'translateY(-50%)'
-                  }}>
-                  <Typography component="strong" color="textSecondary" variant="body2">
-                    No Artifacts
-                  </Typography>
-                </Box>
-              )
+              noRowsOverlay: NoArtifactRowsOverlay
             }}
             // onStateChange={(params) => setSelected(params.rowSelection)}
           />

--- a/app/src/features/datasets/components/DatasetArtifacts.tsx
+++ b/app/src/features/datasets/components/DatasetArtifacts.tsx
@@ -1,7 +1,9 @@
 import { mdiDotsVertical, mdiLockPlus, mdiTrashCanOutline, mdiTrayArrowDown } from '@mdi/js';
 import Icon from '@mdi/react';
-import { Alert, Button, Chip } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -79,7 +81,7 @@ const AttachmentItemMenuButton: React.FC<IAttachmentItemMenuButtonProps> = (prop
               </MenuItem>
             )}
             <MenuItem
-              disabled={!props.hasAdministrativePermissions && props.isPendingReview}
+              disabled={!props.hasAdministrativePermissions}
               onClick={() => {
                 props.onDownload(props.artifact);
                 setAnchorEl(null);
@@ -118,7 +120,6 @@ const AttachmentItemMenuButton: React.FC<IAttachmentItemMenuButtonProps> = (prop
 const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
   const { datasetId } = props;
   const [showAlert, setShowAlert] = useState<boolean>(true);
-  const [selected, setSelected] = useState<number[]>([]);
 
   const keycloakWrapper = useKeycloakWrapper();
   const biohubApi = useApi();
@@ -170,11 +171,11 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
       flex: 1,
       renderCell: (params) => {
         const { security_review_timestamp } = params.row;
-        if (!security_review_timestamp) {
+        if (!security_review_timestamp && hasAdministrativePermissions) {
           return <Chip color="info" sx={{ textTransform: 'uppercase' }} label="Pending Review" />;
         }
 
-        return <Chip color="success" sx={{ textTransform: 'uppercase' }} label="Unsecured" />;
+        return <Chip color="warning" sx={{ textTransform: 'uppercase' }} label="Secured" />;
       }
     },
     {
@@ -198,6 +199,7 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
     <>
       <ActionToolbar label="Documents" labelProps={{ variant: 'h4' }}>
         <Box display="flex" gap={1}>
+        {/*
           <Button
             title="Apply Security Rules"
             variant="contained"
@@ -210,11 +212,12 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
           <IconButton disabled title="Download Files" aria-label={`Download selected files`}>
             <Icon path={mdiTrayArrowDown} color="primary" size={1} />
           </IconButton>
+        */}
         </Box>
       </ActionToolbar>
       <Divider></Divider>
-      <Box px={1}>
-        {numPendingDocuments > 0 && showAlert && (
+      <Box px={2}>
+        {hasAdministrativePermissions && numPendingDocuments > 0 && showAlert && (
           <Box pt={2} pb={2}>
             <Alert onClose={() => setShowAlert(false)} severity="info">
               <strong>
@@ -246,7 +249,24 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
                 }
               }
             }}
-            onStateChange={(params) => setSelected(params.rowSelection)}
+            slots={{
+              noRowsOverlay: () => (
+                <Box sx={{
+                  p: 2,
+                  display: 'flex',
+                  flexFlow: 'column',
+                  alignItems: 'center',
+                  top: '50%',
+                  position: 'relative',
+                  transform: 'translateY(-50%)'
+                }}>
+                  <Typography component="strong" color="textSecondary" variant="body2">
+                    No Artifacts
+                  </Typography>
+                </Box>
+              )
+            }}
+            // onStateChange={(params) => setSelected(params.rowSelection)}
           />
         </Box>
       </Box>

--- a/app/src/features/datasets/components/DatasetArtifacts.tsx
+++ b/app/src/features/datasets/components/DatasetArtifacts.tsx
@@ -1,6 +1,5 @@
 import { mdiDotsVertical, mdiLockPlus, mdiTrashCanOutline, mdiTrayArrowDown } from '@mdi/js';
 import Icon from '@mdi/react';
-import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -9,6 +8,7 @@ import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { ActionToolbar } from 'components/toolbar/ActionToolbars';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
@@ -199,7 +199,7 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
     <>
       <ActionToolbar label="Documents" labelProps={{ variant: 'h4' }}>
         <Box display="flex" gap={1}>
-        {/*
+          {/*
           <Button
             title="Apply Security Rules"
             variant="contained"
@@ -251,15 +251,16 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
             }}
             slots={{
               noRowsOverlay: () => (
-                <Box sx={{
-                  p: 2,
-                  display: 'flex',
-                  flexFlow: 'column',
-                  alignItems: 'center',
-                  top: '50%',
-                  position: 'relative',
-                  transform: 'translateY(-50%)'
-                }}>
+                <Box
+                  sx={{
+                    p: 2,
+                    display: 'flex',
+                    flexFlow: 'column',
+                    alignItems: 'center',
+                    top: '50%',
+                    position: 'relative',
+                    transform: 'translateY(-50%)'
+                  }}>
                   <Typography component="strong" color="textSecondary" variant="body2">
                     No Artifacts
                   </Typography>

--- a/app/src/features/datasets/components/DatasetArtifacts.tsx
+++ b/app/src/features/datasets/components/DatasetArtifacts.tsx
@@ -269,7 +269,6 @@ const DatasetAttachments: React.FC<IDatasetAttachmentsProps> = (props) => {
             slots={{
               noRowsOverlay: NoArtifactRowsOverlay
             }}
-            // onStateChange={(params) => setSelected(params.rowSelection)}
           />
         </Box>
       </Box>

--- a/app/src/features/datasets/components/RelatedDatasets.tsx
+++ b/app/src/features/datasets/components/RelatedDatasets.tsx
@@ -1,0 +1,149 @@
+import { mdiLockPlus, mdiTrayArrowDown } from '@mdi/js';
+import Icon from '@mdi/react';
+import { Alert, Button, Chip } from '@mui/material';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { ActionToolbar } from 'components/toolbar/ActionToolbars';
+import { DATE_FORMAT } from 'constants/dateTimeFormats';
+import { useApi } from 'hooks/useApi';
+import useDataLoader from 'hooks/useDataLoader';
+import { IArtifact } from 'interfaces/useDatasetApi.interface';
+import { useState } from 'react';
+import { getFormattedDate, getFormattedFileSize } from 'utils/Utils';
+
+export interface IRelatedDatasetsProps {
+  datasetId: string;
+}
+
+
+/**
+ * Dataset attachments content for a dataset.
+ *
+ * @return {*}
+ */
+const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
+  const { datasetId } = props;
+  const [showAlert, setShowAlert] = useState<boolean>(true);
+  const [selected, setSelected] = useState<number[]>([]);
+
+  const biohubApi = useApi();
+
+  const artifactsDataLoader = useDataLoader(() => biohubApi.dataset.getDatasetArtifacts(datasetId));
+  artifactsDataLoader.load();
+
+  const artifactsList = artifactsDataLoader.data?.artifacts || [];
+  const numPendingDocuments = artifactsList.filter((artifact) => artifact.security_review_timestamp === null).length;
+
+  const columns: GridColDef<IArtifact>[] = [
+    {
+      field: 'file_name',
+      headerName: 'Title',
+      flex: 2,
+      disableColumnMenu: true
+    },
+    {
+      field: 'file_type',
+      headerName: 'Type',
+      flex: 1
+    },
+    {
+      field: 'create_date',
+      headerName: 'Submitted',
+      valueGetter: ({ value }) => value && new Date(value),
+      valueFormatter: ({ value }) => getFormattedDate(DATE_FORMAT.ShortDateFormat, value),
+      flex: 1
+    },
+    {
+      field: 'file_size',
+      headerName: 'Size',
+      flex: 0,
+      valueFormatter: ({ value }) => getFormattedFileSize(value)
+    },
+    {
+      field: 'status',
+      headerName: 'Status',
+      flex: 1,
+      renderCell: (params) => {
+        const { security_review_timestamp } = params.row;
+        if (!security_review_timestamp) {
+          return <Chip color="info" sx={{ textTransform: 'uppercase' }} label="Pending Review" />;
+        }
+
+        return <Chip color="success" sx={{ textTransform: 'uppercase' }} label="Unsecured" />;
+      }
+    },
+    {
+      field: 'action',
+      headerName: 'Action',
+      sortable: false,
+      renderCell: (params) => {
+        return (
+          null
+        );
+      }
+    }
+  ];
+
+  return (
+    <>
+      <ActionToolbar label="Documents" labelProps={{ variant: 'h4' }}>
+        <Box display="flex" gap={1}>
+          <Button
+            title="Apply Security Rules"
+            variant="contained"
+            color="primary"
+            startIcon={<Icon path={mdiLockPlus} size={1} />}
+            onClick={() => console.log('Apply Security not implemented.')}
+            disabled={selected.length === 0}>
+            Apply Security
+          </Button>
+          <IconButton disabled title="Download Files" aria-label={`Download selected files`}>
+            <Icon path={mdiTrayArrowDown} color="primary" size={1} />
+          </IconButton>
+        </Box>
+      </ActionToolbar>
+      <Divider></Divider>
+      <Box px={1}>
+        {numPendingDocuments > 0 && showAlert && (
+          <Box pt={2} pb={2}>
+            <Alert onClose={() => setShowAlert(false)} severity="info">
+              <strong>
+                {`You have ${numPendingDocuments} project document${numPendingDocuments === 1 ? '' : 's'} to review.`}
+              </strong>
+            </Alert>
+          </Box>
+        )}
+        <Box>
+          <DataGrid
+            getRowId={(row) => row.artifact_id}
+            autoHeight
+            rows={artifactsList}
+            columns={columns}
+            pageSizeOptions={[5]}
+            checkboxSelection
+            disableRowSelectionOnClick
+            disableColumnSelector
+            disableColumnFilter
+            disableColumnMenu
+            sortingOrder={['asc', 'desc']}
+            initialState={{
+              sorting: {
+                sortModel: [{ field: 'create_date', sort: 'desc' }]
+              },
+              pagination: {
+                paginationModel: {
+                  pageSize: 5
+                }
+              }
+            }}
+            onStateChange={(params) => setSelected(params.rowSelection)}
+          />
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default RelatedDatasets;

--- a/app/src/features/datasets/components/RelatedDatasets.tsx
+++ b/app/src/features/datasets/components/RelatedDatasets.tsx
@@ -1,16 +1,11 @@
-import { mdiLockPlus, mdiTrayArrowDown } from '@mdi/js';
-import Icon from '@mdi/react';
-import { Button, Link } from '@mui/material';
+import { Link, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
-import IconButton from '@mui/material/IconButton';
 import { DataGrid, GridColDef, GridRenderCellParams, GridTreeNodeWithRender } from '@mui/x-data-grid';
 import { ActionToolbar } from 'components/toolbar/ActionToolbars';
 import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { IRelatedDataset } from 'interfaces/useDatasetApi.interface';
-import { useState } from 'react';
-// import { Link as RouterLink } from 'react-router-dom'
 
 export interface IRelatedDatasetsProps {
   datasetId: string;
@@ -24,14 +19,13 @@ export interface IRelatedDatasetsProps {
  */
 const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
   const { datasetId } = props;
-  const [selected, setSelected] = useState<number[]>([]);
 
   const biohubApi = useApi();
 
   const relatedDatasetsDataLoader = useDataLoader(() => biohubApi.dataset.getRelatedDatasets(datasetId));
   relatedDatasetsDataLoader.load();
 
-  const relatedDatasetsList = relatedDatasetsDataLoader.data?.datasets || [];
+  const relatedDatasetsList: IRelatedDataset[] = relatedDatasetsDataLoader.data?.datasets || [];
 
   const columns: GridColDef<IRelatedDataset>[] = [
     {
@@ -49,32 +43,34 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
 
   return (
     <>
-      <ActionToolbar label="Related Datasets" labelProps={{ variant: 'h4' }}>
-        <Box display="flex" gap={1}>
-          <Button
-            title="Apply Security Rules"
-            variant="contained"
-            color="primary"
-            startIcon={<Icon path={mdiLockPlus} size={1} />}
-            onClick={() => console.log('Apply Security not implemented.')}
-            disabled={selected.length === 0}>
-            Apply Security
-          </Button>
-          <IconButton disabled title="Download Files" aria-label={`Download selected files`}>
-            <Icon path={mdiTrayArrowDown} color="primary" size={1} />
-          </IconButton>
-        </Box>
-      </ActionToolbar>
+      <ActionToolbar label="Related Datasets" labelProps={{ variant: 'h4' }} />
       <Divider></Divider>
-      <Box px={1}>
+      <Box px={2}>
         <Box>
           <DataGrid
             getRowId={(row) => row.datasetId}
             autoHeight
+            disableVirtualization
             rows={relatedDatasetsList}
+            slots={{
+              noRowsOverlay: () => (
+                <Box sx={{
+                  p: 2,
+                  display: 'flex',
+                  flexFlow: 'column',
+                  alignItems: 'center',
+                  top: '50%',
+                  position: 'relative',
+                  transform: 'translateY(-50%)'
+                }}>
+                  <Typography component="strong" color="textSecondary" variant="body2">
+                    No Related Datasets
+                  </Typography>
+                </Box>
+              )
+            }}
             columns={columns}
             pageSizeOptions={[5]}
-            checkboxSelection
             disableRowSelectionOnClick
             disableColumnSelector
             disableColumnFilter
@@ -90,7 +86,6 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
                 }
               }
             }}
-            onStateChange={(params) => setSelected(params.rowSelection)}
           />
         </Box>
       </Box>

--- a/app/src/features/datasets/components/RelatedDatasets.tsx
+++ b/app/src/features/datasets/components/RelatedDatasets.tsx
@@ -11,6 +11,23 @@ export interface IRelatedDatasetsProps {
   datasetId: string;
 }
 
+const NoDatasetRowsOverlay = () => (
+  <Box
+    sx={{
+      p: 2,
+      display: 'flex',
+      flexFlow: 'column',
+      alignItems: 'center',
+      top: '50%',
+      position: 'relative',
+      transform: 'translateY(-50%)'
+    }}>
+    <Typography component="strong" color="textSecondary" variant="body2">
+      No Related Datasets
+    </Typography>
+  </Box>
+);
+
 /**
  * Dataset attachments content for a dataset.
  *
@@ -50,22 +67,7 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
             disableVirtualization
             rows={relatedDatasetsList}
             slots={{
-              noRowsOverlay: () => (
-                <Box
-                  sx={{
-                    p: 2,
-                    display: 'flex',
-                    flexFlow: 'column',
-                    alignItems: 'center',
-                    top: '50%',
-                    position: 'relative',
-                    transform: 'translateY(-50%)'
-                  }}>
-                  <Typography component="strong" color="textSecondary" variant="body2">
-                    No Related Datasets
-                  </Typography>
-                </Box>
-              )
+              noRowsOverlay: NoDatasetRowsOverlay
             }}
             columns={columns}
             pageSizeOptions={[5]}

--- a/app/src/features/datasets/components/RelatedDatasets.tsx
+++ b/app/src/features/datasets/components/RelatedDatasets.tsx
@@ -11,7 +11,6 @@ export interface IRelatedDatasetsProps {
   datasetId: string;
 }
 
-
 /**
  * Dataset attachments content for a dataset.
  *
@@ -34,9 +33,7 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
       flex: 1,
       disableColumnMenu: true,
       renderCell: (params: GridRenderCellParams<IRelatedDataset, any, any, GridTreeNodeWithRender>) => {
-        return (
-          <Link href={params.row.url}>{params.row.title}</Link>
-        )
+        return <Link href={params.row.url}>{params.row.title}</Link>;
       }
     }
   ];
@@ -54,15 +51,16 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
             rows={relatedDatasetsList}
             slots={{
               noRowsOverlay: () => (
-                <Box sx={{
-                  p: 2,
-                  display: 'flex',
-                  flexFlow: 'column',
-                  alignItems: 'center',
-                  top: '50%',
-                  position: 'relative',
-                  transform: 'translateY(-50%)'
-                }}>
+                <Box
+                  sx={{
+                    p: 2,
+                    display: 'flex',
+                    flexFlow: 'column',
+                    alignItems: 'center',
+                    top: '50%',
+                    position: 'relative',
+                    transform: 'translateY(-50%)'
+                  }}>
                   <Typography component="strong" color="textSecondary" variant="body2">
                     No Related Datasets
                   </Typography>

--- a/app/src/features/datasets/components/RelatedDatasets.tsx
+++ b/app/src/features/datasets/components/RelatedDatasets.tsx
@@ -1,6 +1,6 @@
 import { mdiLockPlus, mdiTrayArrowDown } from '@mdi/js';
 import Icon from '@mdi/react';
-import { Alert, Button, Chip } from '@mui/material';
+import { Button, Chip } from '@mui/material';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
@@ -9,7 +9,7 @@ import { ActionToolbar } from 'components/toolbar/ActionToolbars';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { IArtifact } from 'interfaces/useDatasetApi.interface';
+import { IRelatedDataset } from 'interfaces/useDatasetApi.interface';
 import { useState } from 'react';
 import { getFormattedDate, getFormattedFileSize } from 'utils/Utils';
 
@@ -25,18 +25,16 @@ export interface IRelatedDatasetsProps {
  */
 const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
   const { datasetId } = props;
-  const [showAlert, setShowAlert] = useState<boolean>(true);
   const [selected, setSelected] = useState<number[]>([]);
 
   const biohubApi = useApi();
 
-  const artifactsDataLoader = useDataLoader(() => biohubApi.dataset.getDatasetArtifacts(datasetId));
-  artifactsDataLoader.load();
+  const relatedDatasetsDataLoader = useDataLoader(() => biohubApi.dataset.getRelatedDatasets(datasetId));
+  relatedDatasetsDataLoader.load();
 
-  const artifactsList = artifactsDataLoader.data?.artifacts || [];
-  const numPendingDocuments = artifactsList.filter((artifact) => artifact.security_review_timestamp === null).length;
+  const relatedDatasetsList = relatedDatasetsDataLoader.data?.datasets || [];
 
-  const columns: GridColDef<IArtifact>[] = [
+  const columns: GridColDef<IRelatedDataset>[] = [
     {
       field: 'file_name',
       headerName: 'Title',
@@ -88,7 +86,7 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
 
   return (
     <>
-      <ActionToolbar label="Documents" labelProps={{ variant: 'h4' }}>
+      <ActionToolbar label="Related Datasets" labelProps={{ variant: 'h4' }}>
         <Box display="flex" gap={1}>
           <Button
             title="Apply Security Rules"
@@ -106,20 +104,11 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
       </ActionToolbar>
       <Divider></Divider>
       <Box px={1}>
-        {numPendingDocuments > 0 && showAlert && (
-          <Box pt={2} pb={2}>
-            <Alert onClose={() => setShowAlert(false)} severity="info">
-              <strong>
-                {`You have ${numPendingDocuments} project document${numPendingDocuments === 1 ? '' : 's'} to review.`}
-              </strong>
-            </Alert>
-          </Box>
-        )}
         <Box>
           <DataGrid
             getRowId={(row) => row.artifact_id}
             autoHeight
-            rows={artifactsList}
+            rows={relatedDatasetsList}
             columns={columns}
             pageSizeOptions={[5]}
             checkboxSelection

--- a/app/src/features/datasets/components/RelatedDatasets.tsx
+++ b/app/src/features/datasets/components/RelatedDatasets.tsx
@@ -1,17 +1,16 @@
 import { mdiLockPlus, mdiTrayArrowDown } from '@mdi/js';
 import Icon from '@mdi/react';
-import { Button, Chip } from '@mui/material';
+import { Button, Link } from '@mui/material';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridRenderCellParams, GridTreeNodeWithRender } from '@mui/x-data-grid';
 import { ActionToolbar } from 'components/toolbar/ActionToolbars';
-import { DATE_FORMAT } from 'constants/dateTimeFormats';
 import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { IRelatedDataset } from 'interfaces/useDatasetApi.interface';
 import { useState } from 'react';
-import { getFormattedDate, getFormattedFileSize } from 'utils/Utils';
+// import { Link as RouterLink } from 'react-router-dom'
 
 export interface IRelatedDatasetsProps {
   datasetId: string;
@@ -36,50 +35,14 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
 
   const columns: GridColDef<IRelatedDataset>[] = [
     {
-      field: 'file_name',
+      field: 'title',
       headerName: 'Title',
-      flex: 2,
-      disableColumnMenu: true
-    },
-    {
-      field: 'file_type',
-      headerName: 'Type',
-      flex: 1
-    },
-    {
-      field: 'create_date',
-      headerName: 'Submitted',
-      valueGetter: ({ value }) => value && new Date(value),
-      valueFormatter: ({ value }) => getFormattedDate(DATE_FORMAT.ShortDateFormat, value),
-      flex: 1
-    },
-    {
-      field: 'file_size',
-      headerName: 'Size',
-      flex: 0,
-      valueFormatter: ({ value }) => getFormattedFileSize(value)
-    },
-    {
-      field: 'status',
-      headerName: 'Status',
       flex: 1,
-      renderCell: (params) => {
-        const { security_review_timestamp } = params.row;
-        if (!security_review_timestamp) {
-          return <Chip color="info" sx={{ textTransform: 'uppercase' }} label="Pending Review" />;
-        }
-
-        return <Chip color="success" sx={{ textTransform: 'uppercase' }} label="Unsecured" />;
-      }
-    },
-    {
-      field: 'action',
-      headerName: 'Action',
-      sortable: false,
-      renderCell: (params) => {
+      disableColumnMenu: true,
+      renderCell: (params: GridRenderCellParams<IRelatedDataset, any, any, GridTreeNodeWithRender>) => {
         return (
-          null
-        );
+          <Link href={params.row.url}>{params.row.title}</Link>
+        )
       }
     }
   ];
@@ -106,7 +69,7 @@ const RelatedDatasets: React.FC<IRelatedDatasetsProps> = (props) => {
       <Box px={1}>
         <Box>
           <DataGrid
-            getRowId={(row) => row.artifact_id}
+            getRowId={(row) => row.datasetId}
             autoHeight
             rows={relatedDatasetsList}
             columns={columns}

--- a/app/src/hooks/api/useDatasetApi.test.ts
+++ b/app/src/hooks/api/useDatasetApi.test.ts
@@ -65,19 +65,13 @@ describe('useDatasetApi', () => {
 
   it('getRelatedDatasets works as expected', async () => {
     mock.onGet(`api/dwc/submission/${'aaaa'}/related`).reply(200, {
-      datasets: [
-        { datasetId: 'bbb' },
-        { datasetId: 'ccc' },
-      ]
+      datasets: [{ datasetId: 'bbb' }, { datasetId: 'ccc' }]
     });
 
     const actualResult = await useDatasetApi(axios).getRelatedDatasets('aaaa');
 
     expect(actualResult).toEqual({
-      datasets: [
-        { datasetId: 'bbb' },
-        { datasetId: 'ccc' },
-      ]
+      datasets: [{ datasetId: 'bbb' }, { datasetId: 'ccc' }]
     });
   });
 });

--- a/app/src/hooks/api/useDatasetApi.test.ts
+++ b/app/src/hooks/api/useDatasetApi.test.ts
@@ -62,4 +62,9 @@ describe('useDatasetApi', () => {
 
     expect(actualResult).toEqual('http://example.com');
   });
+
+  // @TODO
+  it('getRelatedDatasets works as expected', async () => {
+    //
+  })
 });

--- a/app/src/hooks/api/useDatasetApi.test.ts
+++ b/app/src/hooks/api/useDatasetApi.test.ts
@@ -63,8 +63,21 @@ describe('useDatasetApi', () => {
     expect(actualResult).toEqual('http://example.com');
   });
 
-  // @TODO
   it('getRelatedDatasets works as expected', async () => {
-    //
+    mock.onGet(`api/dwc/submission/${'aaaa'}/related`).reply(200, {
+      datasets: [
+        { datasetId: 'bbb' },
+        { datasetId: 'ccc' },
+      ]
+    });
+
+    const actualResult = await useDatasetApi(axios).getRelatedDatasets('aaaa');
+
+    expect(actualResult).toEqual({
+      datasets: [
+        { datasetId: 'bbb' },
+        { datasetId: 'ccc' },
+      ]
+    });
   });
 });

--- a/app/src/hooks/api/useDatasetApi.test.ts
+++ b/app/src/hooks/api/useDatasetApi.test.ts
@@ -66,5 +66,5 @@ describe('useDatasetApi', () => {
   // @TODO
   it('getRelatedDatasets works as expected', async () => {
     //
-  })
+  });
 });

--- a/app/src/hooks/api/useDatasetApi.ts
+++ b/app/src/hooks/api/useDatasetApi.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from 'axios';
-import { IListArtifactsResponse } from 'interfaces/useDatasetApi.interface';
+import { IListArtifactsResponse, IListRelatedDatasetsResponse } from 'interfaces/useDatasetApi.interface';
 import { IKeywordSearchResponse } from 'interfaces/useSearchApi.interface';
 
 /**
@@ -55,11 +55,24 @@ const useDatasetApi = (axios: AxiosInstance) => {
     return data;
   };
 
+  /**
+   * Fetch a list of datasets related to the given dataset
+   *
+   * @param {string} datasetId
+   * @return {*}  {Promise<IRelatedDataset>}
+   */
+  const getRelatedDatasets = async (datasetId: string): Promise<IListRelatedDatasetsResponse> => {
+    const { data } = await axios.get<IListRelatedDatasetsResponse>(`api/dwc/submission/${datasetId}/related`);
+
+    return data;
+  }
+
   return {
     listAllDatasets,
     getDatasetEML,
     getDatasetArtifacts,
-    getArtifactSignedUrl
+    getArtifactSignedUrl,
+    getRelatedDatasets
   };
 };
 

--- a/app/src/hooks/api/useDatasetApi.ts
+++ b/app/src/hooks/api/useDatasetApi.ts
@@ -65,7 +65,7 @@ const useDatasetApi = (axios: AxiosInstance) => {
     const { data } = await axios.get<IListRelatedDatasetsResponse>(`api/dwc/submission/${datasetId}/related`);
 
     return data;
-  }
+  };
 
   return {
     listAllDatasets,

--- a/app/src/interfaces/useDatasetApi.interface.ts
+++ b/app/src/interfaces/useDatasetApi.interface.ts
@@ -21,9 +21,11 @@ export interface IListArtifactsResponse {
   artifacts: IArtifact[];
 }
 
-
-// @TODO
-export type IRelatedDataset = Record<string, any>;
+export interface IRelatedDataset {
+  datasetId: string;
+  title: string;
+  url: string;
+}
 
 export interface IListRelatedDatasetsResponse {
   datasets: IRelatedDataset[];

--- a/app/src/interfaces/useDatasetApi.interface.ts
+++ b/app/src/interfaces/useDatasetApi.interface.ts
@@ -20,3 +20,11 @@ export interface IArtifact {
 export interface IListArtifactsResponse {
   artifacts: IArtifact[];
 }
+
+
+// @TODO
+export type IRelatedDataset = Record<string, any>;
+
+export interface IListRelatedDatasetsResponse {
+  datasets: IRelatedDataset[];
+}

--- a/app/src/themes/appTheme.ts
+++ b/app/src/themes/appTheme.ts
@@ -43,7 +43,33 @@ const appTheme = createTheme({
     MuiAlert: {
       styleOverrides: {
         root: {
-          fontSize: '1rem'
+          fontSize: '0.9rem',
+          padding: '12px 20px',
+          borderWidth: '1px',
+          borderStyle: 'solid'
+        },
+        icon: {
+          marginRight: '1rem'
+        },
+        standardInfo: {
+          borderColor: '#a3d4fa',
+          '& .MuiAlert-icon': {
+            color: '#313132'
+          }
+        },
+        standardError: {
+          color: '#A12622',
+          borderColor: '#ebccd1',
+          '& .MuiAlert-icon': {
+            color: '#A12622'
+          }
+        },
+        standardSuccess: {
+          backgroundColor: '#dff0d8',
+          borderColor: '#c0dcb3',
+          '& .MuiAlert-icon': {
+            color: '#2d4821'
+          }
         }
       }
     },

--- a/app/src/themes/appTheme.ts
+++ b/app/src/themes/appTheme.ts
@@ -154,6 +154,26 @@ const appTheme = createTheme({
             }
         }
       }
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 700
+        },
+        colorPrimary: {
+          color: '#003366',
+          backgroundColor: '#DCEBFB',
+          textTransform: 'uppercase',
+          fontSize: '12px',
+          '&.colorSuccess': {
+            color: '#2D4821',
+            backgroundColor: '#DFF0D8'
+          }
+        },
+        colorSecondary: {
+          backgroundColor: 'red'
+        }
+      }
     }
   }
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       - OBJECT_STORE_SECRET_KEY_ID=${OBJECT_STORE_SECRET_KEY_ID}
       - OBJECT_STORE_BUCKET_NAME=${OBJECT_STORE_BUCKET_NAME}
       - LOG_LEVEL=${LOG_LEVEL}
+      - APP_HOST=${APP_HOST}
     volumes:
       - ./api:/opt/app-root/src
       - /opt/app-root/src/node_modules # prevents local node_modules overriding container node_modules


### PR DESCRIPTION
# Overview
Allows the user to see and navigate to information related to a given dataset.

## Applicable Links

 - [Jira @BHBC-2238](https://quartech.atlassian.net/browse/BHBC-2238)
 - [Wireframes](https://preview.uxpin.com/b2be84efca658f9d07b74a9c8e377e75c4070e6f#/pages/161112036/simulate/sitemap?mode=i)

## Description of relevant changes

 - Adds a Related Datasets table to the dataset page
 - Adds endpoint, service method, and appropriate tests for retrieving related datasets
 - Adds MUI Alert and MUI Chip styles from SIMS
 - Minor tweaks to the Dataset Artifacts component
 - Changes typedef for EML source from `string` to `Record<string, unknown>`

## Testing Procedure
1. Create a project and survey in SIMS
2. Click **Submit Data**
3. Click **SELECT ALL** and then submit.
4. In BioHub, navigate to the survey you submitted: **Map Search** -> **Species Inventory Project** -> **Find Data**

You should be able to:
 - [ ] See the project as a related dataset
 - [ ] Click on the project name and navigate to the related dataset page. **Since project submission is not implemented (and therefore the project EML has not been injested), you shoud expect to see an error on the project dataset page.**