### PR TITLE
SIMSBIOHUB-846: Correct TEST and PROD environment URLs in Helm values

### DIFF
--- a/infrastructure/biohub-platform/values-prod.yaml
+++ b/infrastructure/biohub-platform/values-prod.yaml
@@ -106,7 +106,7 @@ biohub-platform-api:
   app:
     nodeEnv: production
     nodeOptions: --max_old_space_size=4500  # 75% of 6Gi memory limit
-    appHost: sims.nrs.gov.bc.ca  # Vanity URL for prod
+    appHost: biohub-platform.apps.silver.devops.gov.bc.ca
 
     # Keycloak
     keycloak:

--- a/infrastructure/biohub-platform/values-test.yaml
+++ b/infrastructure/biohub-platform/values-test.yaml
@@ -30,14 +30,14 @@ biohub-platform-app:
   # App configuration
   app:
     nodeEnv: production
-    apiHost: api-biohub-platform.apps.silver.devops.gov.bc.ca
+    apiHost: api-test-biohub-platform.apps.silver.devops.gov.bc.ca
 
     # Siteminder
-    siteminderLogoutURL: "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi"
+    siteminderLogoutURL: "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi"
 
     # Keycloak
     keycloak:
-      host: "https://loginproxy.gov.bc.ca/auth"
+      host: "https://test.loginproxy.gov.bc.ca/auth"
     
   # Openshift Resources
   replicas: 1


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-846](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-846)

## Description of Changes

This PR fixes incorrect URLs in Helm values files:

### `values-test.yaml` - TEST environment fixes

| Setting | Before (Wrong) | After (Correct) |
|---------|---------------|-----------------|
| `biohub-platform-app.app.apiHost` | `api-biohub-platform.apps.silver.devops.gov.bc.ca` | `api-test-biohub-platform.apps.silver.devops.gov.bc.ca` |
| `biohub-platform-app.app.siteminderLogoutURL` | `https://logon7.gov.bc.ca/clp-cgi/logoff.cgi` | `https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi` |
| `biohub-platform-app.app.keycloak.host` | `https://loginproxy.gov.bc.ca/auth` | `https://test.loginproxy.gov.bc.ca/auth` |

### `values-prod.yaml` - PROD environment fixes

| Setting | Before (Wrong) | After (Correct) |
|---------|---------------|-----------------|
| `biohub-platform-api.app.appHost` | `sims.nrs.gov.bc.ca` | `biohub-platform.apps.silver.devops.gov.bc.ca` |

The PROD fix corrects the `appHost` which was incorrectly set to the SIMS vanity URL instead of the BioHub Platform URL.

## Testing Notes

- Deploy to TEST environment and verify:
  - App can reach the API at `api-test-biohub-platform.apps.silver.devops.gov.bc.ca`
  - Siteminder logout redirects to the test URL
  - Keycloak authentication works with test.loginproxy.gov.bc.ca

- For PROD deployment, verify:
  - The API `appHost` correctly identifies as `biohub-platform.apps.silver.devops.gov.bc.ca`