### PR TITLE
SIMSBIOHUB-840: Fix Nodemon Failing to Restart API When Changed

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -11,9 +11,9 @@
   "scripts": {
     "start": "ts-node src/app",
     "build": "tsc --project tsconfig.production.json",
-    "start-reload": "./node_modules/.bin/nodemon src/app.ts --exec ts-node",
+    "start-reload": "nodemon --watch src --ext ts --exec ts-node --files src/app.ts",
     "queue": "ts-node src/queue",
-    "queue-reload": "./node_modules/.bin/nodemon src/queue.ts --exec ts-node",
+    "queue-reload": "nodemon --watch src --ext ts --exec ts-node --files src/queue.ts",
     "test": "mocha",
     "test-watch": "mocha --watch",
     "coverage": "nyc mocha",


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-840

## Description of Changes

- Fixes the `start_reload` and `queue_reload` scripts so that nodemon correctly restarts when a ```api/src/*.ts``` file changes.

## Testing Notes

- Saving any ```api/src/*.ts``` should show the API restarting in Docker