### PR TITLE
Fix the failing GET /user/self endpoint

### DIFF
--- a/api/src/paths/user/self.ts
+++ b/api/src/paths/user/self.ts
@@ -2,24 +2,12 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { getDBConnection } from '../../database/db';
 import { HTTP400 } from '../../errors/http-error';
-import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
 import { UserService } from '../../services/user-service';
 import { getLogger } from '../../utils/logger';
 
 const defaultLog = getLogger('paths/user/{userId}');
 
-export const GET: Operation = [
-  authorizeRequestHandler(() => {
-    return {
-      and: [
-        {
-          discriminator: 'SystemUser'
-        }
-      ]
-    };
-  }),
-  getUser()
-];
+export const GET: Operation = [getUser()];
 
 GET.apiDoc = {
   description: 'Get user details for the currently authenticated user.',

--- a/app/src/hooks/useBiohubUserWrapper.tsx
+++ b/app/src/hooks/useBiohubUserWrapper.tsx
@@ -40,8 +40,10 @@ function useBiohubUserWrapper(): IBiohubUserWrapper {
   const biohubUserDataLoader = useDataLoader(() => biohubApi.user.getUser());
 
   useEffect(() => {
-    biohubUserDataLoader.load();
-  }, [biohubUserDataLoader]);
+    if (auth.isAuthenticated) {
+      biohubUserDataLoader.load();
+    }
+  }, [auth.isAuthenticated, biohubUserDataLoader]);
 
   const isLoading = !biohubUserDataLoader.isReady;
 


### PR DESCRIPTION
## Links to Jira Tickets

https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-826

## Description of Changes

When refreshing any page in BioHub, a GET request is made to GET /user/self. The initial request fails with a 401 Unauthorized error

Acceptance Critieria
Fix the timing of the request to wait for the user to be authenticated
Remove the authorization middleware from the GET /user/self endpoint
The relevant middleware to remove is lines 12-20 in user/self.ts (the "SystemUser" discriminator, which checks that the user exists in the system_user table).
Keep the ```Bearer: []``` requirement (line 27 in user/self.ts) to require authentication

## Testing Notes

Open browser console, there should NOT be a reference to http://localhost:6100/api/user/self 401 (Unauthorized)
