### PR TITLE
Remove auth check from taxonomy endpoints

### DIFF
--- a/api/src/paths/taxonomy/taxon/index.ts
+++ b/api/src/paths/taxonomy/taxon/index.ts
@@ -10,11 +10,7 @@ export const GET: Operation = [findTaxonBySearchTerms()];
 GET.apiDoc = {
   description: 'Find taxon records by search criteria.',
   tags: ['taxonomy'],
-  security: [
-    {
-      Bearer: []
-    }
-  ],
+  security: [],
   parameters: [
     {
       description: 'Taxonomy search terms.',

--- a/api/src/paths/taxonomy/taxon/tsn/index.ts
+++ b/api/src/paths/taxonomy/taxon/tsn/index.ts
@@ -11,11 +11,7 @@ export const GET: Operation = [getTaxonByTSN()];
 GET.apiDoc = {
   description: 'Get taxon records by TSN ids.',
   tags: ['taxonomy'],
-  security: [
-    {
-      Bearer: []
-    }
-  ],
+  security: [],
   parameters: [
     {
       description: 'Taxon TSN ids.',


### PR DESCRIPTION
## Links to Jira Tickets

- N/A

## Description of Changes

- Removes the bearer security from /taxon and taxon/{tsn} paths
- The SIMS Standards page can be viewed while logged out, but for logged out users to search species on the standards page, the taxonomy search endpoints need to be public

## Notes

- Alternatively, SIMS could send taxonomy requests with a service account token?
