### PR TITLE
Create Non-Admin System Role

### DIFF
--- a/api/src/constants/roles.ts
+++ b/api/src/constants/roles.ts
@@ -6,5 +6,6 @@
  */
 export enum SYSTEM_ROLE {
   SYSTEM_ADMIN = 'System Administrator',
-  DATA_ADMINISTRATOR = 'Data Administrator'
+  DATA_ADMINISTRATOR = 'Data Administrator',
+  MEMBER = 'Member'
 }

--- a/database/src/migrations/20251208000000_add_member_role.ts
+++ b/database/src/migrations/20251208000000_add_member_role.ts
@@ -1,0 +1,30 @@
+import { Knex } from 'knex';
+
+/**
+ * Migration to support auto-creation of system users on first sign-in (SIMSBIOHUB-838).
+ *
+ * Adds 'Member' role to system_role table (least privileged role for new users).
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Add 'Member' role
+    --------------------------------------------------------------------------------
+    INSERT INTO system_role (name, record_effective_date, description)
+    VALUES ('Member', now(), 'Default role for new users with basic access permissions.');
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Remove 'Member' role
+    --------------------------------------------------------------------------------
+    DELETE FROM system_role WHERE name = 'Member';
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-839](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-839)

## Description of Changes

As a BioHub administrator, I want to add a non-admin system role called "Member", so that users can be assigned access rights for protected endpoints without granting full administrative privileges.

## Acceptance Criteria

### 1. Create Member Role
CREATE a new system role called "Member" in the `system_role` table.

## Notes

- The `SystemUser` middleware will be used to protect endpoints that can only be accessed by users with the Member role, such as download requests, so no middleware changes needed.


## Testing Notes
