### PR TITLE
SIMSBIOHUB-793: Fix for service account

### DIFF
--- a/api/src/database/db.ts
+++ b/api/src/database/db.ts
@@ -6,7 +6,7 @@ import { SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 import { ApiExecuteSQLError, ApiGeneralError } from '../errors/api-error';
 import * as UserQueries from '../queries/database/user-context-queries';
 import { SystemUser } from '../repositories/user-repository';
-import { getUserGuid, getUserIdentitySource } from '../utils/keycloak-utils';
+import { getServiceClientSystemUser, getUserGuid, getUserIdentitySource } from '../utils/keycloak-utils';
 import { getLogger } from '../utils/logger';
 import { asyncErrorWrapper, syncErrorWrapper } from './db-utils';
 
@@ -447,7 +447,13 @@ export const getDBConnection = function (keycloakToken: object): IDBConnection {
   const _setUserContext = async () => {
     const userGuid = getUserGuid(_token);
 
-    const userIdentitySource = getUserIdentitySource(_token);
+    // Check if this is a known service client - if so, use SYSTEM identity source
+    let userIdentitySource = getUserIdentitySource(_token);
+    const serviceClientUser = getServiceClientSystemUser(_token);
+    if (serviceClientUser) {
+      // This is a known service client, use SYSTEM identity source
+      userIdentitySource = SYSTEM_IDENTITY_SOURCE.SYSTEM;
+    }
 
     if (!userGuid || !userIdentitySource) {
       throw new ApiGeneralError('Failed to identify authenticated user');


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-793: Sending SIMS submissions to TAR file](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-793)

## Description of Changes

**Problem:**
Service client users (e.g., `service-account-sims-svc-****`) were failing to authenticate when calling `/api/submission/upload/archive`, resulting in a "Failed to set user context" error. The `api_set_context` database function couldn't find the user because it was being queried with the wrong identity source.

**Root Cause:**
Service client tokens don't include an `identity_provider` field, causing `getUserIdentitySource` to default to `DATABASE` identity source. However, service clients are stored in the database with `SYSTEM` identity source, creating a mismatch that prevented the user lookup from succeeding.

**Solution:**
Updated `_setUserContext` in `api/src/database/db.ts` to check if the token belongs to a known service client (using `getServiceClientSystemUser`, which matches by the token's `sub` field). If it's a known service client, the identity source is overridden to `SYSTEM` instead of defaulting to `DATABASE`.

**Changes:**
- Modified `api/src/database/db.ts` to check for known service clients before setting user context
- Added import for `getServiceClientSystemUser` from `keycloak-utils`

## Testing Notes

- Test from SIMS