### PR TITLE
BugFix: Common Name Parsing

### DIFF
--- a/api/src/services/itis-service.ts
+++ b/api/src/services/itis-service.ts
@@ -6,7 +6,7 @@ import { TaxonSearchResult } from './taxonomy-service';
 const defaultLog = getLogger('services/itis-service');
 
 export type ItisSolrSearchResponse = {
-  commonNames: string[];
+  commonNames?: string[];
   kingdom: string;
   name: string;
   parentTSN: string;

--- a/api/src/services/itis-service.ts
+++ b/api/src/services/itis-service.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { sortTaxonSearchResults } from '../utils/itis-sort';
+import { getItisTaxonCommonNames, sortTaxonSearchResults } from '../utils/itis-utils';
 import { getLogger } from '../utils/logger';
 import { TaxonSearchResult } from './taxonomy-service';
 
@@ -83,8 +83,7 @@ export class ItisService {
    */
   _sanitizeItisData = (data: ItisSolrSearchResponse[]): TaxonSearchResult[] => {
     return data.map((item: ItisSolrSearchResponse) => {
-      const englishNames = item.commonNames?.filter((name) => name.split('$')[2] === 'English');
-      const commonNames = englishNames?.map((name) => name.split('$')[1]) ?? [];
+      const commonNames = getItisTaxonCommonNames(item.commonNames);
 
       return {
         tsn: Number(item.tsn),

--- a/api/src/services/taxonomy-service.ts
+++ b/api/src/services/taxonomy-service.ts
@@ -1,5 +1,6 @@
 import { IDBConnection } from '../database/db';
 import { TaxonomyRepository, TaxonRecord } from '../repositories/taxonomy-repository';
+import { getItisTaxonCommonNames } from '../utils/itis-utils';
 import { getLogger } from '../utils/logger';
 import { ItisService, ItisSolrSearchResponse } from './itis-service';
 
@@ -72,7 +73,7 @@ export class TaxonomyService {
    * @memberof TaxonomyService
    */
   async addItisTaxonRecord(itisSolrResponse: ItisSolrSearchResponse): Promise<TaxonRecord> {
-    const commonNames = this._parseItisTaxonCommonNames(itisSolrResponse?.commonNames);
+    const commonNames = getItisTaxonCommonNames(itisSolrResponse?.commonNames);
 
     return this.taxonRepository.addItisTaxonRecord(
       Number(itisSolrResponse.tsn),
@@ -82,27 +83,6 @@ export class TaxonomyService {
       itisSolrResponse.updateDate
     );
   }
-
-  /**
-   * Parse the raw common names string from an ITIS taxon record into an array of english common names.
-   *
-   * @example
-   * const commonNames = [
-   *   '$withered wooly milk-vetch$English$N$152846$2012-12-21 00:00:00$',
-   *   '$woolly locoweed$English$N$124501$2011-06-29 00:00:00$',
-   *   '$Davis Mountains locoweed$English$N$124502$2011-06-29 00:00:00$',
-   *   '$woolly milkvetch$English$N$72035$2012-12-21 00:00:00$'
-   * ]
-   *
-   * const result = _parseItisTaxonCommonNames(commonNames)
-   * // result: ['withered wooly milk-vetch', 'woolly locoweed', 'Davis Mountains locoweed', 'woolly milkvetch']
-   *
-   * @param {string[]} [commonNames]
-   * @memberof TaxonomyService
-   */
-  _parseItisTaxonCommonNames = (commonNames?: string[]): string[] => {
-    return commonNames?.filter((name) => name.split('$')[2] === 'English').map((name) => name.split('$')[1]) ?? [];
-  };
 
   /**
    * Delete an existing taxon record.

--- a/api/src/services/taxonomy-service.ts
+++ b/api/src/services/taxonomy-service.ts
@@ -72,18 +72,7 @@ export class TaxonomyService {
    * @memberof TaxonomyService
    */
   async addItisTaxonRecord(itisSolrResponse: ItisSolrSearchResponse): Promise<TaxonRecord> {
-    const commonNames =
-      itisSolrResponse.commonNames
-        .filter((name) => name.split('$')[2] === 'English')
-        .map((name) => name.split('$')[1]) ?? [];
-    /* Sample itisResponse:
-     * commonNames: [
-     *   '$withered wooly milk-vetch$English$N$152846$2012-12-21 00:00:00$',
-     *   '$woolly locoweed$English$N$124501$2011-06-29 00:00:00$',
-     *   '$Davis Mountains locoweed$English$N$124502$2011-06-29 00:00:00$',
-     *   '$woolly milkvetch$English$N$72035$2012-12-21 00:00:00$'
-     * ]
-     */
+    const commonNames = this._parseItisTaxonCommonNames(itisSolrResponse?.commonNames);
 
     return this.taxonRepository.addItisTaxonRecord(
       Number(itisSolrResponse.tsn),
@@ -93,6 +82,27 @@ export class TaxonomyService {
       itisSolrResponse.updateDate
     );
   }
+
+  /**
+   * Parse the raw common names string from an ITIS taxon record into an array of english common names.
+   *
+   * @example
+   * const commonNames = [
+   *   '$withered wooly milk-vetch$English$N$152846$2012-12-21 00:00:00$',
+   *   '$woolly locoweed$English$N$124501$2011-06-29 00:00:00$',
+   *   '$Davis Mountains locoweed$English$N$124502$2011-06-29 00:00:00$',
+   *   '$woolly milkvetch$English$N$72035$2012-12-21 00:00:00$'
+   * ]
+   *
+   * const result = _parseItisTaxonCommonNames(commonNames)
+   * // result: ['withered wooly milk-vetch', 'woolly locoweed', 'Davis Mountains locoweed', 'woolly milkvetch']
+   *
+   * @param {string[]} [commonNames]
+   * @memberof TaxonomyService
+   */
+  _parseItisTaxonCommonNames = (commonNames?: string[]): string[] => {
+    return commonNames?.filter((name) => name.split('$')[2] === 'English').map((name) => name.split('$')[1]) ?? [];
+  };
 
   /**
    * Delete an existing taxon record.

--- a/api/src/utils/itis-utils.test.ts
+++ b/api/src/utils/itis-utils.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import { TaxonSearchResult } from '../services/taxonomy-service';
-import { sortTaxonSearchResults } from './itis-sort';
+import { getItisTaxonCommonNames, sortTaxonSearchResults } from './itis-utils';
 
 describe('itis-sort', () => {
   describe('sortTaxonSearchResults', () => {
@@ -76,5 +76,44 @@ describe('itis-sort', () => {
       expect(result[1].tsn).to.equal(2);
       expect(result[2].tsn).to.equal(3);
     });
+  });
+});
+
+describe('getItisTaxonCommonNames', () => {
+  it('Returns an empty array if provided common names is undefined', () => {
+    const rawCommonNames = undefined;
+
+    const commonNames = getItisTaxonCommonNames(rawCommonNames);
+
+    expect(commonNames).to.eql([]);
+  });
+
+  it('Returns an empty array if the provided common names is empty', () => {
+    const rawCommonNames: string[] = [];
+
+    const commonNames = getItisTaxonCommonNames(rawCommonNames);
+
+    expect(commonNames).to.eql([]);
+  });
+
+  it('Returns an array of english common names', () => {
+    const rawCommonNames = [
+      '$withered wooly milk-vetch (German)$German$N$152846$2012-12-21 00:00:00$',
+      '$withered wooly milk-vetch$English$N$152846$2012-12-21 00:00:00$',
+      '$woolly locoweed$English$N$124501$2011-06-29 00:00:00$',
+      '$Davis Mountains locoweed (French)$French$N$124502$2011-06-29 00:00:00$',
+      '$Davis Mountains locoweed$English$N$124502$2011-06-29 00:00:00$',
+      '$woolly milkvetch$English$N$72035$2012-12-21 00:00:00$',
+      '$woolly milkvetch (French)$French$N$124502$2011-06-29 00:00:00$'
+    ];
+
+    const commonNames = getItisTaxonCommonNames(rawCommonNames);
+
+    expect(commonNames).to.eql([
+      'withered wooly milk-vetch',
+      'woolly locoweed',
+      'Davis Mountains locoweed',
+      'woolly milkvetch'
+    ]);
   });
 });

--- a/api/src/utils/itis-utils.ts
+++ b/api/src/utils/itis-utils.ts
@@ -87,3 +87,24 @@ export const sortTaxonSearchResults = (
   // Sort the data by the score
   return taxonSearchResults.sort((a, b) => calculateScore(b) - calculateScore(a));
 };
+
+/**
+ * Parse the raw common names string from an ITIS taxon record into an array of english common names.
+ *
+ * @example
+ * const commonNames = [
+ *   '$withered wooly milk-vetch$English$N$152846$2012-12-21 00:00:00$',
+ *   '$woolly locoweed$English$N$124501$2011-06-29 00:00:00$',
+ *   '$Davis Mountains locoweed$English$N$124502$2011-06-29 00:00:00$',
+ *   '$woolly milkvetch$English$N$72035$2012-12-21 00:00:00$'
+ * ]
+ *
+ * const result = _parseItisTaxonCommonNames(commonNames)
+ * // result: ['withered wooly milk-vetch', 'woolly locoweed', 'Davis Mountains locoweed', 'woolly milkvetch']
+ *
+ * @param {string[]} [commonNames]
+ * @memberof TaxonomyService
+ */
+export const getItisTaxonCommonNames = (commonNames?: string[]): string[] => {
+  return commonNames?.filter((name) => name.split('$')[2] === 'English').map((name) => name.split('$')[1]) ?? [];
+};

--- a/api/src/utils/itis-utils.ts
+++ b/api/src/utils/itis-utils.ts
@@ -99,7 +99,7 @@ export const sortTaxonSearchResults = (
  *   '$woolly milkvetch$English$N$72035$2012-12-21 00:00:00$'
  * ]
  *
- * const result = _parseItisTaxonCommonNames(commonNames)
+ * const result = getItisTaxonCommonNames(commonNames)
  * // result: ['withered wooly milk-vetch', 'woolly locoweed', 'Davis Mountains locoweed', 'woolly milkvetch']
  *
  * @param {string[]} [commonNames]


### PR DESCRIPTION
## Links to Jira Tickets

n/a

## Description of Changes

Rename `itis-sort.ts` to `itis-utils.ts`
Add shared util function for parsing common names: correctly handles case where commonNames field is missing from itis response. Updated itis response interface to mark commonNames as optional.

## Testing Notes

BioHub taxon endpoints return taxon records as expected, with an emphasis on the commonNames portion containing the expected values.

In SIMS, when adding a taxon to a survey that has no common names (like a higher rank taxon), when you go to edit the survey, the taxon should correctly be returned and show up in the UI. Before this fix, taxons with no common names were not returned at all from one of the biohub taxon endpoints.
