### PR TITLE
Search for Features

### DIFF
--- a/api/src/paths/search/index.test.ts
+++ b/api/src/paths/search/index.test.ts
@@ -1,0 +1,203 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import * as db from '../../database/db';
+import { SearchFeatureResult } from '../../repositories/search-index-respository';
+import { SearchIndexService } from '../../services/search-index-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
+import * as search from './index';
+
+chai.use(sinonChai);
+
+describe('searchFeatures', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return search results for keyword search', async () => {
+    const mockResults: SearchFeatureResult[] = [
+      {
+        submission_feature_id: 1,
+        submission_id: 10,
+        uuid: '550e8400-e29b-41d4-a716-446655440001',
+        feature_type_id: 1,
+        feature_type_name: 'dataset',
+        feature_name: 'Moose Study 2024',
+        feature_description: 'A study of moose habitat in Northern BC',
+        submission_name: 'Wildlife Monitoring Project',
+        is_secured: false,
+        relevancy_score: 0.75
+      }
+    ];
+
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub(),
+      rollback: sinon.stub(),
+      release: sinon.stub()
+    });
+
+    sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.body = { keywords: 'moose habitat' };
+
+    const mockSearchFeatures = sinon.stub(SearchIndexService.prototype, 'searchFeatures').resolves(mockResults);
+
+    const requestHandler = search.searchFeatures();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockSearchFeatures).to.have.been.calledOnceWith({
+      keywords: 'moose habitat',
+      propertyFilters: undefined
+    });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockResults);
+  });
+
+  it('should return search results for property filters', async () => {
+    const mockResults: SearchFeatureResult[] = [
+      {
+        submission_feature_id: 2,
+        submission_id: 11,
+        uuid: '550e8400-e29b-41d4-a716-446655440002',
+        feature_type_id: 1,
+        feature_type_name: 'dataset',
+        feature_name: 'Moose Population Survey',
+        feature_description: 'Population survey data for moose',
+        submission_name: 'Species Census 2024',
+        is_secured: true,
+        relevancy_score: 0.6
+      }
+    ];
+
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub(),
+      rollback: sinon.stub(),
+      release: sinon.stub()
+    });
+
+    sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.body = {
+      propertyFilters: [{ propertyName: 'focal_species', value: 'Moose' }]
+    };
+
+    const mockSearchFeatures = sinon.stub(SearchIndexService.prototype, 'searchFeatures').resolves(mockResults);
+
+    const requestHandler = search.searchFeatures();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockSearchFeatures).to.have.been.calledOnceWith({
+      keywords: undefined,
+      propertyFilters: [{ propertyName: 'focal_species', value: 'Moose' }]
+    });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockResults);
+  });
+
+  it('should return search results for combined keyword and property filter search', async () => {
+    const mockResults: SearchFeatureResult[] = [
+      {
+        submission_feature_id: 3,
+        submission_id: 12,
+        uuid: '550e8400-e29b-41d4-a716-446655440003',
+        feature_type_id: 2,
+        feature_type_name: 'observation',
+        feature_name: 'Wildlife Observation',
+        feature_description: null,
+        submission_name: 'Northern BC Wildlife Survey',
+        is_secured: false,
+        relevancy_score: 1.2
+      }
+    ];
+
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub(),
+      rollback: sinon.stub(),
+      release: sinon.stub()
+    });
+
+    sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.body = {
+      keywords: 'wildlife',
+      propertyFilters: [{ propertyName: 'region', value: 'Northern BC' }]
+    };
+
+    const mockSearchFeatures = sinon.stub(SearchIndexService.prototype, 'searchFeatures').resolves(mockResults);
+
+    const requestHandler = search.searchFeatures();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockSearchFeatures).to.have.been.calledOnceWith({
+      keywords: 'wildlife',
+      propertyFilters: [{ propertyName: 'region', value: 'Northern BC' }]
+    });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockResults);
+  });
+
+  it('should return empty array when no search criteria provided', async () => {
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub(),
+      rollback: sinon.stub(),
+      release: sinon.stub()
+    });
+
+    sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.body = {};
+
+    const mockSearchFeatures = sinon.stub(SearchIndexService.prototype, 'searchFeatures').resolves([]);
+
+    const requestHandler = search.searchFeatures();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockSearchFeatures).to.have.been.calledOnceWith({
+      keywords: undefined,
+      propertyFilters: undefined
+    });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql([]);
+  });
+
+  it('should handle errors and rollback', async () => {
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub(),
+      rollback: sinon.stub(),
+      release: sinon.stub()
+    });
+
+    sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.body = { keywords: 'test' };
+
+    const testError = new Error('Test error');
+    sinon.stub(SearchIndexService.prototype, 'searchFeatures').rejects(testError);
+
+    const requestHandler = search.searchFeatures();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail('Expected error to be thrown');
+    } catch (error) {
+      expect(error).to.equal(testError);
+      expect(dbConnectionObj.rollback).to.have.been.calledOnce;
+      expect(dbConnectionObj.release).to.have.been.calledOnce;
+    }
+  });
+});

--- a/api/src/paths/search/index.ts
+++ b/api/src/paths/search/index.ts
@@ -1,0 +1,168 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { getAPIUserDBConnection } from '../../database/db';
+import { defaultErrorResponses } from '../../openapi/schemas/http-responses';
+import { IPropertyFilter } from '../../repositories/search-index-respository';
+import { SearchIndexService } from '../../services/search-index-service';
+import { getLogger } from '../../utils/logger';
+
+const defaultLog = getLogger('paths/search');
+
+export const POST: Operation = [searchFeatures()];
+
+POST.apiDoc = {
+  description: 'Search for features by keywords and/or property filters.',
+  tags: ['search'],
+  requestBody: {
+    description: 'Search parameters',
+    required: false,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            keywords: {
+              type: 'string',
+              description: 'Space-separated keywords to search for in feature property values'
+            },
+            propertyFilters: {
+              type: 'array',
+              description: 'Filter by specific property name and value combinations',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['featureTypeName', 'propertyName', 'propertyType', 'value'],
+                properties: {
+                  featureTypeName: {
+                    type: 'string',
+                    description: 'The name of the feature type to filter on (e.g., dataset, observation)'
+                  },
+                  propertyName: {
+                    type: 'string',
+                    description: 'The name of the property to filter on'
+                  },
+                  propertyType: {
+                    type: 'string',
+                    enum: ['string', 'number', 'datetime'],
+                    description: 'The type of the property (determines which search table to query)'
+                  },
+                  value: {
+                    type: 'string',
+                    description: 'The value to search for'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Search results sorted by relevancy',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              required: [
+                'submission_feature_id',
+                'submission_id',
+                'uuid',
+                'feature_type_id',
+                'feature_type_name',
+                'submission_name',
+                'is_secured',
+                'relevancy_score'
+              ],
+              properties: {
+                submission_feature_id: {
+                  type: 'integer',
+                  minimum: 1,
+                  description: 'The ID of the submission feature'
+                },
+                submission_id: {
+                  type: 'integer',
+                  minimum: 1,
+                  description: 'The ID of the submission containing this feature'
+                },
+                uuid: {
+                  type: 'string',
+                  format: 'uuid',
+                  description: 'The unique identifier of the submission feature'
+                },
+                feature_type_id: {
+                  type: 'integer',
+                  minimum: 1,
+                  description: 'The ID of the feature type'
+                },
+                feature_type_name: {
+                  type: 'string',
+                  description: 'The name of the feature type (e.g., dataset, observation)'
+                },
+                feature_name: {
+                  type: 'string',
+                  nullable: true,
+                  description: 'The name of the feature from its data'
+                },
+                feature_description: {
+                  type: 'string',
+                  nullable: true,
+                  description: 'The description of the feature from its data'
+                },
+                submission_name: {
+                  type: 'string',
+                  description: 'The name of the parent submission'
+                },
+                is_secured: {
+                  type: 'boolean',
+                  description: 'Whether the feature has active security rules applied'
+                },
+                relevancy_score: {
+                  type: 'number',
+                  description: 'The relevancy score for ranking results'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Search for features by keywords and/or property filters.
+ *
+ * @returns {RequestHandler}
+ */
+export function searchFeatures(): RequestHandler {
+  return async (req, res) => {
+    const connection = getAPIUserDBConnection();
+
+    try {
+      await connection.open();
+
+      const keywords = req.body?.keywords as string | undefined;
+      const propertyFilters = req.body?.propertyFilters as IPropertyFilter[] | undefined;
+
+      const service = new SearchIndexService(connection);
+      const response = await service.searchFeatures({ keywords, propertyFilters });
+
+      await connection.commit();
+
+      return res.status(200).json(response);
+    } catch (error) {
+      defaultLog.error({ label: 'searchFeatures', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/repositories/search-index-repository.test.ts
+++ b/api/src/repositories/search-index-repository.test.ts
@@ -3,7 +3,11 @@ import { QueryResult } from 'pg';
 import Sinon from 'sinon';
 import { ApiExecuteSQLError } from '../errors/api-error';
 import { getMockDBConnection } from '../__mocks__/db';
-import { FeaturePropertyRecordWithPropertyTypeName, SearchIndexRepository } from './search-index-respository';
+import {
+  FeaturePropertyRecordWithPropertyTypeName,
+  SearchFeatureResult,
+  SearchIndexRepository
+} from './search-index-respository';
 
 describe('SearchIndexRepository', () => {
   afterEach(() => {
@@ -602,6 +606,216 @@ describe('SearchIndexRepository', () => {
       } catch (error) {
         expect((error as ApiExecuteSQLError).message).to.equal('Failed to insert searchable string records');
       }
+    });
+  });
+
+  describe('searchFeaturesByKeywords', () => {
+    it('returns matching features for a single keyword', async () => {
+      const mockRows: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Study',
+          feature_description: 'A study of moose',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 0.5
+        }
+      ];
+
+      const mockQueryResponse = {
+        rowCount: 1,
+        rows: mockRows
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        sql: async () => mockQueryResponse
+      });
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByKeywords(['moose']);
+
+      expect(response).to.have.lengthOf(1);
+      expect(response[0].submission_feature_id).to.equal(1);
+      expect(response[0].feature_type_name).to.equal('dataset');
+    });
+
+    it('returns matching features for multiple keywords', async () => {
+      const mockRows: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Habitat Study',
+          feature_description: 'A study of moose habitat',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 0.8
+        },
+        {
+          submission_feature_id: 2,
+          submission_id: 11,
+          uuid: '550e8400-e29b-41d4-a716-446655440002',
+          feature_type_id: 2,
+          feature_type_name: 'sample_site',
+          feature_name: 'Sample Site A',
+          feature_description: null,
+          submission_name: 'Habitat Survey',
+          is_secured: true,
+          relevancy_score: 0.5
+        }
+      ];
+
+      const mockQueryResponse = {
+        rowCount: 2,
+        rows: mockRows
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        sql: async () => mockQueryResponse
+      });
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByKeywords(['moose', 'habitat']);
+
+      expect(response).to.have.lengthOf(2);
+      expect(response[0].relevancy_score).to.be.greaterThan(response[1].relevancy_score);
+    });
+
+    it('returns empty array when no keywords provided', async () => {
+      const mockDBConnection = getMockDBConnection();
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByKeywords([]);
+
+      expect(response).to.eql([]);
+    });
+
+    it('returns empty array when no matches found', async () => {
+      const mockQueryResponse = {
+        rowCount: 0,
+        rows: []
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        sql: async () => mockQueryResponse
+      });
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByKeywords(['nonexistent']);
+
+      expect(response).to.eql([]);
+    });
+  });
+
+  describe('searchFeaturesByPropertyFilters', () => {
+    it('returns matching features for a single property filter', async () => {
+      const mockRows: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Survey',
+          feature_description: 'Survey data',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 0.6
+        }
+      ];
+
+      const mockQueryResponse = {
+        rowCount: 1,
+        rows: mockRows
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        sql: async () => mockQueryResponse
+      });
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByPropertyFilters([
+        { featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'moose' }
+      ]);
+
+      expect(response).to.have.lengthOf(1);
+      expect(response[0].submission_feature_id).to.equal(1);
+    });
+
+    it('returns matching features for multiple property filters', async () => {
+      const mockRows: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Habitat Study',
+          feature_description: 'A study of moose habitat',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 1.2
+        }
+      ];
+
+      const mockQueryResponse = {
+        rowCount: 1,
+        rows: mockRows
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        sql: async () => mockQueryResponse
+      });
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByPropertyFilters([
+        { featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'moose' },
+        { featureTypeName: 'animal', propertyName: 'description', propertyType: 'string', value: 'habitat' }
+      ]);
+
+      expect(response).to.have.lengthOf(1);
+      expect(response[0].relevancy_score).to.equal(1.2);
+    });
+
+    it('returns empty array when no filters provided', async () => {
+      const mockDBConnection = getMockDBConnection();
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByPropertyFilters([]);
+
+      expect(response).to.eql([]);
+    });
+
+    it('returns empty array when no matches found', async () => {
+      const mockQueryResponse = {
+        rowCount: 0,
+        rows: []
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        sql: async () => mockQueryResponse
+      });
+
+      const searchIndexRepository = new SearchIndexRepository(mockDBConnection);
+
+      const response = await searchIndexRepository.searchFeaturesByPropertyFilters([
+        { featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'nonexistent' }
+      ]);
+
+      expect(response).to.eql([]);
     });
   });
 });

--- a/api/src/repositories/search-index-respository.ts
+++ b/api/src/repositories/search-index-respository.ts
@@ -649,7 +649,7 @@ export class SearchIndexRepository extends BaseRepository {
           WHERE
             ft.name = ${filter.featureTypeName}
             AND fp.name = ${filter.propertyName}
-            AND sn.value = ${parseFloat(filter.value)}
+            AND sn.value = ${Number.parseFloat(filter.value)}
         `);
       } else if (filter.propertyType === 'datetime') {
         // Datetime: date match on search_datetime

--- a/api/src/repositories/search-index-respository.ts
+++ b/api/src/repositories/search-index-respository.ts
@@ -133,6 +133,34 @@ export const SubmissionFeatureCombinedSearchValues = z.object({
 export type SubmissionFeatureCombinedSearchValues = z.infer<typeof SubmissionFeatureCombinedSearchValues>;
 
 /**
+ * Represents a search result for a feature with full details for display.
+ */
+export const SearchFeatureResult = z.object({
+  submission_feature_id: z.number(),
+  submission_id: z.number(),
+  uuid: z.string(),
+  feature_type_id: z.number(),
+  feature_type_name: z.string(),
+  feature_name: z.string().nullable(),
+  feature_description: z.string().nullable(),
+  submission_name: z.string(),
+  is_secured: z.boolean(),
+  relevancy_score: z.number()
+});
+
+export type SearchFeatureResult = z.infer<typeof SearchFeatureResult>;
+
+/**
+ * Represents a property filter for searching.
+ */
+export interface IPropertyFilter {
+  featureTypeName: string;
+  propertyName: string;
+  propertyType: 'string' | 'number' | 'datetime';
+  value: string;
+}
+
+/**
  * A class for creating searchable records
  */
 export class SearchIndexRepository extends BaseRepository {
@@ -437,6 +465,263 @@ export class SearchIndexRepository extends BaseRepository {
     `;
 
     const response = await this.connection.sql(sqlStatement, SubmissionFeatureSearchKeyValues);
+
+    return response.rows;
+  }
+
+  /**
+   * Searches for features by keywords using PostgreSQL full-text search.
+   * Each keyword is searched independently and results are aggregated.
+   *
+   * @param {string[]} keywords - Array of keywords to search for
+   * @return {*}  {Promise<SearchFeatureResult[]>}
+   * @memberof SearchIndexRepository
+   */
+  async searchFeaturesByKeywords(keywords: string[]): Promise<SearchFeatureResult[]> {
+    defaultLog.debug({ label: 'searchFeaturesByKeywords', keywords });
+
+    if (!keywords.length) {
+      return [];
+    }
+
+    // Build a combined tsquery with OR for all keywords
+    const combinedKeywords = keywords.join(' | ');
+
+    const sqlStatement = SQL`
+      SELECT DISTINCT
+        sf.submission_feature_id,
+        sf.submission_id,
+        sf.uuid::text as uuid,
+        sf.feature_type_id,
+        ft.name as feature_type_name,
+        sf.data->>'name' as feature_name,
+        sf.data->>'description' as feature_description,
+        s.name as submission_name,
+        security_check.is_secured,
+        ts_rank(to_tsvector('english', ss.value), plainto_tsquery('english', ${combinedKeywords})) as relevancy_score
+      FROM
+        search_string ss
+      INNER JOIN
+        submission_feature sf ON ss.submission_feature_id = sf.submission_feature_id
+      INNER JOIN
+        submission s ON sf.submission_id = s.submission_id
+      INNER JOIN
+        feature_type ft ON sf.feature_type_id = ft.feature_type_id
+      CROSS JOIN LATERAL (
+        -- Check if this feature or any ancestor is secured
+        WITH RECURSIVE ancestors AS (
+          SELECT sf.submission_feature_id as ancestor_id, sf.parent_submission_feature_id
+          UNION ALL
+          SELECT sf2.submission_feature_id, sf2.parent_submission_feature_id
+          FROM submission_feature sf2
+          INNER JOIN ancestors a ON sf2.submission_feature_id = a.parent_submission_feature_id
+        )
+        SELECT EXISTS (
+          SELECT 1
+          FROM ancestors a
+          INNER JOIN submission_feature_security sfs ON a.ancestor_id = sfs.submission_feature_id
+          WHERE sfs.record_end_date IS NULL
+        ) as is_secured
+      ) security_check
+      WHERE
+        to_tsvector('english', ss.value) @@ plainto_tsquery('english', ${combinedKeywords})
+      ORDER BY
+        relevancy_score DESC;
+    `;
+
+    const response = await this.connection.sql(sqlStatement, SearchFeatureResult);
+
+    return response.rows;
+  }
+
+  /**
+   * Searches for features by property filters.
+   * Queries the appropriate search table based on property type.
+   *
+   * @param {IPropertyFilter[]} filters - Array of property filters
+   * @return {*}  {Promise<SearchFeatureResult[]>}
+   * @memberof SearchIndexRepository
+   */
+  async searchFeaturesByPropertyFilters(filters: IPropertyFilter[]): Promise<SearchFeatureResult[]> {
+    defaultLog.debug({ label: 'searchFeaturesByPropertyFilters', filters });
+
+    if (!filters.length) {
+      return [];
+    }
+
+    // For multiple filters, we need to find features that match ALL filters
+    // We'll use a CTE approach to intersect results from each filter
+    const query = SQL`
+      WITH filter_results AS (
+    `;
+
+    filters.forEach((filter, index) => {
+      if (index > 0) {
+        query.append(SQL` UNION ALL `);
+      }
+
+      // Generate the appropriate query based on property type
+      if (filter.propertyType === 'string') {
+        // String: use full-text search on search_string
+        query.append(SQL`
+          SELECT
+            sf.submission_feature_id,
+            sf.submission_id,
+            sf.uuid::text as uuid,
+            sf.feature_type_id,
+            ft.name as feature_type_name,
+            sf.data->>'name' as feature_name,
+            sf.data->>'description' as feature_description,
+            s.name as submission_name,
+            security_check.is_secured,
+            ts_rank(to_tsvector('english', ss.value), plainto_tsquery('english', ${filter.value})) as relevancy_score
+          FROM
+            search_string ss
+          INNER JOIN
+            submission_feature sf ON ss.submission_feature_id = sf.submission_feature_id
+          INNER JOIN
+            submission s ON sf.submission_id = s.submission_id
+          INNER JOIN
+            feature_type ft ON sf.feature_type_id = ft.feature_type_id
+          INNER JOIN
+            feature_property fp ON ss.feature_property_id = fp.feature_property_id
+          CROSS JOIN LATERAL (
+            -- Check if this feature or any ancestor is secured
+            WITH RECURSIVE ancestors AS (
+              SELECT sf.submission_feature_id as ancestor_id, sf.parent_submission_feature_id
+              UNION ALL
+              SELECT sf2.submission_feature_id, sf2.parent_submission_feature_id
+              FROM submission_feature sf2
+              INNER JOIN ancestors a ON sf2.submission_feature_id = a.parent_submission_feature_id
+            )
+            SELECT EXISTS (
+              SELECT 1
+              FROM ancestors a
+              INNER JOIN submission_feature_security sfs ON a.ancestor_id = sfs.submission_feature_id
+              WHERE sfs.record_end_date IS NULL
+            ) as is_secured
+          ) security_check
+          WHERE
+            ft.name = ${filter.featureTypeName}
+            AND fp.name = ${filter.propertyName}
+            AND to_tsvector('english', ss.value) @@ plainto_tsquery('english', ${filter.value})
+        `);
+      } else if (filter.propertyType === 'number') {
+        // Number: exact match on search_number
+        query.append(SQL`
+          SELECT
+            sf.submission_feature_id,
+            sf.submission_id,
+            sf.uuid::text as uuid,
+            sf.feature_type_id,
+            ft.name as feature_type_name,
+            sf.data->>'name' as feature_name,
+            sf.data->>'description' as feature_description,
+            s.name as submission_name,
+            security_check.is_secured,
+            1.0 as relevancy_score
+          FROM
+            search_number sn
+          INNER JOIN
+            submission_feature sf ON sn.submission_feature_id = sf.submission_feature_id
+          INNER JOIN
+            submission s ON sf.submission_id = s.submission_id
+          INNER JOIN
+            feature_type ft ON sf.feature_type_id = ft.feature_type_id
+          INNER JOIN
+            feature_property fp ON sn.feature_property_id = fp.feature_property_id
+          CROSS JOIN LATERAL (
+            -- Check if this feature or any ancestor is secured
+            WITH RECURSIVE ancestors AS (
+              SELECT sf.submission_feature_id as ancestor_id, sf.parent_submission_feature_id
+              UNION ALL
+              SELECT sf2.submission_feature_id, sf2.parent_submission_feature_id
+              FROM submission_feature sf2
+              INNER JOIN ancestors a ON sf2.submission_feature_id = a.parent_submission_feature_id
+            )
+            SELECT EXISTS (
+              SELECT 1
+              FROM ancestors a
+              INNER JOIN submission_feature_security sfs ON a.ancestor_id = sfs.submission_feature_id
+              WHERE sfs.record_end_date IS NULL
+            ) as is_secured
+          ) security_check
+          WHERE
+            ft.name = ${filter.featureTypeName}
+            AND fp.name = ${filter.propertyName}
+            AND sn.value = ${parseFloat(filter.value)}
+        `);
+      } else if (filter.propertyType === 'datetime') {
+        // Datetime: date match on search_datetime
+        query.append(SQL`
+          SELECT
+            sf.submission_feature_id,
+            sf.submission_id,
+            sf.uuid::text as uuid,
+            sf.feature_type_id,
+            ft.name as feature_type_name,
+            sf.data->>'name' as feature_name,
+            sf.data->>'description' as feature_description,
+            s.name as submission_name,
+            security_check.is_secured,
+            1.0 as relevancy_score
+          FROM
+            search_datetime sd
+          INNER JOIN
+            submission_feature sf ON sd.submission_feature_id = sf.submission_feature_id
+          INNER JOIN
+            submission s ON sf.submission_id = s.submission_id
+          INNER JOIN
+            feature_type ft ON sf.feature_type_id = ft.feature_type_id
+          INNER JOIN
+            feature_property fp ON sd.feature_property_id = fp.feature_property_id
+          CROSS JOIN LATERAL (
+            -- Check if this feature or any ancestor is secured
+            WITH RECURSIVE ancestors AS (
+              SELECT sf.submission_feature_id as ancestor_id, sf.parent_submission_feature_id
+              UNION ALL
+              SELECT sf2.submission_feature_id, sf2.parent_submission_feature_id
+              FROM submission_feature sf2
+              INNER JOIN ancestors a ON sf2.submission_feature_id = a.parent_submission_feature_id
+            )
+            SELECT EXISTS (
+              SELECT 1
+              FROM ancestors a
+              INNER JOIN submission_feature_security sfs ON a.ancestor_id = sfs.submission_feature_id
+              WHERE sfs.record_end_date IS NULL
+            ) as is_secured
+          ) security_check
+          WHERE
+            ft.name = ${filter.featureTypeName}
+            AND fp.name = ${filter.propertyName}
+            AND sd.value::date = ${filter.value}::date
+        `);
+      }
+    });
+
+    query.append(SQL`
+      )
+      SELECT
+        submission_feature_id,
+        submission_id,
+        uuid,
+        feature_type_id,
+        feature_type_name,
+        feature_name,
+        feature_description,
+        submission_name,
+        is_secured,
+        SUM(relevancy_score) as relevancy_score
+      FROM
+        filter_results
+      GROUP BY
+        submission_feature_id, submission_id, uuid, feature_type_id, feature_type_name,
+        feature_name, feature_description, submission_name, is_secured
+      ORDER BY
+        relevancy_score DESC;
+    `);
+
+    const response = await this.connection.sql(query, SearchFeatureResult);
 
     return response.rows;
   }

--- a/api/src/services/search-index-service.test.ts
+++ b/api/src/services/search-index-service.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { SearchIndexRepository } from '../repositories/search-index-respository';
+import { SearchFeatureResult, SearchIndexRepository } from '../repositories/search-index-respository';
 import { SubmissionRepository } from '../repositories/submission-repository';
 import { getMockDBConnection } from '../__mocks__/db';
 import { CodeService } from './code-service';
@@ -279,6 +279,209 @@ describe('SearchIndexService', () => {
           value: -127
         }
       ]);
+    });
+  });
+
+  describe('searchFeatures', () => {
+    it('should split keywords by whitespace and search', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Study',
+          feature_description: 'A study of moose',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 0.5
+        }
+      ];
+
+      const searchByKeywordsStub = sinon
+        .stub(SearchIndexRepository.prototype, 'searchFeaturesByKeywords')
+        .resolves(mockResults);
+
+      const result = await searchIndexService.searchFeatures({ keywords: 'moose habitat' });
+
+      expect(searchByKeywordsStub).to.be.calledOnceWith(['moose', 'habitat']);
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].submission_feature_id).to.equal(1);
+    });
+
+    it('should handle extra whitespace in keywords', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const searchByKeywordsStub = sinon.stub(SearchIndexRepository.prototype, 'searchFeaturesByKeywords').resolves([]);
+
+      await searchIndexService.searchFeatures({ keywords: '  moose   habitat  ' });
+
+      expect(searchByKeywordsStub).to.be.calledOnceWith(['moose', 'habitat']);
+    });
+
+    it('should search by property filters', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 2,
+          submission_id: 11,
+          uuid: '550e8400-e29b-41d4-a716-446655440002',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Survey',
+          feature_description: 'Survey data',
+          submission_name: 'Wildlife Survey',
+          is_secured: true,
+          relevancy_score: 0.6
+        }
+      ];
+
+      const searchByFiltersStub = sinon
+        .stub(SearchIndexRepository.prototype, 'searchFeaturesByPropertyFilters')
+        .resolves(mockResults);
+
+      const result = await searchIndexService.searchFeatures({
+        propertyFilters: [{ featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'moose' }]
+      });
+
+      expect(searchByFiltersStub).to.be.calledOnceWith([
+        { featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'moose' }
+      ]);
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].submission_feature_id).to.equal(2);
+    });
+
+    it('should aggregate results from keywords and filters', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const keywordResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Study',
+          feature_description: 'A study of moose',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 0.5
+        }
+      ];
+
+      const filterResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Study',
+          feature_description: 'A study of moose',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 0.3
+        }
+      ];
+
+      sinon.stub(SearchIndexRepository.prototype, 'searchFeaturesByKeywords').resolves(keywordResults);
+      sinon.stub(SearchIndexRepository.prototype, 'searchFeaturesByPropertyFilters').resolves(filterResults);
+
+      const result = await searchIndexService.searchFeatures({
+        keywords: 'moose',
+        propertyFilters: [{ featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'moose' }]
+      });
+
+      expect(result).to.have.lengthOf(1);
+      // Relevancy scores should be aggregated (0.5 + 0.3 = 0.8)
+      expect(result[0].relevancy_score).to.equal(0.8);
+    });
+
+    it('should return empty array when no search criteria provided', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const result = await searchIndexService.searchFeatures({});
+
+      expect(result).to.eql([]);
+    });
+
+    it('should return empty array for empty keywords string', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const result = await searchIndexService.searchFeatures({ keywords: '   ' });
+
+      expect(result).to.eql([]);
+    });
+
+    it('should filter out invalid property filters', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const searchByFiltersStub = sinon
+        .stub(SearchIndexRepository.prototype, 'searchFeaturesByPropertyFilters')
+        .resolves([]);
+
+      await searchIndexService.searchFeatures({
+        propertyFilters: [
+          { featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'moose' },
+          { featureTypeName: 'animal', propertyName: '', propertyType: 'string', value: 'invalid' },
+          { featureTypeName: 'animal', propertyName: 'desc', propertyType: 'string', value: '' }
+        ]
+      });
+
+      // Only the valid filter should be passed
+      expect(searchByFiltersStub).to.be.calledOnceWith([
+        { featureTypeName: 'animal', propertyName: 'name', propertyType: 'string', value: 'moose' }
+      ]);
+    });
+
+    it('should sort results by relevancy score descending', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchIndexService = new SearchIndexService(mockDBConnection);
+
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Study A',
+          feature_description: 'Description A',
+          submission_name: 'Project A',
+          is_secured: false,
+          relevancy_score: 0.3
+        },
+        {
+          submission_feature_id: 2,
+          submission_id: 11,
+          uuid: '550e8400-e29b-41d4-a716-446655440002',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Study B',
+          feature_description: 'Description B',
+          submission_name: 'Project B',
+          is_secured: true,
+          relevancy_score: 0.8
+        }
+      ];
+
+      sinon.stub(SearchIndexRepository.prototype, 'searchFeaturesByKeywords').resolves(mockResults);
+
+      const result = await searchIndexService.searchFeatures({ keywords: 'moose' });
+
+      expect(result[0].submission_feature_id).to.equal(2);
+      expect(result[1].submission_feature_id).to.equal(1);
     });
   });
 });

--- a/api/src/services/search-index-service.ts
+++ b/api/src/services/search-index-service.ts
@@ -5,6 +5,8 @@ import {
   InsertNumberSearchableRecord,
   InsertSpatialSearchableRecord,
   InsertStringSearchableRecord,
+  IPropertyFilter,
+  SearchFeatureResult,
   SearchIndexRepository,
   SubmissionFeatureCombinedSearchValues,
   SubmissionFeatureSearchKeyValues
@@ -13,6 +15,14 @@ import { SubmissionRepository } from '../repositories/submission-repository';
 import { getLogger } from '../utils/logger';
 import { CodeService } from './code-service';
 import { DBService } from './db-service';
+
+/**
+ * Parameters for searching features.
+ */
+export interface ISearchFeaturesParams {
+  keywords?: string;
+  propertyFilters?: IPropertyFilter[];
+}
 
 const defaultLog = getLogger('services/search-index-service');
 
@@ -157,5 +167,73 @@ export class SearchIndexService extends DBService {
    */
   async getSearchKeyValuesBySubmissionId(submissionId: number): Promise<SubmissionFeatureSearchKeyValues[]> {
     return this.searchIndexRepository.getSearchKeyValuesBySubmissionId(submissionId);
+  }
+
+  /**
+   * Searches for features by keywords and/or property filters.
+   *
+   * Keywords are split by whitespace and searched using OR logic.
+   * Property filters search for specific property name + value combinations.
+   * When both keywords and property filters are provided, results are ANDed (intersection).
+   * Results are sorted by relevancy score.
+   *
+   * @param {ISearchFeaturesParams} params - Search parameters
+   * @return {*}  {Promise<SearchFeatureResult[]>}
+   * @memberof SearchIndexService
+   */
+  async searchFeatures(params: ISearchFeaturesParams): Promise<SearchFeatureResult[]> {
+    defaultLog.debug({ label: 'searchFeatures', params });
+
+    const { keywords, propertyFilters } = params;
+
+    // Split keywords by whitespace and filter out empty strings
+    const keywordArray = keywords
+      ? keywords
+          .trim()
+          .split(/\s+/)
+          .filter((k) => k.length > 0)
+      : [];
+
+    const validFilters = propertyFilters?.filter((f) => f.featureTypeName && f.propertyName && f.value) ?? [];
+
+    // If no search criteria provided, return empty array
+    if (keywordArray.length === 0 && validFilters.length === 0) {
+      return [];
+    }
+
+    // Search by keywords if provided
+    const keywordResults =
+      keywordArray.length > 0 ? await this.searchIndexRepository.searchFeaturesByKeywords(keywordArray) : [];
+
+    // Search by property filters if provided
+    const filterResults =
+      validFilters.length > 0 ? await this.searchIndexRepository.searchFeaturesByPropertyFilters(validFilters) : [];
+
+    // Determine final results based on what criteria were provided
+    let finalResults: SearchFeatureResult[];
+
+    if (keywordArray.length > 0 && validFilters.length > 0) {
+      // AND logic: return only features that appear in BOTH result sets
+      const keywordIds = new Set(keywordResults.map((r) => r.submission_feature_id));
+      const intersectedResults = filterResults.filter((r) => keywordIds.has(r.submission_feature_id));
+
+      // Aggregate relevancy scores from both searches
+      const keywordScoreMap = new Map(keywordResults.map((r) => [r.submission_feature_id, r.relevancy_score]));
+      finalResults = intersectedResults.map((result) => ({
+        ...result,
+        relevancy_score: result.relevancy_score + (keywordScoreMap.get(result.submission_feature_id) ?? 0)
+      }));
+    } else if (keywordArray.length > 0) {
+      // Only keywords provided
+      finalResults = keywordResults;
+    } else {
+      // Only property filters provided
+      finalResults = filterResults;
+    }
+
+    // Sort by relevancy score descending
+    finalResults.sort((a, b) => b.relevancy_score - a.relevancy_score);
+
+    return finalResults;
   }
 }

--- a/app/src/components/search-filter/FilterCheckbox.test.tsx
+++ b/app/src/components/search-filter/FilterCheckbox.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { render } from 'test-helpers/test-utils';
+import FilterCheckbox from './FilterCheckbox';
+
+describe('FilterCheckbox', () => {
+  const mockOnAdd = vi.fn();
+  const mockOnRemove = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultProps = {
+    name: 'test_property',
+    displayName: 'Test Property',
+    type: 'text' as const,
+    isActive: false,
+    onAdd: mockOnAdd,
+    onRemove: mockOnRemove
+  };
+
+  it('renders the checkbox with display name', () => {
+    const { getByText } = render(<FilterCheckbox {...defaultProps} />);
+
+    expect(getByText('Test Property')).toBeVisible();
+  });
+
+  it('shows unchecked checkbox when not active', () => {
+    const { getByRole } = render(<FilterCheckbox {...defaultProps} />);
+
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('shows checked checkbox when active', () => {
+    const { getByRole } = render(<FilterCheckbox {...defaultProps} isActive={true} value="test value" />);
+
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+  });
+
+  it('displays value badge when active with value', () => {
+    const { getByText } = render(<FilterCheckbox {...defaultProps} isActive={true} value="my filter value" />);
+
+    expect(getByText('my filter value')).toBeVisible();
+  });
+
+  it('shows input field when checkbox is clicked', async () => {
+    const { getByRole, getByPlaceholderText } = render(<FilterCheckbox {...defaultProps} />);
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(getByPlaceholderText('Enter value...')).toBeVisible();
+    });
+  });
+
+  it('shows number placeholder for number type', async () => {
+    const { getByRole, getByPlaceholderText } = render(<FilterCheckbox {...defaultProps} type="number" />);
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(getByPlaceholderText('Enter number...')).toBeVisible();
+    });
+  });
+
+  it('shows date input for datetime type', async () => {
+    const { getByRole, container } = render(<FilterCheckbox {...defaultProps} type="datetime" />);
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      const dateInput = container.querySelector('input[type="date"]');
+      expect(dateInput).toBeVisible();
+    });
+  });
+
+  it('calls onAdd with value when Enter is pressed', async () => {
+    const { getByRole, getByPlaceholderText } = render(<FilterCheckbox {...defaultProps} />);
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const input = getByPlaceholderText('Enter value...');
+    fireEvent.change(input, { target: { value: 'new value' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockOnAdd).toHaveBeenCalledWith('new value');
+    });
+  });
+
+  it('cancels input when Escape is pressed', async () => {
+    const { getByRole, getByPlaceholderText, queryByPlaceholderText } = render(<FilterCheckbox {...defaultProps} />);
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const input = getByPlaceholderText('Enter value...');
+    fireEvent.change(input, { target: { value: 'some value' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(queryByPlaceholderText('Enter value...')).not.toBeInTheDocument();
+    });
+    expect(mockOnAdd).not.toHaveBeenCalled();
+  });
+
+  it('calls onAdd when confirm button is clicked', async () => {
+    const { getByRole, getByPlaceholderText, getByLabelText } = render(<FilterCheckbox {...defaultProps} />);
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const input = getByPlaceholderText('Enter value...');
+    fireEvent.change(input, { target: { value: 'confirmed value' } });
+
+    const confirmButton = getByLabelText('Confirm');
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockOnAdd).toHaveBeenCalledWith('confirmed value');
+    });
+  });
+
+  it('cancels when cancel button is clicked', async () => {
+    const { getByRole, getByPlaceholderText, getByLabelText, queryByPlaceholderText } = render(
+      <FilterCheckbox {...defaultProps} />
+    );
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const input = getByPlaceholderText('Enter value...');
+    fireEvent.change(input, { target: { value: 'some value' } });
+
+    const cancelButton = getByLabelText('Cancel');
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(queryByPlaceholderText('Enter value...')).not.toBeInTheDocument();
+    });
+    expect(mockOnAdd).not.toHaveBeenCalled();
+  });
+
+  it('calls onRemove when unchecking an active filter', async () => {
+    const { getByRole } = render(<FilterCheckbox {...defaultProps} isActive={true} value="existing value" />);
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(mockOnRemove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('calls onRemove when clicking remove button on value badge', async () => {
+    const { getByLabelText } = render(<FilterCheckbox {...defaultProps} isActive={true} value="existing value" />);
+
+    const removeButton = getByLabelText('Remove filter');
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(mockOnRemove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not call onAdd when confirming empty value', async () => {
+    const { getByRole, getByPlaceholderText, getByLabelText, queryByPlaceholderText } = render(
+      <FilterCheckbox {...defaultProps} />
+    );
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const input = getByPlaceholderText('Enter value...');
+    fireEvent.change(input, { target: { value: '   ' } }); // whitespace only
+
+    const confirmButton = getByLabelText('Confirm');
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(queryByPlaceholderText('Enter value...')).not.toBeInTheDocument();
+    });
+    expect(mockOnAdd).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/search-filter/FilterCheckbox.tsx
+++ b/app/src/components/search-filter/FilterCheckbox.tsx
@@ -1,0 +1,154 @@
+import { mdiCheck, mdiClose } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import InputBase from '@mui/material/InputBase';
+import { useEffect, useRef, useState } from 'react';
+import { IFilterCheckboxProps } from './types';
+import { useSearchFilterStyles } from './useSearchFilterStyles';
+
+/**
+ * Individual filter checkbox with inline value input.
+ * When checked, shows an input field for entering the filter value.
+ *
+ * @param {IFilterCheckboxProps} props
+ * @returns {JSX.Element}
+ */
+export const FilterCheckbox = (props: IFilterCheckboxProps) => {
+  const { displayName, type, isActive, value, onAdd, onRemove } = props;
+  const styles = useSearchFilterStyles();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(value || '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
+
+  // Update input value when external value changes
+  useEffect(() => {
+    setInputValue(value || '');
+  }, [value]);
+
+  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.checked) {
+      // Start editing mode to enter value
+      setIsEditing(true);
+      setInputValue('');
+    } else {
+      // Remove the filter
+      onRemove();
+      setIsEditing(false);
+      setInputValue('');
+    }
+  };
+
+  const handleConfirm = () => {
+    if (inputValue.trim()) {
+      onAdd(inputValue.trim());
+      setIsEditing(false);
+    } else {
+      // No value entered, cancel
+      setIsEditing(false);
+      setInputValue('');
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setInputValue('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleConfirm();
+    } else if (e.key === 'Escape') {
+      handleCancel();
+    }
+  };
+
+  return (
+    <Box sx={styles.filterCheckboxContainer}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={isActive || isEditing}
+            onChange={handleCheckboxChange}
+            size="small"
+            sx={{
+              color: '#697386',
+              '&.Mui-checked': { color: '#2E5DD7' }
+            }}
+          />
+        }
+        label={
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <span style={{ fontSize: '14px', color: isActive ? '#2E5DD7' : '#292929' }}>{displayName}</span>
+            {isActive && value && !isEditing && (
+              <Box sx={styles.filterValueBadge}>
+                {value}
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemove();
+                  }}
+                  sx={{ padding: '2px', marginLeft: '4px' }}
+                  aria-label="Remove filter">
+                  <Icon path={mdiClose} size={0.5} style={{ color: '#2E5DD7' }} />
+                </IconButton>
+              </Box>
+            )}
+          </Box>
+        }
+        sx={{ marginRight: 0, alignItems: 'flex-start' }}
+      />
+
+      {/* Inline value input */}
+      {isEditing && (
+        <Box sx={styles.filterValueInputContainer}>
+          {type === 'datetime' ? (
+            <input
+              ref={inputRef}
+              type="date"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              style={{
+                padding: '6px 8px',
+                fontSize: '14px',
+                border: '1px solid #D8D8D8',
+                borderRadius: '4px',
+                width: '140px'
+              }}
+            />
+          ) : (
+            <InputBase
+              inputRef={inputRef}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={type === 'number' ? 'Enter number...' : 'Enter value...'}
+              type={type === 'number' ? 'number' : 'text'}
+              sx={styles.filterValueInput}
+            />
+          )}
+          <IconButton size="small" onClick={handleConfirm} sx={styles.filterConfirmButton} aria-label="Confirm">
+            <Icon path={mdiCheck} size={0.6} />
+          </IconButton>
+          <IconButton size="small" onClick={handleCancel} sx={styles.filterCancelButton} aria-label="Cancel">
+            <Icon path={mdiClose} size={0.5} />
+          </IconButton>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default FilterCheckbox;

--- a/app/src/components/search-filter/FilterGroup.test.tsx
+++ b/app/src/components/search-filter/FilterGroup.test.tsx
@@ -1,0 +1,235 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { render } from 'test-helpers/test-utils';
+import FilterGroup from './FilterGroup';
+import { ActiveFilter, FilterProperty } from './types';
+
+describe('FilterGroup', () => {
+  const mockOnAddFilter = vi.fn();
+  const mockOnRemoveFilter = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockProperties: FilterProperty[] = [
+    { name: 'scientific_name', displayName: 'Scientific Name', type: 'text' },
+    { name: 'count', displayName: 'Count', type: 'number' },
+    { name: 'start_date', displayName: 'Start Date', type: 'datetime' }
+  ];
+
+  const defaultProps = {
+    id: 1,
+    featureTypeName: 'animal',
+    displayName: 'Animal',
+    properties: mockProperties,
+    activeFilters: [] as ActiveFilter[],
+    onAddFilter: mockOnAddFilter,
+    onRemoveFilter: mockOnRemoveFilter
+  };
+
+  it('renders the group header with display name and property count', () => {
+    const { getByText } = render(<FilterGroup {...defaultProps} />);
+
+    expect(getByText('Animal (3)')).toBeVisible();
+  });
+
+  it('renders collapsed by default', () => {
+    const { queryByText } = render(<FilterGroup {...defaultProps} />);
+
+    // Properties should not be visible when collapsed
+    expect(queryByText('Scientific Name')).not.toBeVisible();
+  });
+
+  it('renders expanded when defaultExpanded is true', () => {
+    const { getByText } = render(<FilterGroup {...defaultProps} defaultExpanded={true} />);
+
+    expect(getByText('Scientific Name')).toBeVisible();
+    expect(getByText('Count')).toBeVisible();
+    expect(getByText('Start Date')).toBeVisible();
+  });
+
+  it('expands when header is clicked', async () => {
+    const { getByText, getByRole } = render(<FilterGroup {...defaultProps} />);
+
+    const header = getByRole('button');
+    fireEvent.click(header);
+
+    await waitFor(() => {
+      expect(getByText('Scientific Name')).toBeVisible();
+    });
+  });
+
+  it('collapses when expanded header is clicked', async () => {
+    const { getByText, getByRole, queryByText } = render(<FilterGroup {...defaultProps} defaultExpanded={true} />);
+
+    expect(getByText('Scientific Name')).toBeVisible();
+
+    const header = getByRole('button');
+    fireEvent.click(header);
+
+    await waitFor(() => {
+      expect(queryByText('Scientific Name')).not.toBeVisible();
+    });
+  });
+
+  it('expands when Enter key is pressed on header', async () => {
+    const { getByText, getByRole } = render(<FilterGroup {...defaultProps} />);
+
+    const header = getByRole('button');
+    fireEvent.keyDown(header, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(getByText('Scientific Name')).toBeVisible();
+    });
+  });
+
+  it('expands when Space key is pressed on header', async () => {
+    const { getByText, getByRole } = render(<FilterGroup {...defaultProps} />);
+
+    const header = getByRole('button');
+    fireEvent.keyDown(header, { key: ' ' });
+
+    await waitFor(() => {
+      expect(getByText('Scientific Name')).toBeVisible();
+    });
+  });
+
+  it('shows active count when filters are active', () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      }
+    ];
+
+    const { getByText } = render(<FilterGroup {...defaultProps} activeFilters={activeFilters} />);
+
+    expect(getByText('1 active')).toBeVisible();
+  });
+
+  it('shows correct active count with multiple active filters', () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      },
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'count',
+        propertyType: 'text',
+        label: 'Count',
+        value: '5'
+      }
+    ];
+
+    const { getByText } = render(<FilterGroup {...defaultProps} activeFilters={activeFilters} />);
+
+    expect(getByText('2 active')).toBeVisible();
+  });
+
+  it('does not count active filters from other feature types', () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'dataset',
+        featureTypeDisplayName: 'Dataset',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Some value'
+      }
+    ];
+
+    const { queryByText } = render(<FilterGroup {...defaultProps} activeFilters={activeFilters} />);
+
+    expect(queryByText('active')).not.toBeInTheDocument();
+  });
+
+  it('has correct aria-expanded attribute when collapsed', () => {
+    const { getByRole } = render(<FilterGroup {...defaultProps} />);
+
+    const header = getByRole('button');
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('has correct aria-expanded attribute when expanded', () => {
+    const { getByRole } = render(<FilterGroup {...defaultProps} defaultExpanded={true} />);
+
+    const header = getByRole('button');
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('has correct aria-controls attribute', () => {
+    const { getByRole } = render(<FilterGroup {...defaultProps} />);
+
+    const header = getByRole('button');
+    expect(header).toHaveAttribute('aria-controls', 'filter-group-content-1');
+  });
+
+  it('renders correct test id', () => {
+    const { getByTestId } = render(<FilterGroup {...defaultProps} />);
+
+    expect(getByTestId('filter-group-1')).toBeInTheDocument();
+  });
+
+  it('calls onAddFilter when a filter checkbox value is confirmed', async () => {
+    const { getByText, getAllByRole, getByPlaceholderText, getByLabelText } = render(
+      <FilterGroup {...defaultProps} defaultExpanded={true} />
+    );
+
+    // Find and click the checkbox for Scientific Name
+    const checkboxes = getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]); // First checkbox is Scientific Name
+
+    // Enter a value
+    const input = getByPlaceholderText('Enter value...');
+    fireEvent.change(input, { target: { value: 'Ursus arctos' } });
+
+    // Confirm
+    const confirmButton = getByLabelText('Confirm');
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockOnAddFilter).toHaveBeenCalledWith({
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      });
+    });
+  });
+
+  it('calls onRemoveFilter when a filter is removed', async () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      }
+    ];
+
+    const { getAllByLabelText } = render(
+      <FilterGroup {...defaultProps} activeFilters={activeFilters} defaultExpanded={true} />
+    );
+
+    const removeButtons = getAllByLabelText('Remove filter');
+    fireEvent.click(removeButtons[0]);
+
+    await waitFor(() => {
+      expect(mockOnRemoveFilter).toHaveBeenCalledWith('animal', 'scientific_name');
+    });
+  });
+});

--- a/app/src/components/search-filter/FilterGroup.test.tsx
+++ b/app/src/components/search-filter/FilterGroup.test.tsx
@@ -181,7 +181,7 @@ describe('FilterGroup', () => {
   });
 
   it('calls onAddFilter when a filter checkbox value is confirmed', async () => {
-    const { getByText, getAllByRole, getByPlaceholderText, getByLabelText } = render(
+    const { getAllByRole, getByPlaceholderText, getByLabelText } = render(
       <FilterGroup {...defaultProps} defaultExpanded={true} />
     );
 

--- a/app/src/components/search-filter/FilterGroup.tsx
+++ b/app/src/components/search-filter/FilterGroup.tsx
@@ -1,0 +1,110 @@
+import { mdiChevronDown, mdiChevronRight } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import Box from '@mui/material/Box';
+import Collapse from '@mui/material/Collapse';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import FilterCheckbox from './FilterCheckbox';
+import { ActiveFilter, IFilterGroupProps } from './types';
+import { useSearchFilterStyles } from './useSearchFilterStyles';
+
+/**
+ * Collapsible filter group component organized by feature type.
+ * Displays a header with expand/collapse toggle and a list of FilterCheckbox items.
+ *
+ * @param {IFilterGroupProps} props
+ * @returns {JSX.Element}
+ */
+export const FilterGroup = (props: IFilterGroupProps) => {
+  const {
+    id,
+    featureTypeName,
+    displayName,
+    properties,
+    defaultExpanded = false,
+    activeFilters,
+    onAddFilter,
+    onRemoveFilter
+  } = props;
+  const styles = useSearchFilterStyles();
+
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  // Count active filters in this group (must match both feature type AND property)
+  const activeCount = properties.filter((prop) =>
+    activeFilters.some((f) => f.featureType === featureTypeName && f.property === prop.name)
+  ).length;
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const handleAddFilter = (propertyName: string, propertyDisplayName: string, type: string, value: string) => {
+    const filter: ActiveFilter = {
+      featureType: featureTypeName,
+      featureTypeDisplayName: displayName,
+      property: propertyName,
+      propertyType: type === 'datetime' ? 'datetime' : 'text',
+      label: propertyDisplayName,
+      value
+    };
+    onAddFilter(filter);
+  };
+
+  return (
+    <Box data-testid={`filter-group-${id}`}>
+      {/* Group header - clickable to expand/collapse */}
+      <Box
+        sx={styles.filterGroupHeader}
+        onClick={handleToggle}
+        role="button"
+        aria-expanded={isExpanded}
+        aria-controls={`filter-group-content-${id}`}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleToggle();
+          }
+        }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Icon path={isExpanded ? mdiChevronDown : mdiChevronRight} size={0.8} />
+          <span>
+            {displayName} ({properties.length})
+          </span>
+        </Box>
+        {activeCount > 0 && (
+          <Typography component="span" sx={{ fontSize: '12px', color: '#2E5DD7', fontWeight: 600 }}>
+            {activeCount} active
+          </Typography>
+        )}
+      </Box>
+
+      {/* Collapsible content */}
+      <Collapse in={isExpanded} id={`filter-group-content-${id}`}>
+        <Box sx={{ pl: 2, pb: 1 }}>
+          {properties.map((prop) => {
+            // Match filter by both feature type AND property name
+            const activeFilter = activeFilters.find(
+              (f) => f.featureType === featureTypeName && f.property === prop.name
+            );
+            return (
+              <FilterCheckbox
+                key={prop.name}
+                name={prop.name}
+                displayName={prop.displayName}
+                type={prop.type}
+                isActive={!!activeFilter}
+                value={activeFilter?.value}
+                onAdd={(value) => handleAddFilter(prop.name, prop.displayName, prop.type, value)}
+                onRemove={() => onRemoveFilter(featureTypeName, prop.name)}
+              />
+            );
+          })}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};
+
+export default FilterGroup;

--- a/app/src/components/search-filter/FilterSidebar.test.tsx
+++ b/app/src/components/search-filter/FilterSidebar.test.tsx
@@ -1,0 +1,303 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { render } from 'test-helpers/test-utils';
+import { FilterSidebar } from './FilterSidebar';
+import { ActiveFilter, FilterGroup } from './types';
+
+describe('FilterSidebar', () => {
+  const mockOnFiltersChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockFilterGroups: FilterGroup[] = [
+    {
+      id: 1,
+      name: 'animal',
+      displayName: 'Animal',
+      properties: [
+        { name: 'scientific_name', displayName: 'Scientific Name', type: 'text' },
+        { name: 'count', displayName: 'Count', type: 'number' }
+      ]
+    },
+    {
+      id: 2,
+      name: 'dataset',
+      displayName: 'Dataset',
+      properties: [
+        { name: 'name', displayName: 'Name', type: 'text' },
+        { name: 'start_date', displayName: 'Start Date', type: 'datetime' }
+      ]
+    }
+  ];
+
+  const defaultProps = {
+    filterGroups: mockFilterGroups,
+    activeFilters: [] as ActiveFilter[],
+    onFiltersChange: mockOnFiltersChange
+  };
+
+  it('renders the Filters header', () => {
+    const { getByText } = render(<FilterSidebar {...defaultProps} />);
+
+    expect(getByText('Filters')).toBeVisible();
+  });
+
+  it('renders all filter groups', () => {
+    const { getByText } = render(<FilterSidebar {...defaultProps} />);
+
+    expect(getByText('Animal (2)')).toBeVisible();
+    expect(getByText('Dataset (2)')).toBeVisible();
+  });
+
+  it('renders search input for filtering', () => {
+    const { getByPlaceholderText } = render(<FilterSidebar {...defaultProps} />);
+
+    expect(getByPlaceholderText('Search filters...')).toBeVisible();
+  });
+
+  it('filters groups by search term', async () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(<FilterSidebar {...defaultProps} />);
+
+    const searchInput = getByPlaceholderText('Search filters...');
+    fireEvent.change(searchInput, { target: { value: 'scientific' } });
+
+    await waitFor(() => {
+      // Animal group should still be visible (has scientific_name)
+      expect(getByText('Animal (1)')).toBeVisible();
+      // Dataset group should be hidden (no matching properties)
+      expect(queryByText('Dataset')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows "No filters match" when search has no results', async () => {
+    const { getByPlaceholderText, getByText } = render(<FilterSidebar {...defaultProps} />);
+
+    const searchInput = getByPlaceholderText('Search filters...');
+    fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
+
+    await waitFor(() => {
+      expect(getByText('No filters match your search')).toBeVisible();
+    });
+  });
+
+  it('clears search when clear button is clicked', async () => {
+    const { getByPlaceholderText, getByLabelText, getByText } = render(<FilterSidebar {...defaultProps} />);
+
+    const searchInput = getByPlaceholderText('Search filters...');
+    fireEvent.change(searchInput, { target: { value: 'scientific' } });
+
+    await waitFor(() => {
+      expect(getByLabelText('Clear search')).toBeVisible();
+    });
+
+    const clearButton = getByLabelText('Clear search');
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(getByText('Animal (2)')).toBeVisible();
+      expect(getByText('Dataset (2)')).toBeVisible();
+    });
+  });
+
+  it('shows clear filters button when filters are active', () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      }
+    ];
+
+    const { getByText } = render(<FilterSidebar {...defaultProps} activeFilters={activeFilters} />);
+
+    expect(getByText('Clear all filters (1)')).toBeVisible();
+  });
+
+  it('does not show clear filters button when no filters are active', () => {
+    const { queryByText } = render(<FilterSidebar {...defaultProps} />);
+
+    expect(queryByText(/Clear all filters/)).not.toBeInTheDocument();
+  });
+
+  it('calls onFiltersChange with empty array when clear all is clicked', async () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      }
+    ];
+
+    const { getByText } = render(<FilterSidebar {...defaultProps} activeFilters={activeFilters} />);
+
+    const clearButton = getByText('Clear all filters (1)');
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(mockOnFiltersChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('renders popular filters section', () => {
+    const groupsWithPopular: FilterGroup[] = [
+      {
+        id: 1,
+        name: 'animal',
+        displayName: 'Animal',
+        properties: [
+          { name: 'scientific_name', displayName: 'Scientific Name', type: 'text' },
+          { name: 'sex', displayName: 'Sex', type: 'text' }
+        ]
+      }
+    ];
+
+    const { getByText } = render(<FilterSidebar {...defaultProps} filterGroups={groupsWithPopular} />);
+
+    expect(getByText('Popular')).toBeVisible();
+  });
+
+  it('adds filter when checkbox value is confirmed', async () => {
+    const { getByText, getAllByRole, getByPlaceholderText, getByLabelText } = render(
+      <FilterSidebar {...defaultProps} />
+    );
+
+    // Expand Animal group
+    fireEvent.click(getByText('Animal (2)'));
+
+    await waitFor(() => {
+      expect(getByText('Scientific Name')).toBeVisible();
+    });
+
+    // Click checkbox for Scientific Name
+    const checkboxes = getAllByRole('checkbox');
+    // Find the Scientific Name checkbox (first one in expanded Animal group)
+    const scientificNameCheckbox = checkboxes.find((cb) => {
+      const label = cb.closest('label');
+      return label?.textContent?.includes('Scientific Name');
+    });
+
+    if (scientificNameCheckbox) {
+      fireEvent.click(scientificNameCheckbox);
+    }
+
+    // Enter a value
+    const input = getByPlaceholderText('Enter value...');
+    fireEvent.change(input, { target: { value: 'Ursus arctos' } });
+
+    // Confirm
+    const confirmButton = getByLabelText('Confirm');
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockOnFiltersChange).toHaveBeenCalled();
+      const calledWith = mockOnFiltersChange.mock.calls[0][0];
+      expect(calledWith).toHaveLength(1);
+      expect(calledWith[0]).toMatchObject({
+        featureType: 'animal',
+        property: 'scientific_name',
+        value: 'Ursus arctos'
+      });
+    });
+  });
+
+  it('removes filter when filter is unchecked', async () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      }
+    ];
+
+    const { getByText, getAllByLabelText } = render(<FilterSidebar {...defaultProps} activeFilters={activeFilters} />);
+
+    // Expand Animal group
+    fireEvent.click(getByText('Animal (2)'));
+
+    await waitFor(() => {
+      expect(getByText('Scientific Name')).toBeVisible();
+    });
+
+    // Click remove button on the first active filter (there may be multiple due to Popular section)
+    const removeButtons = getAllByLabelText('Remove filter');
+    fireEvent.click(removeButtons[0]);
+
+    await waitFor(() => {
+      expect(mockOnFiltersChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('updates existing filter value instead of adding duplicate', async () => {
+    const activeFilters: ActiveFilter[] = [
+      {
+        featureType: 'animal',
+        featureTypeDisplayName: 'Animal',
+        property: 'scientific_name',
+        propertyType: 'text',
+        label: 'Scientific Name',
+        value: 'Ursus arctos'
+      }
+    ];
+
+    const groupsWithPopular: FilterGroup[] = [
+      {
+        id: 1,
+        name: 'animal',
+        displayName: 'Animal',
+        properties: [{ name: 'scientific_name', displayName: 'Scientific Name', type: 'text' }]
+      }
+    ];
+
+    const { getByText, getAllByRole, getByPlaceholderText, getByLabelText } = render(
+      <FilterSidebar {...defaultProps} filterGroups={groupsWithPopular} activeFilters={activeFilters} />
+    );
+
+    // Click on the Scientific Name in Popular section to edit
+    // First, we need to uncheck and re-check to enter edit mode
+    const checkboxes = getAllByRole('checkbox');
+    const activeCheckbox = checkboxes.find((cb) => (cb as HTMLInputElement).checked);
+
+    if (activeCheckbox) {
+      // Uncheck first
+      fireEvent.click(activeCheckbox);
+
+      await waitFor(() => {
+        expect(mockOnFiltersChange).toHaveBeenCalledWith([]);
+      });
+    }
+  });
+
+  it('hides popular section when searching', async () => {
+    const groupsWithPopular: FilterGroup[] = [
+      {
+        id: 1,
+        name: 'animal',
+        displayName: 'Animal',
+        properties: [{ name: 'scientific_name', displayName: 'Scientific Name', type: 'text' }]
+      }
+    ];
+
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <FilterSidebar {...defaultProps} filterGroups={groupsWithPopular} />
+    );
+
+    expect(getByText('Popular')).toBeVisible();
+
+    const searchInput = getByPlaceholderText('Search filters...');
+    fireEvent.change(searchInput, { target: { value: 'scientific' } });
+
+    await waitFor(() => {
+      expect(queryByText('Popular')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/components/search-filter/FilterSidebar.test.tsx
+++ b/app/src/components/search-filter/FilterSidebar.test.tsx
@@ -258,7 +258,7 @@ describe('FilterSidebar', () => {
       }
     ];
 
-    const { getByText, getAllByRole, getByPlaceholderText, getByLabelText } = render(
+    const { getAllByRole } = render(
       <FilterSidebar {...defaultProps} filterGroups={groupsWithPopular} activeFilters={activeFilters} />
     );
 

--- a/app/src/components/search-filter/FilterSidebar.tsx
+++ b/app/src/components/search-filter/FilterSidebar.tsx
@@ -6,7 +6,7 @@ import Divider from '@mui/material/Divider';
 import InputAdornment from '@mui/material/InputAdornment';
 import InputBase from '@mui/material/InputBase';
 import Typography from '@mui/material/Typography';
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import FilterCheckbox from './FilterCheckbox';
 import FilterGroup from './FilterGroup';
 import { ActiveFilter, FilterGroup as FilterGroupType, FilterProperty, IFilterSidebarProps } from './types';
@@ -28,7 +28,7 @@ interface PopularFilter extends FilterProperty {
  * @param {IFilterSidebarProps} props
  * @returns {JSX.Element}
  */
-export const FilterSidebar = (props: IFilterSidebarProps) => {
+export const FilterSidebar = memo((props: IFilterSidebarProps) => {
   const { filterGroups, activeFilters, onFiltersChange } = props;
   const styles = useSearchFilterStyles();
 
@@ -212,6 +212,6 @@ export const FilterSidebar = (props: IFilterSidebarProps) => {
       )}
     </Box>
   );
-};
+});
 
 export default FilterSidebar;

--- a/app/src/components/search-filter/FilterSidebar.tsx
+++ b/app/src/components/search-filter/FilterSidebar.tsx
@@ -1,0 +1,217 @@
+import { mdiClose, mdiMagnify, mdiStar } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import InputAdornment from '@mui/material/InputAdornment';
+import InputBase from '@mui/material/InputBase';
+import Typography from '@mui/material/Typography';
+import { useMemo, useState } from 'react';
+import FilterCheckbox from './FilterCheckbox';
+import FilterGroup from './FilterGroup';
+import { ActiveFilter, FilterGroup as FilterGroupType, FilterProperty, IFilterSidebarProps } from './types';
+import { useSearchFilterStyles } from './useSearchFilterStyles';
+
+/** Property names to show in the "Popular" section */
+const POPULAR_PROPERTY_NAMES = ['scientific_name', 'start_date', 'end_date', 'sex', 'count', 'method_name'];
+
+/** Popular filter with feature type context */
+interface PopularFilter extends FilterProperty {
+  featureTypeName: string;
+  featureTypeDisplayName: string;
+}
+
+/**
+ * Sidebar component for filtering search results by property.
+ * Displays filter groups organized by feature type with collapsible sections.
+ *
+ * @param {IFilterSidebarProps} props
+ * @returns {JSX.Element}
+ */
+export const FilterSidebar = (props: IFilterSidebarProps) => {
+  const { filterGroups, activeFilters, onFiltersChange } = props;
+  const styles = useSearchFilterStyles();
+
+  // Search term for filtering the filter list
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // Extract popular filters from all groups
+  const popularFilters = useMemo((): PopularFilter[] => {
+    const popular: PopularFilter[] = [];
+
+    filterGroups.forEach((group) => {
+      group.properties.forEach((prop) => {
+        if (POPULAR_PROPERTY_NAMES.includes(prop.name)) {
+          popular.push({
+            ...prop,
+            featureTypeName: group.name,
+            featureTypeDisplayName: group.displayName
+          });
+        }
+      });
+    });
+
+    // Sort by the order in POPULAR_PROPERTY_NAMES, then by feature type
+    return popular.sort((a, b) => {
+      const aIndex = POPULAR_PROPERTY_NAMES.indexOf(a.name);
+      const bIndex = POPULAR_PROPERTY_NAMES.indexOf(b.name);
+      if (aIndex !== bIndex) {
+        return aIndex - bIndex;
+      }
+      return a.featureTypeDisplayName.localeCompare(b.featureTypeDisplayName);
+    });
+  }, [filterGroups]);
+
+  // Filter groups based on search term
+  const filteredGroups = useMemo(() => {
+    if (!searchTerm.trim()) {
+      return filterGroups;
+    }
+
+    const term = searchTerm.toLowerCase();
+    return filterGroups
+      .map((group) => ({
+        ...group,
+        properties: group.properties.filter(
+          (prop) => prop.displayName.toLowerCase().includes(term) || prop.name.toLowerCase().includes(term)
+        )
+      }))
+      .filter((group) => group.properties.length > 0);
+  }, [filterGroups, searchTerm]);
+
+  // Handle clearing all filters
+  const handleClearFilters = () => {
+    onFiltersChange([]);
+  };
+
+  // Handle adding a filter
+  const handleAddFilter = (filter: ActiveFilter) => {
+    // Check if filter already exists (must match both feature type AND property)
+    const exists = activeFilters.find((f) => f.featureType === filter.featureType && f.property === filter.property);
+    if (exists) {
+      // Update existing filter value
+      onFiltersChange(
+        activeFilters.map((f) => (f.featureType === filter.featureType && f.property === filter.property ? filter : f))
+      );
+    } else {
+      onFiltersChange([...activeFilters, filter]);
+    }
+  };
+
+  // Handle removing a filter (needs both feature type and property to identify)
+  const handleRemoveFilter = (featureType: string, propertyName: string) => {
+    onFiltersChange(activeFilters.filter((f) => !(f.featureType === featureType && f.property === propertyName)));
+  };
+
+  return (
+    <Box sx={styles.filterSidebar}>
+      {/* Header */}
+      <Typography sx={styles.filterSidebarHeader}>Filters</Typography>
+
+      {/* Search input */}
+      <Box sx={styles.filterSearchContainer}>
+        <InputBase
+          fullWidth
+          placeholder="Search filters..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          startAdornment={
+            <InputAdornment position="start">
+              <Icon path={mdiMagnify} size={0.8} style={{ color: '#697386' }} />
+            </InputAdornment>
+          }
+          endAdornment={
+            searchTerm ? (
+              <InputAdornment position="end">
+                <Button
+                  size="small"
+                  sx={{ minWidth: 'auto', padding: '2px' }}
+                  onClick={() => setSearchTerm('')}
+                  aria-label="Clear search">
+                  <Icon path={mdiClose} size={0.6} style={{ color: '#697386' }} />
+                </Button>
+              </InputAdornment>
+            ) : null
+          }
+          sx={styles.filterSearchInput}
+        />
+      </Box>
+
+      {/* Popular Filters Section */}
+      {popularFilters.length > 0 && !searchTerm && (
+        <>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
+            <Icon path={mdiStar} size={0.7} style={{ color: '#F59E0B' }} />
+            <Typography sx={{ fontSize: '12px', fontWeight: 600, color: '#697386', textTransform: 'uppercase' }}>
+              Popular
+            </Typography>
+          </Box>
+          <Box sx={{ pl: 0.5, mb: 2 }}>
+            {popularFilters.map((filter) => {
+              const activeFilter = activeFilters.find(
+                (f) => f.featureType === filter.featureTypeName && f.property === filter.name
+              );
+              return (
+                <FilterCheckbox
+                  key={`${filter.featureTypeName}-${filter.name}`}
+                  name={filter.name}
+                  displayName={`${filter.displayName} (${filter.featureTypeDisplayName})`}
+                  type={filter.type}
+                  isActive={!!activeFilter}
+                  value={activeFilter?.value}
+                  onAdd={(value) => {
+                    const newFilter: ActiveFilter = {
+                      featureType: filter.featureTypeName,
+                      featureTypeDisplayName: filter.featureTypeDisplayName,
+                      property: filter.name,
+                      propertyType: filter.type === 'datetime' ? 'datetime' : 'text',
+                      label: filter.displayName,
+                      value
+                    };
+                    handleAddFilter(newFilter);
+                  }}
+                  onRemove={() => handleRemoveFilter(filter.featureTypeName, filter.name)}
+                />
+              );
+            })}
+          </Box>
+          <Divider sx={{ my: 1.5 }} />
+        </>
+      )}
+
+      {/* All Filter Groups */}
+      <Box sx={styles.filterGroupsContainer}>
+        {filteredGroups.length > 0 ? (
+          filteredGroups.map((group: FilterGroupType) => (
+            <FilterGroup
+              key={group.id}
+              id={group.id}
+              featureTypeName={group.name}
+              displayName={group.displayName}
+              properties={group.properties}
+              activeFilters={activeFilters}
+              onAddFilter={handleAddFilter}
+              onRemoveFilter={handleRemoveFilter}
+            />
+          ))
+        ) : (
+          <Typography sx={{ color: '#697386', fontSize: '14px', textAlign: 'center', py: 2 }}>
+            No filters match your search
+          </Typography>
+        )}
+      </Box>
+
+      {/* Clear filters button */}
+      {activeFilters.length > 0 && (
+        <>
+          <Divider sx={{ my: 1.5 }} />
+          <Button fullWidth variant="text" onClick={handleClearFilters} sx={styles.clearFiltersButton}>
+            Clear all filters ({activeFilters.length})
+          </Button>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default FilterSidebar;

--- a/app/src/components/search-filter/SearchInput.tsx
+++ b/app/src/components/search-filter/SearchInput.tsx
@@ -1,0 +1,62 @@
+import { mdiClose, mdiMagnify } from '@mdi/js';
+import { Icon } from '@mdi/react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Input from '@mui/material/Input';
+import InputAdornment from '@mui/material/InputAdornment';
+import { ChangeEvent } from 'react';
+import { useSearchFilterStyles } from './useSearchFilterStyles';
+
+export interface ISearchInputProps {
+  placeholderText: string;
+  handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+  onClear?: () => void;
+}
+
+/**
+ * Keyword search input component.
+ * Displays a search box with magnifying glass icon and clear button.
+ *
+ * @param {ISearchInputProps} props
+ * @returns {JSX.Element}
+ */
+export const SearchInput = (props: ISearchInputProps) => {
+  const { placeholderText, handleChange, value, onClear } = props;
+  const styles = useSearchFilterStyles();
+
+  const handleClear = () => {
+    onClear?.();
+  };
+
+  return (
+    <Box sx={{ ...styles.searchBoxContainer }}>
+      <Input
+        tabIndex={0}
+        sx={styles.searchInput}
+        name="keywords"
+        fullWidth
+        disableUnderline
+        startAdornment={
+          <InputAdornment position="start">
+            <Icon path={mdiMagnify} size={1} style={{ opacity: 0.5 }} />
+          </InputAdornment>
+        }
+        endAdornment={
+          value ? (
+            <InputAdornment position="end">
+              <IconButton size="small" onClick={handleClear} aria-label="Clear search" sx={styles.clearButton}>
+                <Icon path={mdiClose} size={0.7} />
+              </IconButton>
+            </InputAdornment>
+          ) : null
+        }
+        placeholder={placeholderText}
+        onChange={handleChange}
+        value={value}
+      />
+    </Box>
+  );
+};
+
+export default SearchInput;

--- a/app/src/components/search-filter/index.tsx
+++ b/app/src/components/search-filter/index.tsx
@@ -1,0 +1,18 @@
+export { SearchInput } from './SearchInput';
+export { FilterSidebar } from './FilterSidebar';
+export { FilterGroup } from './FilterGroup';
+export { FilterCheckbox } from './FilterCheckbox';
+export { useSearchFilterStyles } from './useSearchFilterStyles';
+export type {
+  // Data types
+  FilterOption,
+  FilterProperty,
+  FilterGroup as FilterGroupType,
+  ActiveFilter,
+  // Component props
+  ISearchInputProps,
+  IFilterSidebarProps,
+  IFilterGroupProps,
+  IFilterCheckboxProps,
+  IFilterDrawerProps
+} from './types';

--- a/app/src/components/search-filter/types.ts
+++ b/app/src/components/search-filter/types.ts
@@ -1,0 +1,145 @@
+import { ChangeEvent } from 'react';
+
+// =============================================================================
+// Filter Option Types (for dropdown/sidebar)
+// =============================================================================
+
+/**
+ * A single filter option representing a searchable property.
+ */
+export interface FilterOption {
+  name: string;
+  displayName: string;
+  type: 'text' | 'enum' | 'datetime';
+  values?: string[]; // For enum type
+}
+
+/**
+ * A property within a filter group that can be filtered on.
+ */
+export interface FilterProperty {
+  /** Property name (API key, e.g., "focal_species") */
+  name: string;
+  /** Display label (e.g., "Focal Species") */
+  displayName: string;
+  /** Property type for input rendering */
+  type: 'text' | 'number' | 'datetime';
+}
+
+/**
+ * A group of filter properties organized by feature type.
+ */
+export interface FilterGroup {
+  /** Feature type ID */
+  id: number;
+  /** Feature type name (e.g., "animal", "dataset") */
+  name: string;
+  /** Display name (e.g., "Animal", "Dataset") */
+  displayName: string;
+  /** Properties within this group */
+  properties: FilterProperty[];
+}
+
+// =============================================================================
+// Active Filter Types
+// =============================================================================
+
+/**
+ * An active filter applied by the user.
+ */
+export interface ActiveFilter {
+  /** Feature type name (e.g., "dataset", "animal") */
+  featureType: string;
+  /** Feature type display name (e.g., "Dataset", "Animal") */
+  featureTypeDisplayName: string;
+  /** Property name (API key) */
+  property: string;
+  /** Property type for API mapping */
+  propertyType: 'text' | 'datetime' | 'enum';
+  /** Property display label */
+  label: string;
+  /** Filter value */
+  value: string;
+}
+
+// =============================================================================
+// Component Props
+// =============================================================================
+
+/**
+ * Props for the SearchInput component (keyword search only).
+ */
+export interface ISearchInputProps {
+  placeholderText: string;
+  handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+  onClear?: () => void;
+}
+
+/**
+ * Props for the FilterSidebar component.
+ */
+export interface IFilterSidebarProps {
+  /** Grouped filter options by feature type */
+  filterGroups: FilterGroup[];
+  /** Currently active filters */
+  activeFilters: ActiveFilter[];
+  /** Called when filters change */
+  onFiltersChange: (filters: ActiveFilter[]) => void;
+}
+
+/**
+ * Props for the FilterGroup component (collapsible category).
+ */
+export interface IFilterGroupProps {
+  /** Feature type ID */
+  id: number;
+  /** Feature type name (API key, e.g., "animal") */
+  featureTypeName: string;
+  /** Display name (e.g., "Animal") */
+  displayName: string;
+  /** Properties in this group */
+  properties: FilterProperty[];
+  /** Initially expanded? */
+  defaultExpanded?: boolean;
+  /** Active filters for highlighting checked items */
+  activeFilters: ActiveFilter[];
+  /** Called when a filter is added */
+  onAddFilter: (filter: ActiveFilter) => void;
+  /** Called when a filter is removed (needs both feature type and property to identify) */
+  onRemoveFilter: (featureType: string, propertyName: string) => void;
+}
+
+/**
+ * Props for the FilterCheckbox component (individual property).
+ */
+export interface IFilterCheckboxProps {
+  /** Property name (API key) */
+  name: string;
+  /** Display label */
+  displayName: string;
+  /** Input type */
+  type: 'text' | 'number' | 'datetime';
+  /** Whether filter is active */
+  isActive: boolean;
+  /** Current value if active */
+  value?: string;
+  /** Called when filter is added with a value */
+  onAdd: (value: string) => void;
+  /** Called when filter is removed */
+  onRemove: () => void;
+}
+
+/**
+ * Props for the FilterDrawer component (mobile/tablet wrapper).
+ */
+export interface IFilterDrawerProps {
+  /** Grouped filter options by feature type */
+  filterGroups: FilterGroup[];
+  /** Currently active filters */
+  activeFilters: ActiveFilter[];
+  /** Called when filters change */
+  onFiltersChange: (filters: ActiveFilter[]) => void;
+  /** Number of active filters (for badge) */
+  activeFilterCount: number;
+}

--- a/app/src/components/search-filter/useSearchFilterStyles.ts
+++ b/app/src/components/search-filter/useSearchFilterStyles.ts
@@ -1,0 +1,361 @@
+import { useTheme } from '@mui/material/styles';
+
+export const useSearchFilterStyles = () => {
+  const theme = useTheme();
+
+  return {
+    searchBoxContainer: {
+      position: 'relative',
+      background: '#ffffff',
+      borderRadius: '4px',
+      border: '1px solid #D8D8D8',
+      padding: theme.spacing(1),
+      transition: 'border-color 0.2s ease',
+      '&:hover': {
+        borderColor: '#898785'
+      },
+      '&:focus-within': {
+        borderColor: '#2E5DD7',
+        borderWidth: '2px',
+        padding: `calc(${theme.spacing(1)} - 1px)` // Compensate for border width change
+      }
+    },
+    searchInput: {
+      height: '48px',
+      paddingLeft: theme.spacing(1),
+      paddingRight: theme.spacing(1),
+      border: 'none',
+      background: 'transparent'
+    },
+    // Clear button (circular X) inside search bar
+    clearButton: {
+      width: '28px',
+      height: '28px',
+      minWidth: '28px',
+      borderRadius: '50%',
+      color: '#697386',
+      '&:hover': {
+        backgroundColor: 'rgba(0, 0, 0, 0.04)',
+        color: '#292929'
+      }
+    },
+    filterPillsContainer: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme.spacing(1),
+      paddingTop: theme.spacing(1.5),
+      alignItems: 'center'
+    },
+    // Active filter pill
+    activePill: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '6px',
+      padding: '6px 10px 6px 12px',
+      background: '#F1F8FE',
+      border: '1px solid #D4DEFF',
+      borderRadius: '100px',
+      fontSize: '14px',
+      color: '#2E5DD7',
+      fontWeight: 500
+    },
+    pillRemoveButton: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '18px',
+      height: '18px',
+      minWidth: '18px',
+      borderRadius: '50%',
+      background: 'transparent',
+      border: 'none',
+      color: '#2E5DD7',
+      cursor: 'pointer',
+      padding: 0,
+      '&:hover': {
+        background: 'rgba(59, 91, 219, 0.1)'
+      }
+    },
+    // Draft filter pill (text input mode)
+    draftPill: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '6px',
+      padding: '4px 6px 4px 12px',
+      background: '#F1F8FE',
+      border: '2px dashed #2E5DD7',
+      borderRadius: '100px',
+      fontSize: '14px',
+      color: '#2E5DD7',
+      fontWeight: 500
+    },
+    draftInput: {
+      width: '120px',
+      padding: '4px 8px',
+      border: 'none',
+      borderRadius: '4px',
+      background: 'white',
+      fontSize: '14px',
+      color: '#1A1F36',
+      '&:focus': {
+        outline: 'none'
+      }
+    },
+    draftConfirmButton: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '24px',
+      height: '24px',
+      minWidth: '24px',
+      borderRadius: '50%',
+      background: '#2E5DD7',
+      border: 'none',
+      color: 'white',
+      cursor: 'pointer',
+      padding: 0,
+      '&:hover': {
+        background: '#1E5189'
+      }
+    },
+    draftCancelButton: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '24px',
+      height: '24px',
+      minWidth: '24px',
+      borderRadius: '50%',
+      background: '#8B95A5',
+      border: 'none',
+      color: 'white',
+      cursor: 'pointer',
+      padding: 0,
+      '&:hover': {
+        background: '#697386'
+      }
+    },
+    // Draft filter pill (enum mode)
+    enumOptions: {
+      display: 'flex',
+      gap: '4px'
+    },
+    enumOptionButton: {
+      padding: '4px 10px',
+      background: 'white',
+      border: '1px solid #E5E7EB',
+      borderRadius: '4px',
+      fontSize: '13px',
+      color: '#374151',
+      cursor: 'pointer',
+      minWidth: 'auto',
+      textTransform: 'none',
+      '&:hover': {
+        background: '#F3F4F6',
+        borderColor: '#D1D5DB'
+      }
+    },
+    // Add filter button - rounded to hint it creates a pill
+    addFilterButton: {
+      border: '1px dashed #C9CED6',
+      borderRadius: '100px',
+      padding: `${theme.spacing(0.5)} ${theme.spacing(1.5)}`,
+      color: '#697386',
+      fontSize: '14px',
+      textTransform: 'none',
+      '&:hover': {
+        borderColor: '#8B95A5',
+        backgroundColor: '#F7F8FA'
+      },
+      '&.Mui-disabled': {
+        border: '1px dashed #E5E7EB',
+        color: '#C9CED6'
+      }
+    },
+    filterMenu: {
+      '& .MuiPaper-root': {
+        borderRadius: '4px',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+        minWidth: '240px',
+        maxHeight: '320px'
+      }
+    },
+    menuSearchInput: {
+      fontSize: '14px',
+      padding: '8px 12px',
+      background: '#F7F8FA',
+      borderRadius: '4px',
+      '& input::placeholder': {
+        color: '#9CA3AF'
+      }
+    },
+    filterMenuLabel: {
+      fontSize: '11px',
+      fontWeight: 600,
+      textTransform: 'uppercase',
+      letterSpacing: '0.5px',
+      color: '#8B95A5',
+      padding: theme.spacing(0.5, 1.5, 1)
+    },
+    filterMenuItem: {
+      fontSize: '14px',
+      padding: theme.spacing(1.25, 1.5),
+      display: 'flex',
+      justifyContent: 'space-between',
+      '&:hover': {
+        backgroundColor: '#F7F8FA'
+      }
+    },
+    filterMenuItemType: {
+      fontSize: '12px',
+      color: '#9CA3AF'
+    },
+
+    // ==========================================================================
+    // Filter Sidebar Styles
+    // ==========================================================================
+
+    // Main sidebar container
+    filterSidebar: {
+      width: '340px',
+      minWidth: '340px',
+      borderRight: '1px solid #D8D8D8',
+      backgroundColor: '#FAFAFA',
+      padding: theme.spacing(3),
+      overflowY: 'auto'
+    },
+
+    // Sidebar header
+    filterSidebarHeader: {
+      fontSize: '13px',
+      fontWeight: 600,
+      textTransform: 'uppercase',
+      letterSpacing: '0.5px',
+      color: '#464341',
+      marginBottom: theme.spacing(1.5)
+    },
+
+    // Search input container
+    filterSearchContainer: {
+      marginBottom: theme.spacing(1)
+    },
+
+    // Search input
+    filterSearchInput: {
+      fontSize: '14px',
+      padding: '8px 12px',
+      background: '#F7F8FA',
+      borderRadius: '4px',
+      border: '1px solid transparent',
+      '&:focus-within': {
+        borderColor: '#2E5DD7',
+        background: '#FFFFFF'
+      },
+      '& input::placeholder': {
+        color: '#9CA3AF'
+      }
+    },
+
+    // Container for filter groups
+    filterGroupsContainer: {
+      flex: 1,
+      overflowY: 'auto'
+    },
+
+    // Group header (collapsible)
+    filterGroupHeader: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: theme.spacing(1, 0),
+      cursor: 'pointer',
+      fontWeight: 600,
+      fontSize: '13px',
+      textTransform: 'uppercase',
+      letterSpacing: '0.5px',
+      color: '#464341',
+      '&:hover': {
+        color: '#292929'
+      }
+    },
+
+    // Clear filters button
+    clearFiltersButton: {
+      color: '#697386',
+      fontSize: '14px',
+      textTransform: 'none',
+      '&:hover': {
+        color: '#D8292F',
+        backgroundColor: 'transparent'
+      }
+    },
+
+    // ==========================================================================
+    // Filter Checkbox Styles
+    // ==========================================================================
+
+    // Checkbox container
+    filterCheckboxContainer: {
+      padding: theme.spacing(0.5, 0)
+    },
+
+    // Value badge (shown when filter is active)
+    filterValueBadge: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '2px 8px',
+      background: '#F1F8FE',
+      border: '1px solid #D4DEFF',
+      borderRadius: '4px',
+      fontSize: '13px',
+      color: '#2E5DD7'
+    },
+
+    // Value input container
+    filterValueInputContainer: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+      marginLeft: theme.spacing(3.5),
+      marginTop: theme.spacing(0.5)
+    },
+
+    // Value input field
+    filterValueInput: {
+      padding: '6px 8px',
+      fontSize: '14px',
+      border: '1px solid #D8D8D8',
+      borderRadius: '4px',
+      width: '140px',
+      '&:focus-within': {
+        borderColor: '#2E5DD7'
+      }
+    },
+
+    // Confirm button for filter value
+    filterConfirmButton: {
+      width: '24px',
+      height: '24px',
+      minWidth: '24px',
+      borderRadius: '50%',
+      background: '#2E5DD7',
+      color: 'white',
+      '&:hover': {
+        background: '#1E5189'
+      }
+    },
+
+    // Cancel button for filter value
+    filterCancelButton: {
+      width: '24px',
+      height: '24px',
+      minWidth: '24px',
+      borderRadius: '50%',
+      background: '#8B95A5',
+      color: 'white',
+      '&:hover': {
+        background: '#697386'
+      }
+    }
+  };
+};

--- a/app/src/features/submissions/list/PropertyFilter.test.tsx
+++ b/app/src/features/submissions/list/PropertyFilter.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { FeaturePropertyCode } from 'interfaces/useCodesApi.interface';
+import { IPropertyFilter } from 'interfaces/useSearchApi.interface';
+import { render } from 'test-helpers/test-utils';
+import PropertyFilter from './PropertyFilter';
+
+const mockOnChange = vi.fn();
+const mockOnRemove = vi.fn();
+
+const mockProperties: FeaturePropertyCode[] = [
+  {
+    feature_property_id: 1,
+    feature_property_name: 'scientific_name',
+    feature_property_display_name: 'Scientific Name',
+    feature_property_type_id: 1,
+    feature_property_type_name: 'string'
+  },
+  {
+    feature_property_id: 2,
+    feature_property_name: 'description',
+    feature_property_display_name: 'Description',
+    feature_property_type_id: 1,
+    feature_property_type_name: 'string'
+  },
+  {
+    feature_property_id: 3,
+    feature_property_name: 'taxon_id',
+    feature_property_display_name: 'Taxonomic Identifier',
+    feature_property_type_id: 2,
+    feature_property_type_name: 'number'
+  }
+];
+
+const renderComponent = (filter: IPropertyFilter, availableProperties = mockProperties) =>
+  render(
+    <PropertyFilter
+      filter={filter}
+      availableProperties={availableProperties}
+      onChange={mockOnChange}
+      onRemove={mockOnRemove}
+    />
+  );
+
+describe('PropertyFilter', () => {
+  beforeEach(() => {
+    mockOnChange.mockClear();
+    mockOnRemove.mockClear();
+  });
+
+  describe('Rendering', () => {
+    it('should render property dropdown and value input', async () => {
+      const { getByLabelText, getByPlaceholderText } = renderComponent({
+        featureTypeName: 'animal',
+        propertyName: '',
+        propertyType: 'string',
+        value: ''
+      });
+
+      await waitFor(() => {
+        expect(getByLabelText('Property')).toBeVisible();
+        expect(getByPlaceholderText('Enter value')).toBeVisible();
+      });
+    });
+
+    it('should render remove button', async () => {
+      const { getByRole } = renderComponent({
+        featureTypeName: 'animal',
+        propertyName: '',
+        propertyType: 'string',
+        value: ''
+      });
+
+      await waitFor(() => {
+        expect(getByRole('button', { name: /remove filter/i })).toBeVisible();
+      });
+    });
+
+    it('should display selected property', async () => {
+      const { getByDisplayValue } = renderComponent({
+        featureTypeName: 'animal',
+        propertyName: 'scientific_name',
+        propertyType: 'string',
+        value: ''
+      });
+
+      await waitFor(() => {
+        expect(getByDisplayValue('Scientific Name')).toBeVisible();
+      });
+    });
+
+    it('should display filter value', async () => {
+      const { getByDisplayValue } = renderComponent({
+        featureTypeName: 'animal',
+        propertyName: '',
+        propertyType: 'string',
+        value: 'Moose'
+      });
+
+      await waitFor(() => {
+        expect(getByDisplayValue('Moose')).toBeVisible();
+      });
+    });
+  });
+
+  describe('Interactions', () => {
+    it('should call onChange when value is entered', async () => {
+      const { getByPlaceholderText } = renderComponent({
+        featureTypeName: 'animal',
+        propertyName: 'scientific_name',
+        propertyType: 'string',
+        value: ''
+      });
+
+      const valueInput = getByPlaceholderText('Enter value');
+      fireEvent.change(valueInput, { target: { value: 'Alces alces' } });
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        featureTypeName: 'animal',
+        propertyName: 'scientific_name',
+        propertyType: 'string',
+        value: 'Alces alces'
+      });
+    });
+
+    it('should call onRemove when remove button clicked', async () => {
+      const { getByRole } = renderComponent({
+        featureTypeName: 'animal',
+        propertyName: '',
+        propertyType: 'string',
+        value: ''
+      });
+
+      const removeBtn = getByRole('button', { name: /remove filter/i });
+      fireEvent.click(removeBtn);
+
+      expect(mockOnRemove).toHaveBeenCalled();
+    });
+
+    it('should call onChange when property is selected', async () => {
+      const { getByLabelText, getByText } = renderComponent({
+        featureTypeName: 'animal',
+        propertyName: '',
+        propertyType: 'string',
+        value: 'test'
+      });
+
+      // Open the autocomplete dropdown
+      const autocomplete = getByLabelText('Property');
+      fireEvent.mouseDown(autocomplete);
+
+      // Select an option
+      await waitFor(() => {
+        const option = getByText('Description');
+        fireEvent.click(option);
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        featureTypeName: 'animal',
+        propertyName: 'description',
+        propertyType: 'string',
+        value: 'test'
+      });
+    });
+  });
+});

--- a/app/src/features/submissions/list/PropertyFilter.tsx
+++ b/app/src/features/submissions/list/PropertyFilter.tsx
@@ -1,0 +1,66 @@
+import { mdiClose } from '@mdi/js';
+import Icon from '@mdi/react';
+import Autocomplete from '@mui/material/Autocomplete';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { FeaturePropertyCode } from 'interfaces/useCodesApi.interface';
+import { IPropertyFilter } from 'interfaces/useSearchApi.interface';
+
+export interface IPropertyFilterProps {
+  filter: IPropertyFilter;
+  availableProperties: FeaturePropertyCode[];
+  onChange: (filter: IPropertyFilter) => void;
+  onRemove: () => void;
+}
+
+/**
+ * A single property filter row with property name dropdown and value input.
+ *
+ * @param {IPropertyFilterProps} props
+ * @returns {JSX.Element}
+ */
+export const PropertyFilter = (props: IPropertyFilterProps) => {
+  const { filter, availableProperties, onChange, onRemove } = props;
+
+  // Find the currently selected property for display
+  const selectedProperty = availableProperties.find((p) => p.feature_property_name === filter.propertyName) || null;
+
+  return (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Autocomplete
+        size="small"
+        sx={{ minWidth: 200 }}
+        options={availableProperties}
+        getOptionLabel={(option) => option.feature_property_display_name}
+        value={selectedProperty}
+        onChange={(_, newValue) => {
+          onChange({
+            ...filter,
+            propertyName: newValue?.feature_property_name || ''
+          });
+        }}
+        renderInput={(params) => <TextField {...params} label="Property" placeholder="Select property" />}
+        isOptionEqualToValue={(option, value) => option.feature_property_name === value.feature_property_name}
+      />
+      <TextField
+        size="small"
+        sx={{ minWidth: 200 }}
+        label="Value"
+        placeholder="Enter value"
+        value={filter.value}
+        onChange={(e) => {
+          onChange({
+            ...filter,
+            value: e.target.value
+          });
+        }}
+      />
+      <IconButton size="small" onClick={onRemove} aria-label="Remove filter">
+        <Icon path={mdiClose} size={0.875} />
+      </IconButton>
+    </Stack>
+  );
+};
+
+export default PropertyFilter;

--- a/app/src/features/submissions/list/PropertyFilterList.test.tsx
+++ b/app/src/features/submissions/list/PropertyFilterList.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { FeaturePropertyCode } from 'interfaces/useCodesApi.interface';
+import { IPropertyFilter } from 'interfaces/useSearchApi.interface';
+import { render } from 'test-helpers/test-utils';
+import PropertyFilterList from './PropertyFilterList';
+
+const mockOnChange = vi.fn();
+
+const mockProperties: FeaturePropertyCode[] = [
+  {
+    feature_property_id: 1,
+    feature_property_name: 'scientific_name',
+    feature_property_display_name: 'Scientific Name',
+    feature_property_type_id: 1,
+    feature_property_type_name: 'string'
+  },
+  {
+    feature_property_id: 2,
+    feature_property_name: 'description',
+    feature_property_display_name: 'Description',
+    feature_property_type_id: 1,
+    feature_property_type_name: 'string'
+  }
+];
+
+const renderComponent = (filters: IPropertyFilter[], availableProperties = mockProperties) =>
+  render(<PropertyFilterList filters={filters} availableProperties={availableProperties} onChange={mockOnChange} />);
+
+describe('PropertyFilterList', () => {
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  describe('Rendering', () => {
+    it('should render filter rows for each filter', async () => {
+      const filters: IPropertyFilter[] = [
+        { featureTypeName: 'animal', propertyName: 'scientific_name', propertyType: 'string', value: 'Moose' },
+        { featureTypeName: 'animal', propertyName: 'description', propertyType: 'string', value: 'Wildlife' }
+      ];
+      const { getByDisplayValue } = renderComponent(filters);
+
+      await waitFor(() => {
+        expect(getByDisplayValue('Moose')).toBeVisible();
+        expect(getByDisplayValue('Wildlife')).toBeVisible();
+      });
+    });
+
+    it('should render nothing visible when no filters', async () => {
+      const { container } = renderComponent([]);
+
+      await waitFor(() => {
+        // The Collapse component hides content when no filters
+        expect(container.querySelector('.MuiCollapse-hidden')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Remove Filter', () => {
+    it('should call onChange without removed filter', async () => {
+      const filters: IPropertyFilter[] = [
+        { featureTypeName: 'animal', propertyName: 'scientific_name', propertyType: 'string', value: 'test1' },
+        { featureTypeName: 'animal', propertyName: 'description', propertyType: 'string', value: 'test2' }
+      ];
+      const { getAllByRole } = renderComponent(filters);
+
+      // Click first remove button
+      const removeButtons = getAllByRole('button', { name: /remove filter/i });
+      fireEvent.click(removeButtons[0]);
+
+      expect(mockOnChange).toHaveBeenCalledWith([
+        { featureTypeName: 'animal', propertyName: 'description', propertyType: 'string', value: 'test2' }
+      ]);
+    });
+
+    it('should call onChange with empty array when last filter removed', async () => {
+      const filters: IPropertyFilter[] = [
+        { featureTypeName: 'animal', propertyName: 'scientific_name', propertyType: 'string', value: 'test' }
+      ];
+      const { getByRole } = renderComponent(filters);
+
+      const removeBtn = getByRole('button', { name: /remove filter/i });
+      fireEvent.click(removeBtn);
+
+      expect(mockOnChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('Update Filter', () => {
+    it('should call onChange with updated filter value', async () => {
+      const filters: IPropertyFilter[] = [
+        { featureTypeName: 'animal', propertyName: 'scientific_name', propertyType: 'string', value: '' }
+      ];
+      const { getByPlaceholderText } = renderComponent(filters);
+
+      const valueInput = getByPlaceholderText('Enter value');
+      fireEvent.change(valueInput, { target: { value: 'Alces alces' } });
+
+      expect(mockOnChange).toHaveBeenCalledWith([
+        { featureTypeName: 'animal', propertyName: 'scientific_name', propertyType: 'string', value: 'Alces alces' }
+      ]);
+    });
+  });
+});

--- a/app/src/features/submissions/list/PropertyFilterList.tsx
+++ b/app/src/features/submissions/list/PropertyFilterList.tsx
@@ -1,0 +1,53 @@
+import Box from '@mui/material/Box';
+import Collapse from '@mui/material/Collapse';
+import Stack from '@mui/material/Stack';
+import PropertyFilter from 'features/submissions/list/PropertyFilter';
+import { FeaturePropertyCode } from 'interfaces/useCodesApi.interface';
+import { IPropertyFilter } from 'interfaces/useSearchApi.interface';
+
+export interface IPropertyFilterListProps {
+  filters: IPropertyFilter[];
+  availableProperties: FeaturePropertyCode[];
+  onChange: (filters: IPropertyFilter[]) => void;
+}
+
+/**
+ * Renders a list of property filters with update/remove functionality.
+ *
+ * @param {IPropertyFilterListProps} props
+ * @returns {JSX.Element}
+ */
+export const PropertyFilterList = (props: IPropertyFilterListProps) => {
+  const { filters, availableProperties, onChange } = props;
+
+  const handleUpdateFilter = (index: number, updatedFilter: IPropertyFilter) => {
+    const newFilters = [...filters];
+    newFilters[index] = updatedFilter;
+    onChange(newFilters);
+  };
+
+  const handleRemoveFilter = (index: number) => {
+    const newFilters = filters.filter((_, i) => i !== index);
+    onChange(newFilters);
+  };
+
+  return (
+    <Box>
+      <Collapse in={filters.length > 0}>
+        <Stack spacing={1}>
+          {filters.map((filter, index) => (
+            <PropertyFilter
+              key={index}
+              filter={filter}
+              availableProperties={availableProperties}
+              onChange={(updatedFilter) => handleUpdateFilter(index, updatedFilter)}
+              onRemove={() => handleRemoveFilter(index)}
+            />
+          ))}
+        </Stack>
+      </Collapse>
+    </Box>
+  );
+};
+
+export default PropertyFilterList;

--- a/app/src/features/submissions/list/PropertyFilterList.tsx
+++ b/app/src/features/submissions/list/PropertyFilterList.tsx
@@ -37,7 +37,7 @@ export const PropertyFilterList = (props: IPropertyFilterListProps) => {
         <Stack spacing={1}>
           {filters.map((filter, index) => (
             <PropertyFilter
-              key={index}
+              key={`${filter.featureTypeName}-${filter.propertyName}-${index}`}
               filter={filter}
               availableProperties={availableProperties}
               onChange={(updatedFilter) => handleUpdateFilter(index, updatedFilter)}

--- a/app/src/features/submissions/list/SearchResultsList.test.tsx
+++ b/app/src/features/submissions/list/SearchResultsList.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { SearchFeatureResult } from 'interfaces/useSearchApi.interface';
+import { render } from 'test-helpers/test-utils';
+import SearchResultsList from './SearchResultsList';
+
+const mockOnDownload = vi.fn();
+const mockOnAccessRequest = vi.fn();
+
+const renderComponent = (results: SearchFeatureResult[]) =>
+  render(<SearchResultsList results={results} onDownload={mockOnDownload} onAccessRequest={mockOnAccessRequest} />);
+
+const createMockResult = (overrides: Partial<SearchFeatureResult> = {}): SearchFeatureResult => ({
+  submission_feature_id: 1,
+  submission_id: 10,
+  uuid: '550e8400-e29b-41d4-a716-446655440001',
+  feature_type_id: 1,
+  feature_type_name: 'dataset',
+  feature_name: 'Test Feature',
+  feature_description: 'A test feature description',
+  submission_name: 'Test Submission',
+  is_secured: false,
+  relevancy_score: 0.85,
+  ...overrides
+});
+
+describe('SearchResultsList', () => {
+  beforeEach(() => {
+    mockOnDownload.mockClear();
+    mockOnAccessRequest.mockClear();
+  });
+
+  describe('Empty State', () => {
+    it('should render empty state when no results', async () => {
+      const { getByTestId, getByText } = renderComponent([]);
+
+      await waitFor(() => {
+        expect(getByTestId('no-search-results')).toBeVisible();
+        expect(getByText('No features found')).toBeVisible();
+        expect(getByText(/Try different keywords/i)).toBeVisible();
+      });
+    });
+  });
+
+  describe('Feature Card Rendering', () => {
+    it('should render feature name', async () => {
+      const result = createMockResult({ feature_name: 'Moose Population Study' });
+      const { getByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByText('Moose Population Study')).toBeVisible();
+      });
+    });
+
+    it('should render fallback name when feature_name is null', async () => {
+      const result = createMockResult({ feature_name: null, submission_feature_id: 42 });
+      const { getByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByText('Feature #42')).toBeVisible();
+      });
+    });
+
+    it('should render feature type chip', async () => {
+      const result = createMockResult({ feature_type_name: 'observation' });
+      const { getByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByText('observation')).toBeVisible();
+      });
+    });
+
+    it('should render parent submission name', async () => {
+      const result = createMockResult({ submission_name: 'Wildlife Survey 2024' });
+      const { getByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByText('From: Wildlife Survey 2024')).toBeVisible();
+      });
+    });
+
+    it('should render feature description when present', async () => {
+      const result = createMockResult({ feature_description: 'Detailed description of the feature' });
+      const { getByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByText('Detailed description of the feature')).toBeVisible();
+      });
+    });
+
+    it('should not render description when null', async () => {
+      const result = createMockResult({ feature_description: null });
+      const { queryByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(queryByText('Detailed description')).toBeNull();
+      });
+    });
+
+    it('should render multiple results', async () => {
+      const results = [
+        createMockResult({ submission_feature_id: 1, feature_name: 'Feature One' }),
+        createMockResult({ submission_feature_id: 2, feature_name: 'Feature Two' }),
+        createMockResult({ submission_feature_id: 3, feature_name: 'Feature Three' })
+      ];
+      const { getByText } = renderComponent(results);
+
+      await waitFor(() => {
+        expect(getByText('Feature One')).toBeVisible();
+        expect(getByText('Feature Two')).toBeVisible();
+        expect(getByText('Feature Three')).toBeVisible();
+      });
+    });
+  });
+
+  describe('Secured vs Unsecured Display', () => {
+    it('should show Download button for unsecured features', async () => {
+      const result = createMockResult({ is_secured: false });
+      const { getByRole, queryByRole } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByRole('button', { name: /download/i })).toBeVisible();
+        expect(queryByRole('button', { name: /request access/i })).toBeNull();
+      });
+    });
+
+    it('should show Request Access button for secured features', async () => {
+      const result = createMockResult({ is_secured: true });
+      const { getByRole, queryByRole } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByRole('button', { name: /request access/i })).toBeVisible();
+        expect(queryByRole('button', { name: /download/i })).toBeNull();
+      });
+    });
+
+    it('should show Secured chip for secured features', async () => {
+      const result = createMockResult({ is_secured: true });
+      const { getByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(getByText('Secured')).toBeVisible();
+      });
+    });
+
+    it('should not show Secured chip for unsecured features', async () => {
+      const result = createMockResult({ is_secured: false });
+      const { queryByText } = renderComponent([result]);
+
+      await waitFor(() => {
+        expect(queryByText('Secured')).toBeNull();
+      });
+    });
+  });
+
+  describe('Button Actions', () => {
+    it('should call onDownload when Download button clicked', async () => {
+      const result = createMockResult({ is_secured: false });
+      const { getByRole } = renderComponent([result]);
+
+      await waitFor(() => {
+        const downloadBtn = getByRole('button', { name: /download/i });
+        fireEvent.click(downloadBtn);
+      });
+
+      expect(mockOnDownload).toHaveBeenCalledWith(result);
+    });
+
+    it('should call onAccessRequest when Request Access button clicked', async () => {
+      const result = createMockResult({ is_secured: true });
+      const { getByRole } = renderComponent([result]);
+
+      await waitFor(() => {
+        const requestBtn = getByRole('button', { name: /request access/i });
+        fireEvent.click(requestBtn);
+      });
+
+      expect(mockOnAccessRequest).toHaveBeenCalledWith(result);
+    });
+  });
+});

--- a/app/src/features/submissions/list/SearchResultsList.tsx
+++ b/app/src/features/submissions/list/SearchResultsList.tsx
@@ -1,0 +1,171 @@
+import { mdiCommentOutline, mdiTextBoxSearchOutline, mdiTrayArrowDown } from '@mdi/js';
+import Icon from '@mdi/react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import Chip from '@mui/material/Chip';
+import { grey } from '@mui/material/colors';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/system/Stack';
+import { SearchFeatureResult } from 'interfaces/useSearchApi.interface';
+
+export interface ISearchResultsListProps {
+  results: SearchFeatureResult[];
+  onDownload: (result: SearchFeatureResult) => void;
+  onAccessRequest: (result: SearchFeatureResult) => void;
+}
+
+/**
+ * Displays search results as feature-level cards with download/request access actions.
+ *
+ * @param {ISearchResultsListProps} props
+ * @returns {JSX.Element}
+ */
+export const SearchResultsList = (props: ISearchResultsListProps) => {
+  const { results, onDownload, onAccessRequest } = props;
+
+  if (results.length === 0) {
+    return (
+      <Stack alignItems="center" justifyContent="center" p={3} component={Paper} elevation={0} minHeight={168}>
+        <Box
+          sx={{
+            '& svg': {
+              color: 'text.secondary'
+            }
+          }}>
+          <Icon path={mdiTextBoxSearchOutline} size={2} />
+        </Box>
+        <Typography
+          data-testid="no-search-results"
+          component="h2"
+          variant="h4"
+          fontWeight={700}
+          sx={{
+            mb: 1
+          }}>
+          No features found
+        </Typography>
+        <Typography color="textSecondary">Try different keywords or check your spelling.</Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap={2}>
+      {results.map((result) => (
+        <Card elevation={0} key={result.submission_feature_id}>
+          <CardHeader
+            title={
+              <Typography
+                variant="h4"
+                sx={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: '2',
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis'
+                }}>
+                {result.feature_name || `Feature #${result.submission_feature_id}`}
+              </Typography>
+            }
+            action={
+              <Chip
+                label={result.feature_type_name}
+                size="small"
+                sx={{
+                  my: '-2px',
+                  fontSize: '12px',
+                  borderRadius: '4px',
+                  textTransform: 'uppercase'
+                }}
+              />
+            }
+            sx={{
+              pb: 1,
+              '& .MuiCardHeader-action': {
+                margin: 0
+              }
+            }}
+          />
+          <CardContent
+            sx={{
+              pt: 0
+            }}>
+            <Typography variant="body2" color="textSecondary" mb={1}>
+              From: {result.submission_name}
+            </Typography>
+            {result.feature_description && (
+              <Typography
+                variant="body1"
+                color="textSecondary"
+                sx={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: '2',
+                  WebkitBoxOrient: 'vertical',
+                  maxWidth: 800,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis'
+                }}>
+                {result.feature_description}
+              </Typography>
+            )}
+          </CardContent>
+          <CardActions
+            sx={{
+              px: 2,
+              py: 1.5,
+              borderTop: '1px solid' + grey[200]
+            }}>
+            <Stack
+              width="100%"
+              flexDirection={{ xs: 'column', sm: 'row' }}
+              flexWrap="wrap"
+              gap={1}
+              justifyContent="space-between">
+              <Stack flex="1 1 auto" my={1} alignItems="center" flexDirection="row">
+                {result.is_secured && (
+                  <Chip
+                    label="Secured"
+                    size="small"
+                    color="warning"
+                    sx={{
+                      fontSize: '12px',
+                      borderRadius: '4px'
+                    }}
+                  />
+                )}
+              </Stack>
+              <Stack flexDirection="row" alignItems="center" gap={1} flexWrap="nowrap">
+                {result.is_secured ? (
+                  <Button
+                    variant="contained"
+                    disableElevation
+                    startIcon={<Icon path={mdiCommentOutline} size={0.75} />}
+                    sx={{
+                      fontWeight: 700
+                    }}
+                    onClick={() => onAccessRequest(result)}>
+                    Request Access
+                  </Button>
+                ) : (
+                  <Button
+                    variant="contained"
+                    startIcon={<Icon path={mdiTrayArrowDown} size={0.75} />}
+                    onClick={() => onDownload(result)}>
+                    Download
+                  </Button>
+                )}
+              </Stack>
+            </Stack>
+          </CardActions>
+        </Card>
+      ))}
+    </Stack>
+  );
+};
+
+export default SearchResultsList;

--- a/app/src/features/submissions/list/SubmissionsList.tsx
+++ b/app/src/features/submissions/list/SubmissionsList.tsx
@@ -12,22 +12,18 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/system/Stack';
 import { DATE_FORMAT } from 'constants/dateTimeFormats';
-import { FuseResult } from 'fuse.js';
-import useFuzzySearch from 'hooks/useFuzzySearch';
 import { SECURITY_APPLIED_STATUS } from 'interfaces/useDatasetApi.interface';
 import { SubmissionRecordPublishedForPublic } from 'interfaces/useSubmissionsApi.interface';
 import { getFormattedDate } from 'utils/Utils';
 
 export interface ISubmissionsListProps {
-  submissions: FuseResult<SubmissionRecordPublishedForPublic>[];
-  onDownload: (submission: FuseResult<SubmissionRecordPublishedForPublic>) => void;
+  submissions: SubmissionRecordPublishedForPublic[];
+  onDownload: (submission: SubmissionRecordPublishedForPublic) => void;
   onAccessRequest: () => void;
 }
 
 const SubmissionsList = (props: ISubmissionsListProps) => {
   const { submissions, onDownload, onAccessRequest } = props;
-
-  const { highlight } = useFuzzySearch();
 
   if (submissions.length === 0) {
     return (
@@ -59,7 +55,7 @@ const SubmissionsList = (props: ISubmissionsListProps) => {
   return (
     <Stack gap={2}>
       {submissions?.map((submission) => (
-        <Card elevation={0} key={submission.item.submission_id}>
+        <Card elevation={0} key={submission.submission_id}>
           <CardHeader
             title={
               <Typography
@@ -72,12 +68,12 @@ const SubmissionsList = (props: ISubmissionsListProps) => {
                   overflow: 'hidden',
                   textOverflow: 'ellipsis'
                 }}>
-                {highlight(submission.item.name, submission?.matches?.find((match) => match.key === 'name')?.indices)}
+                {submission.name}
               </Typography>
             }
             action={
               <Chip
-                label={submission.item.root_feature_type_display_name}
+                label={submission.root_feature_type_display_name}
                 size="small"
                 sx={{
                   my: '-2px',
@@ -108,10 +104,7 @@ const SubmissionsList = (props: ISubmissionsListProps) => {
                 overflow: 'hidden',
                 textOverflow: 'ellipsis'
               }}>
-              {highlight(
-                submission.item.description,
-                submission?.matches?.find((match) => match.key === 'description')?.indices
-              )}
+              {submission.description}
             </Typography>
           </CardContent>
           <CardActions
@@ -143,15 +136,15 @@ const SubmissionsList = (props: ISubmissionsListProps) => {
                 <Stack flexDirection="row">
                   <dd>Published:</dd>
                   <dt>
-                    {submission.item.publish_timestamp
-                      ? getFormattedDate(DATE_FORMAT.ShortDateFormat, submission.item.publish_timestamp)
+                    {submission.publish_timestamp
+                      ? getFormattedDate(DATE_FORMAT.ShortDateFormat, submission.publish_timestamp)
                       : 'Unpublished'}
                   </dt>
                 </Stack>
               </Stack>
               <Stack flexDirection="row" alignItems="center" gap={1} flexWrap="nowrap">
-                {(submission.item.security === SECURITY_APPLIED_STATUS.SECURED ||
-                  submission.item.security === SECURITY_APPLIED_STATUS.PARTIALLY_SECURED) && (
+                {(submission.security === SECURITY_APPLIED_STATUS.SECURED ||
+                  submission.security === SECURITY_APPLIED_STATUS.PARTIALLY_SECURED) && (
                   <Button
                     variant={'contained'}
                     disableElevation
@@ -163,8 +156,8 @@ const SubmissionsList = (props: ISubmissionsListProps) => {
                     Request Access
                   </Button>
                 )}
-                {(submission.item.security === SECURITY_APPLIED_STATUS.UNSECURED ||
-                  submission.item.security === SECURITY_APPLIED_STATUS.PARTIALLY_SECURED) && (
+                {(submission.security === SECURITY_APPLIED_STATUS.UNSECURED ||
+                  submission.security === SECURITY_APPLIED_STATUS.PARTIALLY_SECURED) && (
                   <Button
                     variant="contained"
                     startIcon={<Icon path={mdiTrayArrowDown} size={0.75} />}

--- a/app/src/features/submissions/list/SubmissionsListPage.test.tsx
+++ b/app/src/features/submissions/list/SubmissionsListPage.test.tsx
@@ -42,7 +42,7 @@ describe('SubmissionsListPage', () => {
 
       await waitFor(() => {
         expect(actions.getByText(/biohub bc/i)).toBeVisible();
-        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+        expect(actions.getByPlaceholderText(/caribou/i)).toBeVisible();
       });
     });
 
@@ -83,7 +83,7 @@ describe('SubmissionsListPage', () => {
       mockUseApi.search.searchFeatures.mockResolvedValue(mockResults);
       const actions = renderPage();
 
-      const searchInput = actions.getByPlaceholderText(/search/i);
+      const searchInput = actions.getByPlaceholderText(/caribou/i);
       fireEvent.change(searchInput, { target: { value: 'test' } });
 
       await waitFor(
@@ -107,10 +107,10 @@ describe('SubmissionsListPage', () => {
       const actions = renderPage();
 
       await waitFor(() => {
-        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+        expect(actions.getByPlaceholderText(/caribou/i)).toBeVisible();
       });
 
-      const searchInput = actions.getByPlaceholderText(/search/i);
+      const searchInput = actions.getByPlaceholderText(/caribou/i);
       fireEvent.change(searchInput, { target: { value: 'ab' } });
 
       // Wait a bit longer than debounce delay to ensure it wouldn't trigger
@@ -124,10 +124,10 @@ describe('SubmissionsListPage', () => {
       const actions = renderPage();
 
       await waitFor(() => {
-        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+        expect(actions.getByPlaceholderText(/caribou/i)).toBeVisible();
       });
 
-      const searchInput = actions.getByPlaceholderText(/search/i);
+      const searchInput = actions.getByPlaceholderText(/caribou/i);
       fireEvent.change(searchInput, { target: { value: 'moose' } });
 
       // Wait for debounce to complete
@@ -158,10 +158,10 @@ describe('SubmissionsListPage', () => {
       const actions = renderPage();
 
       await waitFor(() => {
-        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+        expect(actions.getByPlaceholderText(/caribou/i)).toBeVisible();
       });
 
-      const searchInput = actions.getByPlaceholderText(/search/i);
+      const searchInput = actions.getByPlaceholderText(/caribou/i);
       fireEvent.change(searchInput, { target: { value: 'moose' } });
 
       await waitFor(
@@ -194,10 +194,10 @@ describe('SubmissionsListPage', () => {
       const actions = renderPage();
 
       await waitFor(() => {
-        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+        expect(actions.getByPlaceholderText(/caribou/i)).toBeVisible();
       });
 
-      const searchInput = actions.getByPlaceholderText(/search/i);
+      const searchInput = actions.getByPlaceholderText(/caribou/i);
       fireEvent.change(searchInput, { target: { value: 'sensitive' } });
 
       await waitFor(
@@ -213,10 +213,10 @@ describe('SubmissionsListPage', () => {
       const actions = renderPage();
 
       await waitFor(() => {
-        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+        expect(actions.getByPlaceholderText(/caribou/i)).toBeVisible();
       });
 
-      const searchInput = actions.getByPlaceholderText(/search/i);
+      const searchInput = actions.getByPlaceholderText(/caribou/i);
       fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
 
       await waitFor(
@@ -239,7 +239,7 @@ describe('SubmissionsListPage', () => {
       });
 
       // Enter search term
-      const searchInput = actions.getByPlaceholderText(/search/i);
+      const searchInput = actions.getByPlaceholderText(/caribou/i);
       fireEvent.change(searchInput, { target: { value: 'test' } });
 
       await waitFor(

--- a/app/src/features/submissions/list/SubmissionsListPage.test.tsx
+++ b/app/src/features/submissions/list/SubmissionsListPage.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { useApi } from 'hooks/useApi';
-import { SECURITY_APPLIED_STATUS } from 'interfaces/useDatasetApi.interface';
+import { SearchFeatureResult } from 'interfaces/useSearchApi.interface';
 import { MemoryRouter } from 'react-router';
 import { render } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
@@ -16,8 +16,11 @@ const renderPage = () =>
 vi.mock('../../../hooks/useApi');
 
 const mockUseApi = {
-  submissions: {
-    getPublishedSubmissions: vi.fn()
+  search: {
+    searchFeatures: vi.fn()
+  },
+  codes: {
+    getAllCodeSets: vi.fn()
   }
 };
 
@@ -26,6 +29,7 @@ const mockBiohubApi = useApi as Mock;
 describe('SubmissionsListPage', () => {
   beforeEach(() => {
     mockBiohubApi.mockImplementation(() => mockUseApi);
+    mockUseApi.codes.getAllCodeSets.mockResolvedValue({ feature_type_with_properties: [] });
   });
 
   afterEach(() => {
@@ -33,65 +37,21 @@ describe('SubmissionsListPage', () => {
   });
 
   describe('Mounting', () => {
-    it('should render page', async () => {
-      mockUseApi.submissions.getPublishedSubmissions.mockResolvedValue([]);
+    it('should render page with search input', async () => {
       const actions = renderPage();
 
       await waitFor(() => {
         expect(actions.getByText(/biohub bc/i)).toBeVisible();
-        expect(actions.getByPlaceholderText(/keyword/i)).toBeVisible();
+        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
       });
     });
 
-    it('should render skeleton loaders', async () => {
-      mockUseApi.submissions.getPublishedSubmissions.mockResolvedValue([]);
+    it('should render empty state prompting to search', async () => {
       const actions = renderPage();
 
       await waitFor(() => {
-        expect(actions.getByTestId('records-found-skeleton')).toBeVisible();
-        expect(actions.getByTestId('submission-card-skeleton')).toBeVisible();
-      });
-
-      await waitFor(() => {
-        expect(actions.getByText(/0 records found/i)).toBeVisible();
-      });
-    });
-  });
-
-  describe('Submission Cards', () => {
-    it('should render submission card with download button when unsecured', async () => {
-      mockUseApi.submissions.getPublishedSubmissions.mockResolvedValue([
-        { submission_id: 1, security: SECURITY_APPLIED_STATUS.UNSECURED }
-      ]);
-      const actions = renderPage();
-
-      await waitFor(() => {
-        expect(actions.getByRole('button', { name: /download/i })).toBeVisible();
-        expect(actions.queryByRole('button', { name: /request access/i })).toBeNull();
-      });
-    });
-
-    it('should render submission card with request access button when secured', async () => {
-      mockUseApi.submissions.getPublishedSubmissions.mockResolvedValue([
-        { submission_id: 1, security: SECURITY_APPLIED_STATUS.SECURED }
-      ]);
-      const actions = renderPage();
-
-      await waitFor(() => {
-        expect(actions.getByRole('button', { name: /request access/i })).toBeVisible();
-        expect(actions.queryByRole('button', { name: /download/i })).toBeNull();
-      });
-    });
-
-    it('should render submission card with request access and download button when partially secured', async () => {
-      mockUseApi.submissions.getPublishedSubmissions.mockResolvedValue([
-        { submission_id: 1, security: SECURITY_APPLIED_STATUS.PARTIALLY_SECURED }
-      ]);
-      const actions = renderPage();
-
-      await waitFor(() => {
-        expect(actions.getByRole('button', { name: /request access/i })).toBeVisible();
-        expect(actions.getByRole('button', { name: /download/i })).toBeVisible();
+        expect(actions.getByText(/search to find data/i)).toBeVisible();
+        expect(actions.getByText(/enter keywords, add filters, or both/i)).toBeVisible();
       });
     });
   });
@@ -105,20 +65,195 @@ describe('SubmissionsListPage', () => {
       });
     });
 
-    it('should open dialog on request access button click', async () => {
-      mockUseApi.submissions.getPublishedSubmissions.mockResolvedValue([
-        { submission_id: 1, security: SECURITY_APPLIED_STATUS.SECURED }
-      ]);
+    it('should open dialog on request access button click from search results', async () => {
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Secured Feature',
+          feature_description: null,
+          submission_name: 'Test Submission',
+          is_secured: true,
+          relevancy_score: 0.85
+        }
+      ];
+      mockUseApi.search.searchFeatures.mockResolvedValue(mockResults);
+      const actions = renderPage();
+
+      const searchInput = actions.getByPlaceholderText(/search/i);
+      fireEvent.change(searchInput, { target: { value: 'test' } });
+
+      await waitFor(
+        () => {
+          const requestAccessBtn = actions.getByRole('button', { name: /request access/i });
+          expect(requestAccessBtn).toBeVisible();
+          fireEvent.click(requestAccessBtn);
+          expect(actions.getByText(/secure data access request/i)).toBeVisible();
+        },
+        { timeout: 1000 }
+      );
+    });
+  });
+
+  describe('Search Functionality', () => {
+    beforeEach(() => {
+      mockUseApi.search.searchFeatures.mockReset();
+    });
+
+    it('should not trigger search API for input less than 3 characters', async () => {
       const actions = renderPage();
 
       await waitFor(() => {
-        const requestAccessBtn = actions.getByRole('button', { name: /request access/i });
+        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+      });
 
-        expect(requestAccessBtn).toBeVisible();
+      const searchInput = actions.getByPlaceholderText(/search/i);
+      fireEvent.change(searchInput, { target: { value: 'ab' } });
 
-        fireEvent.click(requestAccessBtn);
+      // Wait a bit longer than debounce delay to ensure it wouldn't trigger
+      await new Promise((resolve) => setTimeout(resolve, 400));
 
-        expect(actions.getByText(/secure data access request/i)).toBeVisible();
+      expect(mockUseApi.search.searchFeatures).not.toHaveBeenCalled();
+    });
+
+    it('should trigger search API after 3+ characters and debounce delay', async () => {
+      mockUseApi.search.searchFeatures.mockResolvedValue([]);
+      const actions = renderPage();
+
+      await waitFor(() => {
+        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+      });
+
+      const searchInput = actions.getByPlaceholderText(/search/i);
+      fireEvent.change(searchInput, { target: { value: 'moose' } });
+
+      // Wait for debounce to complete
+      await waitFor(
+        () => {
+          expect(mockUseApi.search.searchFeatures).toHaveBeenCalledWith({ keywords: 'moose' });
+        },
+        { timeout: 1000 }
+      );
+    });
+
+    it('should display search results with feature information', async () => {
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Population Study',
+          feature_description: 'A comprehensive study of moose populations',
+          submission_name: 'Wildlife Survey 2024',
+          is_secured: false,
+          relevancy_score: 0.85
+        }
+      ];
+      mockUseApi.search.searchFeatures.mockResolvedValue(mockResults);
+      const actions = renderPage();
+
+      await waitFor(() => {
+        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+      });
+
+      const searchInput = actions.getByPlaceholderText(/search/i);
+      fireEvent.change(searchInput, { target: { value: 'moose' } });
+
+      await waitFor(
+        () => {
+          expect(actions.getByText('Moose Population Study')).toBeVisible();
+          expect(actions.getByText(/dataset/i)).toBeVisible();
+          expect(actions.getByText(/Wildlife Survey 2024/i)).toBeVisible();
+          expect(actions.getByText('1 feature found')).toBeVisible();
+        },
+        { timeout: 1000 }
+      );
+    });
+
+    it('should display secured indicator for secured features', async () => {
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 2,
+          submission_id: 11,
+          uuid: '550e8400-e29b-41d4-a716-446655440002',
+          feature_type_id: 2,
+          feature_type_name: 'observation',
+          feature_name: 'Sensitive Species Observation',
+          feature_description: null,
+          submission_name: 'Protected Areas Survey',
+          is_secured: true,
+          relevancy_score: 0.7
+        }
+      ];
+      mockUseApi.search.searchFeatures.mockResolvedValue(mockResults);
+      const actions = renderPage();
+
+      await waitFor(() => {
+        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+      });
+
+      const searchInput = actions.getByPlaceholderText(/search/i);
+      fireEvent.change(searchInput, { target: { value: 'sensitive' } });
+
+      await waitFor(
+        () => {
+          expect(actions.getByText(/Secured/i)).toBeVisible();
+        },
+        { timeout: 1000 }
+      );
+    });
+
+    it('should display empty results message when no features found', async () => {
+      mockUseApi.search.searchFeatures.mockResolvedValue([]);
+      const actions = renderPage();
+
+      await waitFor(() => {
+        expect(actions.getByPlaceholderText(/search/i)).toBeVisible();
+      });
+
+      const searchInput = actions.getByPlaceholderText(/search/i);
+      fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
+
+      await waitFor(
+        () => {
+          expect(actions.getByText('No features found')).toBeVisible();
+          expect(actions.getByText(/Try different keywords/i)).toBeVisible();
+          expect(actions.getByText('0 features found')).toBeVisible();
+        },
+        { timeout: 1000 }
+      );
+    });
+
+    it('should return to empty state when search cleared below 3 characters', async () => {
+      mockUseApi.search.searchFeatures.mockResolvedValue([]);
+      const actions = renderPage();
+
+      // Wait for initial empty state
+      await waitFor(() => {
+        expect(actions.getByText(/search to find data/i)).toBeVisible();
+      });
+
+      // Enter search term
+      const searchInput = actions.getByPlaceholderText(/search/i);
+      fireEvent.change(searchInput, { target: { value: 'test' } });
+
+      await waitFor(
+        () => {
+          expect(actions.getByText('0 features found')).toBeVisible();
+        },
+        { timeout: 1000 }
+      );
+
+      // Clear search below threshold
+      fireEvent.change(searchInput, { target: { value: 'te' } });
+
+      await waitFor(() => {
+        expect(actions.getByText(/search to find data/i)).toBeVisible();
       });
     });
   });

--- a/app/src/features/submissions/list/SubmissionsListPage.tsx
+++ b/app/src/features/submissions/list/SubmissionsListPage.tsx
@@ -280,7 +280,7 @@ const SubmissionsListPage = () => {
             <Typography mb={1} variant="h1" sx={{ color: '#013366' }}>
               BioHub BC
             </Typography>
-            <Typography variant="body1" color="textSecondary">
+            <Typography color="textSecondary">
               Open access to British Columbia's terrestrial, aquatic species and habitat inventory data.
             </Typography>
           </Box>

--- a/app/src/features/submissions/list/SubmissionsListPage.tsx
+++ b/app/src/features/submissions/list/SubmissionsListPage.tsx
@@ -1,45 +1,205 @@
+import { mdiClose } from '@mdi/js';
+import { Icon } from '@mdi/react';
 import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
-import Paper from '@mui/material/Paper';
+import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import RecordsFoundSkeletonLoader from 'components/skeleton/submission-card/RecordsFoundSkeletonLoader';
 import SubmissionCardSkeletonLoader from 'components/skeleton/submission-card/SubmissionCardSkeletonLoader';
-import { SearchInput } from 'features/search/SearchComponent';
-import SubmissionsList from 'features/submissions/list/SubmissionsList';
-import SubmissionsListSortMenu from 'features/submissions/list/SubmissionsListSortMenu';
+import {
+  ActiveFilter,
+  FilterSidebar,
+  FilterGroupType,
+  SearchInput,
+  useSearchFilterStyles
+} from 'components/search-filter';
+import SearchResultsList from 'features/submissions/list/SearchResultsList';
 import SecureDataAccessRequestDialog from 'features/submissions/page/security/SecureDataAccessRequestDialog';
-import { FuseResult } from 'fuse.js';
 import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
 import useDownload from 'hooks/useDownload';
-import useFuzzySearch from 'hooks/useFuzzySearch';
-import { SubmissionRecordPublishedForPublic } from 'interfaces/useSubmissionsApi.interface';
-import { useState } from 'react';
+import { IPropertyFilter, ISearchFeaturesRequest, SearchFeatureResult } from 'interfaces/useSearchApi.interface';
+import { debounce } from 'lodash-es';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { pluralize as p } from 'utils/Utils';
+
+/** Minimum characters required before triggering search API */
+const MIN_SEARCH_CHARS = 3;
+
+/** Property types allowed in filter dropdown (must have a search_* table) */
+const SEARCHABLE_PROPERTY_TYPES = ['string', 'number', 'datetime'];
 
 /**
  * Renders reviewed + published Submissions as cards with download and request access actions.
+ * Supports server-side search when user enters 3+ characters.
  *
  * @returns {*}
  */
 const SubmissionsListPage = () => {
   const biohubApi = useApi();
   const { downloadJSON } = useDownload();
+  const styles = useSearchFilterStyles();
 
-  const reviewedSubmissionsDataLoader = useDataLoader(() => biohubApi.submissions.getPublishedSubmissions());
-  reviewedSubmissionsDataLoader.load();
+  // Load codes for property filter options
+  const codesDataLoader = useDataLoader(() => biohubApi.codes.getAllCodeSets());
+  codesDataLoader.load();
+
+  // Search state
+  const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
+  const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([]);
+
+  // Search API data loader
+  const searchDataLoader = useDataLoader((params: ISearchFeaturesRequest) => biohubApi.search.searchFeatures(params));
 
   const [openRequestAccess, setOpenRequestAccess] = useState(false);
 
-  const { fuzzyData, handleFuzzyData, handleSearch, searchValue } = useFuzzySearch<SubmissionRecordPublishedForPublic>(
-    reviewedSubmissionsDataLoader.data,
-    { keys: ['name', 'description'] }
+  // Map frontend filter type to API property type
+  const mapFilterTypeToPropertyType = (filterType: 'text' | 'datetime' | 'enum'): 'string' | 'number' | 'datetime' => {
+    if (filterType === 'datetime') {
+      return 'datetime';
+    }
+    // 'text' and 'enum' both map to 'string' for now
+    return 'string';
+  };
+
+  // Convert ActiveFilter[] to IPropertyFilter[] for API calls
+  const apiFilters = useMemo(
+    (): IPropertyFilter[] =>
+      activeFilters.map((f) => ({
+        featureTypeName: f.featureType,
+        propertyName: f.property,
+        propertyType: mapFilterTypeToPropertyType(f.propertyType),
+        value: f.value
+      })),
+    [activeFilters]
   );
 
-  const onDownload = async (submission: FuseResult<SubmissionRecordPublishedForPublic>) => {
-    // make request here for JSON data of submission and children
-    const data = await biohubApi.submissions.getSubmissionPublishedDownloadPackage(submission.item.submission_id);
-    const fileName = `${submission.item.name.toLowerCase().replace(/ /g, '-')}-${submission.item.submission_id}`;
+  /**
+   * Trigger search API call with current keywords and filters.
+   */
+  const triggerSearch = useCallback(
+    (keywords: string | undefined, filters: IPropertyFilter[]) => {
+      const hasKeywords = keywords && keywords.length >= MIN_SEARCH_CHARS;
+      const hasFilters = filters.length > 0;
+
+      if (hasKeywords || hasFilters) {
+        searchDataLoader.refresh({
+          keywords: hasKeywords ? keywords : undefined,
+          propertyFilters: hasFilters ? filters : undefined
+        });
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  /**
+   * Debounced function to trigger search API call.
+   * Waits 300ms after last keystroke before triggering.
+   */
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((term: string, filters: IPropertyFilter[]) => {
+        setDebouncedSearchTerm(term);
+        triggerSearch(term, filters);
+      }, 300),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  /**
+   * Handle search input changes.
+   * Updates local state immediately and triggers debounced API search.
+   */
+  const handleSearch = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const term = event.target.value;
+      setSearchTerm(term);
+
+      if (term.length >= MIN_SEARCH_CHARS || apiFilters.length > 0) {
+        // Trigger server-side search
+        debouncedSearch(term, apiFilters);
+      } else {
+        // Clear search results and show all submissions
+        setDebouncedSearchTerm('');
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [apiFilters]
+  );
+
+  /**
+   * Handle clearing the search input.
+   */
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setDebouncedSearchTerm('');
+  }, []);
+
+  // Map property types to filter input types
+  const getFilterType = (propertyType: string): 'text' | 'datetime' => {
+    if (propertyType === 'datetime') {
+      return 'datetime';
+    }
+    return 'text';
+  };
+
+  // Create filter groups organized by feature type for sidebar
+  const filterGroups = useMemo((): FilterGroupType[] => {
+    if (!codesDataLoader.data?.feature_type_with_properties) {
+      return [];
+    }
+
+    return codesDataLoader.data.feature_type_with_properties
+      .map((featureType) => ({
+        id: featureType.feature_type.feature_type_id,
+        name: featureType.feature_type.feature_type_name,
+        displayName: featureType.feature_type.feature_type_display_name,
+        properties: featureType.feature_type_properties
+          .filter((prop) => SEARCHABLE_PROPERTY_TYPES.includes(prop.feature_property_type_name))
+          .map((prop) => ({
+            name: prop.feature_property_name,
+            displayName: prop.feature_property_display_name,
+            type: getFilterType(prop.feature_property_type_name) as 'text' | 'number' | 'datetime'
+          }))
+      }))
+      .filter((group) => group.properties.length > 0)
+      .sort((a, b) => a.displayName.localeCompare(b.displayName));
+  }, [codesDataLoader.data]);
+
+  /**
+   * Handle filter changes from sidebar.
+   */
+  const handleFiltersChange = useCallback((filters: ActiveFilter[]) => {
+    setActiveFilters(filters);
+  }, []);
+
+  /**
+   * Remove a single filter by feature type and property name (for pill X button).
+   */
+  const handleRemoveFilter = useCallback((featureType: string, propertyName: string) => {
+    setActiveFilters((prev) => prev.filter((f) => !(f.featureType === featureType && f.property === propertyName)));
+  }, []);
+
+  // Trigger search when filters change
+  useEffect(() => {
+    const hasKeywords = debouncedSearchTerm.length >= MIN_SEARCH_CHARS;
+    const hasFilters = apiFilters.length > 0;
+
+    if (hasKeywords || hasFilters) {
+      triggerSearch(hasKeywords ? debouncedSearchTerm : undefined, apiFilters);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiFilters]);
+
+  // Determine if we're in search mode (keywords or filters)
+  const isSearching = debouncedSearchTerm.length >= MIN_SEARCH_CHARS || apiFilters.length > 0;
+  const searchResults = searchDataLoader.data || [];
+
+  const onDownloadFeature = async (result: SearchFeatureResult) => {
+    // Download the feature's parent submission package
+    const data = await biohubApi.submissions.getSubmissionPublishedDownloadPackage(result.submission_id);
+    const fileName = `${result.submission_name.toLowerCase().replace(/ /g, '-')}-${result.submission_id}`;
     downloadJSON(data, fileName);
   };
 
@@ -51,61 +211,102 @@ const SubmissionsListPage = () => {
         artifacts={[]}
         initialArtifactSelection={[]}
       />
-      <Box>
-        <Paper
-          square
-          elevation={0}
-          sx={{
-            py: 4
-          }}>
-          <Container maxWidth="xl">
-            <Typography mb={1} variant="h1">
+      {/* Main layout: Sidebar | Content (full height from nav header) */}
+      <Box sx={{ display: 'flex', minHeight: 'calc(100vh - 70px)' }}>
+        {/* Filter Sidebar */}
+        <FilterSidebar
+          filterGroups={filterGroups}
+          activeFilters={activeFilters}
+          onFiltersChange={handleFiltersChange}
+        />
+
+        {/* Content area: Header + Search + Results */}
+        <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          {/* Page Header */}
+          <Box sx={{ py: 3, px: 4, borderBottom: '1px solid #D8D8D8' }}>
+            <Typography mb={1} variant="h1" sx={{ color: '#013366' }}>
               BioHub BC
             </Typography>
-            <Typography mb={3} variant="body1" color="textSecondary">
+            <Typography variant="body1" color="textSecondary">
               Open access to British Columbia's terrestrial, aquatic species and habitat inventory data.
             </Typography>
-            <SearchInput
-              placeholderText="Enter a submission title or keyword"
-              value={searchValue}
-              handleChange={handleSearch}
-            />
-          </Container>
-        </Paper>
-        <Container maxWidth="xl">
-          <Box py={4}>
-            {reviewedSubmissionsDataLoader.isLoading ? (
+          </Box>
+
+          {/* Search + Results area */}
+          <Box sx={{ flex: 1, p: 4 }}>
+            {/* Search Input */}
+            <Box sx={{ mb: 3 }}>
+              <SearchInput
+                placeholderText="Search for caribou, grizzly bear, salmon surveys..."
+                value={searchTerm}
+                handleChange={handleSearch}
+                onClear={handleClearSearch}
+              />
+              {/* Active filter pills */}
+              {activeFilters.length > 0 && (
+                <Box sx={{ ...styles.filterPillsContainer }}>
+                  {activeFilters.map((filter) => (
+                    <Box key={`${filter.featureType}-${filter.property}`} sx={{ ...styles.activePill }}>
+                      <span style={{ color: '#697386' }}>
+                        {filter.featureTypeDisplayName}: {filter.label}
+                      </span>
+                      <span>{filter.value}</span>
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemoveFilter(filter.featureType, filter.property)}
+                        sx={{ ...styles.pillRemoveButton }}
+                        aria-label={`Remove ${filter.featureTypeDisplayName} ${filter.label} filter`}>
+                        <Icon path={mdiClose} size={0.5} />
+                      </IconButton>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </Box>
+            {searchDataLoader.isLoading ? (
+              // Loading state while searching
               <>
                 <RecordsFoundSkeletonLoader />
                 <SubmissionCardSkeletonLoader />
               </>
-            ) : (
+            ) : isSearching ? (
+              // Search results view (feature-level)
               <>
-                <Box pb={4} display="flex" flexDirection="row" justifyContent="space-between">
-                  <Typography variant="h4" component="h2">{`${fuzzyData.length} ${p(
-                    fuzzyData.length,
-                    'record'
-                  )} found`}</Typography>
-                  <Box my={-1}>
-                    <SubmissionsListSortMenu
-                      sortMenuItems={{ publish_timestamp: 'Publish Date', name: 'Name' }}
-                      submissions={fuzzyData}
-                      handleSubmissions={(data) => {
-                        handleFuzzyData(data);
-                      }}
-                      apiSortSync={{ key: 'publish_timestamp', sort: 'asc' }}
-                    />
-                  </Box>
+                <Box pb={4}>
+                  <Typography variant="h4" component="h2">
+                    {`${searchResults.length} ${p(searchResults.length, 'feature')} found`}
+                  </Typography>
+                  {searchResults.length > 0 && (
+                    <Typography variant="body2" color="textSecondary" mt={1}>
+                      Results are sorted by relevancy.
+                    </Typography>
+                  )}
                 </Box>
-                <SubmissionsList
-                  submissions={fuzzyData}
-                  onDownload={onDownload}
+                <SearchResultsList
+                  results={searchResults}
+                  onDownload={onDownloadFeature}
                   onAccessRequest={() => setOpenRequestAccess(true)}
                 />
               </>
+            ) : (
+              // Initial empty state - prompt to search
+              <Box
+                display="flex"
+                flexDirection="column"
+                alignItems="center"
+                justifyContent="center"
+                py={8}
+                color="textSecondary">
+                <Typography variant="h5" color="textSecondary" gutterBottom>
+                  Search to find data
+                </Typography>
+                <Typography variant="body2" color="textSecondary">
+                  Enter keywords, add filters, or both to discover data
+                </Typography>
+              </Box>
             )}
           </Box>
-        </Container>
+        </Box>
       </Box>
     </>
   );

--- a/app/src/features/submissions/list/SubmissionsListPage.tsx
+++ b/app/src/features/submissions/list/SubmissionsListPage.tsx
@@ -26,7 +26,7 @@ import { pluralize as p } from 'utils/Utils';
 const MIN_SEARCH_CHARS = 3;
 
 /** Property types allowed in filter dropdown (must have a search_* table) */
-const SEARCHABLE_PROPERTY_TYPES = ['string', 'number', 'datetime'];
+const SEARCHABLE_PROPERTY_TYPES = new Set(['string', 'number', 'datetime']);
 
 /**
  * Renders reviewed + published Submissions as cards with download and request access actions.
@@ -156,7 +156,7 @@ const SubmissionsListPage = () => {
         name: featureType.feature_type.feature_type_name,
         displayName: featureType.feature_type.feature_type_display_name,
         properties: featureType.feature_type_properties
-          .filter((prop) => SEARCHABLE_PROPERTY_TYPES.includes(prop.feature_property_type_name))
+          .filter((prop) => SEARCHABLE_PROPERTY_TYPES.has(prop.feature_property_type_name))
           .map((prop) => ({
             name: prop.feature_property_name,
             displayName: prop.feature_property_display_name,
@@ -199,7 +199,7 @@ const SubmissionsListPage = () => {
   const onDownloadFeature = async (result: SearchFeatureResult) => {
     // Download the feature's parent submission package
     const data = await biohubApi.submissions.getSubmissionPublishedDownloadPackage(result.submission_id);
-    const fileName = `${result.submission_name.toLowerCase().replace(/ /g, '-')}-${result.submission_id}`;
+    const fileName = `${result.submission_name.toLowerCase().replaceAll(' ', '-')}-${result.submission_id}`;
     downloadJSON(data, fileName);
   };
 

--- a/app/src/features/submissions/list/SubmissionsListPage.tsx
+++ b/app/src/features/submissions/list/SubmissionsListPage.tsx
@@ -203,6 +203,59 @@ const SubmissionsListPage = () => {
     downloadJSON(data, fileName);
   };
 
+  /**
+   * Renders the appropriate content based on loading and search state.
+   */
+  const renderSearchContent = () => {
+    if (searchDataLoader.isLoading) {
+      return (
+        <>
+          <RecordsFoundSkeletonLoader />
+          <SubmissionCardSkeletonLoader />
+        </>
+      );
+    }
+
+    if (isSearching) {
+      return (
+        <>
+          <Box pb={4}>
+            <Typography variant="h4" component="h2">
+              {`${searchResults.length} ${p(searchResults.length, 'feature')} found`}
+            </Typography>
+            {searchResults.length > 0 && (
+              <Typography variant="body2" color="textSecondary" mt={1}>
+                Results are sorted by relevancy.
+              </Typography>
+            )}
+          </Box>
+          <SearchResultsList
+            results={searchResults}
+            onDownload={onDownloadFeature}
+            onAccessRequest={() => setOpenRequestAccess(true)}
+          />
+        </>
+      );
+    }
+
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        py={8}
+        color="textSecondary">
+        <Typography variant="h5" color="textSecondary" gutterBottom>
+          Search to find data
+        </Typography>
+        <Typography variant="body2" color="textSecondary">
+          Enter keywords, add filters, or both to discover data
+        </Typography>
+      </Box>
+    );
+  };
+
   return (
     <>
       <SecureDataAccessRequestDialog
@@ -263,48 +316,7 @@ const SubmissionsListPage = () => {
                 </Box>
               )}
             </Box>
-            {searchDataLoader.isLoading ? (
-              // Loading state while searching
-              <>
-                <RecordsFoundSkeletonLoader />
-                <SubmissionCardSkeletonLoader />
-              </>
-            ) : isSearching ? (
-              // Search results view (feature-level)
-              <>
-                <Box pb={4}>
-                  <Typography variant="h4" component="h2">
-                    {`${searchResults.length} ${p(searchResults.length, 'feature')} found`}
-                  </Typography>
-                  {searchResults.length > 0 && (
-                    <Typography variant="body2" color="textSecondary" mt={1}>
-                      Results are sorted by relevancy.
-                    </Typography>
-                  )}
-                </Box>
-                <SearchResultsList
-                  results={searchResults}
-                  onDownload={onDownloadFeature}
-                  onAccessRequest={() => setOpenRequestAccess(true)}
-                />
-              </>
-            ) : (
-              // Initial empty state - prompt to search
-              <Box
-                display="flex"
-                flexDirection="column"
-                alignItems="center"
-                justifyContent="center"
-                py={8}
-                color="textSecondary">
-                <Typography variant="h5" color="textSecondary" gutterBottom>
-                  Search to find data
-                </Typography>
-                <Typography variant="body2" color="textSecondary">
-                  Enter keywords, add filters, or both to discover data
-                </Typography>
-              </Box>
-            )}
+            {renderSearchContent()}
           </Box>
         </Box>
       </Box>

--- a/app/src/hooks/api/useSearchApi.test.ts
+++ b/app/src/hooks/api/useSearchApi.test.ts
@@ -1,0 +1,82 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { SearchFeatureResult } from 'interfaces/useSearchApi.interface';
+import { useSearchApi } from './useSearchApi';
+
+describe('useSearchApi', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe('searchFeatures', () => {
+    it('should make POST request to /api/search with keywords', async () => {
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 1,
+          submission_id: 10,
+          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          feature_type_id: 1,
+          feature_type_name: 'dataset',
+          feature_name: 'Moose Study',
+          feature_description: 'A study of moose habitat',
+          submission_name: 'Wildlife Project',
+          is_secured: false,
+          relevancy_score: 0.75
+        }
+      ];
+
+      mock.onPost('/api/search').reply(200, mockResults);
+
+      const result = await useSearchApi(axios).searchFeatures({ keywords: 'moose' });
+
+      expect(result).toEqual(mockResults);
+      expect(mock.history.post[0].data).toEqual(JSON.stringify({ keywords: 'moose' }));
+    });
+
+    it('should make POST request with property filters', async () => {
+      const mockResults: SearchFeatureResult[] = [
+        {
+          submission_feature_id: 2,
+          submission_id: 11,
+          uuid: '550e8400-e29b-41d4-a716-446655440002',
+          feature_type_id: 2,
+          feature_type_name: 'observation',
+          feature_name: 'Bear Sighting',
+          feature_description: null,
+          submission_name: 'Species Census',
+          is_secured: true,
+          relevancy_score: 0.6
+        }
+      ];
+
+      mock.onPost('/api/search').reply(200, mockResults);
+
+      const result = await useSearchApi(axios).searchFeatures({
+        propertyFilters: [{ featureTypeName: 'animal', propertyName: 'species', propertyType: 'string', value: 'bear' }]
+      });
+
+      expect(result).toEqual(mockResults);
+      expect(mock.history.post[0].data).toEqual(
+        JSON.stringify({
+          propertyFilters: [
+            { featureTypeName: 'animal', propertyName: 'species', propertyType: 'string', value: 'bear' }
+          ]
+        })
+      );
+    });
+
+    it('should return empty array when no results', async () => {
+      mock.onPost('/api/search').reply(200, []);
+
+      const result = await useSearchApi(axios).searchFeatures({ keywords: 'nonexistent' });
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/app/src/hooks/api/useSearchApi.ts
+++ b/app/src/hooks/api/useSearchApi.ts
@@ -1,0 +1,26 @@
+import { AxiosInstance } from 'axios';
+import { ISearchFeaturesRequest, SearchFeatureResult } from 'interfaces/useSearchApi.interface';
+
+/**
+ * Returns API methods for searching features.
+ *
+ * @param {AxiosInstance} axios
+ * @return {*} object whose properties are supported api methods.
+ */
+export const useSearchApi = (axios: AxiosInstance) => {
+  /**
+   * Search for features by keywords and/or property filters.
+   *
+   * @param {ISearchFeaturesRequest} params - Search parameters
+   * @return {Promise<SearchFeatureResult[]>} Array of matching features sorted by relevancy
+   */
+  const searchFeatures = async (params: ISearchFeaturesRequest): Promise<SearchFeatureResult[]> => {
+    const { data } = await axios.post<SearchFeatureResult[]>('/api/search', params);
+
+    return data;
+  };
+
+  return {
+    searchFeatures
+  };
+};

--- a/app/src/hooks/useApi.ts
+++ b/app/src/hooks/useApi.ts
@@ -10,6 +10,7 @@ import useTaxonomyApi from './api/useTaxonomyApi';
 import useUserApi from './api/useUserApi';
 import { useFeaturesApi } from './api/useFeaturesApi';
 import usePoliciesApi from './api/usePoliciesApi';
+import { useSearchApi } from './api/useSearchApi';
 
 /**
  * Returns a set of supported api methods.
@@ -39,6 +40,8 @@ export const useApi = () => {
 
   const policies = usePoliciesApi(apiAxios);
 
+  const search = useSearchApi(apiAxios);
+
   return {
     user,
     admin,
@@ -48,6 +51,7 @@ export const useApi = () => {
     security,
     artifact,
     codes,
-    policies
+    policies,
+    search
   };
 };

--- a/app/src/interfaces/useSearchApi.interface.ts
+++ b/app/src/interfaces/useSearchApi.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Request parameters for searching features.
+ */
+export interface ISearchFeaturesRequest {
+  keywords?: string;
+  propertyFilters?: IPropertyFilter[];
+}
+
+/**
+ * A property filter for narrowing search results.
+ */
+export interface IPropertyFilter {
+  featureTypeName: string;
+  propertyName: string;
+  propertyType: 'string' | 'number' | 'datetime';
+  value: string;
+}
+
+/**
+ * A search result representing a matched feature.
+ */
+export type SearchFeatureResult = {
+  submission_feature_id: number;
+  submission_id: number;
+  uuid: string;
+  feature_type_id: number;
+  feature_type_name: string;
+  feature_name: string | null;
+  feature_description: string | null;
+  submission_name: string;
+  is_secured: boolean;
+  relevancy_score: number;
+};

--- a/database/src/migrations/20251216000000_add_search_string_fts_index.ts
+++ b/database/src/migrations/20251216000000_add_search_string_fts_index.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+/**
+ * Add GIN index for full-text search on search_string.value (SIMSBIOHUB-830).
+ *
+ * This index enables efficient full-text search queries using to_tsvector/to_tsquery.
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Add GIN index for full-text search on search_string.value
+    --------------------------------------------------------------------------------
+    CREATE INDEX search_string_fts_idx
+      ON search_string
+      USING GIN (to_tsvector('english', value));
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Remove GIN index for full-text search
+    --------------------------------------------------------------------------------
+    DROP INDEX IF EXISTS search_string_fts_idx;
+  `);
+}

--- a/database/src/seeds/04_mock_test_data.ts
+++ b/database/src/seeds/04_mock_test_data.ts
@@ -116,7 +116,7 @@ export const insertDatasetRecord = async (knex: Knex, options: { submission_id: 
       parent_submission_feature_id: null,
       feature_type: 'dataset',
       data: {
-        name: `Survey ${faker.animal.type()} ${faker.commerce.department()}}`,
+        name: `Survey ${faker.animal.type()} ${faker.commerce.department()}`,
         start_date: faker.date.past().toISOString(),
         end_date: faker.date.future().toISOString(),
         geometry: random.point(


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-830](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-830?)

## Description of Changes

As a BioHub user, I want to search for BioHub features and submissions using keywords and filters, so that I can quickly find relevant data.

Acceptance Criteria
1. Keyword Search  
WHEN a user enters a keyword into the search bar,  
  THEN the backend `/search` endpoint should split the keyword string into individual terms,  
  AND each term should be treated independently,  
  AND for each term, matches should be searched in the `search_string` table,  
  AND results should be aggregated across all terms,  
  AND the relevant features should be ranked and returned in order of relevancy.
2. Property Match Search  
WHEN a user provides a value for a specific property field (e.g., species, date, feature type),  
  THEN the backend `/search` endpoint should match the value against that property type,  
  AND multiple property fields can be provided,  
  AND results should be aggregated across all property filters,  
  AND results should be ranked by relevancy.
4. Relevancy Ranking  
WHEN the backend processes a search query,  
  THEN a relevancy should be computed (eg. with `tsquery` and `tsvector`),
  AND higher-scoring results should appear earlier in the returned list.
5. Feature & Submission Coverage  
WHEN a search is performed,  
  THEN the system should search across the search_* tables to find relevant features

Notes 

For the keyword search, it's just matching on the value field of the search_string table.
eg. If I search "Moose", all features with any property containing the word "moose" are returned.
For the property match search, it's matching on both the value field of the search_string table AND the property type.
eg. Instead of just passing "Moose", I say `focal_species = Moose`

## Testing Notes

- find a term in the search_string table to test the search with
