### PR TITLE
SIMSBIOHUB-842: Update Pagination for Frontend Data Grids

### DIFF
--- a/api/src/openapi/schemas/policy.ts
+++ b/api/src/openapi/schemas/policy.ts
@@ -5,6 +5,7 @@
  */
 
 import { OpenAPIV3 } from 'openapi-types';
+import { paginationResponseSchema } from './pagination';
 
 /**
  * Schema for policy statement condition.
@@ -162,24 +163,7 @@ export const PoliciesListResponseSchema: OpenAPIV3.SchemaObject = {
       items: PolicyWithStatementsSchema,
       description: 'List of policies with statements'
     },
-    pagination: {
-      type: 'object',
-      required: ['total', 'page', 'limit'],
-      properties: {
-        total: {
-          type: 'integer',
-          description: 'Total number of policies'
-        },
-        page: {
-          type: 'integer',
-          description: 'Current page number (0-indexed)'
-        },
-        limit: {
-          type: 'integer',
-          description: 'Number of items per page'
-        }
-      }
-    }
+    pagination: paginationResponseSchema
   }
 };
 

--- a/api/src/openapi/schemas/team-policy.ts
+++ b/api/src/openapi/schemas/team-policy.ts
@@ -5,6 +5,7 @@
  */
 
 import { OpenAPIV3 } from 'openapi-types';
+import { paginationResponseSchema } from './pagination';
 
 /**
  * Schema for a team-policy association with names for display.
@@ -46,13 +47,14 @@ export const TeamPolicyDetailsSchema: OpenAPIV3.SchemaObject = {
 export const TeamPoliciesResponseSchema: OpenAPIV3.SchemaObject = {
   title: 'TeamPoliciesResponse',
   type: 'object',
-  required: ['team_policies'],
+  required: ['team_policies', 'pagination'],
   properties: {
     team_policies: {
       type: 'array',
       items: TeamPolicyDetailsSchema,
       description: 'List of team-policy associations with names'
-    }
+    },
+    pagination: paginationResponseSchema
   }
 };
 

--- a/api/src/openapi/schemas/team.ts
+++ b/api/src/openapi/schemas/team.ts
@@ -5,6 +5,7 @@
  */
 
 import { OpenAPIV3 } from 'openapi-types';
+import { paginationResponseSchema } from './pagination';
 
 /**
  * Schema for a team member with user details.
@@ -102,24 +103,7 @@ export const TeamsListResponseSchema: OpenAPIV3.SchemaObject = {
       items: TeamWithMembersSchema,
       description: 'List of teams with members'
     },
-    pagination: {
-      type: 'object',
-      required: ['total', 'page', 'limit'],
-      properties: {
-        total: {
-          type: 'integer',
-          description: 'Total number of teams'
-        },
-        page: {
-          type: 'integer',
-          description: 'Current page number (0-indexed)'
-        },
-        limit: {
-          type: 'integer',
-          description: 'Number of items per page'
-        }
-      }
-    }
+    pagination: paginationResponseSchema
   }
 };
 

--- a/api/src/paths/administrative/policies/index.test.ts
+++ b/api/src/paths/administrative/policies/index.test.ts
@@ -57,7 +57,7 @@ describe('paths/administrative/policies/index', () => {
             statements: []
           }
         ],
-        pagination: { total: 1, page: 0, limit: 50 }
+        pagination: { total: 1, per_page: 10, current_page: 1, last_page: 1 }
       };
 
       const getPoliciesWithStatementsStub = sinon
@@ -67,15 +67,20 @@ describe('paths/administrative/policies/index', () => {
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
       mockReq.query = {
-        page: '0',
-        limit: '50'
+        page: '1',
+        limit: '10'
       };
 
       const requestHandler = getPolicies();
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith({ page: 0, limit: 50, search: undefined });
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(undefined, {
+        page: 1,
+        limit: 10,
+        sort: undefined,
+        order: undefined
+      });
       expect(mockRes.statusValue).to.equal(200);
       expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
     });
@@ -91,7 +96,50 @@ describe('paths/administrative/policies/index', () => {
 
       const mockPoliciesResponse = {
         policies: [],
-        pagination: { total: 0, page: 0, limit: 50 }
+        pagination: { total: 0, per_page: 25, current_page: 2, last_page: 1 }
+      };
+
+      const getPoliciesWithStatementsStub = sinon
+        .stub(PolicyService.prototype, 'getPoliciesWithStatements')
+        .resolves(mockPoliciesResponse);
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.query = {
+        page: '2',
+        limit: '25',
+        search: 'test'
+      };
+
+      const requestHandler = getPolicies();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith('test', {
+        page: 2,
+        limit: 25,
+        sort: undefined,
+        order: undefined
+      });
+      expect(mockRes.statusValue).to.equal(200);
+      expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
+    });
+
+    it('should call service.getPoliciesWithStatements with sort ascending', async () => {
+      const dbConnectionObj = getMockDBConnection({
+        commit: sinon.stub(),
+        rollback: sinon.stub(),
+        release: sinon.stub()
+      });
+
+      sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+
+      const mockPoliciesResponse = {
+        policies: [
+          { policy_id: '1', name: 'Alpha Policy', description: null, statements: [] },
+          { policy_id: '2', name: 'Beta Policy', description: null, statements: [] }
+        ],
+        pagination: { total: 2, per_page: 10, current_page: 1, last_page: 1, sort: 'name', order: 'asc' as const }
       };
 
       const getPoliciesWithStatementsStub = sinon
@@ -102,15 +150,65 @@ describe('paths/administrative/policies/index', () => {
 
       mockReq.query = {
         page: '1',
-        limit: '25',
-        search: 'test'
+        limit: '10',
+        sort: 'name',
+        order: 'asc'
       };
 
       const requestHandler = getPolicies();
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith({ page: 1, limit: 25, search: 'test' });
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(undefined, {
+        page: 1,
+        limit: 10,
+        sort: 'name',
+        order: 'asc'
+      });
+      expect(mockRes.statusValue).to.equal(200);
+      expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
+    });
+
+    it('should call service.getPoliciesWithStatements with sort descending', async () => {
+      const dbConnectionObj = getMockDBConnection({
+        commit: sinon.stub(),
+        rollback: sinon.stub(),
+        release: sinon.stub()
+      });
+
+      sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+
+      const mockPoliciesResponse = {
+        policies: [
+          { policy_id: '2', name: 'Zebra Policy', description: null, statements: [] },
+          { policy_id: '1', name: 'Alpha Policy', description: null, statements: [] }
+        ],
+        pagination: { total: 2, per_page: 10, current_page: 1, last_page: 1, sort: 'name', order: 'desc' as const }
+      };
+
+      const getPoliciesWithStatementsStub = sinon
+        .stub(PolicyService.prototype, 'getPoliciesWithStatements')
+        .resolves(mockPoliciesResponse);
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.query = {
+        page: '1',
+        limit: '10',
+        sort: 'name',
+        order: 'desc'
+      };
+
+      const requestHandler = getPolicies();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(undefined, {
+        page: 1,
+        limit: 10,
+        sort: 'name',
+        order: 'desc'
+      });
       expect(mockRes.statusValue).to.equal(200);
       expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
     });

--- a/api/src/paths/administrative/policies/index.ts
+++ b/api/src/paths/administrative/policies/index.ts
@@ -11,6 +11,7 @@ import {
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { PolicyService } from '../../../services/access-policy/policy-service';
 import { getLogger } from '../../../utils/logger';
+import { ApiPaginationOptions } from '../../../zod-schema/pagination';
 
 const defaultLog = getLogger('paths/administrative/policies');
 
@@ -40,30 +41,36 @@ GET.apiDoc = {
     {
       in: 'query',
       name: 'page',
-      schema: {
-        type: 'integer',
-        minimum: 0,
-        default: 0
-      },
-      description: 'Page number (0-indexed)'
+      required: false,
+      schema: { type: 'integer', minimum: 1 },
+      description: 'Page number (1-indexed, defaults to 1)'
     },
     {
       in: 'query',
       name: 'limit',
-      schema: {
-        type: 'integer',
-        minimum: 1,
-        maximum: 100,
-        default: 50
-      },
-      description: 'Number of items per page'
+      required: false,
+      schema: { type: 'integer', minimum: 1, maximum: 100 },
+      description: 'Items per page (defaults to 10, max 100)'
+    },
+    {
+      in: 'query',
+      name: 'sort',
+      required: false,
+      schema: { type: 'string' },
+      description: 'Column to sort by (e.g., name)'
+    },
+    {
+      in: 'query',
+      name: 'order',
+      required: false,
+      schema: { type: 'string', enum: ['asc', 'desc'] },
+      description: 'Sort direction'
     },
     {
       in: 'query',
       name: 'search',
-      schema: {
-        type: 'string'
-      },
+      required: false,
+      schema: { type: 'string' },
       description: 'Search term to filter policies by name'
     }
   ],
@@ -89,15 +96,19 @@ export function getPolicies(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req['keycloak_token']);
 
-    const page = Number(req.query.page) || 0;
-    const limit = Number(req.query.limit) || 50;
     const search = req.query.search as string | undefined;
+    const pagination: ApiPaginationOptions = {
+      page: Number(req.query.page) || 1,
+      limit: Math.min(Number(req.query.limit) || 10, 100),
+      sort: req.query.sort as string | undefined,
+      order: req.query.order as 'asc' | 'desc' | undefined
+    };
 
     try {
       await connection.open();
 
       const policyService = new PolicyService(connection);
-      const response = await policyService.getPoliciesWithStatements({ page, limit, search });
+      const response = await policyService.getPoliciesWithStatements(search, pagination);
 
       await connection.commit();
 

--- a/api/src/paths/administrative/policies/index.ts
+++ b/api/src/paths/administrative/policies/index.ts
@@ -3,6 +3,7 @@ import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
 import {
   CreatePolicyRequestSchema,
   PoliciesListResponseSchema,
@@ -38,34 +39,7 @@ GET.apiDoc = {
     }
   ],
   parameters: [
-    {
-      in: 'query',
-      name: 'page',
-      required: false,
-      schema: { type: 'integer', minimum: 1 },
-      description: 'Page number (1-indexed, defaults to 1)'
-    },
-    {
-      in: 'query',
-      name: 'limit',
-      required: false,
-      schema: { type: 'integer', minimum: 1, maximum: 100 },
-      description: 'Items per page (defaults to 10, max 100)'
-    },
-    {
-      in: 'query',
-      name: 'sort',
-      required: false,
-      schema: { type: 'string' },
-      description: 'Column to sort by (e.g., name)'
-    },
-    {
-      in: 'query',
-      name: 'order',
-      required: false,
-      schema: { type: 'string', enum: ['asc', 'desc'] },
-      description: 'Sort direction'
-    },
+    ...paginationRequestQueryParamSchema,
     {
       in: 'query',
       name: 'search',

--- a/api/src/paths/administrative/team-policies/index.test.ts
+++ b/api/src/paths/administrative/team-policies/index.test.ts
@@ -16,13 +16,15 @@ describe('team-policies', () => {
       sinon.restore();
     });
 
-    it('should return team policies on success', async () => {
+    it('should return team policies with pagination on success', async () => {
       const mockDBConnection = getMockDBConnection();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
+      mockReq.query = { page: '1', limit: '10' };
+
       sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
 
-      const mockResponse: TeamPolicyDetails[] = [
+      const mockTeamPolicies: TeamPolicyDetails[] = [
         {
           team_policy_id: '11111111-1111-1111-1111-111111111111',
           team_id: '22222222-2222-2222-2222-222222222222',
@@ -32,14 +34,46 @@ describe('team-policies', () => {
         }
       ];
 
-      sinon.stub(TeamPolicyService.prototype, 'getAllTeamPolicies').resolves(mockResponse);
+      const mockResponse = {
+        team_policies: mockTeamPolicies,
+        pagination: { total: 1, per_page: 10, current_page: 1, last_page: 1 }
+      };
+
+      sinon.stub(TeamPolicyService.prototype, 'getAllTeamPoliciesWithPagination').resolves(mockResponse);
 
       const requestHandler = teamPolicies.getTeamPolicies();
 
       await requestHandler(mockReq, mockRes, mockNext);
 
       expect(mockRes.statusValue).to.equal(200);
-      expect(mockRes.jsonValue).to.eql({ team_policies: mockResponse });
+      expect(mockRes.jsonValue).to.eql(mockResponse);
+    });
+
+    it('should pass sort and order params to service', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.query = { page: '1', limit: '10', sort: 'team_name', order: 'desc' };
+
+      sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+      const mockResponse = {
+        team_policies: [],
+        pagination: { total: 0, per_page: 10, current_page: 1, last_page: 1, sort: 'team_name', order: 'desc' as const }
+      };
+
+      const stub = sinon.stub(TeamPolicyService.prototype, 'getAllTeamPoliciesWithPagination').resolves(mockResponse);
+
+      const requestHandler = teamPolicies.getTeamPolicies();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(stub).to.have.been.calledWith({
+        page: 1,
+        limit: 10,
+        sort: 'team_name',
+        order: 'desc'
+      });
     });
   });
 

--- a/api/src/paths/administrative/team-policies/index.ts
+++ b/api/src/paths/administrative/team-policies/index.ts
@@ -3,6 +3,7 @@ import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
 import {
   CreateTeamPolicyRequestSchema,
   TeamPoliciesResponseSchema,
@@ -37,36 +38,7 @@ GET.apiDoc = {
       Bearer: []
     }
   ],
-  parameters: [
-    {
-      in: 'query',
-      name: 'page',
-      required: false,
-      schema: { type: 'integer', minimum: 1 },
-      description: 'Page number (1-indexed, defaults to 1)'
-    },
-    {
-      in: 'query',
-      name: 'limit',
-      required: false,
-      schema: { type: 'integer', minimum: 1, maximum: 100 },
-      description: 'Items per page (defaults to 10, max 100)'
-    },
-    {
-      in: 'query',
-      name: 'sort',
-      required: false,
-      schema: { type: 'string' },
-      description: 'Column to sort by (e.g., team_name, policy_name)'
-    },
-    {
-      in: 'query',
-      name: 'order',
-      required: false,
-      schema: { type: 'string', enum: ['asc', 'desc'] },
-      description: 'Sort direction'
-    }
-  ],
+  parameters: [...paginationRequestQueryParamSchema],
   responses: {
     200: {
       description: 'List of team-policy associations.',

--- a/api/src/paths/administrative/team-policies/index.ts
+++ b/api/src/paths/administrative/team-policies/index.ts
@@ -11,6 +11,7 @@ import {
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamPolicyService } from '../../../services/access-policy/team-policy-service';
 import { getLogger } from '../../../utils/logger';
+import { ApiPaginationOptions } from '../../../zod-schema/pagination';
 
 const defaultLog = getLogger('paths/administrative/team-policies');
 
@@ -36,6 +37,36 @@ GET.apiDoc = {
       Bearer: []
     }
   ],
+  parameters: [
+    {
+      in: 'query',
+      name: 'page',
+      required: false,
+      schema: { type: 'integer', minimum: 1 },
+      description: 'Page number (1-indexed, defaults to 1)'
+    },
+    {
+      in: 'query',
+      name: 'limit',
+      required: false,
+      schema: { type: 'integer', minimum: 1, maximum: 100 },
+      description: 'Items per page (defaults to 10, max 100)'
+    },
+    {
+      in: 'query',
+      name: 'sort',
+      required: false,
+      schema: { type: 'string' },
+      description: 'Column to sort by (e.g., team_name, policy_name)'
+    },
+    {
+      in: 'query',
+      name: 'order',
+      required: false,
+      schema: { type: 'string', enum: ['asc', 'desc'] },
+      description: 'Sort direction'
+    }
+  ],
   responses: {
     200: {
       description: 'List of team-policy associations.',
@@ -58,15 +89,22 @@ export function getTeamPolicies(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req['keycloak_token']);
 
+    const pagination: ApiPaginationOptions = {
+      page: Number(req.query.page) || 1,
+      limit: Math.min(Number(req.query.limit) || 10, 100),
+      sort: req.query.sort as string | undefined,
+      order: req.query.order as 'asc' | 'desc' | undefined
+    };
+
     try {
       await connection.open();
 
       const teamPolicyService = new TeamPolicyService(connection);
-      const teamPolicies = await teamPolicyService.getAllTeamPolicies();
+      const response = await teamPolicyService.getAllTeamPoliciesWithPagination(pagination);
 
       await connection.commit();
 
-      return res.status(200).json({ team_policies: teamPolicies });
+      return res.status(200).json(response);
     } catch (error) {
       defaultLog.error({ label: 'getTeamPolicies', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/administrative/teams/index.test.ts
+++ b/api/src/paths/administrative/teams/index.test.ts
@@ -39,7 +39,7 @@ describe('getTeams', () => {
   it('should return 200 with paginated teams', async () => {
     const mockTeams = {
       teams: [{ team_id: 'team-1', name: 'Team Alpha', description: 'First', members: [] }],
-      pagination: { total: 1, page: 1, limit: 50, last_page: 1 }
+      pagination: { total: 1, per_page: 50, current_page: 1, last_page: 1 }
     };
 
     const mockDBConnection = getMockDBConnection();
@@ -61,7 +61,7 @@ describe('getTeams', () => {
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
     const getTeamsStub = sinon.stub(TeamService.prototype, 'getTeamsWithMembers').resolves({
       teams: [],
-      pagination: { total: 0, page: 1, limit: 50, last_page: 1 }
+      pagination: { total: 0, per_page: 50, current_page: 1, last_page: 1 }
     });
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -70,12 +70,11 @@ describe('getTeams', () => {
     const requestHandler = getTeams();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(getTeamsStub).to.have.been.calledWith({
+    expect(getTeamsStub).to.have.been.calledWith('Research', {
       page: 1,
       limit: 50,
       sort: undefined,
-      order: undefined,
-      search: 'Research'
+      order: undefined
     });
   });
 
@@ -84,7 +83,7 @@ describe('getTeams', () => {
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
     const getTeamsStub = sinon.stub(TeamService.prototype, 'getTeamsWithMembers').resolves({
       teams: [],
-      pagination: { total: 0, page: 1, limit: 100, last_page: 1 }
+      pagination: { total: 0, per_page: 100, current_page: 1, last_page: 1 }
     });
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -93,12 +92,11 @@ describe('getTeams', () => {
     const requestHandler = getTeams();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(getTeamsStub).to.have.been.calledWith({
+    expect(getTeamsStub).to.have.been.calledWith(undefined, {
       page: 1,
       limit: 100,
       sort: undefined,
-      order: undefined,
-      search: undefined
+      order: undefined
     });
   });
 });

--- a/api/src/paths/administrative/teams/index.ts
+++ b/api/src/paths/administrative/teams/index.ts
@@ -7,6 +7,7 @@ import { CreateTeamRequestSchema, TeamsListResponseSchema, TeamWithMembersSchema
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamService } from '../../../services/access-policy/team-service';
 import { getLogger } from '../../../utils/logger';
+import { ApiPaginationOptions } from '../../../zod-schema/pagination';
 
 const defaultLog = getLogger('paths/administrative/teams');
 
@@ -75,16 +76,19 @@ GET.apiDoc = {
 export function getTeams(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
-    const page = Number(req.query.page) || 1;
-    const limit = Math.min(Number(req.query.limit) || 10, 100);
-    const sort = req.query.sort as string | undefined;
-    const order = req.query.order as 'asc' | 'desc' | undefined;
+
     const search = req.query.search as string | undefined;
+    const pagination: ApiPaginationOptions = {
+      page: Number(req.query.page) || 1,
+      limit: Math.min(Number(req.query.limit) || 10, 100),
+      sort: req.query.sort as string | undefined,
+      order: req.query.order as 'asc' | 'desc' | undefined
+    };
 
     try {
       await connection.open();
       const teamService = new TeamService(connection);
-      const result = await teamService.getTeamsWithMembers({ page, limit, sort, order, search });
+      const result = await teamService.getTeamsWithMembers(search, pagination);
       await connection.commit();
       return res.status(200).json(result);
     } catch (error) {

--- a/api/src/paths/administrative/teams/index.ts
+++ b/api/src/paths/administrative/teams/index.ts
@@ -21,7 +21,7 @@ export const GET: Operation = [
 
 GET.apiDoc = {
   description: 'Get all teams with optional pagination and search.',
-  tags: ['team'],
+  tags: ['admin'],
   security: [{ Bearer: [] }],
   parameters: [
     ...paginationRequestQueryParamSchema,
@@ -84,7 +84,7 @@ export const POST: Operation = [
 
 POST.apiDoc = {
   description: 'Create a new team with members.',
-  tags: ['team'],
+  tags: ['admin'],
   security: [{ Bearer: [] }],
   requestBody: {
     required: true,

--- a/api/src/paths/administrative/teams/index.ts
+++ b/api/src/paths/administrative/teams/index.ts
@@ -3,6 +3,7 @@ import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
 import { CreateTeamRequestSchema, TeamsListResponseSchema, TeamWithMembersSchema } from '../../../openapi/schemas/team';
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamService } from '../../../services/access-policy/team-service';
@@ -23,34 +24,7 @@ GET.apiDoc = {
   tags: ['team'],
   security: [{ Bearer: [] }],
   parameters: [
-    {
-      in: 'query',
-      name: 'page',
-      required: false,
-      schema: { type: 'integer', minimum: 1 },
-      description: 'Page number (1-indexed, defaults to 1)'
-    },
-    {
-      in: 'query',
-      name: 'limit',
-      required: false,
-      schema: { type: 'integer', minimum: 1, maximum: 100 },
-      description: 'Items per page (defaults to 10, max 100)'
-    },
-    {
-      in: 'query',
-      name: 'sort',
-      required: false,
-      schema: { type: 'string' },
-      description: 'Column to sort by (e.g., name)'
-    },
-    {
-      in: 'query',
-      name: 'order',
-      required: false,
-      schema: { type: 'string', enum: ['asc', 'desc'] },
-      description: 'Sort direction'
-    },
+    ...paginationRequestQueryParamSchema,
     {
       in: 'query',
       name: 'search',

--- a/api/src/paths/administrative/teams/{teamId}/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.ts
@@ -24,7 +24,7 @@ export const GET: Operation = [
 
 GET.apiDoc = {
   description: 'Get a team by ID with its members.',
-  tags: ['team'],
+  tags: ['admin'],
   security: [{ Bearer: [] }],
   parameters: [
     {
@@ -79,7 +79,7 @@ export const PUT: Operation = [
 
 PUT.apiDoc = {
   description: 'Update an existing team and its members.',
-  tags: ['team'],
+  tags: ['admin'],
   security: [{ Bearer: [] }],
   parameters: [
     {
@@ -139,7 +139,7 @@ export const DELETE: Operation = [
 
 DELETE.apiDoc = {
   description: 'Soft delete a team by ID.',
-  tags: ['team'],
+  tags: ['admin'],
   security: [{ Bearer: [] }],
   parameters: [
     {

--- a/api/src/repositories/authorization/policy-repository.test.ts
+++ b/api/src/repositories/authorization/policy-repository.test.ts
@@ -4,6 +4,7 @@ import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { ApiExecuteSQLError } from '../../errors/api-error';
+import { Policy } from '../../models/policy';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { PolicyRepository } from './policy-repository';
 
@@ -103,9 +104,9 @@ describe('PolicyRepository', () => {
 
   describe('getPoliciesWithPagination', () => {
     it('returns paginated policies with total count', async () => {
-      const mockPolicies = [
-        { policy_id: '1', name: 'Policy1', description: 'Test1' },
-        { policy_id: '2', name: 'Policy2', description: 'Test2' }
+      const mockPolicies: Policy[] = [
+        { policy_id: '11111111-1111-1111-1111-111111111111', name: 'Policy1', description: 'Test1' },
+        { policy_id: '22222222-2222-2222-2222-222222222222', name: 'Policy2', description: 'Test2' }
       ];
 
       const knexStub = sinon.stub();
@@ -115,7 +116,7 @@ describe('PolicyRepository', () => {
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repository = new PolicyRepository(mockDBConnection);
-      const result = await repository.getPoliciesWithPagination({ page: 0, limit: 2 });
+      const result = await repository.getPoliciesWithPagination(undefined, { page: 1, limit: 2 });
 
       expect(result.policies).to.eql(mockPolicies);
       expect(result.total).to.equal(5);
@@ -131,7 +132,7 @@ describe('PolicyRepository', () => {
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repository = new PolicyRepository(mockDBConnection);
-      const result = await repository.getPoliciesWithPagination({ page: 0, limit: 50, search: 'Telemetry' });
+      const result = await repository.getPoliciesWithPagination('Telemetry', { page: 1, limit: 50 });
 
       expect(result.policies).to.eql(mockPolicies);
       expect(result.total).to.equal(1);
@@ -145,7 +146,7 @@ describe('PolicyRepository', () => {
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repository = new PolicyRepository(mockDBConnection);
-      const result = await repository.getPoliciesWithPagination({ page: 0, limit: 50 });
+      const result = await repository.getPoliciesWithPagination(undefined, { page: 1, limit: 50 });
 
       expect(result.policies).to.eql([]);
       expect(result.total).to.equal(0);

--- a/api/src/repositories/authorization/policy-repository.ts
+++ b/api/src/repositories/authorization/policy-repository.ts
@@ -4,6 +4,7 @@ import { FeatureUrn } from '../../database/urn-utils.interface';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { CreatePolicy, Policy, UpdatePolicy } from '../../models/policy';
 import { PolicyEffect } from '../../models/policy-statement';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
 /**
@@ -85,24 +86,21 @@ export class PolicyRepository extends BaseRepository {
   /**
    * Get policies with pagination and optional search.
    *
-   * @param {object} options - Pagination and search options.
-   * @param {number} options.page - Page number (0-indexed).
-   * @param {number} options.limit - Number of items per page.
-   * @param {string} [options.search] - Optional search term to filter by policy name.
+   * @param {string} [search] - Optional search term to filter by policy name.
+   * @param {ApiPaginationOptions} pagination - Pagination options.
    * @return {Promise<{ policies: Policy[]; total: number }>} - Paginated policies and total count.
    * @memberof PolicyRepository
    */
-  async getPoliciesWithPagination(options: {
-    page: number;
-    limit: number;
-    search?: string;
-  }): Promise<{ policies: Policy[]; total: number }> {
+  async getPoliciesWithPagination(
+    search: string | undefined,
+    pagination: ApiPaginationOptions
+  ): Promise<{ policies: Policy[]; total: number }> {
     const knex = getKnex();
 
     let baseQuery = knex.table('policy').where('record_end_date', null);
 
-    if (options.search) {
-      baseQuery = baseQuery.whereILike('name', `%${options.search}%`);
+    if (search) {
+      baseQuery = baseQuery.whereILike('name', `%${search}%`);
     }
 
     // Get total count
@@ -110,13 +108,13 @@ export class PolicyRepository extends BaseRepository {
     const countResult = await this.connection.knex(countQuery);
     const total = Number(countResult.rows[0]?.count || 0);
 
-    // Get paginated results
+    // Get paginated results (page is 1-indexed, so offset = (page - 1) * limit)
     const paginatedQuery = baseQuery
       .clone()
       .select(['policy_id', 'name', 'description'])
-      .orderBy('name', 'asc')
-      .offset(options.page * options.limit)
-      .limit(options.limit);
+      .orderBy(pagination.sort || 'name', pagination.order || 'asc')
+      .offset((pagination.page - 1) * pagination.limit)
+      .limit(pagination.limit);
 
     const response = await this.connection.knex(paginatedQuery, Policy);
 

--- a/api/src/repositories/authorization/team-policy-repository.ts
+++ b/api/src/repositories/authorization/team-policy-repository.ts
@@ -1,6 +1,7 @@
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
 /**
@@ -105,6 +106,49 @@ export class TeamPolicyRepository extends BaseRepository {
     const response = await this.connection.knex(query, TeamPolicyDetails);
 
     return response.rows;
+  }
+
+  /**
+   * Get all active team-policy associations with pagination support.
+   *
+   * @param {ApiPaginationOptions} options - Pagination options.
+   * @return {Promise<{ teamPolicies: TeamPolicyDetails[]; total: number }>}
+   * @memberof TeamPolicyRepository
+   */
+  async getAllTeamPoliciesWithPagination(
+    options: ApiPaginationOptions
+  ): Promise<{ teamPolicies: TeamPolicyDetails[]; total: number }> {
+    const knex = getKnex();
+
+    // Base query for filtering
+    const baseQuery = () =>
+      knex
+        .from('team_policy as tp')
+        .innerJoin('team as t', 'tp.team_id', 't.team_id')
+        .innerJoin('policy as p', 'tp.policy_id', 'p.policy_id')
+        .whereNull('tp.record_end_date')
+        .whereNull('t.record_end_date')
+        .whereNull('p.record_end_date');
+
+    // Get total count
+    const countQuery = baseQuery().count('* as count').first();
+    const countResult = await this.connection.knex(countQuery);
+    const total = Number(countResult.rows[0]?.count ?? 0);
+
+    // Determine sort column (map frontend field names to SQL columns)
+    const sortColumn = options.sort === 'team_name' ? 't.name' : options.sort === 'policy_name' ? 'p.name' : 't.name';
+    const sortOrder = options.order || 'asc';
+
+    // Get paginated results (page is 1-indexed, so offset = (page - 1) * limit)
+    const dataQuery = baseQuery()
+      .select(['tp.team_policy_id', 'tp.team_id', 'tp.policy_id', 't.name as team_name', 'p.name as policy_name'])
+      .orderBy(sortColumn, sortOrder)
+      .offset((options.page - 1) * options.limit)
+      .limit(options.limit);
+
+    const response = await this.connection.knex(dataQuery, TeamPolicyDetails);
+
+    return { teamPolicies: response.rows, total };
   }
 
   /**

--- a/api/src/repositories/authorization/team-repository.test.ts
+++ b/api/src/repositories/authorization/team-repository.test.ts
@@ -4,6 +4,7 @@ import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { ApiExecuteSQLError } from '../../errors/api-error';
+import { Team } from '../../models/team';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamRepository } from './team-repository';
 
@@ -103,9 +104,9 @@ describe('TeamRepository', () => {
 
   describe('getTeamsWithPagination', () => {
     it('returns paginated teams with total count', async () => {
-      const mockTeams = [
-        { team_id: 'uuid-1', name: 'Team Alpha', description: 'First team' },
-        { team_id: 'uuid-2', name: 'Team Beta', description: 'Second team' }
+      const mockTeams: Team[] = [
+        { team_id: '11111111-1111-1111-1111-111111111111', name: 'Team Alpha', description: 'First team' },
+        { team_id: '22222222-2222-2222-2222-222222222222', name: 'Team Beta', description: 'Second team' }
       ];
 
       // First call returns count, second returns teams
@@ -116,7 +117,7 @@ describe('TeamRepository', () => {
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination({ page: 1, limit: 2 });
+      const result = await repository.getTeamsWithPagination(undefined, { page: 1, limit: 2 });
 
       expect(result.teams).to.eql(mockTeams);
       expect(result.total).to.equal(5);
@@ -132,7 +133,7 @@ describe('TeamRepository', () => {
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination({ page: 1, limit: 50, search: 'Research' });
+      const result = await repository.getTeamsWithPagination('Research', { page: 1, limit: 50 });
 
       expect(result.teams).to.eql(mockTeams);
       expect(result.total).to.equal(1);
@@ -146,7 +147,7 @@ describe('TeamRepository', () => {
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination({ page: 1, limit: 50 });
+      const result = await repository.getTeamsWithPagination(undefined, { page: 1, limit: 50 });
 
       expect(result.teams).to.eql([]);
       expect(result.total).to.equal(0);
@@ -162,7 +163,7 @@ describe('TeamRepository', () => {
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination({ page: 2, limit: 3 });
+      const result = await repository.getTeamsWithPagination(undefined, { page: 2, limit: 3 });
 
       // Page 2 with limit 3 should offset by 3 ((2-1) * 3) for 1-indexed pagination
       expect(result.teams).to.eql(mockTeams);

--- a/api/src/repositories/authorization/team-repository.ts
+++ b/api/src/repositories/authorization/team-repository.ts
@@ -1,6 +1,7 @@
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { CreateTeam, Team, UpdateTeam } from '../../models/team';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
 /**
@@ -85,28 +86,21 @@ export class TeamRepository extends BaseRepository {
   /**
    * Get teams with pagination and optional search.
    *
-   * @param {object} options - Pagination and search options.
-   * @param {number} options.page - Page number (1-indexed).
-   * @param {number} options.limit - Number of items per page.
-   * @param {string} [options.sort] - Column to sort by.
-   * @param {string} [options.order] - Sort direction ('asc' or 'desc').
-   * @param {string} [options.search] - Optional search term to filter by team name.
+   * @param {string} [search] - Optional search term to filter by team name.
+   * @param {ApiPaginationOptions} pagination - Pagination options.
    * @return {Promise<{ teams: Team[]; total: number }>}
    * @memberof TeamRepository
    */
-  async getTeamsWithPagination(options: {
-    page: number;
-    limit: number;
-    sort?: string;
-    order?: 'asc' | 'desc';
-    search?: string;
-  }): Promise<{ teams: Team[]; total: number }> {
+  async getTeamsWithPagination(
+    search: string | undefined,
+    pagination: ApiPaginationOptions
+  ): Promise<{ teams: Team[]; total: number }> {
     const knex = getKnex();
 
     let baseQuery = knex.table('team').whereNull('record_end_date');
 
-    if (options.search) {
-      baseQuery = baseQuery.whereILike('name', `%${options.search}%`);
+    if (search) {
+      baseQuery = baseQuery.whereILike('name', `%${search}%`);
     }
 
     // Build count query
@@ -116,9 +110,9 @@ export class TeamRepository extends BaseRepository {
     const paginatedQuery = baseQuery
       .clone()
       .select(['team_id', 'name', 'description'])
-      .orderBy(options.sort || 'name', options.order || 'asc')
-      .offset((options.page - 1) * options.limit)
-      .limit(options.limit);
+      .orderBy(pagination.sort || 'name', pagination.order || 'asc')
+      .offset((pagination.page - 1) * pagination.limit)
+      .limit(pagination.limit);
 
     // Execute both queries in parallel
     const [countResult, response] = await Promise.all([

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -137,9 +137,9 @@ describe('PolicyService', () => {
         .stub(PolicyStatementConditionRepository.prototype, 'getPolicyStatementConditions')
         .resolves(mockConditions);
 
-      const result = await policyService.getPoliciesWithStatements({ page: 0, limit: 50 });
+      const result = await policyService.getPoliciesWithStatements(undefined, { page: 1, limit: 10 });
 
-      expect(getPoliciesWithPaginationStub).to.have.been.calledWith({ page: 0, limit: 50 });
+      expect(getPoliciesWithPaginationStub).to.have.been.calledWith(undefined, { page: 1, limit: 10 });
       expect(getPolicyStatementsStub).to.have.been.called;
       expect(getConditionsStub).to.have.been.called;
       expect(result).to.eql({
@@ -147,7 +147,7 @@ describe('PolicyService', () => {
           { ...mockPolicies[0], statements: [{ ...mockStatements[0], conditions: mockConditions }] },
           { ...mockPolicies[1], statements: [{ ...mockStatements[0], conditions: mockConditions }] }
         ],
-        pagination: { total: 2, page: 0, limit: 50 }
+        pagination: { total: 2, per_page: 10, current_page: 1, last_page: 1, sort: undefined, order: undefined }
       });
     });
 
@@ -156,12 +156,12 @@ describe('PolicyService', () => {
         .stub(PolicyRepository.prototype, 'getPoliciesWithPagination')
         .resolves({ policies: [], total: 0 });
 
-      const result = await policyService.getPoliciesWithStatements({ page: 0, limit: 50 });
+      const result = await policyService.getPoliciesWithStatements(undefined, { page: 1, limit: 10 });
 
-      expect(getPoliciesWithPaginationStub).to.have.been.calledWith({ page: 0, limit: 50 });
+      expect(getPoliciesWithPaginationStub).to.have.been.calledWith(undefined, { page: 1, limit: 10 });
       expect(result).to.eql({
         policies: [],
-        pagination: { total: 0, page: 0, limit: 50 }
+        pagination: { total: 0, per_page: 10, current_page: 1, last_page: 1, sort: undefined, order: undefined }
       });
     });
   });

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -2,6 +2,8 @@ import { IDBConnection } from '../../database/db';
 import { parseFeatureUrn } from '../../database/urn-utils';
 import { CreatePolicy, Policy, UpdatePolicy } from '../../models/policy';
 import { PolicyRepository } from '../../repositories/authorization/policy-repository';
+import { makePaginationResponse } from '../../utils/pagination';
+import { ApiPaginationOptions, ApiPaginationResults } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 import {
   CreatePolicyStatementInput,
@@ -94,18 +96,19 @@ export class PolicyService extends DBService {
   /**
    * Get all policies with their statements, with pagination and search.
    *
-   * @param {object} options - Pagination and search options.
-   * @param {number} options.page - Page number (0-indexed).
-   * @param {number} options.limit - Number of items per page.
-   * @param {string} [options.search] - Optional search term to filter by policy name.
-   * @return {Promise<{ policies: PolicyWithStatements[]; pagination: { total: number; page: number; limit: number } }>}
+   * @param {string} [search] - Optional search term to filter by policy name.
+   * @param {ApiPaginationOptions} pagination - Pagination options.
+   * @return {Promise<{ policies: PolicyWithStatements[]; pagination: ApiPaginationResults }>}
    * @memberof PolicyService
    */
-  async getPoliciesWithStatements(options: { page: number; limit: number; search?: string }): Promise<{
+  async getPoliciesWithStatements(
+    search: string | undefined,
+    pagination: ApiPaginationOptions
+  ): Promise<{
     policies: PolicyWithStatements[];
-    pagination: { total: number; page: number; limit: number };
+    pagination: ApiPaginationResults;
   }> {
-    const { policies, total } = await this.policyRepository.getPoliciesWithPagination(options);
+    const { policies, total } = await this.policyRepository.getPoliciesWithPagination(search, pagination);
 
     const policiesWithStatements = await Promise.all(
       policies.map(async (policy) => ({
@@ -116,7 +119,7 @@ export class PolicyService extends DBService {
 
     return {
       policies: policiesWithStatements,
-      pagination: { total, page: options.page, limit: options.limit }
+      pagination: makePaginationResponse(total, pagination)
     };
   }
 

--- a/api/src/services/access-policy/team-policy-service.ts
+++ b/api/src/services/access-policy/team-policy-service.ts
@@ -1,6 +1,8 @@
 import { IDBConnection } from '../../database/db';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
 import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
+import { makePaginationResponse } from '../../utils/pagination';
+import { ApiPaginationOptions, ApiPaginationResults } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 
 export class TeamPolicyService extends DBService {
@@ -52,6 +54,24 @@ export class TeamPolicyService extends DBService {
    */
   getAllTeamPolicies(): Promise<TeamPolicyDetails[]> {
     return this.teamPolicyRepository.getAllTeamPolicies();
+  }
+
+  /**
+   * Get all team-policy associations with pagination support.
+   *
+   * @param {ApiPaginationOptions} options - Pagination options.
+   * @return {Promise<{ team_policies: TeamPolicyDetails[]; pagination: ApiPaginationResults }>}
+   * @memberof TeamPolicyService
+   */
+  async getAllTeamPoliciesWithPagination(
+    options: ApiPaginationOptions
+  ): Promise<{ team_policies: TeamPolicyDetails[]; pagination: ApiPaginationResults }> {
+    const { teamPolicies, total } = await this.teamPolicyRepository.getAllTeamPoliciesWithPagination(options);
+
+    return {
+      team_policies: teamPolicies,
+      pagination: makePaginationResponse(total, options)
+    };
   }
 
   /**

--- a/api/src/services/access-policy/team-service.test.ts
+++ b/api/src/services/access-policy/team-service.test.ts
@@ -132,12 +132,12 @@ describe('TeamService', () => {
       sinon.stub(TeamRepository.prototype, 'getTeamsWithPagination').resolves({ teams: mockTeams, total: 2 });
       sinon.stub(service.connection, 'knex').resolves({ rows: mockMembers } as any);
 
-      const result = await service.getTeamsWithMembers({ page: 1, limit: 50 });
+      const result = await service.getTeamsWithMembers(undefined, { page: 1, limit: 50 });
 
       expect(result.pagination).to.eql({
         total: 2,
-        page: 1,
-        limit: 50,
+        per_page: 50,
+        current_page: 1,
         last_page: 1,
         sort: undefined,
         order: undefined
@@ -149,13 +149,13 @@ describe('TeamService', () => {
     it('should return empty array when no teams exist', async () => {
       sinon.stub(TeamRepository.prototype, 'getTeamsWithPagination').resolves({ teams: [], total: 0 });
 
-      const result = await service.getTeamsWithMembers({ page: 1, limit: 50 });
+      const result = await service.getTeamsWithMembers(undefined, { page: 1, limit: 50 });
 
       expect(result.teams).to.eql([]);
       expect(result.pagination).to.eql({
         total: 0,
-        page: 1,
-        limit: 50,
+        per_page: 50,
+        current_page: 1,
         last_page: 1,
         sort: undefined,
         order: undefined

--- a/api/src/services/access-policy/team-service.ts
+++ b/api/src/services/access-policy/team-service.ts
@@ -2,6 +2,8 @@ import { IDBConnection } from '../../database/db';
 import { CreateTeam, Team, UpdateTeam } from '../../models/team';
 import { TeamMemberRepository, TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
 import { TeamRepository } from '../../repositories/authorization/team-repository';
+import { makePaginationResponse } from '../../utils/pagination';
+import { ApiPaginationOptions, ApiPaginationResults } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 
 /**
@@ -79,33 +81,19 @@ export class TeamService extends DBService {
   /**
    * Get all teams with their members, with pagination and search.
    *
-   * @param {object} options - Pagination and search options.
-   * @param {number} options.page - Page number (1-indexed).
-   * @param {number} options.limit - Number of items per page.
-   * @param {string} [options.sort] - Column to sort by.
-   * @param {('asc' | 'desc')} [options.order] - Sort direction.
-   * @param {string} [options.search] - Optional search term to filter by team name.
-   * @return {Promise<{ teams: TeamWithMembers[]; pagination: { total: number; page: number; limit: number; last_page: number; sort?: string; order?: string } }>}
+   * @param {string} [search] - Optional search term to filter by team name.
+   * @param {ApiPaginationOptions} pagination - Pagination options.
+   * @return {Promise<{ teams: TeamWithMembers[]; pagination: ApiPaginationResults }>}
    * @memberof TeamService
    */
-  async getTeamsWithMembers(options: {
-    page: number;
-    limit: number;
-    sort?: string;
-    order?: 'asc' | 'desc';
-    search?: string;
-  }): Promise<{
+  async getTeamsWithMembers(
+    search: string | undefined,
+    pagination: ApiPaginationOptions
+  ): Promise<{
     teams: TeamWithMembers[];
-    pagination: {
-      total: number;
-      page: number;
-      limit: number;
-      last_page: number;
-      sort?: string;
-      order?: string;
-    };
+    pagination: ApiPaginationResults;
   }> {
-    const { teams, total } = await this.teamRepository.getTeamsWithPagination(options);
+    const { teams, total } = await this.teamRepository.getTeamsWithPagination(search, pagination);
 
     const teamsWithMembers = await Promise.all(
       teams.map(async (team) => ({
@@ -116,14 +104,7 @@ export class TeamService extends DBService {
 
     return {
       teams: teamsWithMembers,
-      pagination: {
-        total,
-        page: options.page,
-        limit: options.limit,
-        last_page: Math.max(1, Math.ceil(total / options.limit)),
-        sort: options.sort,
-        order: options.order
-      }
+      pagination: makePaginationResponse(total, pagination)
     };
   }
 

--- a/app/src/features/admin/policies/ManagePoliciesPage.test.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.test.tsx
@@ -1,29 +1,125 @@
-import { cleanup, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { useApi } from 'hooks/useApi';
+import { IPolicy } from 'interfaces/usePoliciesApi.interface';
+import { ITeamPolicyDetails } from 'interfaces/useTeamPoliciesApi.interface';
+import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
 import { MemoryRouter } from 'react-router';
 import { render } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
 import { ManagePoliciesPage } from './ManagePoliciesPage';
 
-// Mock Monaco Editor - it doesn't work well in jsdom and causes hangs
-vi.mock('@monaco-editor/react', () => ({
-  default: ({ value, onChange }: { value?: string; onChange?: (value?: string) => void }) => (
-    <textarea data-testid="monaco-editor" value={value || ''} onChange={(e) => onChange?.(e.target.value)} />
-  ),
-  loader: {
-    init: vi.fn().mockResolvedValue({
-      languages: {
-        json: {
-          jsonDefaults: {
-            setDiagnosticsOptions: vi.fn()
-          }
-        }
-      }
-    })
-  }
+// Types for mock component props
+interface MockActivePoliciesListProps {
+  policies: IPolicy[];
+  onSelectPolicy: (id: string | null) => void;
+  selectedPolicyId: string | null;
+}
+
+interface MockTeamsContainerProps {
+  teams: ITeamWithMembers[];
+  onSelectTeam: (id: string | null) => void;
+  selectedTeamId: string | null;
+}
+
+interface MockTeamPoliciesContainerProps {
+  teamPolicies: ITeamPolicyDetails[];
+  selectedTeam: ITeamWithMembers | null;
+  selectedPolicy: IPolicy | null;
+}
+
+// Mock child components - we test them separately, here we test page logic
+vi.mock('./components/ActivePoliciesList', () => ({
+  ActivePoliciesList: ({ policies, onSelectPolicy, selectedPolicyId }: MockActivePoliciesListProps) => (
+    <div data-testid="active-policies-list">
+      {policies.map((p) => (
+        <div
+          key={p.policy_id}
+          data-testid={`policy-${p.policy_id}`}
+          data-selected={selectedPolicyId === p.policy_id}
+          onClick={() => onSelectPolicy(selectedPolicyId === p.policy_id ? null : p.policy_id)}
+        >
+          {p.name}
+        </div>
+      ))}
+    </div>
+  )
 }));
 
-const renderContainer = () => {
+vi.mock('./components/TeamsContainer', () => ({
+  TeamsContainer: ({ teams, onSelectTeam, selectedTeamId }: MockTeamsContainerProps) => (
+    <div data-testid="teams-container">
+      {teams.map((t) => (
+        <div
+          key={t.team_id}
+          data-testid={`team-${t.team_id}`}
+          data-selected={selectedTeamId === t.team_id}
+          onClick={() => onSelectTeam(selectedTeamId === t.team_id ? null : t.team_id)}
+        >
+          {t.name}
+        </div>
+      ))}
+    </div>
+  )
+}));
+
+vi.mock('./components/TeamPoliciesContainer', () => ({
+  TeamPoliciesContainer: ({ teamPolicies, selectedTeam, selectedPolicy }: MockTeamPoliciesContainerProps) => (
+    <div data-testid="team-policies-container">
+      <div data-testid="header">
+        {selectedTeam && selectedPolicy
+          ? `Assignment: ${selectedTeam.name} + ${selectedPolicy.name}`
+          : selectedTeam
+            ? `Policies for "${selectedTeam.name}"`
+            : selectedPolicy
+              ? `Teams with "${selectedPolicy.name}"`
+              : 'Team-Policy Assignments'}
+      </div>
+      {teamPolicies.map((tp) => (
+        <div key={tp.team_policy_id} data-testid={`tp-${tp.team_policy_id}`}>
+          {tp.team_name} - {tp.policy_name}
+        </div>
+      ))}
+    </div>
+  )
+}));
+
+vi.mock('../../../hooks/useApi');
+const mockBiohubApi = useApi as Mock;
+
+// Mock data
+const mockPolicies = [
+  { policy_id: 'p1', name: 'Policy One', description: 'First policy', statements: [] },
+  { policy_id: 'p2', name: 'Policy Two', description: 'Second policy', statements: [] }
+];
+
+const mockTeams = [
+  { team_id: 't1', name: 'Team Alpha', description: 'First team', members: [] },
+  { team_id: 't2', name: 'Team Beta', description: 'Second team', members: [] }
+];
+
+const mockTeamPolicies = [
+  { team_policy_id: 'tp1', team_id: 't1', policy_id: 'p1', team_name: 'Team Alpha', policy_name: 'Policy One' },
+  { team_policy_id: 'tp2', team_id: 't2', policy_id: 'p2', team_name: 'Team Beta', policy_name: 'Policy Two' },
+  { team_policy_id: 'tp3', team_id: 't1', policy_id: 'p2', team_name: 'Team Alpha', policy_name: 'Policy Two' }
+];
+
+const mockGetPolicies = vi.fn();
+const mockGetTeams = vi.fn();
+const mockGetTeamPolicies = vi.fn();
+
+const mockUseApi = {
+  policies: {
+    getPolicies: mockGetPolicies
+  },
+  teams: {
+    getTeams: mockGetTeams
+  },
+  teamPolicies: {
+    getTeamPolicies: mockGetTeamPolicies
+  }
+};
+
+const renderPage = () => {
   return render(
     <MemoryRouter initialEntries={['/']}>
       <ManagePoliciesPage />
@@ -31,42 +127,293 @@ const renderContainer = () => {
   );
 };
 
-vi.mock('../../../hooks/useApi');
-
-const mockBiohubApi = useApi as Mock;
-
-const mockUseApi = {
-  policies: {
-    getPolicies: vi.fn()
-  }
+const setupMocksWithData = () => {
+  mockGetPolicies.mockResolvedValue({
+    policies: mockPolicies,
+    pagination: { total: 2, page: 1, limit: 10 }
+  });
+  mockGetTeams.mockResolvedValue({
+    teams: mockTeams,
+    pagination: { total: 2, page: 1, limit: 10 }
+  });
+  mockGetTeamPolicies.mockResolvedValue({
+    team_policies: mockTeamPolicies,
+    pagination: { total: 3, page: 1, limit: 10 }
+  });
 };
 
 describe('ManagePoliciesPage', () => {
   beforeEach(() => {
     mockBiohubApi.mockImplementation(() => mockUseApi);
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it('renders the main page content correctly', async () => {
-    mockUseApi.policies.getPolicies.mockResolvedValue({ policies: [], pagination: { total: 0, page: 1, limit: 10 } });
+  describe('Client-Side Filtering (Team-Policy Assignments)', () => {
+    it('shows all assignments when nothing selected', async () => {
+      // Step 1: Setup API mocks to return test data
+      setupMocksWithData();
 
-    const { getByText } = renderContainer();
+      // Step 2: Render page
+      const { getByTestId } = renderPage();
 
-    await waitFor(() => {
-      expect(getByText('Manage Policies')).toBeVisible();
+      // Step 3: Verify all 3 assignments are visible (no filtering)
+      await waitFor(() => {
+        expect(getByTestId('tp-tp1')).toBeVisible();
+        expect(getByTestId('tp-tp2')).toBeVisible();
+        expect(getByTestId('tp-tp3')).toBeVisible();
+      });
+    });
+
+    it('filters assignments when policy is selected', async () => {
+      // Step 1: Setup API mocks
+      setupMocksWithData();
+
+      // Step 2: Render page
+      const { getByTestId, queryByTestId } = renderPage();
+
+      // Step 3: Wait for policies to load
+      await waitFor(() => {
+        expect(getByTestId('policy-p1')).toBeVisible();
+      });
+
+      // Step 4: Click on Policy One (p1) to select it
+      fireEvent.click(getByTestId('policy-p1'));
+
+      // Step 5: Verify filtering - only tp1 has policy_id='p1'
+      await waitFor(() => {
+        expect(getByTestId('tp-tp1')).toBeVisible();
+        expect(queryByTestId('tp-tp2')).toBeNull();
+        expect(queryByTestId('tp-tp3')).toBeNull();
+      });
+    });
+
+    it('filters assignments when team is selected', async () => {
+      // Step 1: Setup API mocks
+      setupMocksWithData();
+
+      // Step 2: Render page
+      const { getByTestId, queryByTestId } = renderPage();
+
+      // Step 3: Wait for teams to load
+      await waitFor(() => {
+        expect(getByTestId('team-t1')).toBeVisible();
+      });
+
+      // Step 4: Click on Team Alpha (t1) to select it
+      fireEvent.click(getByTestId('team-t1'));
+
+      // Step 5: Verify filtering - tp1 and tp3 have team_id='t1'
+      await waitFor(() => {
+        expect(getByTestId('tp-tp1')).toBeVisible();
+        expect(queryByTestId('tp-tp2')).toBeNull();
+        expect(getByTestId('tp-tp3')).toBeVisible();
+      });
+    });
+
+    it('filters assignments when both team and policy selected', async () => {
+      // Step 1: Setup API mocks
+      setupMocksWithData();
+
+      // Step 2: Render page
+      const { getByTestId, queryByTestId } = renderPage();
+
+      // Step 3: Wait for data to load
+      await waitFor(() => {
+        expect(getByTestId('policy-p2')).toBeVisible();
+        expect(getByTestId('team-t1')).toBeVisible();
+      });
+
+      // Step 4: Select Policy Two AND Team Alpha
+      fireEvent.click(getByTestId('policy-p2'));
+      fireEvent.click(getByTestId('team-t1'));
+
+      // Step 5: Verify intersection - only tp3 has both team_id='t1' AND policy_id='p2'
+      await waitFor(() => {
+        expect(queryByTestId('tp-tp1')).toBeNull();
+        expect(queryByTestId('tp-tp2')).toBeNull();
+        expect(getByTestId('tp-tp3')).toBeVisible();
+      });
     });
   });
 
-  it('renders the active policies component', async () => {
-    mockUseApi.policies.getPolicies.mockResolvedValue({ policies: [], pagination: { total: 0, page: 1, limit: 10 } });
+  describe('Dynamic Header Updates', () => {
+    it('updates header when team selected', async () => {
+      // Step 1: Setup and render
+      setupMocksWithData();
+      const { getByTestId } = renderPage();
 
-    const { getByText } = renderContainer();
+      // Step 2: Wait for data to load
+      await waitFor(() => {
+        expect(getByTestId('team-t1')).toBeVisible();
+      });
 
-    await waitFor(() => {
-      expect(getByText('No Policies')).toBeVisible();
+      // Step 3: Select a team
+      fireEvent.click(getByTestId('team-t1'));
+
+      // Step 4: Verify header shows team-specific text
+      await waitFor(() => {
+        expect(getByTestId('header')).toHaveTextContent('Policies for "Team Alpha"');
+      });
+    });
+
+    it('updates header when policy selected', async () => {
+      // Step 1: Setup and render
+      setupMocksWithData();
+      const { getByTestId } = renderPage();
+
+      // Step 2: Wait for data to load
+      await waitFor(() => {
+        expect(getByTestId('policy-p1')).toBeVisible();
+      });
+
+      // Step 3: Select a policy
+      fireEvent.click(getByTestId('policy-p1'));
+
+      // Step 4: Verify header shows policy-specific text
+      await waitFor(() => {
+        expect(getByTestId('header')).toHaveTextContent('Teams with "Policy One"');
+      });
+    });
+
+    it('updates header when both selected', async () => {
+      // Step 1: Setup and render
+      setupMocksWithData();
+      const { getByTestId } = renderPage();
+
+      // Step 2: Wait for data to load
+      await waitFor(() => {
+        expect(getByTestId('team-t1')).toBeVisible();
+        expect(getByTestId('policy-p1')).toBeVisible();
+      });
+
+      // Step 3: Select both team and policy
+      fireEvent.click(getByTestId('team-t1'));
+      fireEvent.click(getByTestId('policy-p1'));
+
+      // Step 4: Verify header shows combined assignment text
+      await waitFor(() => {
+        expect(getByTestId('header')).toHaveTextContent('Assignment: Team Alpha + Policy One');
+      });
+    });
+  });
+
+  describe('API Integration', () => {
+    it('calls getPolicies with correct pagination params on mount', async () => {
+      // Step 1: Setup mocks
+      setupMocksWithData();
+
+      // Step 2: Render page (triggers API calls)
+      renderPage();
+
+      // Step 3: Verify getPolicies was called with correct params
+      await waitFor(() => {
+        expect(mockGetPolicies).toHaveBeenCalledWith(
+          { search: undefined },
+          expect.objectContaining({
+            page: 1,
+            limit: 10,
+            sort: 'name',
+            order: 'asc'
+          })
+        );
+      });
+    });
+
+    it('calls getTeams with correct pagination params on mount', async () => {
+      // Step 1: Setup mocks
+      setupMocksWithData();
+
+      // Step 2: Render page (triggers API calls)
+      renderPage();
+
+      // Step 3: Verify getTeams was called with correct params
+      await waitFor(() => {
+        expect(mockGetTeams).toHaveBeenCalledWith(
+          { search: undefined },
+          expect.objectContaining({
+            page: 1,
+            limit: 10,
+            sort: 'name',
+            order: 'asc'
+          })
+        );
+      });
+    });
+
+    it('calls getTeamPolicies with correct pagination params on mount', async () => {
+      // Step 1: Setup mocks
+      setupMocksWithData();
+
+      // Step 2: Render page (triggers API calls)
+      renderPage();
+
+      // Step 3: Verify getTeamPolicies was called with correct params
+      await waitFor(() => {
+        expect(mockGetTeamPolicies).toHaveBeenCalledWith(
+          expect.objectContaining({
+            page: 1,
+            limit: 10,
+            sort: 'team_name',
+            order: 'asc'
+          })
+        );
+      });
+    });
+  });
+
+  describe('Selection State', () => {
+    it('deselects policy when clicking selected policy', async () => {
+      // Step 1: Setup and render
+      setupMocksWithData();
+      const { getByTestId } = renderPage();
+
+      // Step 2: Wait for data to load
+      await waitFor(() => {
+        expect(getByTestId('policy-p1')).toBeVisible();
+      });
+
+      // Step 3: Click to SELECT policy
+      fireEvent.click(getByTestId('policy-p1'));
+      await waitFor(() => {
+        expect(getByTestId('header')).toHaveTextContent('Teams with "Policy One"');
+      });
+
+      // Step 4: Click again to DESELECT (toggle behavior)
+      fireEvent.click(getByTestId('policy-p1'));
+
+      // Step 5: Verify header returns to default state
+      await waitFor(() => {
+        expect(getByTestId('header')).toHaveTextContent('Team-Policy Assignments');
+      });
+    });
+
+    it('deselects team when clicking selected team', async () => {
+      // Step 1: Setup and render
+      setupMocksWithData();
+      const { getByTestId } = renderPage();
+
+      // Step 2: Wait for data to load
+      await waitFor(() => {
+        expect(getByTestId('team-t1')).toBeVisible();
+      });
+
+      // Step 3: Click to SELECT team
+      fireEvent.click(getByTestId('team-t1'));
+      await waitFor(() => {
+        expect(getByTestId('header')).toHaveTextContent('Policies for "Team Alpha"');
+      });
+
+      // Step 4: Click again to DESELECT (toggle behavior)
+      fireEvent.click(getByTestId('team-t1'));
+
+      // Step 5: Verify header returns to default state
+      await waitFor(() => {
+        expect(getByTestId('header')).toHaveTextContent('Team-Policy Assignments');
+      });
     });
   });
 });

--- a/app/src/features/admin/policies/ManagePoliciesPage.test.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.test.tsx
@@ -36,8 +36,7 @@ vi.mock('./components/ActivePoliciesList', () => ({
           key={p.policy_id}
           data-testid={`policy-${p.policy_id}`}
           data-selected={selectedPolicyId === p.policy_id}
-          onClick={() => onSelectPolicy(selectedPolicyId === p.policy_id ? null : p.policy_id)}
-        >
+          onClick={() => onSelectPolicy(selectedPolicyId === p.policy_id ? null : p.policy_id)}>
           {p.name}
         </div>
       ))}
@@ -53,8 +52,7 @@ vi.mock('./components/TeamsContainer', () => ({
           key={t.team_id}
           data-testid={`team-${t.team_id}`}
           data-selected={selectedTeamId === t.team_id}
-          onClick={() => onSelectTeam(selectedTeamId === t.team_id ? null : t.team_id)}
-        >
+          onClick={() => onSelectTeam(selectedTeamId === t.team_id ? null : t.team_id)}>
           {t.name}
         </div>
       ))}

--- a/app/src/features/admin/policies/ManagePoliciesPage.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.tsx
@@ -1,10 +1,13 @@
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
+import { GridPaginationModel, GridSortModel } from '@mui/x-data-grid';
 import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { debounce } from 'lodash-es';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ApiPaginationRequestOptions } from 'types/misc';
+import { firstOrNull } from 'utils/Utils';
 import { ActivePoliciesList } from './components/ActivePoliciesList';
 import { TeamPoliciesContainer } from './components/TeamPoliciesContainer';
 import { TeamsContainer } from './components/TeamsContainer';
@@ -32,23 +35,105 @@ export const ManagePoliciesPage = () => {
   const [teamSearchTerm, setTeamSearchTerm] = useState('');
   const [debouncedTeamSearchTerm, setDebouncedTeamSearchTerm] = useState('');
 
+  // Policies pagination state
+  const [policiesPaginationModel, setPoliciesPaginationModel] = useState<GridPaginationModel>({
+    page: 0,
+    pageSize: 50
+  });
+  const [policiesSortModel, setPoliciesSortModel] = useState<GridSortModel>([{ field: 'name', sort: 'asc' }]);
+
+  // Teams pagination state
+  const [teamsPaginationModel, setTeamsPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: 10 });
+  const [teamsSortModel, setTeamsSortModel] = useState<GridSortModel>([{ field: 'name', sort: 'asc' }]);
+
+  // TeamPolicies pagination state
+  const [teamPoliciesPaginationModel, setTeamPoliciesPaginationModel] = useState<GridPaginationModel>({
+    page: 0,
+    pageSize: 10
+  });
+  const [teamPoliciesSortModel, setTeamPoliciesSortModel] = useState<GridSortModel>([
+    { field: 'team_name', sort: 'asc' }
+  ]);
+
+  // Policies pagination options (memoized to prevent unnecessary re-renders)
+  const policiesPagination: ApiPaginationRequestOptions = useMemo(() => {
+    const sort = firstOrNull(policiesSortModel);
+    return {
+      page: policiesPaginationModel.page + 1,
+      limit: policiesPaginationModel.pageSize,
+      sort: sort?.field,
+      order: sort?.sort as 'asc' | 'desc' | undefined
+    };
+  }, [policiesPaginationModel, policiesSortModel]);
+
+  // Teams pagination options (memoized to prevent unnecessary re-renders)
+  const teamsPagination: ApiPaginationRequestOptions = useMemo(() => {
+    const sort = firstOrNull(teamsSortModel);
+    return {
+      page: teamsPaginationModel.page + 1,
+      limit: teamsPaginationModel.pageSize,
+      sort: sort?.field,
+      order: sort?.sort as 'asc' | 'desc' | undefined
+    };
+  }, [teamsPaginationModel, teamsSortModel]);
+
+  // TeamPolicies pagination options (memoized to prevent unnecessary re-renders)
+  const teamPoliciesPagination: ApiPaginationRequestOptions = useMemo(() => {
+    const sort = firstOrNull(teamPoliciesSortModel);
+    return {
+      page: teamPoliciesPaginationModel.page + 1,
+      limit: teamPoliciesPaginationModel.pageSize,
+      sort: sort?.field,
+      order: sort?.sort as 'asc' | 'desc' | undefined
+    };
+  }, [teamPoliciesPaginationModel, teamPoliciesSortModel]);
+
   // Data loaders
-  const policiesDataLoader = useDataLoader((search?: string) =>
-    biohubApi.policies.getPolicies({ search: search || undefined })
+  const policiesDataLoader = useDataLoader((pagination: ApiPaginationRequestOptions, search?: string) =>
+    biohubApi.policies.getPolicies({ search }, pagination)
   );
 
-  const teamsDataLoader = useDataLoader((search?: string) =>
-    biohubApi.teams.getTeams({ page: 1, limit: 100, search: search || undefined })
+  const teamsDataLoader = useDataLoader((pagination: ApiPaginationRequestOptions, search?: string) =>
+    biohubApi.teams.getTeams({ search }, pagination)
   );
 
-  const teamPoliciesDataLoader = useDataLoader(() => biohubApi.teamPolicies.getTeamPolicies());
+  const teamPoliciesDataLoader = useDataLoader((pagination: ApiPaginationRequestOptions) =>
+    biohubApi.teamPolicies.getTeamPolicies(pagination)
+  );
 
   // Load data on mount
   useEffect(() => {
-    policiesDataLoader.load(debouncedPolicySearchTerm);
-    teamsDataLoader.load(debouncedTeamSearchTerm);
-    teamPoliciesDataLoader.load();
-  }, [teamPoliciesDataLoader, teamsDataLoader, policiesDataLoader, debouncedPolicySearchTerm, debouncedTeamSearchTerm]);
+    policiesDataLoader.load(policiesPagination, debouncedPolicySearchTerm);
+    teamsDataLoader.load(teamsPagination, debouncedTeamSearchTerm);
+    teamPoliciesDataLoader.load(teamPoliciesPagination);
+  }, [
+    teamPoliciesDataLoader,
+    teamsDataLoader,
+    policiesDataLoader,
+    debouncedPolicySearchTerm,
+    debouncedTeamSearchTerm,
+    policiesPagination,
+    teamsPagination,
+    teamPoliciesPagination
+  ]);
+
+  // Refresh policies when pagination/sort changes
+  useEffect(() => {
+    policiesDataLoader.refresh(policiesPagination, debouncedPolicySearchTerm);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [policiesPagination]);
+
+  // Refresh teams when pagination/sort changes
+  useEffect(() => {
+    teamsDataLoader.refresh(teamsPagination, debouncedTeamSearchTerm);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamsPagination]);
+
+  // Refresh teamPolicies when pagination/sort changes
+  useEffect(() => {
+    teamPoliciesDataLoader.refresh(teamPoliciesPagination);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamPoliciesPagination]);
 
   // Data
   const policies = policiesDataLoader.data?.policies ?? [];
@@ -79,9 +164,9 @@ export const ManagePoliciesPage = () => {
   // Debounced search handlers
   const debouncedPolicyRefresh = useMemo(
     () =>
-      debounce((term: string) => {
+      debounce((term: string, pagination: ApiPaginationRequestOptions) => {
         setDebouncedPolicySearchTerm(term);
-        policiesDataLoader.refresh(term);
+        policiesDataLoader.refresh(pagination, term);
       }, 300),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
@@ -89,9 +174,9 @@ export const ManagePoliciesPage = () => {
 
   const debouncedTeamRefresh = useMemo(
     () =>
-      debounce((term: string) => {
+      debounce((term: string, pagination: ApiPaginationRequestOptions) => {
         setDebouncedTeamSearchTerm(term);
-        teamsDataLoader.refresh(term);
+        teamsDataLoader.refresh(pagination, term);
       }, 300),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
@@ -100,19 +185,23 @@ export const ManagePoliciesPage = () => {
   const handlePolicySearch = useCallback(
     (term: string) => {
       setPolicySearchTerm(term);
-      debouncedPolicyRefresh(term);
+      // Reset to first page when searching
+      setPoliciesPaginationModel((prev) => ({ ...prev, page: 0 }));
+      debouncedPolicyRefresh(term, { ...policiesPagination, page: 1 });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [policiesPagination]
   );
 
   const handleTeamSearch = useCallback(
     (term: string) => {
       setTeamSearchTerm(term);
-      debouncedTeamRefresh(term);
+      // Reset to first page when searching
+      setTeamsPaginationModel((prev) => ({ ...prev, page: 0 }));
+      debouncedTeamRefresh(term, { ...teamsPagination, page: 1 });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [teamsPagination]
   );
 
   // Selection handlers
@@ -126,24 +215,29 @@ export const ManagePoliciesPage = () => {
 
   // Refresh handlers
   const refreshPolicies = useCallback(() => {
-    policiesDataLoader.refresh(debouncedPolicySearchTerm);
+    policiesDataLoader.refresh(policiesPagination, debouncedPolicySearchTerm);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedPolicySearchTerm]);
+  }, [debouncedPolicySearchTerm, policiesPagination]);
 
   const refreshTeams = useCallback(() => {
-    teamsDataLoader.refresh(debouncedTeamSearchTerm);
+    teamsDataLoader.refresh(teamsPagination, debouncedTeamSearchTerm);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedTeamSearchTerm]);
+  }, [debouncedTeamSearchTerm, teamsPagination]);
 
   const refreshTeamPolicies = useCallback(() => {
-    teamPoliciesDataLoader.refresh();
+    teamPoliciesDataLoader.refresh(teamPoliciesPagination);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [teamPoliciesPagination]);
 
   return (
     <Box py={7}>
       <ActivePoliciesList
         policies={policies}
+        rowCount={policiesDataLoader.data?.pagination.total ?? 0}
+        paginationModel={policiesPaginationModel}
+        setPaginationModel={setPoliciesPaginationModel}
+        sortModel={policiesSortModel}
+        setSortModel={setPoliciesSortModel}
         refresh={refreshPolicies}
         searchTerm={policySearchTerm}
         onSearch={handlePolicySearch}
@@ -155,6 +249,11 @@ export const ManagePoliciesPage = () => {
         <Paper>
           <TeamsContainer
             teams={teams}
+            rowCount={teamsDataLoader.data?.pagination.total ?? 0}
+            paginationModel={teamsPaginationModel}
+            setPaginationModel={setTeamsPaginationModel}
+            sortModel={teamsSortModel}
+            setSortModel={setTeamsSortModel}
             refresh={refreshTeams}
             searchTerm={teamSearchTerm}
             onSearch={handleTeamSearch}
@@ -168,6 +267,11 @@ export const ManagePoliciesPage = () => {
         <Paper>
           <TeamPoliciesContainer
             teamPolicies={filteredTeamPolicies}
+            rowCount={teamPoliciesDataLoader.data?.pagination.total ?? 0}
+            paginationModel={teamPoliciesPaginationModel}
+            setPaginationModel={setTeamPoliciesPaginationModel}
+            sortModel={teamPoliciesSortModel}
+            setSortModel={setTeamPoliciesSortModel}
             selectedTeam={selectedTeam}
             selectedPolicy={selectedPolicy}
             refresh={refreshTeamPolicies}

--- a/app/src/features/admin/policies/ManagePoliciesPage.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.tsx
@@ -43,8 +43,13 @@ export const ManagePoliciesPage = () => {
   });
 
   // TeamPolicies - simpler pattern (no search, has client-side filtering)
-  const [teamPoliciesPaginationModel, setTeamPoliciesPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: 10 });
-  const [teamPoliciesSortModel, setTeamPoliciesSortModel] = useState<GridSortModel>([{ field: 'team_name', sort: 'asc' }]);
+  const [teamPoliciesPaginationModel, setTeamPoliciesPaginationModel] = useState<GridPaginationModel>({
+    page: 0,
+    pageSize: 10
+  });
+  const [teamPoliciesSortModel, setTeamPoliciesSortModel] = useState<GridSortModel>([
+    { field: 'team_name', sort: 'asc' }
+  ]);
 
   const teamPoliciesDataLoader = useDataLoader((pagination: ApiPaginationRequestOptions) =>
     biohubApi.teamPolicies.getTeamPolicies(pagination)

--- a/app/src/features/admin/policies/ManagePoliciesPage.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.tsx
@@ -38,7 +38,7 @@ export const ManagePoliciesPage = () => {
   // Policies pagination state
   const [policiesPaginationModel, setPoliciesPaginationModel] = useState<GridPaginationModel>({
     page: 0,
-    pageSize: 50
+    pageSize: 10
   });
   const [policiesSortModel, setPoliciesSortModel] = useState<GridSortModel>([{ field: 'name', sort: 'asc' }]);
 

--- a/app/src/features/admin/policies/ManagePoliciesPage.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.tsx
@@ -89,11 +89,11 @@ export const ManagePoliciesPage = () => {
   }, [teamPoliciesPaginationModel, teamPoliciesSortModel]);
 
   // Data loaders
-  const policiesDataLoader = useDataLoader((pagination: ApiPaginationRequestOptions, search?: string) =>
+  const policiesDataLoader = useDataLoader((search: string | undefined, pagination: ApiPaginationRequestOptions) =>
     biohubApi.policies.getPolicies({ search }, pagination)
   );
 
-  const teamsDataLoader = useDataLoader((pagination: ApiPaginationRequestOptions, search?: string) =>
+  const teamsDataLoader = useDataLoader((search: string | undefined, pagination: ApiPaginationRequestOptions) =>
     biohubApi.teams.getTeams({ search }, pagination)
   );
 
@@ -103,8 +103,8 @@ export const ManagePoliciesPage = () => {
 
   // Load data on mount
   useEffect(() => {
-    policiesDataLoader.load(policiesPagination, debouncedPolicySearchTerm);
-    teamsDataLoader.load(teamsPagination, debouncedTeamSearchTerm);
+    policiesDataLoader.load(debouncedPolicySearchTerm, policiesPagination);
+    teamsDataLoader.load(debouncedTeamSearchTerm, teamsPagination);
     teamPoliciesDataLoader.load(teamPoliciesPagination);
   }, [
     teamPoliciesDataLoader,
@@ -119,13 +119,13 @@ export const ManagePoliciesPage = () => {
 
   // Refresh policies when pagination/sort changes
   useEffect(() => {
-    policiesDataLoader.refresh(policiesPagination, debouncedPolicySearchTerm);
+    policiesDataLoader.refresh(debouncedPolicySearchTerm, policiesPagination);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [policiesPagination]);
 
   // Refresh teams when pagination/sort changes
   useEffect(() => {
-    teamsDataLoader.refresh(teamsPagination, debouncedTeamSearchTerm);
+    teamsDataLoader.refresh(debouncedTeamSearchTerm, teamsPagination);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamsPagination]);
 
@@ -166,7 +166,7 @@ export const ManagePoliciesPage = () => {
     () =>
       debounce((term: string, pagination: ApiPaginationRequestOptions) => {
         setDebouncedPolicySearchTerm(term);
-        policiesDataLoader.refresh(pagination, term);
+        policiesDataLoader.refresh(term, pagination);
       }, 300),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
@@ -176,7 +176,7 @@ export const ManagePoliciesPage = () => {
     () =>
       debounce((term: string, pagination: ApiPaginationRequestOptions) => {
         setDebouncedTeamSearchTerm(term);
-        teamsDataLoader.refresh(pagination, term);
+        teamsDataLoader.refresh(term, pagination);
       }, 300),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
@@ -215,12 +215,12 @@ export const ManagePoliciesPage = () => {
 
   // Refresh handlers
   const refreshPolicies = useCallback(() => {
-    policiesDataLoader.refresh(policiesPagination, debouncedPolicySearchTerm);
+    policiesDataLoader.refresh(debouncedPolicySearchTerm, policiesPagination);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedPolicySearchTerm, policiesPagination]);
 
   const refreshTeams = useCallback(() => {
-    teamsDataLoader.refresh(teamsPagination, debouncedTeamSearchTerm);
+    teamsDataLoader.refresh(debouncedTeamSearchTerm, teamsPagination);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedTeamSearchTerm, teamsPagination]);
 

--- a/app/src/features/admin/policies/ManagePoliciesPage.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.tsx
@@ -4,10 +4,9 @@ import Paper from '@mui/material/Paper';
 import { GridPaginationModel, GridSortModel } from '@mui/x-data-grid';
 import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
-import { debounce } from 'lodash-es';
+import { toApiPagination, useServerPaginatedDataGrid } from 'hooks/useServerPaginatedDataGrid';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApiPaginationRequestOptions } from 'types/misc';
-import { firstOrNull } from 'utils/Utils';
 import { ActivePoliciesList } from './components/ActivePoliciesList';
 import { TeamPoliciesContainer } from './components/TeamPoliciesContainer';
 import { TeamsContainer } from './components/TeamsContainer';
@@ -27,124 +26,62 @@ export const ManagePoliciesPage = () => {
   const [selectedPolicyId, setSelectedPolicyId] = useState<string | null>(null);
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
 
-  // Policy search state
-  const [policySearchTerm, setPolicySearchTerm] = useState('');
-  const [debouncedPolicySearchTerm, setDebouncedPolicySearchTerm] = useState('');
-
-  // Team search state
-  const [teamSearchTerm, setTeamSearchTerm] = useState('');
-  const [debouncedTeamSearchTerm, setDebouncedTeamSearchTerm] = useState('');
-
-  // Policies pagination state
-  const [policiesPaginationModel, setPoliciesPaginationModel] = useState<GridPaginationModel>({
-    page: 0,
-    pageSize: 10
+  // Policies data grid
+  const policies = useServerPaginatedDataGrid({
+    fetcher: (search, pagination) => biohubApi.policies.getPolicies({ search }, pagination),
+    extractData: (response) => response.policies,
+    extractTotal: (response) => response.pagination.total,
+    defaultSort: { field: 'name', sort: 'asc' }
   });
-  const [policiesSortModel, setPoliciesSortModel] = useState<GridSortModel>([{ field: 'name', sort: 'asc' }]);
 
-  // Teams pagination state
-  const [teamsPaginationModel, setTeamsPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: 10 });
-  const [teamsSortModel, setTeamsSortModel] = useState<GridSortModel>([{ field: 'name', sort: 'asc' }]);
-
-  // TeamPolicies pagination state
-  const [teamPoliciesPaginationModel, setTeamPoliciesPaginationModel] = useState<GridPaginationModel>({
-    page: 0,
-    pageSize: 10
+  // Teams data grid
+  const teams = useServerPaginatedDataGrid({
+    fetcher: (search, pagination) => biohubApi.teams.getTeams({ search }, pagination),
+    extractData: (response) => response.teams,
+    extractTotal: (response) => response.pagination.total,
+    defaultSort: { field: 'name', sort: 'asc' }
   });
-  const [teamPoliciesSortModel, setTeamPoliciesSortModel] = useState<GridSortModel>([
-    { field: 'team_name', sort: 'asc' }
-  ]);
 
-  // Policies pagination options (memoized to prevent unnecessary re-renders)
-  const policiesPagination: ApiPaginationRequestOptions = useMemo(() => {
-    const sort = firstOrNull(policiesSortModel);
-    return {
-      page: policiesPaginationModel.page + 1,
-      limit: policiesPaginationModel.pageSize,
-      sort: sort?.field,
-      order: sort?.sort as 'asc' | 'desc' | undefined
-    };
-  }, [policiesPaginationModel, policiesSortModel]);
-
-  // Teams pagination options (memoized to prevent unnecessary re-renders)
-  const teamsPagination: ApiPaginationRequestOptions = useMemo(() => {
-    const sort = firstOrNull(teamsSortModel);
-    return {
-      page: teamsPaginationModel.page + 1,
-      limit: teamsPaginationModel.pageSize,
-      sort: sort?.field,
-      order: sort?.sort as 'asc' | 'desc' | undefined
-    };
-  }, [teamsPaginationModel, teamsSortModel]);
-
-  // TeamPolicies pagination options (memoized to prevent unnecessary re-renders)
-  const teamPoliciesPagination: ApiPaginationRequestOptions = useMemo(() => {
-    const sort = firstOrNull(teamPoliciesSortModel);
-    return {
-      page: teamPoliciesPaginationModel.page + 1,
-      limit: teamPoliciesPaginationModel.pageSize,
-      sort: sort?.field,
-      order: sort?.sort as 'asc' | 'desc' | undefined
-    };
-  }, [teamPoliciesPaginationModel, teamPoliciesSortModel]);
-
-  // Data loaders
-  const policiesDataLoader = useDataLoader((search: string | undefined, pagination: ApiPaginationRequestOptions) =>
-    biohubApi.policies.getPolicies({ search }, pagination)
-  );
-
-  const teamsDataLoader = useDataLoader((search: string | undefined, pagination: ApiPaginationRequestOptions) =>
-    biohubApi.teams.getTeams({ search }, pagination)
-  );
+  // TeamPolicies - simpler pattern (no search, has client-side filtering)
+  const [teamPoliciesPaginationModel, setTeamPoliciesPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: 10 });
+  const [teamPoliciesSortModel, setTeamPoliciesSortModel] = useState<GridSortModel>([{ field: 'team_name', sort: 'asc' }]);
 
   const teamPoliciesDataLoader = useDataLoader((pagination: ApiPaginationRequestOptions) =>
     biohubApi.teamPolicies.getTeamPolicies(pagination)
   );
 
-  // Load data on mount
+  // Load teamPolicies on mount
   useEffect(() => {
-    policiesDataLoader.load(debouncedPolicySearchTerm, policiesPagination);
-    teamsDataLoader.load(debouncedTeamSearchTerm, teamsPagination);
-    teamPoliciesDataLoader.load(teamPoliciesPagination);
-  }, [
-    teamPoliciesDataLoader,
-    teamsDataLoader,
-    policiesDataLoader,
-    debouncedPolicySearchTerm,
-    debouncedTeamSearchTerm,
-    policiesPagination,
-    teamsPagination,
-    teamPoliciesPagination
-  ]);
-
-  // Refresh policies when pagination/sort changes
-  useEffect(() => {
-    policiesDataLoader.refresh(debouncedPolicySearchTerm, policiesPagination);
+    teamPoliciesDataLoader.load(toApiPagination(teamPoliciesPaginationModel, teamPoliciesSortModel));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [policiesPagination]);
+  }, []);
 
-  // Refresh teams when pagination/sort changes
-  useEffect(() => {
-    teamsDataLoader.refresh(debouncedTeamSearchTerm, teamsPagination);
+  const handleTeamPoliciesPaginationChange = useCallback(
+    (model: GridPaginationModel) => {
+      setTeamPoliciesPaginationModel(model);
+      teamPoliciesDataLoader.refresh(toApiPagination(model, teamPoliciesSortModel));
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamsPagination]);
-
-  // Refresh teamPolicies when pagination/sort changes
-  useEffect(() => {
-    teamPoliciesDataLoader.refresh(teamPoliciesPagination);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamPoliciesPagination]);
-
-  // Data
-  const policies = policiesDataLoader.data?.policies ?? [];
-  const teams = teamsDataLoader.data?.teams ?? [];
-  const teamPolicies = useMemo(
-    () => teamPoliciesDataLoader.data?.team_policies ?? [],
-    [teamPoliciesDataLoader.data?.team_policies]
+    [teamPoliciesSortModel]
   );
+
+  const handleTeamPoliciesSortChange = useCallback(
+    (model: GridSortModel) => {
+      setTeamPoliciesSortModel(model);
+      teamPoliciesDataLoader.refresh(toApiPagination(teamPoliciesPaginationModel, model));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [teamPoliciesPaginationModel]
+  );
+
+  const refreshTeamPolicies = useCallback(() => {
+    teamPoliciesDataLoader.refresh(toApiPagination(teamPoliciesPaginationModel, teamPoliciesSortModel));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamPoliciesPaginationModel, teamPoliciesSortModel]);
 
   // Filter team-policies based on selection
   const filteredTeamPolicies = useMemo(() => {
+    const teamPolicies = teamPoliciesDataLoader.data?.team_policies ?? [];
     let result = teamPolicies;
 
     if (selectedTeamId) {
@@ -155,54 +92,11 @@ export const ManagePoliciesPage = () => {
     }
 
     return result;
-  }, [teamPolicies, selectedTeamId, selectedPolicyId]);
+  }, [teamPoliciesDataLoader.data?.team_policies, selectedTeamId, selectedPolicyId]);
 
   // Get selected objects for TeamPoliciesContainer
-  const selectedTeam = teams.find((t) => t.team_id === selectedTeamId) ?? null;
-  const selectedPolicy = policies.find((p) => p.policy_id === selectedPolicyId) ?? null;
-
-  // Debounced search handlers
-  const debouncedPolicyRefresh = useMemo(
-    () =>
-      debounce((term: string, pagination: ApiPaginationRequestOptions) => {
-        setDebouncedPolicySearchTerm(term);
-        policiesDataLoader.refresh(term, pagination);
-      }, 300),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
-  const debouncedTeamRefresh = useMemo(
-    () =>
-      debounce((term: string, pagination: ApiPaginationRequestOptions) => {
-        setDebouncedTeamSearchTerm(term);
-        teamsDataLoader.refresh(term, pagination);
-      }, 300),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
-  const handlePolicySearch = useCallback(
-    (term: string) => {
-      setPolicySearchTerm(term);
-      // Reset to first page when searching
-      setPoliciesPaginationModel((prev) => ({ ...prev, page: 0 }));
-      debouncedPolicyRefresh(term, { ...policiesPagination, page: 1 });
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [policiesPagination]
-  );
-
-  const handleTeamSearch = useCallback(
-    (term: string) => {
-      setTeamSearchTerm(term);
-      // Reset to first page when searching
-      setTeamsPaginationModel((prev) => ({ ...prev, page: 0 }));
-      debouncedTeamRefresh(term, { ...teamsPagination, page: 1 });
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [teamsPagination]
-  );
+  const selectedTeam = teams.data.find((t) => t.team_id === selectedTeamId) ?? null;
+  const selectedPolicy = policies.data.find((p) => p.policy_id === selectedPolicyId) ?? null;
 
   // Selection handlers
   const handleSelectPolicy = useCallback((policyId: string | null) => {
@@ -213,34 +107,18 @@ export const ManagePoliciesPage = () => {
     setSelectedTeamId(teamId);
   }, []);
 
-  // Refresh handlers
-  const refreshPolicies = useCallback(() => {
-    policiesDataLoader.refresh(debouncedPolicySearchTerm, policiesPagination);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedPolicySearchTerm, policiesPagination]);
-
-  const refreshTeams = useCallback(() => {
-    teamsDataLoader.refresh(debouncedTeamSearchTerm, teamsPagination);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedTeamSearchTerm, teamsPagination]);
-
-  const refreshTeamPolicies = useCallback(() => {
-    teamPoliciesDataLoader.refresh(teamPoliciesPagination);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamPoliciesPagination]);
-
   return (
     <Box py={7}>
       <ActivePoliciesList
-        policies={policies}
-        rowCount={policiesDataLoader.data?.pagination.total ?? 0}
-        paginationModel={policiesPaginationModel}
-        setPaginationModel={setPoliciesPaginationModel}
-        sortModel={policiesSortModel}
-        setSortModel={setPoliciesSortModel}
-        refresh={refreshPolicies}
-        searchTerm={policySearchTerm}
-        onSearch={handlePolicySearch}
+        policies={policies.data}
+        rowCount={policies.rowCount}
+        paginationModel={policies.paginationModel}
+        setPaginationModel={policies.handlePaginationChange}
+        sortModel={policies.sortModel}
+        setSortModel={policies.handleSortChange}
+        refresh={policies.refresh}
+        searchTerm={policies.searchTerm}
+        onSearch={policies.handleSearch}
         selectedPolicyId={selectedPolicyId}
         onSelectPolicy={handleSelectPolicy}
       />
@@ -248,15 +126,15 @@ export const ManagePoliciesPage = () => {
       <Container maxWidth="xl" sx={{ mt: 4 }}>
         <Paper>
           <TeamsContainer
-            teams={teams}
-            rowCount={teamsDataLoader.data?.pagination.total ?? 0}
-            paginationModel={teamsPaginationModel}
-            setPaginationModel={setTeamsPaginationModel}
-            sortModel={teamsSortModel}
-            setSortModel={setTeamsSortModel}
-            refresh={refreshTeams}
-            searchTerm={teamSearchTerm}
-            onSearch={handleTeamSearch}
+            teams={teams.data}
+            rowCount={teams.rowCount}
+            paginationModel={teams.paginationModel}
+            setPaginationModel={teams.handlePaginationChange}
+            sortModel={teams.sortModel}
+            setSortModel={teams.handleSortChange}
+            refresh={teams.refresh}
+            searchTerm={teams.searchTerm}
+            onSearch={teams.handleSearch}
             selectedTeamId={selectedTeamId}
             onSelectTeam={handleSelectTeam}
           />
@@ -269,9 +147,9 @@ export const ManagePoliciesPage = () => {
             teamPolicies={filteredTeamPolicies}
             rowCount={teamPoliciesDataLoader.data?.pagination.total ?? 0}
             paginationModel={teamPoliciesPaginationModel}
-            setPaginationModel={setTeamPoliciesPaginationModel}
+            setPaginationModel={handleTeamPoliciesPaginationChange}
             sortModel={teamPoliciesSortModel}
-            setSortModel={setTeamPoliciesSortModel}
+            setSortModel={handleTeamPoliciesSortChange}
             selectedTeam={selectedTeam}
             selectedPolicy={selectedPolicy}
             refresh={refreshTeamPolicies}

--- a/app/src/features/admin/policies/components/ActivePoliciesList.test.tsx
+++ b/app/src/features/admin/policies/components/ActivePoliciesList.test.tsx
@@ -1,7 +1,7 @@
 import { useApi } from 'hooks/useApi';
 import { IPolicy } from 'interfaces/usePoliciesApi.interface';
 import { MemoryRouter } from 'react-router';
-import { cleanup, render, waitFor } from 'test-helpers/test-utils';
+import { cleanup, fireEvent, render, waitFor } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
 import { ActivePoliciesList, IActivePoliciesListProps } from './ActivePoliciesList';
 
@@ -36,6 +36,11 @@ const mockUseApi = {
 
 const defaultProps: IActivePoliciesListProps = {
   policies: [],
+  rowCount: 0,
+  paginationModel: { page: 0, pageSize: 50 },
+  setPaginationModel: vi.fn(),
+  sortModel: [{ field: 'name', sort: 'asc' }],
+  setSortModel: vi.fn(),
   refresh: vi.fn(),
   searchTerm: '',
   onSearch: vi.fn(),
@@ -134,6 +139,7 @@ describe('ActivePoliciesList', () => {
 
       const { getByText } = renderContainer({
         policies: mockPolicies,
+        rowCount: 1,
         selectedPolicyId: 'policy-1'
       });
 
@@ -144,6 +150,68 @@ describe('ActivePoliciesList', () => {
       // The row should have the selected class (MUI DataGrid applies Mui-selected)
       const row = getByText('Test Policy').closest('.MuiDataGrid-row');
       expect(row).toHaveClass('Mui-selected');
+    });
+  });
+
+  describe('Server Pagination', () => {
+    const mockPolicies: IPolicy[] = [
+      { policy_id: '1', name: 'Alpha Policy', description: 'First', statements: [] },
+      { policy_id: '2', name: 'Beta Policy', description: 'Second', statements: [] }
+    ];
+
+    it('displays rowCount in header for server-side pagination', async () => {
+      // rowCount prop controls the total displayed, not the array length
+      const { getByText } = renderContainer({ policies: mockPolicies, rowCount: 100 });
+
+      await waitFor(() => {
+        // Header should show rowCount (100), not policies.length (2)
+        expect(getByText('(100)')).toBeVisible();
+      });
+    });
+
+    it('calls setPaginationModel when page size changes', async () => {
+      const mockSetPaginationModel = vi.fn();
+      const { getByRole } = renderContainer({
+        policies: mockPolicies,
+        rowCount: 2,
+        setPaginationModel: mockSetPaginationModel
+      });
+
+      await waitFor(() => {
+        // Find the page size selector (combobox)
+        const pageSizeSelector = getByRole('combobox');
+        expect(pageSizeSelector).toBeVisible();
+      });
+
+      // Change page size
+      const pageSizeSelector = getByRole('combobox');
+      fireEvent.mouseDown(pageSizeSelector);
+
+      await waitFor(() => {
+        const option100 = getByRole('option', { name: '100' });
+        fireEvent.click(option100);
+      });
+
+      expect(mockSetPaginationModel).toHaveBeenCalled();
+    });
+
+    it('calls setSortModel when column header is clicked', async () => {
+      const mockSetSortModel = vi.fn();
+      const { getByText } = renderContainer({
+        policies: mockPolicies,
+        rowCount: 2,
+        setSortModel: mockSetSortModel
+      });
+
+      await waitFor(() => {
+        expect(getByText('Alpha Policy')).toBeVisible();
+      });
+
+      // Click on the Name column header to trigger sort
+      const nameHeader = getByText('Name');
+      fireEvent.click(nameHeader);
+
+      expect(mockSetSortModel).toHaveBeenCalled();
     });
   });
 });

--- a/app/src/features/admin/policies/components/ActivePoliciesList.test.tsx
+++ b/app/src/features/admin/policies/components/ActivePoliciesList.test.tsx
@@ -37,7 +37,7 @@ const mockUseApi = {
 const defaultProps: IActivePoliciesListProps = {
   policies: [],
   rowCount: 0,
-  paginationModel: { page: 0, pageSize: 50 },
+  paginationModel: { page: 0, pageSize: 10 },
   setPaginationModel: vi.fn(),
   sortModel: [{ field: 'name', sort: 'asc' }],
   setSortModel: vi.fn(),
@@ -188,8 +188,8 @@ describe('ActivePoliciesList', () => {
       fireEvent.mouseDown(pageSizeSelector);
 
       await waitFor(() => {
-        const option100 = getByRole('option', { name: '100' });
-        fireEvent.click(option100);
+        const option25 = getByRole('option', { name: '25' });
+        fireEvent.click(option25);
       });
 
       expect(mockSetPaginationModel).toHaveBeenCalled();

--- a/app/src/features/admin/policies/components/ActivePoliciesList.test.tsx
+++ b/app/src/features/admin/policies/components/ActivePoliciesList.test.tsx
@@ -1,24 +1,42 @@
+import { fireEvent } from '@testing-library/react';
 import { useApi } from 'hooks/useApi';
 import { IPolicy } from 'interfaces/usePoliciesApi.interface';
 import { MemoryRouter } from 'react-router';
-import { cleanup, fireEvent, render, waitFor } from 'test-helpers/test-utils';
+import { cleanup, render, waitFor } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
 import { ActivePoliciesList, IActivePoliciesListProps } from './ActivePoliciesList';
 
-// Mock Monaco Editor - it doesn't work well in jsdom and causes hangs
+// Types for DataGrid mock
+interface MockDataGridProps {
+  rows: IPolicy[];
+  localeText?: { noRowsLabel?: string };
+}
+
+// Simple DataGrid mock - just renders rows as divs, no behavior simulation
+vi.mock('@mui/x-data-grid', () => ({
+  DataGrid: ({ rows, localeText }: MockDataGridProps) => (
+    <div data-testid="mock-data-grid">
+      {rows.length === 0 ? (
+        <div>{localeText?.noRowsLabel}</div>
+      ) : (
+        rows.map((row) => (
+          <div key={row.policy_id} data-testid={`row-${row.policy_id}`}>
+            {row.name}
+          </div>
+        ))
+      )}
+    </div>
+  )
+}));
+
+// Mock Monaco Editor
 vi.mock('@monaco-editor/react', () => ({
   default: ({ value, onChange }: { value?: string; onChange?: (value?: string) => void }) => (
     <textarea data-testid="monaco-editor" value={value || ''} onChange={(e) => onChange?.(e.target.value)} />
   ),
   loader: {
     init: vi.fn().mockResolvedValue({
-      languages: {
-        json: {
-          jsonDefaults: {
-            setDiagnosticsOptions: vi.fn()
-          }
-        }
-      }
+      languages: { json: { jsonDefaults: { setDiagnosticsOptions: vi.fn() } } }
     })
   }
 }));
@@ -31,6 +49,9 @@ const mockUseApi = {
     createPolicy: vi.fn(),
     updatePolicy: vi.fn(),
     deletePolicy: vi.fn()
+  },
+  submissions: {
+    getPublishedSubmissionsForAdmins: vi.fn().mockResolvedValue([])
   }
 };
 
@@ -48,7 +69,7 @@ const defaultProps: IActivePoliciesListProps = {
   onSelectPolicy: vi.fn()
 };
 
-const renderContainer = (props: Partial<IActivePoliciesListProps> = {}) => {
+const renderComponent = (props: Partial<IActivePoliciesListProps> = {}) => {
   return render(
     <MemoryRouter initialEntries={['/']}>
       <ActivePoliciesList {...defaultProps} {...props} />
@@ -63,155 +84,115 @@ describe('ActivePoliciesList', () => {
 
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
   });
 
-  it('shows `No Policies` when there are no policies', async () => {
-    const { getByText } = renderContainer({ policies: [] });
+  describe('Header', () => {
+    it('displays rowCount in header', async () => {
+      // Step 1: Render with custom rowCount prop
+      const { getByText } = renderComponent({ rowCount: 42 });
 
-    await waitFor(() => {
-      expect(getByText('No Policies')).toBeVisible();
-    });
-  });
-
-  it('shows a table row for a policy with all fields having values', async () => {
-    const mockPolicies: IPolicy[] = [
-      {
-        policy_id: '1',
-        name: 'Test Policy',
-        description: 'Test description',
-        statements: [
-          {
-            policy_statement_id: 's1',
-            policy_id: '1',
-            effect: 'allow',
-            submission_feature_urn: 'urn:*:*:*',
-            conditions: []
-          }
-        ]
-      }
-    ];
-
-    const { getByText } = renderContainer({ policies: mockPolicies });
-
-    await waitFor(() => {
-      expect(getByText('Test Policy')).toBeVisible();
-      expect(getByText('Test description')).toBeVisible();
-      expect(getByText('allow: urn:*:*:*')).toBeVisible();
-    });
-  });
-
-  it('shows a table row for a policy with fields not having values', async () => {
-    const mockPolicies: IPolicy[] = [
-      {
-        policy_id: '1',
-        name: 'Empty Policy',
-        description: null,
-        statements: []
-      }
-    ];
-
-    const { getAllByText } = renderContainer({ policies: mockPolicies });
-
-    await waitFor(() => {
-      const dashes = getAllByText('-');
-      expect(dashes.length).toBe(2);
-    });
-  });
-
-  it('renders the add new policy button correctly', async () => {
-    const { getByTestId } = renderContainer();
-
-    await waitFor(() => {
-      expect(getByTestId('add-policy-button')).toBeVisible();
-    });
-  });
-
-  describe('Row Selection', () => {
-    it('highlights selected row when selectedPolicyId is provided', async () => {
-      const mockPolicies: IPolicy[] = [
-        {
-          policy_id: 'policy-1',
-          name: 'Test Policy',
-          description: 'Test description',
-          statements: []
-        }
-      ];
-
-      const { getByText } = renderContainer({
-        policies: mockPolicies,
-        rowCount: 1,
-        selectedPolicyId: 'policy-1'
-      });
-
+      // Step 2: Verify dynamic rowCount appears in header
       await waitFor(() => {
-        expect(getByText('Test Policy')).toBeVisible();
+        expect(getByText('(42)')).toBeVisible();
       });
-
-      // The row should have the selected class (MUI DataGrid applies Mui-selected)
-      const row = getByText('Test Policy').closest('.MuiDataGrid-row');
-      expect(row).toHaveClass('Mui-selected');
     });
   });
 
-  describe('Server Pagination', () => {
-    const mockPolicies: IPolicy[] = [
-      { policy_id: '1', name: 'Alpha Policy', description: 'First', statements: [] },
-      { policy_id: '2', name: 'Beta Policy', description: 'Second', statements: [] }
-    ];
+  describe('Search', () => {
+    it('displays controlled search term value', async () => {
+      // Step 1: Render with searchTerm prop set
+      const { getByPlaceholderText } = renderComponent({ searchTerm: 'test query' });
 
-    it('displays rowCount in header for server-side pagination', async () => {
-      // rowCount prop controls the total displayed, not the array length
-      const { getByText } = renderContainer({ policies: mockPolicies, rowCount: 100 });
-
+      // Step 2: Verify input displays the controlled value
       await waitFor(() => {
-        // Header should show rowCount (100), not policies.length (2)
-        expect(getByText('(100)')).toBeVisible();
+        expect(getByPlaceholderText('Search by policy name')).toHaveValue('test query');
       });
     });
 
-    it('calls setPaginationModel when page size changes', async () => {
-      const mockSetPaginationModel = vi.fn();
-      const { getByRole } = renderContainer({
-        policies: mockPolicies,
-        rowCount: 2,
-        setPaginationModel: mockSetPaginationModel
-      });
+    it('calls onSearch when input changes', async () => {
+      // Step 1: Create mock onSearch callback
+      const mockOnSearch = vi.fn();
 
-      await waitFor(() => {
-        // Find the page size selector (combobox)
-        const pageSizeSelector = getByRole('combobox');
-        expect(pageSizeSelector).toBeVisible();
-      });
+      // Step 2: Render with mock callback
+      const { getByPlaceholderText } = renderComponent({ onSearch: mockOnSearch });
 
-      // Change page size
-      const pageSizeSelector = getByRole('combobox');
-      fireEvent.mouseDown(pageSizeSelector);
+      // Step 3: Type in search input
+      const input = getByPlaceholderText('Search by policy name');
+      fireEvent.change(input, { target: { value: 'new search' } });
 
-      await waitFor(() => {
-        const option25 = getByRole('option', { name: '25' });
-        fireEvent.click(option25);
-      });
-
-      expect(mockSetPaginationModel).toHaveBeenCalled();
+      // Step 4: Verify callback was called with input value
+      expect(mockOnSearch).toHaveBeenCalledWith('new search');
     });
+  });
 
-    it('calls setSortModel when column header is clicked', async () => {
-      const mockSetSortModel = vi.fn();
-      const { getByText } = renderContainer({
-        policies: mockPolicies,
-        rowCount: 2,
-        setSortModel: mockSetSortModel
-      });
+  describe('Add Button', () => {
+    it('opens add dialog when clicked', async () => {
+      // Step 1: Render component
+      const { getByTestId, getByText } = renderComponent();
 
+      // Step 2: Click Add button
+      fireEvent.click(getByTestId('add-policy-button'));
+
+      // Step 3: Verify dialog opens
       await waitFor(() => {
-        expect(getByText('Alpha Policy')).toBeVisible();
+        expect(getByText('Add Policy')).toBeVisible();
+      });
+    });
+  });
+
+  describe('Add Policy Dialog', () => {
+    it('calls createPolicy API with form values on submit', async () => {
+      // Step 1: Setup - make createPolicy return {} (simulates successful API response)
+      mockUseApi.policies.createPolicy.mockResolvedValueOnce({});
+
+      // Step 2: Create mock refresh function to verify it's called after submit
+      const mockRefresh = vi.fn();
+
+      // Step 3: Render component with mock refresh prop
+      const { getByTestId, getByLabelText, getByRole } = renderComponent({ refresh: mockRefresh });
+
+      // Step 4: Click "Add" button to open dialog
+      fireEvent.click(getByTestId('add-policy-button'));
+
+      // Step 5: Wait for dialog to appear (async rendering)
+      await waitFor(() => {
+        expect(getByLabelText('Policy Name *')).toBeVisible();
       });
 
-      // Click on the Name column header to trigger sort
-      const nameHeader = getByText('Name');
-      fireEvent.click(nameHeader);
+      // Step 6: Fill form fields
+      fireEvent.change(getByLabelText('Policy Name *'), { target: { value: 'New Policy' } });
+      fireEvent.change(getByLabelText('Description'), { target: { value: 'A description' } });
 
-      expect(mockSetSortModel).toHaveBeenCalled();
+      // Step 7: Submit form
+      fireEvent.click(getByRole('button', { name: /create/i }));
+
+      // Step 8: Verify API was called with correct params
+      await waitFor(() => {
+        expect(mockUseApi.policies.createPolicy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'New Policy',
+            description: 'A description'
+          })
+        );
+      });
+
+      // Step 9: Verify refresh was called after success
+      await waitFor(() => {
+        expect(mockRefresh).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Empty State', () => {
+    it('passes noRowsLabel to DataGrid', async () => {
+      // Step 1: Render with empty policies array
+      const { getByText } = renderComponent({ policies: [], rowCount: 0 });
+
+      // Step 2: Verify empty state message appears (from DataGrid localeText)
+      await waitFor(() => {
+        expect(getByText('No Policies')).toBeVisible();
+      });
     });
   });
 });

--- a/app/src/features/admin/policies/components/ActivePoliciesList.tsx
+++ b/app/src/features/admin/policies/components/ActivePoliciesList.tsx
@@ -434,6 +434,7 @@ export const ActivePoliciesList: React.FC<React.PropsWithChildren<IActivePolicie
             onPaginationModelChange={setPaginationModel}
             pageSizeOptions={[50, 100, 200]}
             sortingMode="server"
+            sortingOrder={['asc', 'desc']}
             sortModel={sortModel}
             onSortModelChange={setSortModel}
             rowCount={rowCount}

--- a/app/src/features/admin/policies/components/ActivePoliciesList.tsx
+++ b/app/src/features/admin/policies/components/ActivePoliciesList.tsx
@@ -432,7 +432,7 @@ export const ActivePoliciesList: React.FC<React.PropsWithChildren<IActivePolicie
             paginationMode="server"
             paginationModel={paginationModel}
             onPaginationModelChange={setPaginationModel}
-            pageSizeOptions={[50, 100, 200]}
+            pageSizeOptions={[10, 25, 50]}
             sortingMode="server"
             sortingOrder={['asc', 'desc']}
             sortModel={sortModel}

--- a/app/src/features/admin/policies/components/ActivePoliciesList.tsx
+++ b/app/src/features/admin/policies/components/ActivePoliciesList.tsx
@@ -19,6 +19,7 @@ import { APIError } from 'hooks/api/useAxios';
 import { useApi } from 'hooks/useApi';
 import { useDialogContext } from 'hooks/useContext';
 import { IPolicy } from 'interfaces/usePoliciesApi.interface';
+import { IServerPaginationProps } from 'types/pagination';
 import { useState } from 'react';
 import {
   AddPolicyForm,
@@ -31,7 +32,7 @@ import { transformApiToPolicyJson, transformPolicyJsonToApi } from '../utils/pol
 /**
  * Props for the ActivePoliciesList component.
  */
-export interface IActivePoliciesListProps {
+export interface IActivePoliciesListProps extends IServerPaginationProps {
   /** Array of policies to display in the table */
   policies: IPolicy[];
   /** Callback to refresh the policies list after create/update/delete */
@@ -61,7 +62,16 @@ export interface IActivePoliciesListProps {
  */
 export const ActivePoliciesList: React.FC<React.PropsWithChildren<IActivePoliciesListProps>> = (props) => {
   const biohubApi = useApi();
-  const { policies, selectedPolicyId, onSelectPolicy } = props;
+  const {
+    policies,
+    rowCount,
+    paginationModel,
+    setPaginationModel,
+    sortModel,
+    setSortModel,
+    selectedPolicyId,
+    onSelectPolicy
+  } = props;
 
   /**
    * Handle row selection changes in the DataGrid.
@@ -381,7 +391,7 @@ export const ActivePoliciesList: React.FC<React.PropsWithChildren<IActivePolicie
             <Typography variant="h4" component="h2" flexGrow={1}>
               Active Policies{' '}
               <Typography sx={{ fontSize: 'inherit' }} color="textSecondary" component="span">
-                ({policies?.length || 0})
+                ({rowCount})
               </Typography>
             </Typography>
             <Stack gap={1} direction="row" alignItems="center">
@@ -419,7 +429,14 @@ export const ActivePoliciesList: React.FC<React.PropsWithChildren<IActivePolicie
             rows={policies}
             columns={columns}
             getRowId={(row) => row.policy_id}
+            paginationMode="server"
+            paginationModel={paginationModel}
+            onPaginationModelChange={setPaginationModel}
             pageSizeOptions={[50, 100, 200]}
+            sortingMode="server"
+            sortModel={sortModel}
+            onSortModelChange={setSortModel}
+            rowCount={rowCount}
             rowSelectionModel={rowSelectionModel}
             onRowSelectionModelChange={handleRowSelectionChange}
             checkboxSelection
@@ -427,13 +444,6 @@ export const ActivePoliciesList: React.FC<React.PropsWithChildren<IActivePolicie
             disableColumnSelector
             disableColumnMenu
             localeText={{ noRowsLabel: 'No Policies' }}
-            initialState={{
-              pagination: {
-                paginationModel: {
-                  pageSize: 50
-                }
-              }
-            }}
             sx={{
               border: 'none',
               '& .MuiDataGrid-columnHeaderTitle': {

--- a/app/src/features/admin/policies/components/TeamPoliciesContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamPoliciesContainer.test.tsx
@@ -52,6 +52,11 @@ const mockUseApi = {
 
 const defaultProps: ITeamPoliciesContainerProps = {
   teamPolicies: mockTeamPolicies,
+  rowCount: 2,
+  paginationModel: { page: 0, pageSize: 10 },
+  setPaginationModel: vi.fn(),
+  sortModel: [{ field: 'team_name', sort: 'asc' }],
+  setSortModel: vi.fn(),
   selectedTeam: null,
   selectedPolicy: null,
   refresh: vi.fn()
@@ -95,7 +100,7 @@ describe('TeamPoliciesContainer', () => {
   });
 
   it('shows empty state when no assignments exist', async () => {
-    const { getByText } = renderContainer({ teamPolicies: [] });
+    const { getByText } = renderContainer({ teamPolicies: [], rowCount: 0 });
 
     await waitFor(() => {
       expect(getByText('No Team-Policy Assignments')).toBeVisible();

--- a/app/src/features/admin/policies/components/TeamPoliciesContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamPoliciesContainer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent } from '@testing-library/react';
+import { GridColDef } from '@mui/x-data-grid';
 import { useApi } from 'hooks/useApi';
 import { IPolicy } from 'interfaces/usePoliciesApi.interface';
 import { ITeamPolicyDetails } from 'interfaces/useTeamPoliciesApi.interface';
@@ -7,6 +8,33 @@ import { MemoryRouter } from 'react-router';
 import { cleanup, render, waitFor } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
 import { ITeamPoliciesContainerProps, TeamPoliciesContainer } from './TeamPoliciesContainer';
+
+// Types for DataGrid mock
+interface MockDataGridProps {
+  rows: ITeamPolicyDetails[];
+  columns: GridColDef[];
+  localeText?: { noRowsLabel?: string };
+}
+
+// Simple DataGrid mock - just renders rows as divs
+vi.mock('@mui/x-data-grid', () => ({
+  DataGrid: ({ rows, columns, localeText }: MockDataGridProps) => (
+    <div data-testid="mock-data-grid">
+      {rows.length === 0 ? (
+        <div>{localeText?.noRowsLabel}</div>
+      ) : (
+        rows.map((row) => (
+          <div key={row.team_policy_id} data-testid={`row-${row.team_policy_id}`}>
+            <span>{row.team_name}</span>
+            <span>{row.policy_name}</span>
+            {/* Render actions column */}
+            {columns.find((c) => c.field === 'actions')?.renderCell?.({ row } as never)}
+          </div>
+        ))
+      )}
+    </div>
+  )
+}));
 
 vi.mock('../../../../hooks/useApi');
 const mockBiohubApi = useApi as Mock;
@@ -62,7 +90,7 @@ const defaultProps: ITeamPoliciesContainerProps = {
   refresh: vi.fn()
 };
 
-const renderContainer = (props: Partial<ITeamPoliciesContainerProps> = {}) => {
+const renderComponent = (props: Partial<ITeamPoliciesContainerProps> = {}) => {
   return render(
     <MemoryRouter initialEntries={['/']}>
       <TeamPoliciesContainer {...defaultProps} {...props} />
@@ -80,68 +108,45 @@ describe('TeamPoliciesContainer', () => {
     vi.clearAllMocks();
   });
 
-  it('renders team-policy associations in DataGrid', async () => {
-    const { getByText } = renderContainer();
+  describe('Header', () => {
+    it('displays rowCount in header', async () => {
+      // Step 1: Render with default props (rowCount: 2)
+      const { getByText } = renderComponent();
 
-    await waitFor(() => {
-      expect(getByText('Alpha Team')).toBeVisible();
-      expect(getByText('Data Access Policy')).toBeVisible();
-      expect(getByText('Beta Team')).toBeVisible();
-      expect(getByText('Security Policy')).toBeVisible();
-    });
-  });
-
-  it('displays assignment count in header', async () => {
-    const { getByText } = renderContainer();
-
-    await waitFor(() => {
-      expect(getByText('(2)')).toBeVisible();
-    });
-  });
-
-  it('shows empty state when no assignments exist', async () => {
-    const { getByText } = renderContainer({ teamPolicies: [], rowCount: 0 });
-
-    await waitFor(() => {
-      expect(getByText('No Team-Policy Assignments')).toBeVisible();
-    });
-  });
-
-  describe('Dynamic Header', () => {
-    it('shows default header when no selection', async () => {
-      const { getByText } = renderContainer();
-
+      // Step 2: Verify dynamic rowCount appears in header
       await waitFor(() => {
-        expect(getByText('Team-Policy Assignments')).toBeVisible();
+        expect(getByText('(2)')).toBeVisible();
       });
     });
 
     it('shows team-specific header when team is selected', async () => {
-      const { getByText } = renderContainer({
-        selectedTeam: mockTeams[0]
-      });
+      // Step 1: Render with selectedTeam prop
+      const { getByText } = renderComponent({ selectedTeam: mockTeams[0] });
 
+      // Step 2: Verify header shows team-specific text
       await waitFor(() => {
         expect(getByText('Policies for "Alpha Team"')).toBeVisible();
       });
     });
 
     it('shows policy-specific header when policy is selected', async () => {
-      const { getByText } = renderContainer({
-        selectedPolicy: mockPolicies[0]
-      });
+      // Step 1: Render with selectedPolicy prop
+      const { getByText } = renderComponent({ selectedPolicy: mockPolicies[0] });
 
+      // Step 2: Verify header shows policy-specific text
       await waitFor(() => {
         expect(getByText('Teams with "Data Access Policy"')).toBeVisible();
       });
     });
 
-    it('shows assignment header when both team and policy are selected', async () => {
-      const { getByText } = renderContainer({
+    it('shows combined header when both team and policy are selected', async () => {
+      // Step 1: Render with both selectedTeam and selectedPolicy props
+      const { getByText } = renderComponent({
         selectedTeam: mockTeams[0],
         selectedPolicy: mockPolicies[0]
       });
 
+      // Step 2: Verify header shows combined assignment text
       await waitFor(() => {
         expect(getByText('Assignment: Alpha Team + Data Access Policy')).toBeVisible();
       });
@@ -150,77 +155,84 @@ describe('TeamPoliciesContainer', () => {
 
   describe('Assign Button', () => {
     it('does not show Assign button when no selection', async () => {
-      const { queryByRole } = renderContainer();
+      // Step 1: Render with no selection (default props)
+      const { queryByRole } = renderComponent();
 
+      // Step 2: Verify Assign button is NOT visible
       await waitFor(() => {
         expect(queryByRole('button', { name: /assign/i })).toBeNull();
       });
     });
 
     it('does not show Assign button when only team is selected', async () => {
-      const { queryByRole } = renderContainer({
-        selectedTeam: mockTeams[0]
-      });
+      // Step 1: Render with only selectedTeam (no policy)
+      const { queryByRole } = renderComponent({ selectedTeam: mockTeams[0] });
 
+      // Step 2: Verify Assign button is NOT visible (needs both)
       await waitFor(() => {
         expect(queryByRole('button', { name: /assign/i })).toBeNull();
       });
     });
 
     it('does not show Assign button when only policy is selected', async () => {
-      const { queryByRole } = renderContainer({
-        selectedPolicy: mockPolicies[0]
-      });
+      // Step 1: Render with only selectedPolicy (no team)
+      const { queryByRole } = renderComponent({ selectedPolicy: mockPolicies[0] });
 
+      // Step 2: Verify Assign button is NOT visible (needs both)
       await waitFor(() => {
         expect(queryByRole('button', { name: /assign/i })).toBeNull();
       });
     });
 
-    it('shows Assign button when both team and policy are selected and not already assigned', async () => {
-      const { getByRole } = renderContainer({
+    it('shows Assign button when both selected and assignment does not exist', async () => {
+      // Step 1: Render with team + policy that are NOT already assigned
+      const { getByRole } = renderComponent({
         selectedTeam: mockTeams[2], // Gamma Team - not in mockTeamPolicies
         selectedPolicy: mockPolicies[2] // Admin Policy - not in mockTeamPolicies
       });
 
+      // Step 2: Verify Assign button IS visible (can create new assignment)
       await waitFor(() => {
         expect(getByRole('button', { name: /assign/i })).toBeVisible();
       });
     });
 
-    it('does not show Assign button when selected combination already exists', async () => {
-      const { queryByRole } = renderContainer({
+    it('does not show Assign button when assignment already exists', async () => {
+      // Step 1: Render with team + policy that ARE already assigned
+      const { queryByRole } = renderComponent({
         selectedTeam: mockTeams[0], // Alpha Team
-        selectedPolicy: mockPolicies[0] // Data Access Policy - already assigned to Alpha Team
+        selectedPolicy: mockPolicies[0] // Data Access Policy - already assigned
       });
 
+      // Step 2: Verify Assign button is NOT visible (duplicate prevention)
       await waitFor(() => {
         expect(queryByRole('button', { name: /assign/i })).toBeNull();
       });
     });
 
-    it('creates assignment when Assign button is clicked', async () => {
-      mockCreateTeamPolicy.mockResolvedValueOnce({
-        team_policy_id: 'tp-new',
-        team_id: 'team-3',
-        policy_id: 'policy-3'
-      });
+    it('calls createTeamPolicy API when Assign is clicked', async () => {
+      // Step 1: Setup - make createTeamPolicy return {} (simulates successful API response)
+      mockCreateTeamPolicy.mockResolvedValueOnce({});
 
+      // Step 2: Create mock refresh function to verify it's called after submit
       const mockRefresh = vi.fn();
-      const { getByRole } = renderContainer({
-        selectedTeam: mockTeams[2], // Gamma Team
-        selectedPolicy: mockPolicies[2], // Admin Policy
+
+      // Step 3: Render component with selected team + policy (enables Assign button)
+      const { getByRole } = renderComponent({
+        selectedTeam: mockTeams[2],
+        selectedPolicy: mockPolicies[2],
         refresh: mockRefresh
       });
 
-      // Wait for Assign button to appear
+      // Step 4: Wait for Assign button to appear
       await waitFor(() => {
         expect(getByRole('button', { name: /assign/i })).toBeVisible();
       });
 
-      // Click Assign button
+      // Step 5: Click Assign button
       fireEvent.click(getByRole('button', { name: /assign/i }));
 
+      // Step 6: Verify API was called with correct params
       await waitFor(() => {
         expect(mockCreateTeamPolicy).toHaveBeenCalledWith({
           team_id: 'team-3',
@@ -228,51 +240,22 @@ describe('TeamPoliciesContainer', () => {
         });
       });
 
-      // Refresh should be called after successful assignment
+      // Step 7: Verify refresh was called after success
       await waitFor(() => {
         expect(mockRefresh).toHaveBeenCalled();
       });
     });
   });
 
-  describe('Delete Team-Policy', () => {
-    it('opens actions menu with remove option', async () => {
-      const { getByText, getAllByTitle } = renderContainer();
+  describe('Empty State', () => {
+    it('shows empty state message', async () => {
+      // Step 1: Render with empty teamPolicies array
+      const { getByText } = renderComponent({ teamPolicies: [], rowCount: 0 });
 
+      // Step 2: Verify empty state message appears (from DataGrid localeText)
       await waitFor(() => {
-        expect(getByText('Alpha Team')).toBeVisible();
+        expect(getByText('No Team-Policy Assignments')).toBeVisible();
       });
-
-      // Click actions menu
-      const actionsButtons = getAllByTitle('Actions');
-      fireEvent.click(actionsButtons[0]);
-
-      // Remove option should be visible
-      await waitFor(() => {
-        expect(getByText('Remove assignment')).toBeVisible();
-      });
-    });
-
-    it('triggers delete flow when remove is clicked', async () => {
-      const { getByText, getAllByTitle } = renderContainer();
-
-      await waitFor(() => {
-        expect(getByText('Alpha Team')).toBeVisible();
-      });
-
-      // Open actions menu and click Remove
-      const actionsButtons = getAllByTitle('Actions');
-      fireEvent.click(actionsButtons[0]);
-
-      await waitFor(() => {
-        expect(getByText('Remove assignment')).toBeVisible();
-      });
-
-      // Click remove - this triggers the confirmation dialog flow
-      fireEvent.click(getByText('Remove assignment'));
-
-      // The remove menu item click should have been processed
-      // (Actual dialog rendering depends on dialogContext which is mocked by test-utils)
     });
   });
 });

--- a/app/src/features/admin/policies/components/TeamPoliciesContainer.tsx
+++ b/app/src/features/admin/policies/components/TeamPoliciesContainer.tsx
@@ -287,6 +287,7 @@ export const TeamPoliciesContainer: React.FC<ITeamPoliciesContainerProps> = (pro
         onPaginationModelChange={setPaginationModel}
         pageSizeOptions={[10, 25, 50]}
         sortingMode="server"
+        sortingOrder={['asc', 'desc']}
         sortModel={sortModel}
         onSortModelChange={setSortModel}
         rowCount={rowCount}

--- a/app/src/features/admin/policies/components/TeamPoliciesContainer.tsx
+++ b/app/src/features/admin/policies/components/TeamPoliciesContainer.tsx
@@ -5,7 +5,7 @@ import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridPaginationModel, GridSortModel } from '@mui/x-data-grid';
 import { CustomMenuIconButton } from 'components/toolbar/ActionToolbars';
 import { ISnackbarProps } from 'contexts/dialogContext';
 import { APIError } from 'hooks/api/useAxios';
@@ -22,6 +22,16 @@ import { useState } from 'react';
 export interface ITeamPoliciesContainerProps {
   /** Array of team-policy associations to display (pre-filtered by parent) */
   teamPolicies: ITeamPolicyDetails[];
+  /** Total number of team-policy associations (for server-side pagination) */
+  rowCount: number;
+  /** Current pagination model from parent */
+  paginationModel: GridPaginationModel;
+  /** Callback when pagination changes */
+  setPaginationModel: (model: GridPaginationModel) => void;
+  /** Current sort model from parent */
+  sortModel: GridSortModel;
+  /** Callback when sort changes */
+  setSortModel: (model: GridSortModel) => void;
   /** Currently selected team from TeamsContainer (null if none selected) */
   selectedTeam: ITeamWithMembers | null;
   /** Currently selected policy from ActivePoliciesList (null if none selected) */
@@ -40,7 +50,17 @@ export interface ITeamPoliciesContainerProps {
  * @returns {React.ReactElement} The team-policies container component
  */
 export const TeamPoliciesContainer: React.FC<ITeamPoliciesContainerProps> = (props) => {
-  const { teamPolicies, selectedTeam, selectedPolicy, refresh } = props;
+  const {
+    teamPolicies,
+    rowCount,
+    paginationModel,
+    setPaginationModel,
+    sortModel,
+    setSortModel,
+    selectedTeam,
+    selectedPolicy,
+    refresh
+  } = props;
 
   const biohubApi = useApi();
   const dialogContext = useDialogContext();
@@ -240,7 +260,7 @@ export const TeamPoliciesContainer: React.FC<ITeamPoliciesContainerProps> = (pro
         <Typography variant="h4" component="h2" flexGrow={1}>
           {getHeaderText()}{' '}
           <Typography sx={{ fontSize: 'inherit' }} component="span" color="textSecondary">
-            ({teamPolicies.length})
+            ({rowCount})
           </Typography>
         </Typography>
         {canAssign && (
@@ -262,18 +282,18 @@ export const TeamPoliciesContainer: React.FC<ITeamPoliciesContainerProps> = (pro
         rows={teamPolicies}
         columns={columns}
         getRowId={(row) => row.team_policy_id}
+        paginationMode="server"
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
         pageSizeOptions={[10, 25, 50]}
+        sortingMode="server"
+        sortModel={sortModel}
+        onSortModelChange={setSortModel}
+        rowCount={rowCount}
         disableRowSelectionOnClick
         disableColumnSelector
         disableColumnMenu
         localeText={{ noRowsLabel: 'No Team-Policy Assignments' }}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: 10
-            }
-          }
-        }}
         sx={{
           border: 'none',
           '& .MuiDataGrid-columnHeaderTitle': {

--- a/app/src/features/admin/policies/components/TeamsContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.test.tsx
@@ -296,5 +296,4 @@ describe('TeamsContainer', () => {
       });
     });
   });
-
 });

--- a/app/src/features/admin/policies/components/TeamsContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.test.tsx
@@ -1,10 +1,39 @@
 import { fireEvent } from '@testing-library/react';
+import { GridColDef } from '@mui/x-data-grid';
 import { useApi } from 'hooks/useApi';
 import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
 import { MemoryRouter } from 'react-router';
 import { cleanup, render, waitFor } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
 import { ITeamsContainerProps, TeamsContainer } from './TeamsContainer';
+
+// Types for DataGrid mock
+interface MockDataGridProps {
+  rows: ITeamWithMembers[];
+  columns: GridColDef[];
+  localeText?: { noRowsLabel?: string };
+}
+
+// Simple DataGrid mock - just renders rows as divs
+vi.mock('@mui/x-data-grid', () => ({
+  DataGrid: ({ rows, columns, localeText }: MockDataGridProps) => (
+    <div data-testid="mock-data-grid">
+      {rows.length === 0 ? (
+        <div>{localeText?.noRowsLabel}</div>
+      ) : (
+        rows.map((row) => (
+          <div key={row.team_id} data-testid={`row-${row.team_id}`}>
+            <span>{row.name}</span>
+            <span>{row.description || '-'}</span>
+            <span>{row.members?.length ?? 0}</span>
+            {/* Render actions column */}
+            {columns.find((c) => c.field === 'actions')?.renderCell?.({ row } as never)}
+          </div>
+        ))
+      )}
+    </div>
+  )
+}));
 
 vi.mock('../../../../hooks/useApi');
 const mockBiohubApi = useApi as Mock;
@@ -59,7 +88,7 @@ const defaultProps: ITeamsContainerProps = {
   onSelectTeam: vi.fn()
 };
 
-const renderContainer = (props: Partial<ITeamsContainerProps> = {}) => {
+const renderComponent = (props: Partial<ITeamsContainerProps> = {}) => {
   return render(
     <MemoryRouter initialEntries={['/']}>
       <TeamsContainer {...defaultProps} {...props} />
@@ -77,119 +106,87 @@ describe('TeamsContainer', () => {
     vi.clearAllMocks();
   });
 
-  it('renders teams in DataGrid', async () => {
-    const { getByText } = renderContainer();
+  describe('Header', () => {
+    it('displays rowCount in header', async () => {
+      // Step 1: Render with default props (rowCount: 2)
+      const { getByText } = renderComponent();
 
-    await waitFor(() => {
-      expect(getByText('Alpha Team')).toBeVisible();
-      expect(getByText('Beta Team')).toBeVisible();
-    });
-  });
-
-  it('displays team count in header', async () => {
-    const { getByText } = renderContainer();
-
-    await waitFor(() => {
-      expect(getByText('(2)')).toBeVisible();
-    });
-  });
-
-  it('displays team descriptions', async () => {
-    const { getByText } = renderContainer();
-
-    await waitFor(() => {
-      expect(getByText('First team')).toBeVisible();
-    });
-  });
-
-  it('displays dash for null description', async () => {
-    const { getAllByText } = renderContainer();
-
-    await waitFor(() => {
-      const dashes = getAllByText('-');
-      expect(dashes.length).toBeGreaterThan(0);
-    });
-  });
-
-  it('displays member count for each team', async () => {
-    const { getByText } = renderContainer();
-
-    await waitFor(() => {
-      // Alpha Team has 1 member, Beta Team has 2
-      expect(getByText('1')).toBeVisible();
-      expect(getByText('2')).toBeVisible();
-    });
-  });
-
-  it('renders search input', async () => {
-    const { getByPlaceholderText } = renderContainer();
-
-    await waitFor(() => {
-      expect(getByPlaceholderText('Search by team name')).toBeVisible();
-    });
-  });
-
-  it('renders Add button', async () => {
-    const { getByRole } = renderContainer();
-
-    await waitFor(() => {
-      expect(getByRole('button', { name: /add/i })).toBeVisible();
-    });
-  });
-
-  it('shows `No Teams` when there are no teams', async () => {
-    const { getByText } = renderContainer({ teams: [], rowCount: 0 });
-
-    await waitFor(() => {
-      expect(getByText('No Teams')).toBeVisible();
-    });
-  });
-
-  describe('Add Team Dialog', () => {
-    it('opens add team dialog when Add button is clicked', async () => {
-      const { getByRole, getByText } = renderContainer();
-
+      // Step 2: Verify dynamic rowCount appears in header
       await waitFor(() => {
-        expect(getByRole('button', { name: /add/i })).toBeVisible();
+        expect(getByText('(2)')).toBeVisible();
       });
+    });
+  });
 
+  describe('Search', () => {
+    it('displays controlled search term value', async () => {
+      // Step 1: Render with searchTerm prop set
+      const { getByPlaceholderText } = renderComponent({ searchTerm: 'Beta' });
+
+      // Step 2: Verify input displays the controlled value
+      await waitFor(() => {
+        expect(getByPlaceholderText('Search by team name')).toHaveValue('Beta');
+      });
+    });
+
+    it('calls onSearch when input changes', async () => {
+      // Step 1: Create mock onSearch callback
+      const mockOnSearch = vi.fn();
+
+      // Step 2: Render with mock callback
+      const { getByPlaceholderText } = renderComponent({ onSearch: mockOnSearch });
+
+      // Step 3: Type in search input
+      const input = getByPlaceholderText('Search by team name');
+      fireEvent.change(input, { target: { value: 'Alpha' } });
+
+      // Step 4: Verify callback was called with input value
+      expect(mockOnSearch).toHaveBeenCalledWith('Alpha');
+    });
+  });
+
+  describe('Add Button', () => {
+    it('opens add dialog when clicked', async () => {
+      // Step 1: Render component
+      const { getByRole, getByText } = renderComponent();
+
+      // Step 2: Click Add button
       fireEvent.click(getByRole('button', { name: /add/i }));
 
+      // Step 3: Verify dialog opens
       await waitFor(() => {
         expect(getByText('Add Team')).toBeVisible();
       });
     });
+  });
 
-    it('creates team and closes dialog on successful submit', async () => {
-      mockCreateTeam.mockResolvedValueOnce({
-        team_id: 'new-team',
-        name: 'New Team',
-        description: 'A new team',
-        members: []
-      });
+  describe('Add Team Dialog', () => {
+    it('calls createTeam API with form values on submit', async () => {
+      // Step 1: Setup - make createTeam return {} (simulates successful API response)
+      mockCreateTeam.mockResolvedValueOnce({});
 
+      // Step 2: Create mock refresh function to verify it's called after submit
       const mockRefresh = vi.fn();
-      const { getByRole, getByLabelText, queryByText } = renderContainer({ refresh: mockRefresh });
 
-      // Wait for initial render
-      await waitFor(() => {
-        expect(getByRole('button', { name: /add/i })).toBeVisible();
-      });
+      // Step 3: Render component with mock refresh prop
+      const { getByRole, getByLabelText, queryByText } = renderComponent({ refresh: mockRefresh });
 
-      // Open dialog
+      // Step 4: Click "Add" button to open dialog
       fireEvent.click(getByRole('button', { name: /add/i }));
 
+      // Step 5: Wait for dialog to appear (async rendering)
       await waitFor(() => {
         expect(getByLabelText('Team Name *')).toBeVisible();
       });
 
-      // Fill in form
+      // Step 6: Fill form fields
       fireEvent.change(getByLabelText('Team Name *'), { target: { value: 'New Team' } });
       fireEvent.change(getByLabelText('Description'), { target: { value: 'A new team' } });
 
-      // Submit form
+      // Step 7: Submit form
       fireEvent.click(getByRole('button', { name: /create/i }));
 
+      // Step 8: Verify API was called with correct params
       await waitFor(() => {
         expect(mockCreateTeam).toHaveBeenCalledWith({
           name: 'New Team',
@@ -198,12 +195,12 @@ describe('TeamsContainer', () => {
         });
       });
 
-      // Dialog should close
+      // Step 9: Verify dialog closes after success
       await waitFor(() => {
         expect(queryByText('Add Team')).toBeNull();
       });
 
-      // Refresh should be called
+      // Step 10: Verify refresh was called after success
       await waitFor(() => {
         expect(mockRefresh).toHaveBeenCalled();
       });
@@ -212,23 +209,26 @@ describe('TeamsContainer', () => {
 
   describe('Edit Team Dialog', () => {
     it('opens edit dialog with team data when Edit is clicked', async () => {
-      const { getByText, getAllByTitle, getByLabelText } = renderContainer();
+      // Step 1: Render component with mock data
+      const { getByText, getAllByTitle, getByLabelText } = renderComponent();
 
+      // Step 2: Wait for data to render
       await waitFor(() => {
         expect(getByText('Alpha Team')).toBeVisible();
       });
 
-      // Click actions menu for Alpha Team
-      const actionsButtons = getAllByTitle('Actions');
-      fireEvent.click(actionsButtons[0]);
+      // Step 3: Open actions menu
+      fireEvent.click(getAllByTitle('Actions')[0]);
 
-      // Click Edit option
+      // Step 4: Wait for menu to appear
       await waitFor(() => {
         expect(getByText('Edit team')).toBeVisible();
       });
+
+      // Step 5: Click Edit option
       fireEvent.click(getByText('Edit team'));
 
-      // Dialog should open with team data
+      // Step 6: Verify dialog opens with pre-populated data from selected team
       await waitFor(() => {
         expect(getByText('Edit Team')).toBeVisible();
         expect(getByLabelText('Team Name *')).toHaveValue('Alpha Team');
@@ -236,43 +236,40 @@ describe('TeamsContainer', () => {
       });
     });
 
-    it('updates team on successful submit', async () => {
-      mockUpdateTeam.mockResolvedValueOnce({
-        team_id: 'team-1',
-        name: 'Updated Team',
-        description: 'Updated description',
-        members: []
-      });
+    it('calls updateTeam API on save', async () => {
+      // Step 1: Setup - make updateTeam return {} (simulates successful API response)
+      mockUpdateTeam.mockResolvedValueOnce({});
 
+      // Step 2: Create mock refresh function
       const mockRefresh = vi.fn();
-      const { getByText, getAllByTitle, getByLabelText, getByRole, queryByText } = renderContainer({
+
+      // Step 3: Render component with mock refresh prop
+      const { getByText, getAllByTitle, getByLabelText, getByRole, queryByText } = renderComponent({
         refresh: mockRefresh
       });
 
+      // Step 4: Wait for data to render
       await waitFor(() => {
         expect(getByText('Alpha Team')).toBeVisible();
       });
 
-      // Open actions menu and click Edit
-      const actionsButtons = getAllByTitle('Actions');
-      fireEvent.click(actionsButtons[0]);
-
-      await waitFor(() => {
-        expect(getByText('Edit team')).toBeVisible();
-      });
+      // Step 5: Open actions menu and click Edit
+      fireEvent.click(getAllByTitle('Actions')[0]);
+      await waitFor(() => expect(getByText('Edit team')).toBeVisible());
       fireEvent.click(getByText('Edit team'));
 
-      // Wait for dialog
+      // Step 6: Wait for edit dialog to appear
       await waitFor(() => {
         expect(getByLabelText('Team Name *')).toBeVisible();
       });
 
-      // Update team name
+      // Step 7: Update form field
       fireEvent.change(getByLabelText('Team Name *'), { target: { value: 'Updated Team' } });
 
-      // Submit
+      // Step 8: Submit form
       fireEvent.click(getByRole('button', { name: /save/i }));
 
+      // Step 9: Verify API was called with correct params (id + updated values)
       await waitFor(() => {
         expect(mockUpdateTeam).toHaveBeenCalledWith('team-1', {
           name: 'Updated Team',
@@ -281,157 +278,23 @@ describe('TeamsContainer', () => {
         });
       });
 
-      // Dialog should close
+      // Step 10: Verify dialog closes after success
       await waitFor(() => {
         expect(queryByText('Edit Team')).toBeNull();
       });
     });
   });
 
-  describe('Delete Team', () => {
-    it('opens delete menu option from actions menu', async () => {
-      const { getByText, getAllByTitle } = renderContainer();
+  describe('Empty State', () => {
+    it('shows empty state message', async () => {
+      // Step 1: Render with empty teams array
+      const { getByText } = renderComponent({ teams: [], rowCount: 0 });
 
+      // Step 2: Verify empty state message appears (from DataGrid localeText)
       await waitFor(() => {
-        expect(getByText('Alpha Team')).toBeVisible();
-      });
-
-      // Click actions menu
-      const actionsButtons = getAllByTitle('Actions');
-      fireEvent.click(actionsButtons[0]);
-
-      // Delete option should be visible
-      await waitFor(() => {
-        expect(getByText('Delete team')).toBeVisible();
-      });
-    });
-
-    it('triggers delete flow when delete menu item is clicked', async () => {
-      const { getByText, getAllByTitle } = renderContainer();
-
-      await waitFor(() => {
-        expect(getByText('Alpha Team')).toBeVisible();
-      });
-
-      // Open actions menu and click Delete
-      const actionsButtons = getAllByTitle('Actions');
-      fireEvent.click(actionsButtons[0]);
-
-      await waitFor(() => {
-        expect(getByText('Delete team')).toBeVisible();
-      });
-
-      // Click delete - this triggers the confirmation dialog flow
-      fireEvent.click(getByText('Delete team'));
-
-      // The delete menu item click should have been processed
-      // (Actual dialog rendering depends on dialogContext which is mocked by test-utils)
-    });
-  });
-
-  describe('Search', () => {
-    it('calls onSearch callback on input change', async () => {
-      const mockOnSearch = vi.fn();
-      const { getByPlaceholderText } = renderContainer({ onSearch: mockOnSearch });
-
-      await waitFor(() => {
-        expect(getByPlaceholderText('Search by team name')).toBeVisible();
-      });
-
-      const searchInput = getByPlaceholderText('Search by team name');
-      fireEvent.change(searchInput, { target: { value: 'Alpha' } });
-
-      expect(mockOnSearch).toHaveBeenCalledWith('Alpha');
-    });
-
-    it('displays controlled search term value', async () => {
-      const { getByPlaceholderText } = renderContainer({ searchTerm: 'Beta' });
-
-      await waitFor(() => {
-        const searchInput = getByPlaceholderText('Search by team name');
-        expect(searchInput).toHaveValue('Beta');
+        expect(getByText('No Teams')).toBeVisible();
       });
     });
   });
 
-  describe('Server Pagination', () => {
-    it('displays rowCount in header for server-side pagination', async () => {
-      // rowCount prop controls the total displayed, not the array length
-      const { getByText } = renderContainer({ teams: mockTeams, rowCount: 100 });
-
-      await waitFor(() => {
-        // Header should show rowCount (100), not teams.length (2)
-        expect(getByText('(100)')).toBeVisible();
-      });
-    });
-
-    it('calls setPaginationModel when page size changes', async () => {
-      const mockSetPaginationModel = vi.fn();
-      const { getByRole } = renderContainer({ setPaginationModel: mockSetPaginationModel });
-
-      await waitFor(() => {
-        // Find the page size selector (combobox)
-        const pageSizeSelector = getByRole('combobox');
-        expect(pageSizeSelector).toBeVisible();
-      });
-
-      // Change page size
-      const pageSizeSelector = getByRole('combobox');
-      fireEvent.mouseDown(pageSizeSelector);
-
-      await waitFor(() => {
-        const option25 = getByRole('option', { name: '25' });
-        fireEvent.click(option25);
-      });
-
-      expect(mockSetPaginationModel).toHaveBeenCalled();
-    });
-
-    it('calls setSortModel when column header is clicked', async () => {
-      const mockSetSortModel = vi.fn();
-      const { getByText } = renderContainer({ setSortModel: mockSetSortModel });
-
-      await waitFor(() => {
-        expect(getByText('Alpha Team')).toBeVisible();
-      });
-
-      // Click on the Name column header to trigger sort
-      const nameHeader = getByText('Name');
-      fireEvent.click(nameHeader);
-
-      expect(mockSetSortModel).toHaveBeenCalled();
-    });
-  });
-
-  describe('Row Selection', () => {
-    it('calls onSelectTeam when a row is clicked', async () => {
-      const mockOnSelectTeam = vi.fn();
-      const { getByText } = renderContainer({ onSelectTeam: mockOnSelectTeam });
-
-      await waitFor(() => {
-        expect(getByText('Alpha Team')).toBeVisible();
-      });
-
-      // Click on a row
-      const row = getByText('Alpha Team').closest('.MuiDataGrid-row');
-      if (row) {
-        fireEvent.click(row);
-      }
-
-      // onSelectTeam should be called
-      // Note: The actual value depends on DataGrid's selection model behavior
-    });
-
-    it('highlights selected row when selectedTeamId is provided', async () => {
-      const { getByText } = renderContainer({ selectedTeamId: 'team-1' });
-
-      await waitFor(() => {
-        expect(getByText('Alpha Team')).toBeVisible();
-      });
-
-      // The row should have the selected class (MUI DataGrid applies Mui-selected)
-      const row = getByText('Alpha Team').closest('.MuiDataGrid-row');
-      expect(row).toHaveClass('Mui-selected');
-    });
-  });
 });

--- a/app/src/features/admin/policies/components/TeamsContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.test.tsx
@@ -47,6 +47,11 @@ const mockUseApi = {
 
 const defaultProps: ITeamsContainerProps = {
   teams: mockTeams,
+  rowCount: 2,
+  paginationModel: { page: 0, pageSize: 10 },
+  setPaginationModel: vi.fn(),
+  sortModel: [{ field: 'name', sort: 'asc' }],
+  setSortModel: vi.fn(),
   refresh: vi.fn(),
   searchTerm: '',
   onSearch: vi.fn(),
@@ -133,7 +138,7 @@ describe('TeamsContainer', () => {
   });
 
   it('shows `No Teams` when there are no teams', async () => {
-    const { getByText } = renderContainer({ teams: [] });
+    const { getByText } = renderContainer({ teams: [], rowCount: 0 });
 
     await waitFor(() => {
       expect(getByText('No Teams')).toBeVisible();
@@ -346,6 +351,55 @@ describe('TeamsContainer', () => {
         const searchInput = getByPlaceholderText('Search by team name');
         expect(searchInput).toHaveValue('Beta');
       });
+    });
+  });
+
+  describe('Server Pagination', () => {
+    it('displays rowCount in header for server-side pagination', async () => {
+      // rowCount prop controls the total displayed, not the array length
+      const { getByText } = renderContainer({ teams: mockTeams, rowCount: 100 });
+
+      await waitFor(() => {
+        // Header should show rowCount (100), not teams.length (2)
+        expect(getByText('(100)')).toBeVisible();
+      });
+    });
+
+    it('calls setPaginationModel when page size changes', async () => {
+      const mockSetPaginationModel = vi.fn();
+      const { getByRole } = renderContainer({ setPaginationModel: mockSetPaginationModel });
+
+      await waitFor(() => {
+        // Find the page size selector (combobox)
+        const pageSizeSelector = getByRole('combobox');
+        expect(pageSizeSelector).toBeVisible();
+      });
+
+      // Change page size
+      const pageSizeSelector = getByRole('combobox');
+      fireEvent.mouseDown(pageSizeSelector);
+
+      await waitFor(() => {
+        const option25 = getByRole('option', { name: '25' });
+        fireEvent.click(option25);
+      });
+
+      expect(mockSetPaginationModel).toHaveBeenCalled();
+    });
+
+    it('calls setSortModel when column header is clicked', async () => {
+      const mockSetSortModel = vi.fn();
+      const { getByText } = renderContainer({ setSortModel: mockSetSortModel });
+
+      await waitFor(() => {
+        expect(getByText('Alpha Team')).toBeVisible();
+      });
+
+      // Click on the Name column header to trigger sort
+      const nameHeader = getByText('Name');
+      fireEvent.click(nameHeader);
+
+      expect(mockSetSortModel).toHaveBeenCalled();
     });
   });
 

--- a/app/src/features/admin/policies/components/TeamsContainer.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.tsx
@@ -404,6 +404,7 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
           onPaginationModelChange={setPaginationModel}
           pageSizeOptions={[10, 25, 50]}
           sortingMode="server"
+          sortingOrder={['asc', 'desc']}
           sortModel={sortModel}
           onSortModelChange={setSortModel}
           rowCount={rowCount}

--- a/app/src/features/admin/policies/components/TeamsContainer.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.tsx
@@ -16,13 +16,14 @@ import { APIError } from 'hooks/api/useAxios';
 import { useApi } from 'hooks/useApi';
 import { useDialogContext } from 'hooks/useContext';
 import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
+import { IServerPaginationProps } from 'types/pagination';
 import { useState } from 'react';
 import { AddTeamForm, AddTeamFormInitialValues, AddTeamFormYupSchema, IAddTeamFormValues } from './AddTeamForm';
 
 /**
  * Props for the TeamsContainer component.
  */
-export interface ITeamsContainerProps {
+export interface ITeamsContainerProps extends IServerPaginationProps {
   /** Array of teams to display in the table */
   teams: ITeamWithMembers[];
   /** Callback to refresh the teams list after create/update/delete */
@@ -51,7 +52,19 @@ export interface ITeamsContainerProps {
  * @returns {React.ReactElement} The teams container component
  */
 export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
-  const { teams, refresh, searchTerm, onSearch, selectedTeamId, onSelectTeam } = props;
+  const {
+    teams,
+    rowCount,
+    paginationModel,
+    setPaginationModel,
+    sortModel,
+    setSortModel,
+    refresh,
+    searchTerm,
+    onSearch,
+    selectedTeamId,
+    onSelectTeam
+  } = props;
 
   const biohubApi = useApi();
   const dialogContext = useDialogContext();
@@ -349,7 +362,7 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
           <Typography variant="h4" component="h2" flexGrow={1}>
             Teams{' '}
             <Typography sx={{ fontSize: 'inherit' }} component="span" color="textSecondary">
-              ({teams.length})
+              ({rowCount})
             </Typography>
           </Typography>
           <Stack gap={1} direction="row" alignItems="center">
@@ -386,7 +399,14 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
           rows={teams}
           columns={columns}
           getRowId={(row) => row.team_id}
+          paginationMode="server"
+          paginationModel={paginationModel}
+          onPaginationModelChange={setPaginationModel}
           pageSizeOptions={[10, 25, 50]}
+          sortingMode="server"
+          sortModel={sortModel}
+          onSortModelChange={setSortModel}
+          rowCount={rowCount}
           rowSelectionModel={rowSelectionModel}
           onRowSelectionModelChange={handleRowSelectionChange}
           checkboxSelection
@@ -394,13 +414,6 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
           disableColumnSelector
           disableColumnMenu
           localeText={{ noRowsLabel: 'No Teams' }}
-          initialState={{
-            pagination: {
-              paginationModel: {
-                pageSize: 10
-              }
-            }
-          }}
           sx={{
             border: 'none',
             '& .MuiDataGrid-columnHeaderTitle': {

--- a/app/src/hooks/api/usePoliciesApi.test.ts
+++ b/app/src/hooks/api/usePoliciesApi.test.ts
@@ -18,7 +18,7 @@ describe('usePoliciesApi', () => {
     it('returns paginated policies', async () => {
       const mockResponse = {
         policies: [{ policy_id: '1', name: 'Policy 1', description: null, statements: [] }],
-        pagination: { total: 1, page: 1, limit: 10 }
+        pagination: { total: 1, current_page: 1, last_page: 1, per_page: 10 }
       };
 
       mock.onGet('/api/administrative/policies').reply(200, mockResponse);
@@ -31,14 +31,14 @@ describe('usePoliciesApi', () => {
     it('passes query params', async () => {
       const mockResponse = {
         policies: [],
-        pagination: { total: 0, page: 2, limit: 20 }
+        pagination: { total: 0, current_page: 2, last_page: 1, per_page: 20 }
       };
 
       mock.onGet('/api/administrative/policies').reply(200, mockResponse);
 
-      const result = await usePoliciesApi(axios).getPolicies({ page: 2, limit: 20 });
+      const result = await usePoliciesApi(axios).getPolicies(undefined, { page: 2, limit: 20 });
 
-      expect(result.pagination.page).toEqual(2);
+      expect(result.pagination.current_page).toEqual(2);
     });
   });
 

--- a/app/src/hooks/api/usePoliciesApi.ts
+++ b/app/src/hooks/api/usePoliciesApi.ts
@@ -5,6 +5,7 @@ import {
   ICreatePolicyRequest,
   IUpdatePolicyRequest
 } from 'interfaces/usePoliciesApi.interface';
+import { ApiPaginationRequestOptions, ApiSearchParams } from 'types/pagination';
 
 /**
  * Returns a set of supported api methods for working with policies.
@@ -16,14 +17,15 @@ const usePoliciesApi = (axios: AxiosInstance) => {
   /**
    * Get all policies with pagination.
    *
-   * @param {object} [params]
+   * @param {ApiSearchParams} [searchParams] - Optional search parameters.
+   * @param {ApiPaginationRequestOptions} [pagination] - Optional pagination parameters.
    * @return {*} {Promise<IPoliciesResponse>}
    */
-  const getPolicies = async (params?: {
-    page?: number;
-    limit?: number;
-    search?: string;
-  }): Promise<IPoliciesResponse> => {
+  const getPolicies = async (
+    searchParams?: ApiSearchParams,
+    pagination?: ApiPaginationRequestOptions
+  ): Promise<IPoliciesResponse> => {
+    const params = { ...searchParams, ...pagination };
     const { data } = await axios.get('/api/administrative/policies', { params });
 
     return data;

--- a/app/src/hooks/api/useTeamPoliciesApi.ts
+++ b/app/src/hooks/api/useTeamPoliciesApi.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance } from 'axios';
 import { ICreateTeamPolicyRequest, ITeamPoliciesResponse, ITeamPolicy } from 'interfaces/useTeamPoliciesApi.interface';
+import { ApiPaginationRequestOptions } from 'types/pagination';
 
 /**
  * Returns a set of supported api methods for working with team-policy associations.
@@ -11,10 +12,11 @@ export const useTeamPoliciesApi = (axios: AxiosInstance) => {
   /**
    * Get all team-policy associations with team and policy names.
    *
+   * @param {ApiPaginationRequestOptions} [pagination] - Optional pagination parameters.
    * @return {*} {Promise<ITeamPoliciesResponse>}
    */
-  const getTeamPolicies = async (): Promise<ITeamPoliciesResponse> => {
-    const { data } = await axios.get('/api/administrative/team-policies');
+  const getTeamPolicies = async (pagination?: ApiPaginationRequestOptions): Promise<ITeamPoliciesResponse> => {
+    const { data } = await axios.get('/api/administrative/team-policies', { params: pagination });
 
     return data;
   };

--- a/app/src/hooks/api/useTeamsApi.ts
+++ b/app/src/hooks/api/useTeamsApi.ts
@@ -6,6 +6,7 @@ import {
   IUpdateTeamRequest,
   IAvailableUsersResponse
 } from 'interfaces/useTeamsApi.interface';
+import { ApiPaginationRequestOptions, ApiSearchParams } from 'types/pagination';
 
 /**
  * Returns a set of supported api methods for working with teams.
@@ -17,16 +18,15 @@ export const useTeamsApi = (axios: AxiosInstance) => {
   /**
    * Get all teams with pagination.
    *
-   * @param {{ page: number; limit: number; sort?: string; order?: 'asc' | 'desc'; search?: string }} params
+   * @param {ApiSearchParams} [searchParams] - Optional search parameters.
+   * @param {ApiPaginationRequestOptions} [pagination] - Optional pagination parameters.
    * @return {*} {Promise<ITeamsResponse>}
    */
-  const getTeams = async (params: {
-    page: number;
-    limit: number;
-    sort?: string;
-    order?: 'asc' | 'desc';
-    search?: string;
-  }): Promise<ITeamsResponse> => {
+  const getTeams = async (
+    searchParams?: ApiSearchParams,
+    pagination?: ApiPaginationRequestOptions
+  ): Promise<ITeamsResponse> => {
+    const params = { ...searchParams, ...pagination };
     const { data } = await axios.get('/api/administrative/teams', { params });
 
     return data;

--- a/app/src/hooks/useDebounce.test.tsx
+++ b/app/src/hooks/useDebounce.test.tsx
@@ -1,20 +1,200 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import useDebounce from './useDebounce';
 
-const mockCallback = vi.fn();
-
 describe('useDebounce', () => {
-  it('should debounce repeated calls', async () => {
-    const { result } = renderHook(() => useDebounce(mockCallback, 500));
-    const debounce = result.current;
-    act(() => debounce());
-    await waitFor(() => {
-      expect(mockCallback.mock.calls[0]).toBeDefined();
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('debounce timing', () => {
+    it('delays callback execution until after delay period', () => {
+      // WHY HIGH VALUE: Tests core debounce timing behavior
+      const mockCallback = vi.fn();
+
+      const { result } = renderHook(() => useDebounce(mockCallback, 300));
+
+      // Step 1: Call the debounced function
+      act(() => {
+        result.current();
+      });
+
+      // Step 2: Verify callback NOT called immediately
+      expect(mockCallback).not.toHaveBeenCalled();
+
+      // Step 3: Advance time past delay
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Step 4: Verify callback was called
+      expect(mockCallback).toHaveBeenCalledTimes(1);
     });
-    // this request should fail as it is being requested too quickly
-    act(() => debounce());
-    await waitFor(() => {
-      expect(mockCallback.mock.calls[1]).not.toBeDefined();
+
+    it('cancels previous call when called again within delay', () => {
+      // WHY HIGH VALUE: Tests debounce cancellation - only last call should execute
+      const mockCallback = vi.fn();
+
+      const { result } = renderHook(() => useDebounce(mockCallback, 300));
+
+      // Step 1: Call multiple times rapidly
+      act(() => {
+        result.current();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        result.current();
+      });
+
+      // Step 2: Advance past original delay (but not past second call's delay)
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      // Step 3: First call should have been cancelled
+      expect(mockCallback).not.toHaveBeenCalled();
+
+      // Step 4: Advance past second call's delay
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      // Step 5: Only the last call should execute
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('parameter passing', () => {
+    it('passes arguments through to callback', () => {
+      // WHY HIGH VALUE: Tests new generic parameter functionality
+      const mockCallback = vi.fn<(term: string, count: number) => void>();
+
+      const { result } = renderHook(() => useDebounce(mockCallback, 300));
+
+      // Step 1: Call with arguments
+      act(() => {
+        result.current('search term', 42);
+      });
+
+      // Step 2: Advance past delay
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Step 3: Verify callback received the arguments
+      expect(mockCallback).toHaveBeenCalledWith('search term', 42);
+    });
+
+    it('passes latest arguments when called multiple times', () => {
+      // WHY HIGH VALUE: Tests that only the last call's arguments are used
+      const mockCallback = vi.fn<(term: string) => void>();
+
+      const { result } = renderHook(() => useDebounce(mockCallback, 300));
+
+      // Step 1: Call multiple times with different arguments
+      act(() => {
+        result.current('first');
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        result.current('second');
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      act(() => {
+        result.current('third');
+      });
+
+      // Step 2: Advance past delay
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Step 3: Only the last call's arguments should be used
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith('third');
+    });
+  });
+
+  describe('callback ref pattern', () => {
+    it('always calls the latest callback', () => {
+      // WHY HIGH VALUE: Tests the ref pattern - ensures callback updates are picked up
+      // This is critical for callbacks that capture changing state
+      const firstCallback = vi.fn();
+      const secondCallback = vi.fn();
+
+      // Step 1: Render with first callback
+      const { result, rerender } = renderHook(({ cb }) => useDebounce(cb, 300), {
+        initialProps: { cb: firstCallback }
+      });
+
+      // Step 2: Call the debounced function
+      act(() => {
+        result.current();
+      });
+
+      // Step 3: Update to second callback BEFORE delay completes
+      rerender({ cb: secondCallback });
+
+      // Step 4: Advance past delay
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Step 5: Second callback should be called (not first)
+      expect(firstCallback).not.toHaveBeenCalled();
+      expect(secondCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('function identity', () => {
+    it('returns stable function when callback changes', () => {
+      // WHY HIGH VALUE: Tests that debounced function doesn't change on every render
+      // This prevents unnecessary re-renders in consuming components
+      const { result, rerender } = renderHook<ReturnType<typeof useDebounce>, { cb: () => void }>(
+        ({ cb }) => useDebounce(cb, 300),
+        { initialProps: { cb: vi.fn() } }
+      );
+
+      const firstResult = result.current;
+
+      // Step 1: Rerender with different callback
+      rerender({ cb: vi.fn() });
+
+      // Step 2: Function identity should be stable
+      expect(result.current).toBe(firstResult);
+    });
+
+    it('returns new function when delay changes', () => {
+      // WHY HIGH VALUE: Tests that delay changes are respected
+      const mockCallback = vi.fn();
+
+      const { result, rerender } = renderHook(({ delay }) => useDebounce(mockCallback, delay), {
+        initialProps: { delay: 300 }
+      });
+
+      const firstResult = result.current;
+
+      // Step 1: Rerender with different delay
+      rerender({ delay: 500 });
+
+      // Step 2: Function should be recreated with new delay
+      expect(result.current).not.toBe(firstResult);
     });
   });
 });

--- a/app/src/hooks/useDebounce.tsx
+++ b/app/src/hooks/useDebounce.tsx
@@ -1,14 +1,29 @@
-import debounce from 'lodash-es/debounce';
+import debounce, { DebouncedFunc } from 'lodash-es/debounce';
 import { useEffect, useMemo, useRef } from 'react';
 
 /**
- * hook to delay multiple repeditive executions of callback
+ * Hook to delay multiple repetitive executions of a callback.
  *
- * @param {() => void} callback - function to fire
- * @param {number} [msDelay] - milliseconds to delay callback fire
- * @returns {DebouncedFunc<() => void>} - debounced callback
+ * Uses a ref to always call the latest callback, so the debounced function
+ * remains stable even when the callback captures changing state.
+ *
+ * @template T - The callback function type
+ * @param callback - Function to debounce (can accept parameters)
+ * @param msDelay - Milliseconds to delay callback execution (default: 500)
+ * @returns Debounced callback with same signature as input
+ *
+ * @example
+ * // No parameters
+ * const debouncedSave = useDebounce(() => save(formData), 300);
+ *
+ * @example
+ * // With parameters - callback always sees current state
+ * const debouncedSearch = useDebounce((term: string) => {
+ *   api.search(term, currentFilters); // currentFilters is always fresh
+ * }, 300);
+ * debouncedSearch('query');
  */
-const useDebounce = (callback: () => void, msDelay = 500) => {
+const useDebounce = <T extends (...args: any[]) => void>(callback: T, msDelay = 500): DebouncedFunc<T> => {
   const ref = useRef(callback);
 
   useEffect(() => {
@@ -16,11 +31,11 @@ const useDebounce = (callback: () => void, msDelay = 500) => {
   }, [callback]);
 
   const debouncedCallback = useMemo(() => {
-    const func = () => {
-      ref.current?.();
+    const func = (...args: Parameters<T>) => {
+      ref.current?.(...args);
     };
 
-    return debounce(func, msDelay);
+    return debounce(func, msDelay) as DebouncedFunc<T>;
   }, [msDelay]);
 
   return debouncedCallback;

--- a/app/src/hooks/useServerPaginatedDataGrid.test.ts
+++ b/app/src/hooks/useServerPaginatedDataGrid.test.ts
@@ -1,0 +1,506 @@
+import { act, renderHook } from '@testing-library/react';
+import { useServerPaginatedDataGrid, toApiPagination } from './useServerPaginatedDataGrid';
+
+// Mock useDataLoader
+const mockLoad = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock('./useDataLoader', () => ({
+  default: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    load: mockLoad,
+    refresh: mockRefresh
+  }))
+}));
+
+// Import the mocked module to control return values
+import useDataLoader from './useDataLoader';
+const mockUseDataLoader = vi.mocked(useDataLoader);
+
+// Test data types
+interface ITestItem {
+  id: string;
+  name: string;
+}
+
+interface ITestResponse {
+  items: ITestItem[];
+  pagination: { total: number };
+}
+
+// Default hook options for tests
+const createDefaultOptions = (overrides = {}) => ({
+  fetcher: vi.fn<(search: string | undefined, pagination: any) => Promise<ITestResponse>>().mockResolvedValue({
+    items: [{ id: '1', name: 'Test' }],
+    pagination: { total: 1 }
+  }),
+  extractData: (response: ITestResponse) => response.items,
+  extractTotal: (response: ITestResponse) => response.pagination.total,
+  defaultSort: { field: 'name', sort: 'asc' as const },
+  ...overrides
+});
+
+describe('useServerPaginatedDataGrid', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    // Reset useDataLoader mock to default
+    mockUseDataLoader.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      isReady: false,
+      load: mockLoad,
+      refresh: mockRefresh,
+      clear: vi.fn(),
+      setData: vi.fn()
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('toApiPagination helper', () => {
+    it('converts 0-indexed page to 1-indexed API page', () => {
+      // WHY HIGH VALUE: Tests critical page index conversion that could cause off-by-one bugs
+      const result = toApiPagination(
+        { page: 0, pageSize: 10 },
+        [{ field: 'name', sort: 'asc' }]
+      );
+
+      expect(result.page).toBe(1);
+    });
+
+    it('passes pageSize as limit', () => {
+      const result = toApiPagination(
+        { page: 0, pageSize: 25 },
+        [{ field: 'name', sort: 'asc' }]
+      );
+
+      expect(result.limit).toBe(25);
+    });
+
+    it('extracts sort field and order from sort model', () => {
+      const result = toApiPagination(
+        { page: 0, pageSize: 10 },
+        [{ field: 'created_at', sort: 'desc' }]
+      );
+
+      expect(result.sort).toBe('created_at');
+      expect(result.order).toBe('desc');
+    });
+
+    it('handles empty sort model', () => {
+      const result = toApiPagination(
+        { page: 0, pageSize: 10 },
+        []
+      );
+
+      expect(result.sort).toBeUndefined();
+      expect(result.order).toBeUndefined();
+    });
+  });
+
+  describe('initial state', () => {
+    it('returns default pagination model with provided pageSize', () => {
+      // WHY HIGH VALUE: Tests that defaults are correctly applied
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({ defaultPageSize: 25 }))
+      );
+
+      expect(result.current.paginationModel).toEqual({ page: 0, pageSize: 25 });
+    });
+
+    it('returns default sort model from options', () => {
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({
+          defaultSort: { field: 'created_at', sort: 'desc' }
+        }))
+      );
+
+      expect(result.current.sortModel).toEqual([{ field: 'created_at', sort: 'desc' }]);
+    });
+
+    it('starts with empty search term', () => {
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      expect(result.current.searchTerm).toBe('');
+    });
+
+    it('starts with empty data array when no response', () => {
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      expect(result.current.data).toEqual([]);
+      expect(result.current.rowCount).toBe(0);
+    });
+  });
+
+  describe('initial data load', () => {
+    it('calls load on mount with default pagination params', () => {
+      // WHY HIGH VALUE: Tests that hook fetches data on mount with correct params
+      renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
+
+      expect(mockLoad).toHaveBeenCalledWith(
+        undefined, // no search term
+        expect.objectContaining({
+          page: 1,
+          limit: 10,
+          sort: 'name',
+          order: 'asc'
+        })
+      );
+    });
+
+    it('uses custom defaultPageSize in initial load', () => {
+      renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({ defaultPageSize: 50 }))
+      );
+
+      expect(mockLoad).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ limit: 50 })
+      );
+    });
+  });
+
+  describe('data extraction', () => {
+    it('extracts data array from response using extractData', async () => {
+      // WHY HIGH VALUE: Tests that extractData callback is used correctly
+      const mockItems = [{ id: '1', name: 'Alpha' }, { id: '2', name: 'Beta' }];
+
+      mockUseDataLoader.mockReturnValue({
+        data: { items: mockItems, pagination: { total: 2 } },
+        error: undefined,
+        isLoading: false,
+        isReady: true,
+        load: mockLoad,
+        refresh: mockRefresh,
+        clear: vi.fn(),
+        setData: vi.fn()
+      });
+
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      expect(result.current.data).toEqual(mockItems);
+    });
+
+    it('extracts total count from response using extractTotal', async () => {
+      mockUseDataLoader.mockReturnValue({
+        data: { items: [], pagination: { total: 42 } },
+        error: undefined,
+        isLoading: false,
+        isReady: true,
+        load: mockLoad,
+        refresh: mockRefresh,
+        clear: vi.fn(),
+        setData: vi.fn()
+      });
+
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      expect(result.current.rowCount).toBe(42);
+    });
+  });
+
+  describe('handleSearch', () => {
+    it('updates searchTerm immediately', () => {
+      // WHY HIGH VALUE: Tests that UI input is responsive (not debounced)
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      act(() => {
+        result.current.handleSearch('test query');
+      });
+
+      // searchTerm updates immediately (not debounced)
+      expect(result.current.searchTerm).toBe('test query');
+    });
+
+    it('debounces the API call', () => {
+      // WHY HIGH VALUE: Tests debounce behavior - API not called immediately
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
+      );
+
+      // Clear the initial load call
+      mockRefresh.mockClear();
+
+      act(() => {
+        result.current.handleSearch('test');
+      });
+
+      // API should NOT be called immediately
+      expect(mockRefresh).not.toHaveBeenCalled();
+
+      // Advance past debounce delay
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Now API should be called
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it('resets to page 1 when searching', () => {
+      // WHY HIGH VALUE: Tests critical UX behavior - search should reset pagination
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
+      );
+
+      // First, change to page 2
+      act(() => {
+        result.current.handlePaginationChange({ page: 2, pageSize: 10 });
+      });
+
+      expect(result.current.paginationModel.page).toBe(2);
+
+      // Clear mocks
+      mockRefresh.mockClear();
+
+      // Now search
+      act(() => {
+        result.current.handleSearch('query');
+      });
+
+      // Advance past debounce
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Page should reset to 0
+      expect(result.current.paginationModel.page).toBe(0);
+
+      // API should be called with page 1
+      expect(mockRefresh).toHaveBeenCalledWith(
+        'query',
+        expect.objectContaining({ page: 1 })
+      );
+    });
+
+    it('passes search term to API after debounce', () => {
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
+      );
+
+      mockRefresh.mockClear();
+
+      act(() => {
+        result.current.handleSearch('alpha');
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(mockRefresh).toHaveBeenCalledWith(
+        'alpha',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('handlePaginationChange', () => {
+    it('updates pagination model immediately', () => {
+      // WHY HIGH VALUE: Tests that pagination state updates correctly
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      act(() => {
+        result.current.handlePaginationChange({ page: 3, pageSize: 25 });
+      });
+
+      expect(result.current.paginationModel).toEqual({ page: 3, pageSize: 25 });
+    });
+
+    it('calls API immediately with new pagination (no debounce)', () => {
+      // WHY HIGH VALUE: Tests that pagination changes fetch immediately (unlike search)
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      mockRefresh.mockClear();
+
+      act(() => {
+        result.current.handlePaginationChange({ page: 2, pageSize: 10 });
+      });
+
+      // Should be called immediately, not debounced
+      expect(mockRefresh).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({
+          page: 3, // 0-indexed page 2 = API page 3
+          limit: 10
+        })
+      );
+    });
+
+    it('preserves current search term when paginating', () => {
+      // WHY HIGH VALUE: Tests that search context is maintained across pagination
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
+      );
+
+      // First, do a search
+      act(() => {
+        result.current.handleSearch('test');
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      mockRefresh.mockClear();
+
+      // Then paginate
+      act(() => {
+        result.current.handlePaginationChange({ page: 1, pageSize: 10 });
+      });
+
+      // Search term should be preserved
+      expect(mockRefresh).toHaveBeenCalledWith(
+        'test',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('handleSortChange', () => {
+    it('updates sort model immediately', () => {
+      // WHY HIGH VALUE: Tests that sort state updates correctly
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      act(() => {
+        result.current.handleSortChange([{ field: 'created_at', sort: 'desc' }]);
+      });
+
+      expect(result.current.sortModel).toEqual([{ field: 'created_at', sort: 'desc' }]);
+    });
+
+    it('calls API immediately with new sort (no debounce)', () => {
+      // WHY HIGH VALUE: Tests that sort changes fetch immediately
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      mockRefresh.mockClear();
+
+      act(() => {
+        result.current.handleSortChange([{ field: 'updated_at', sort: 'asc' }]);
+      });
+
+      expect(mockRefresh).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({
+          sort: 'updated_at',
+          order: 'asc'
+        })
+      );
+    });
+
+    it('preserves current pagination when sorting', () => {
+      // WHY HIGH VALUE: Tests that page context is maintained across sort changes
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      // First, go to page 2
+      act(() => {
+        result.current.handlePaginationChange({ page: 2, pageSize: 10 });
+      });
+
+      mockRefresh.mockClear();
+
+      // Then sort
+      act(() => {
+        result.current.handleSortChange([{ field: 'name', sort: 'desc' }]);
+      });
+
+      // Page should be preserved
+      expect(mockRefresh).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({
+          page: 3 // page 2 (0-indexed) = API page 3
+        })
+      );
+    });
+  });
+
+  describe('refresh', () => {
+    it('calls API with current state', () => {
+      // WHY HIGH VALUE: Tests manual refresh uses all current params
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
+      );
+
+      // Set up some state
+      act(() => {
+        result.current.handleSearch('query');
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      act(() => {
+        result.current.handlePaginationChange({ page: 1, pageSize: 20 });
+      });
+
+      act(() => {
+        result.current.handleSortChange([{ field: 'date', sort: 'desc' }]);
+      });
+
+      mockRefresh.mockClear();
+
+      // Call refresh
+      act(() => {
+        result.current.refresh();
+      });
+
+      // Should use all current state
+      expect(mockRefresh).toHaveBeenCalledWith(
+        'query',
+        expect.objectContaining({
+          page: 2, // page 1 (0-indexed) = API page 2
+          limit: 20,
+          sort: 'date',
+          order: 'desc'
+        })
+      );
+    });
+  });
+
+  describe('isLoading state', () => {
+    it('reflects useDataLoader isLoading state', () => {
+      mockUseDataLoader.mockReturnValue({
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        isReady: false,
+        load: mockLoad,
+        refresh: mockRefresh,
+        clear: vi.fn(),
+        setData: vi.fn()
+      });
+
+      const { result } = renderHook(() =>
+        useServerPaginatedDataGrid(createDefaultOptions())
+      );
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+});

--- a/app/src/hooks/useServerPaginatedDataGrid.test.ts
+++ b/app/src/hooks/useServerPaginatedDataGrid.test.ts
@@ -65,38 +65,26 @@ describe('useServerPaginatedDataGrid', () => {
   describe('toApiPagination helper', () => {
     it('converts 0-indexed page to 1-indexed API page', () => {
       // WHY HIGH VALUE: Tests critical page index conversion that could cause off-by-one bugs
-      const result = toApiPagination(
-        { page: 0, pageSize: 10 },
-        [{ field: 'name', sort: 'asc' }]
-      );
+      const result = toApiPagination({ page: 0, pageSize: 10 }, [{ field: 'name', sort: 'asc' }]);
 
       expect(result.page).toBe(1);
     });
 
     it('passes pageSize as limit', () => {
-      const result = toApiPagination(
-        { page: 0, pageSize: 25 },
-        [{ field: 'name', sort: 'asc' }]
-      );
+      const result = toApiPagination({ page: 0, pageSize: 25 }, [{ field: 'name', sort: 'asc' }]);
 
       expect(result.limit).toBe(25);
     });
 
     it('extracts sort field and order from sort model', () => {
-      const result = toApiPagination(
-        { page: 0, pageSize: 10 },
-        [{ field: 'created_at', sort: 'desc' }]
-      );
+      const result = toApiPagination({ page: 0, pageSize: 10 }, [{ field: 'created_at', sort: 'desc' }]);
 
       expect(result.sort).toBe('created_at');
       expect(result.order).toBe('desc');
     });
 
     it('handles empty sort model', () => {
-      const result = toApiPagination(
-        { page: 0, pageSize: 10 },
-        []
-      );
+      const result = toApiPagination({ page: 0, pageSize: 10 }, []);
 
       expect(result.sort).toBeUndefined();
       expect(result.order).toBeUndefined();
@@ -106,35 +94,31 @@ describe('useServerPaginatedDataGrid', () => {
   describe('initial state', () => {
     it('returns default pagination model with provided pageSize', () => {
       // WHY HIGH VALUE: Tests that defaults are correctly applied
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({ defaultPageSize: 25 }))
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions({ defaultPageSize: 25 })));
 
       expect(result.current.paginationModel).toEqual({ page: 0, pageSize: 25 });
     });
 
     it('returns default sort model from options', () => {
       const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({
-          defaultSort: { field: 'created_at', sort: 'desc' }
-        }))
+        useServerPaginatedDataGrid(
+          createDefaultOptions({
+            defaultSort: { field: 'created_at', sort: 'desc' }
+          })
+        )
       );
 
       expect(result.current.sortModel).toEqual([{ field: 'created_at', sort: 'desc' }]);
     });
 
     it('starts with empty search term', () => {
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       expect(result.current.searchTerm).toBe('');
     });
 
     it('starts with empty data array when no response', () => {
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       expect(result.current.data).toEqual([]);
       expect(result.current.rowCount).toBe(0);
@@ -158,21 +142,19 @@ describe('useServerPaginatedDataGrid', () => {
     });
 
     it('uses custom defaultPageSize in initial load', () => {
-      renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({ defaultPageSize: 50 }))
-      );
+      renderHook(() => useServerPaginatedDataGrid(createDefaultOptions({ defaultPageSize: 50 })));
 
-      expect(mockLoad).toHaveBeenCalledWith(
-        undefined,
-        expect.objectContaining({ limit: 50 })
-      );
+      expect(mockLoad).toHaveBeenCalledWith(undefined, expect.objectContaining({ limit: 50 }));
     });
   });
 
   describe('data extraction', () => {
     it('extracts data array from response using extractData', async () => {
       // WHY HIGH VALUE: Tests that extractData callback is used correctly
-      const mockItems = [{ id: '1', name: 'Alpha' }, { id: '2', name: 'Beta' }];
+      const mockItems = [
+        { id: '1', name: 'Alpha' },
+        { id: '2', name: 'Beta' }
+      ];
 
       mockUseDataLoader.mockReturnValue({
         data: { items: mockItems, pagination: { total: 2 } },
@@ -185,9 +167,7 @@ describe('useServerPaginatedDataGrid', () => {
         setData: vi.fn()
       });
 
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       expect(result.current.data).toEqual(mockItems);
     });
@@ -204,9 +184,7 @@ describe('useServerPaginatedDataGrid', () => {
         setData: vi.fn()
       });
 
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       expect(result.current.rowCount).toBe(42);
     });
@@ -215,9 +193,7 @@ describe('useServerPaginatedDataGrid', () => {
   describe('handleSearch', () => {
     it('updates searchTerm immediately', () => {
       // WHY HIGH VALUE: Tests that UI input is responsive (not debounced)
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       act(() => {
         result.current.handleSearch('test query');
@@ -229,9 +205,7 @@ describe('useServerPaginatedDataGrid', () => {
 
     it('debounces the API call', () => {
       // WHY HIGH VALUE: Tests debounce behavior - API not called immediately
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 })));
 
       // Clear the initial load call
       mockRefresh.mockClear();
@@ -254,9 +228,7 @@ describe('useServerPaginatedDataGrid', () => {
 
     it('resets to page 1 when searching', () => {
       // WHY HIGH VALUE: Tests critical UX behavior - search should reset pagination
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 })));
 
       // First, change to page 2
       act(() => {
@@ -282,16 +254,11 @@ describe('useServerPaginatedDataGrid', () => {
       expect(result.current.paginationModel.page).toBe(0);
 
       // API should be called with page 1
-      expect(mockRefresh).toHaveBeenCalledWith(
-        'query',
-        expect.objectContaining({ page: 1 })
-      );
+      expect(mockRefresh).toHaveBeenCalledWith('query', expect.objectContaining({ page: 1 }));
     });
 
     it('passes search term to API after debounce', () => {
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 })));
 
       mockRefresh.mockClear();
 
@@ -303,19 +270,14 @@ describe('useServerPaginatedDataGrid', () => {
         vi.advanceTimersByTime(300);
       });
 
-      expect(mockRefresh).toHaveBeenCalledWith(
-        'alpha',
-        expect.any(Object)
-      );
+      expect(mockRefresh).toHaveBeenCalledWith('alpha', expect.any(Object));
     });
   });
 
   describe('handlePaginationChange', () => {
     it('updates pagination model immediately', () => {
       // WHY HIGH VALUE: Tests that pagination state updates correctly
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       act(() => {
         result.current.handlePaginationChange({ page: 3, pageSize: 25 });
@@ -326,9 +288,7 @@ describe('useServerPaginatedDataGrid', () => {
 
     it('calls API immediately with new pagination (no debounce)', () => {
       // WHY HIGH VALUE: Tests that pagination changes fetch immediately (unlike search)
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       mockRefresh.mockClear();
 
@@ -348,9 +308,7 @@ describe('useServerPaginatedDataGrid', () => {
 
     it('preserves current search term when paginating', () => {
       // WHY HIGH VALUE: Tests that search context is maintained across pagination
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 })));
 
       // First, do a search
       act(() => {
@@ -369,19 +327,14 @@ describe('useServerPaginatedDataGrid', () => {
       });
 
       // Search term should be preserved
-      expect(mockRefresh).toHaveBeenCalledWith(
-        'test',
-        expect.any(Object)
-      );
+      expect(mockRefresh).toHaveBeenCalledWith('test', expect.any(Object));
     });
   });
 
   describe('handleSortChange', () => {
     it('updates sort model immediately', () => {
       // WHY HIGH VALUE: Tests that sort state updates correctly
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       act(() => {
         result.current.handleSortChange([{ field: 'created_at', sort: 'desc' }]);
@@ -392,9 +345,7 @@ describe('useServerPaginatedDataGrid', () => {
 
     it('calls API immediately with new sort (no debounce)', () => {
       // WHY HIGH VALUE: Tests that sort changes fetch immediately
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       mockRefresh.mockClear();
 
@@ -413,9 +364,7 @@ describe('useServerPaginatedDataGrid', () => {
 
     it('preserves current pagination when sorting', () => {
       // WHY HIGH VALUE: Tests that page context is maintained across sort changes
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       // First, go to page 2
       act(() => {
@@ -442,9 +391,7 @@ describe('useServerPaginatedDataGrid', () => {
   describe('refresh', () => {
     it('calls API with current state', () => {
       // WHY HIGH VALUE: Tests manual refresh uses all current params
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 }))
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions({ debounceMs: 300 })));
 
       // Set up some state
       act(() => {
@@ -496,9 +443,7 @@ describe('useServerPaginatedDataGrid', () => {
         setData: vi.fn()
       });
 
-      const { result } = renderHook(() =>
-        useServerPaginatedDataGrid(createDefaultOptions())
-      );
+      const { result } = renderHook(() => useServerPaginatedDataGrid(createDefaultOptions()));
 
       expect(result.current.isLoading).toBe(true);
     });

--- a/app/src/hooks/useServerPaginatedDataGrid.ts
+++ b/app/src/hooks/useServerPaginatedDataGrid.ts
@@ -1,0 +1,182 @@
+import { GridPaginationModel, GridSortModel } from '@mui/x-data-grid';
+import { useCallback, useEffect, useState } from 'react';
+import { ApiPaginationRequestOptions } from 'types/misc';
+import useDataLoader from './useDataLoader';
+import useDebounce from './useDebounce';
+
+/**
+ * Configuration options for the useServerPaginatedDataGrid hook.
+ */
+export interface IUseServerPaginatedDataGridOptions<TData, TResponse> {
+  /** Function to fetch data from the API */
+  fetcher: (search: string | undefined, pagination: ApiPaginationRequestOptions) => Promise<TResponse>;
+  /** Function to extract the data array from the API response */
+  extractData: (response: TResponse) => TData[];
+  /** Function to extract the total count from the API response */
+  extractTotal: (response: TResponse) => number;
+  /** Default sort configuration */
+  defaultSort: { field: string; sort: 'asc' | 'desc' };
+  /** Default page size */
+  defaultPageSize?: number;
+  /** Debounce delay in ms for search */
+  debounceMs?: number;
+}
+
+/**
+ * Return type for the useServerPaginatedDataGrid hook.
+ */
+export interface IUseServerPaginatedDataGridReturn<TData> {
+  /** The data array */
+  data: TData[];
+  /** Total row count for server-side pagination */
+  rowCount: number;
+  /** Whether data is currently loading */
+  isLoading: boolean;
+  /** Current pagination model (for DataGrid) */
+  paginationModel: GridPaginationModel;
+  /** Handler for pagination changes (pass to DataGrid onPaginationModelChange) */
+  handlePaginationChange: (model: GridPaginationModel) => void;
+  /** Current sort model (for DataGrid) */
+  sortModel: GridSortModel;
+  /** Handler for sort changes (pass to DataGrid onSortModelChange) */
+  handleSortChange: (model: GridSortModel) => void;
+  /** Current search term (for controlled input) */
+  searchTerm: string;
+  /** Handler for search input changes */
+  handleSearch: (term: string) => void;
+  /** Refresh data with current params */
+  refresh: () => void;
+}
+
+/**
+ * Helper to convert GridPaginationModel and GridSortModel to API pagination options.
+ */
+export const toApiPagination = (
+  paginationModel: GridPaginationModel,
+  sortModel: GridSortModel
+): ApiPaginationRequestOptions => {
+  const sort = sortModel[0];
+  return {
+    page: paginationModel.page + 1, // API uses 1-indexed pages
+    limit: paginationModel.pageSize,
+    sort: sort?.field,
+    order: sort?.sort as 'asc' | 'desc' | undefined
+  };
+};
+
+/**
+ * Custom hook for server-side paginated DataGrid with search and sort.
+ *
+ * Encapsulates pagination, sorting, and debounced search state management
+ * for MUI DataGrid with server-side data fetching.
+ *
+ * @example
+ * ```tsx
+ * const policies = useServerPaginatedDataGrid({
+ *   fetcher: (search, pagination) => biohubApi.policies.getPolicies({ search }, pagination),
+ *   extractData: (response) => response.policies,
+ *   extractTotal: (response) => response.pagination.total,
+ *   defaultSort: { field: 'name', sort: 'asc' }
+ * });
+ *
+ * <DataGrid
+ *   rows={policies.data}
+ *   rowCount={policies.rowCount}
+ *   paginationModel={policies.paginationModel}
+ *   onPaginationModelChange={policies.handlePaginationChange}
+ *   sortModel={policies.sortModel}
+ *   onSortModelChange={policies.handleSortChange}
+ *   paginationMode="server"
+ *   sortingMode="server"
+ * />
+ * ```
+ */
+export const useServerPaginatedDataGrid = <TData, TResponse>(
+  options: IUseServerPaginatedDataGridOptions<TData, TResponse>
+): IUseServerPaginatedDataGridReturn<TData> => {
+  const { fetcher, extractData, extractTotal, defaultSort, defaultPageSize = 10, debounceMs = 300 } = options;
+
+  // Pagination state
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: defaultPageSize });
+  const [sortModel, setSortModel] = useState<GridSortModel>([defaultSort]);
+
+  // Search state
+  const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
+
+  // Data loader
+  const dataLoader = useDataLoader((search: string | undefined, pagination: ApiPaginationRequestOptions) =>
+    fetcher(search, pagination)
+  );
+
+  // Load data on mount
+  useEffect(() => {
+    dataLoader.load(debouncedSearchTerm || undefined, toApiPagination(paginationModel, sortModel));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Debounced search - resets to page 1 and fetches
+  // Using useDebounce ensures stable function identity while always seeing latest state
+  const debouncedRefresh = useDebounce((term: string) => {
+    setDebouncedSearchTerm(term);
+    setPaginationModel((prev) => ({ ...prev, page: 0 }));
+    dataLoader.refresh(term || undefined, {
+      ...toApiPagination(paginationModel, sortModel),
+      page: 1
+    });
+  }, debounceMs);
+
+  // Search handler - updates input immediately, debounces API call
+  const handleSearch = useCallback(
+    (term: string) => {
+      setSearchTerm(term);
+      debouncedRefresh(term);
+    },
+    [debouncedRefresh]
+  );
+
+  // Pagination handler - immediate fetch
+  const handlePaginationChange = useCallback(
+    (model: GridPaginationModel) => {
+      setPaginationModel(model);
+      dataLoader.refresh(debouncedSearchTerm || undefined, toApiPagination(model, sortModel));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sortModel, debouncedSearchTerm]
+  );
+
+  // Sort handler - immediate fetch
+  const handleSortChange = useCallback(
+    (model: GridSortModel) => {
+      setSortModel(model);
+      dataLoader.refresh(debouncedSearchTerm || undefined, toApiPagination(paginationModel, model));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [paginationModel, debouncedSearchTerm]
+  );
+
+  // Manual refresh with current params
+  const refresh = useCallback(() => {
+    dataLoader.refresh(debouncedSearchTerm || undefined, toApiPagination(paginationModel, sortModel));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearchTerm, paginationModel, sortModel]);
+
+  // Extract data from response
+  const data = dataLoader.data ? extractData(dataLoader.data) : [];
+  const rowCount = dataLoader.data ? extractTotal(dataLoader.data) : 0;
+
+  return {
+    data,
+    rowCount,
+    isLoading: dataLoader.isLoading,
+    paginationModel,
+    handlePaginationChange,
+    sortModel,
+    handleSortChange,
+    searchTerm,
+    handleSearch,
+    refresh
+  };
+};
+
+export default useServerPaginatedDataGrid;

--- a/app/src/interfaces/usePoliciesApi.interface.ts
+++ b/app/src/interfaces/usePoliciesApi.interface.ts
@@ -1,3 +1,5 @@
+import { ApiPaginationResponseParams } from 'types/pagination';
+
 /**
  * Policy with statements and conditions (API response).
  */
@@ -35,11 +37,7 @@ export interface IPolicyStatementCondition {
  */
 export interface IPoliciesResponse {
   policies: IPolicy[];
-  pagination: {
-    total: number;
-    page: number;
-    limit: number;
-  };
+  pagination: ApiPaginationResponseParams;
 }
 
 /**

--- a/app/src/interfaces/useTeamPoliciesApi.interface.ts
+++ b/app/src/interfaces/useTeamPoliciesApi.interface.ts
@@ -1,3 +1,5 @@
+import { ApiPaginationResponseParams } from 'types/pagination';
+
 /**
  * Team-policy association with team and policy names for display.
  */
@@ -14,6 +16,7 @@ export interface ITeamPolicyDetails {
  */
 export interface ITeamPoliciesResponse {
   team_policies: ITeamPolicyDetails[];
+  pagination: ApiPaginationResponseParams;
 }
 
 /**

--- a/app/src/interfaces/useTeamsApi.interface.ts
+++ b/app/src/interfaces/useTeamsApi.interface.ts
@@ -1,3 +1,5 @@
+import { ApiPaginationResponseParams } from 'types/pagination';
+
 /**
  * Team member with user details.
  */
@@ -22,14 +24,7 @@ export interface ITeamWithMembers {
  */
 export interface ITeamsResponse {
   teams: ITeamWithMembers[];
-  pagination: {
-    total: number;
-    page: number;
-    limit: number;
-    last_page: number;
-    sort?: string;
-    order?: 'asc' | 'desc';
-  };
+  pagination: ApiPaginationResponseParams;
 }
 
 /**

--- a/app/src/types/pagination.ts
+++ b/app/src/types/pagination.ts
@@ -1,4 +1,11 @@
 /**
+ * Defines the supported search parameters for API requests.
+ */
+export interface ApiSearchParams {
+  search?: string;
+}
+
+/**
  * Defines the supported server-side pagination options.
  */
 export type ApiPaginationRequestOptions = {
@@ -39,3 +46,20 @@ export type ApiPaginationResponseParams = {
   sort?: string;
   order?: 'asc' | 'desc';
 };
+
+/**
+ * Props for components using MUI DataGrid with server-side pagination.
+ * Components should extend this interface for their props.
+ */
+export interface IServerPaginationProps {
+  /** Total number of rows (for server-side pagination) */
+  rowCount: number;
+  /** Current pagination model from parent */
+  paginationModel: import('@mui/x-data-grid').GridPaginationModel;
+  /** Callback when pagination changes */
+  setPaginationModel: (model: import('@mui/x-data-grid').GridPaginationModel) => void;
+  /** Current sort model from parent */
+  sortModel: import('@mui/x-data-grid').GridSortModel;
+  /** Callback when sort changes */
+  setSortModel: (model: import('@mui/x-data-grid').GridSortModel) => void;
+}


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-842](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-842)

## Description of Changes

Update DataGrid Pagination to Server-Side for Teams and Policies

## Acceptance Criteria

Pagination controls for several DataGrids are currently inconsistent and lack working server-side pagination.  
All DataGrids related to Teams, Policies, and Team Policies must use *server-side pagination and sorting*, following the implementation pattern used in SIMS’ `AlertContainer.tsx`.

Server-Side Pagination

WHEN the user changes the page or page size  
THEN a new API request is triggered using:

`limit = paginationModel.pageSize`
`page = paginationModel.page + 1`  
  (API pagination pages begin at 1, while MUI DataGrid pagination begins at 0)
Server-Side Sorting

WHEN the user changes the sort order or sort column  
THEN the API request must include:

`sort = sortModel[0]?.field`
`order = sortModel[0]?.sort`
Example

Pagination and sorting must follow the patterns used in [AlertContainer.tsx](https://github.com/bcgov/biohubbc/blob/dev/app/src/features/admin/alert/AlertContainer.tsx), including:

`paginationModel` state using `GridPaginationModel`
`sortModel` state using `GridSortModel`
A memoized `ApiPaginationRequestOptions` derived from both states

## Testing Notes

  Setup

  - Navigate to Admin > Manage Policies (/admin/policies)
  - Open browser DevTools → Network tab to verify API calls

  Test Cases

  1. Page Size (all 3 grids)

  - Change "Rows per page" dropdown (10, 25, 50, 100)
  - Verify API request includes correct limit param
  - Row count displays correctly (e.g., "1-2 of 2")

  2. Sorting (all 3 grids)

  - Click NAME / TEAM column header → sorts ascending (↑)
  - Click again → sorts descending (↓)
  - Verify API request includes sort and order params

  3. Verify API Calls (Network tab)

  GET /api/administrative/policies?limit=50&page=1&sort=name&order=asc
  GET /api/administrative/teams?limit=10&page=1&sort=name&order=asc
  GET /api/administrative/team-policies?limit=10&page=1&sort=team&order=asc
