### PR TITLE
SIMSBIOHUB-855: Add ClamAV Helm chart to biohub-platform

### DIFF
--- a/infrastructure/biohub-platform/Chart.yaml
+++ b/infrastructure/biohub-platform/Chart.yaml
@@ -20,6 +20,10 @@ dependencies:
     condition: database-setup.enabled
     dependsOn:
       - biohub-platform-db
+  - name: biohub-platform-clamav
+    repository: file://../clamav
+    version: 0.1.0
+    condition: clamav.enabled
   - name: biohub-platform-api
     repository: file://../api
     version: 0.1.0

--- a/infrastructure/biohub-platform/values-dev.yaml
+++ b/infrastructure/biohub-platform/values-dev.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -100,6 +103,24 @@ biohub-platform-db-setup:
   app:
     nodeEnv: development
 
+# Values passed to biohub-platform-clamav subchart
+biohub-platform-clamav:
+  environment:
+    licensePlate: "a0ec71"
+    name: dev
+    id: deploy
+    ts: ""
+
+  # Openshift Resources
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 1100m
+      memory: 2Gi
+
 # Values passed to biohub-platform-api subchart
 biohub-platform-api:
   environment:
@@ -130,6 +151,12 @@ biohub-platform-api:
       level: info
       levelFile: debug
       fileMaxFiles: 10
+
+    # ClamAV
+    clamav:
+      enabled: true
+      host: clamav
+      port: 3310
 
   # Openshift Resources
   replicas: 1

--- a/infrastructure/biohub-platform/values-pr.yaml
+++ b/infrastructure/biohub-platform/values-pr.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: false  # PR previews share the DEV environment's ClamAV instance
+
 api:
   enabled: true
 
@@ -102,6 +105,12 @@ biohub-platform-db-setup:
   app:
     nodeEnv: development
 
+# Values passed to biohub-platform-clamav subchart
+# NOTE: ClamAV is DISABLED for PR previews to save resources.
+# PR previews share the DEV environment's ClamAV instance
+biohub-platform-clamav:
+  enabled: false
+
 # Values passed to biohub-platform-api subchart
 biohub-platform-api:
   environment:
@@ -116,7 +125,13 @@ biohub-platform-api:
     nodeEnv: development
     nodeOptions: --max_old_space_size=2250 # 75% of memoryLimit (bytes)
     # appHost will be dynamically set: "biohub-platform-app-1234-a0ec71-dev.apps.silver.devops.gov.bc.ca"
-    
+
+    # ClamAV - PR previews share the DEV environment's ClamAV instance
+    clamav:
+      enabled: true
+      host: clamav  # Use the shared DEV ClamAV service
+      port: 3310
+
     # Keycloak
     keycloak:
       host: "https://dev.loginproxy.gov.bc.ca/auth"

--- a/infrastructure/biohub-platform/values-prod.yaml
+++ b/infrastructure/biohub-platform/values-prod.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -93,6 +96,24 @@ biohub-platform-db-setup:
   app:
     nodeEnv: production
 
+# Values passed to biohub-platform-clamav subchart
+biohub-platform-clamav:
+  environment:
+    licensePlate: "a0ec71"
+    name: prod
+    id: deploy
+    ts: ""
+
+  # Openshift Resources
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 1100m
+      memory: 2Gi
+
 # Values passed to biohub-platform-api subchart
 biohub-platform-api:
   environment:
@@ -117,7 +138,13 @@ biohub-platform-api:
     # Object Store (S3)
     objectStore:
       keyPrefix: biohub
-    
+
+    # ClamAV
+    clamav:
+      enabled: true
+      host: clamav
+      port: 3310
+
     # Logging
     logging:
       level: silent

--- a/infrastructure/biohub-platform/values-test.yaml
+++ b/infrastructure/biohub-platform/values-test.yaml
@@ -15,6 +15,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -100,6 +103,24 @@ biohub-platform-db-setup:
   app:
     nodeEnv: production # This is set to production as test is not a valid name in the Knexfile
 
+# Values passed to biohub-platform-clamav subchart
+biohub-platform-clamav:
+  environment:
+    licensePlate: "a0ec71"
+    name: test
+    id: deploy
+    ts: ""
+
+  # Openshift Resources
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 1100m
+      memory: 2Gi
+
 # Values passed to biohub-platform-api subchart
 biohub-platform-api:
   environment:
@@ -124,7 +145,13 @@ biohub-platform-api:
     # Object Store (S3)
     objectStore:
       keyPrefix: biohub
-      
+
+    # ClamAV
+    clamav:
+      enabled: true
+      host: clamav
+      port: 3310
+
     # Logging
     logging:
       level: warn

--- a/infrastructure/biohub-platform/values.yaml
+++ b/infrastructure/biohub-platform/values.yaml
@@ -20,6 +20,9 @@ database:
 database-setup:
   enabled: true
 
+clamav:
+  enabled: true
+
 api:
   enabled: true
 
@@ -66,6 +69,18 @@ database-setup:
     changeId: ""
     ts: ""
   # Add any database-setup-specific overrides here
+
+clamav:
+  enabled: true
+  environment:
+    licensePlate: "a0ec71"
+    name: ""
+    id: ""
+    changeId: ""
+    ts: ""
+  app:
+    name: clamav
+  # Add any clamav-specific overrides here
 
 api:
   enabled: true

--- a/infrastructure/clamav/Chart.yaml
+++ b/infrastructure/clamav/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: biohub-platform-clamav
+description: ClamAV antivirus service for Biohub Platform
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/infrastructure/clamav/templates/_helpers.tpl
+++ b/infrastructure/clamav/templates/_helpers.tpl
@@ -1,0 +1,96 @@
+{{/*
+Expand the name of the chart
+*/}}
+{{- define "clamav.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Namespace
+*/}}
+{{- define "environment.namespace" -}}
+{{- printf "%s-%s" .Values.environment.licensePlate .Values.environment.name }}
+{{- end }}
+
+{{/*
+Create app suffix
+If environment.id is "deploy" AND environment.name is "dev", the value should be "-dev-deploy"
+If environment.id is "deploy" AND environment.name is not "dev", the value should be "-ENV"
+If environment.id is not "deploy", the value should be "-dev-1234"
+*/}}
+{{- define "clamav.suffix" -}}
+{{- if and .Values.environment.id (eq (toString .Values.environment.id) "deploy") (eq .Values.environment.name "dev") }}
+{{- printf "-%s-%s" .Values.environment.name (toString .Values.environment.id) | trunc 63 | trimSuffix "-" }}
+{{- else if and .Values.environment.id (eq (toString .Values.environment.id) "deploy") (ne .Values.environment.name "dev") }}
+{{- printf "-%s" .Values.environment.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "-%s-%s" .Values.environment.name .Values.environment.changeId | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Note: ClamAV uses a simple name without environment suffix since each environment
+has its own namespace, avoiding any naming conflicts.
+*/}}
+{{- define "clamav.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Values.app.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label
+*/}}
+{{- define "clamav.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+Stable labels only - no changeId or ts. ClamAV rarely changes between deployments,
+so we avoid including deployment-specific values that would cause unnecessary churn
+in the Deployment object. Rollouts happen only when ClamAV config (image, resources, etc.) changes.
+*/}}
+{{- define "clamav.labels" -}}
+app: {{ include "clamav.fullname" . }}
+app-name: {{ .Values.app.name }}
+env-id: {{ .Values.environment.id | quote }}
+env-name: {{ .Values.environment.name | quote }}
+helm.sh/chart: {{ include "clamav.chart" . }}
+{{ include "clamav.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common annotations
+*/}}
+{{- define "clamav.annotations" -}}
+meta.helm.sh/release-name: {{ .Release.Name | quote }}
+meta.helm.sh/release-namespace: {{ include "environment.namespace" . }}
+{{- end }}
+
+{{/*
+Selector labels
+Use stable env name only (dev/test/prod) - never changeId or ts.
+ClamAV pod template stays identical across deployments so no unnecessary rollouts.
+*/}}
+{{- define "clamav.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clamav.name" . }}
+app.kubernetes.io/instance: {{ .Values.environment.name | quote }}
+{{- end }}
+
+{{/*
+Image tag
+For static deployments (id=deploy), we use the environment name
+Otherwise we use the changeId (PR number)
+*/}}
+{{- define "clamav.imageTag" -}}
+{{- .Values.image.tag }}
+{{- end }}

--- a/infrastructure/clamav/templates/deployment.yaml
+++ b/infrastructure/clamav/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "clamav.fullname" . }}
+  namespace: {{ include "environment.namespace" . }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+  annotations:
+    {{- include "clamav.annotations" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      deployment: {{ include "clamav.fullname" . | quote }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      labels:
+        deployment: {{ include "clamav.fullname" . | quote }}
+        app: {{ include "clamav.fullname" . }}
+    spec:
+      containers:
+        - name: clamav
+          image: "{{ .Values.image.registry }}/{{ .Values.image.image }}:{{ include "clamav.imageTag" . }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 240
+            timeoutSeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.targetPort }}
+            initialDelaySeconds: 240
+            timeoutSeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/infrastructure/clamav/templates/service.yaml
+++ b/infrastructure/clamav/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clamav.fullname" . }}
+  namespace: {{ include "environment.namespace" . }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+  annotations:
+    {{- include "clamav.annotations" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.service.targetPort }}
+  selector:
+    deployment: {{ include "clamav.fullname" . | quote }}
+  sessionAffinity: None

--- a/infrastructure/clamav/values-dev.yaml
+++ b/infrastructure/clamav/values-dev.yaml
@@ -1,0 +1,14 @@
+# Development environment values for ClamAV
+environment:
+  name: dev
+  id: deploy
+
+# Openshift Resources
+replicas: 1
+resources:
+  requests:
+    cpu: 100m
+    memory: 500Mi
+  limits:
+    cpu: 1100m
+    memory: 2Gi

--- a/infrastructure/clamav/values-pr.yaml
+++ b/infrastructure/clamav/values-pr.yaml
@@ -1,0 +1,14 @@
+# PR environment values for ClamAV (not used in static deploys)
+environment:
+  name: dev
+  id: ""
+
+# Openshift Resources - reduced for PR environments
+replicas: 1
+resources:
+  requests:
+    cpu: 50m
+    memory: 250Mi
+  limits:
+    cpu: 500m
+    memory: 1Gi

--- a/infrastructure/clamav/values-prod.yaml
+++ b/infrastructure/clamav/values-prod.yaml
@@ -1,0 +1,14 @@
+# Production environment values for ClamAV
+environment:
+  name: prod
+  id: deploy
+
+# Openshift Resources
+replicas: 1
+resources:
+  requests:
+    cpu: 100m
+    memory: 500Mi
+  limits:
+    cpu: 1100m
+    memory: 2Gi

--- a/infrastructure/clamav/values-test.yaml
+++ b/infrastructure/clamav/values-test.yaml
@@ -1,0 +1,14 @@
+# Test environment values for ClamAV
+environment:
+  name: test
+  id: deploy
+
+# Openshift Resources
+replicas: 1
+resources:
+  requests:
+    cpu: 100m
+    memory: 500Mi
+  limits:
+    cpu: 1100m
+    memory: 2Gi

--- a/infrastructure/clamav/values.yaml
+++ b/infrastructure/clamav/values.yaml
@@ -1,0 +1,33 @@
+# Default values for clamav chart
+environment:
+  licensePlate: "a0ec71" # License plate of the project
+  name: "" # Environment name (dev, test, prod)
+  id: "" # Environment id (PR, deploy)
+  changeId: "" # Change id (PR number)
+  ts: "" # Timestamp of the deployment
+
+image:
+  registry: "image-registry.openshift-image-registry.svc:5000" # The base image registry URL
+  image: a0ec71-tools/clamav # Always pull from tools namespace
+  tag: "latest" # Use 'latest' tag which references the ImageStreamTag
+
+# ClamAV configuration
+app:
+  name: clamav
+
+# Openshift Resources
+replicas: ""
+resources:
+  requests:
+    cpu: ""
+    memory: ""
+  limits:
+    cpu: ""
+    memory: ""
+
+# Service configuration
+service:
+  type: ClusterIP
+  name: 3310-tcp
+  port: 3310
+  targetPort: 3310


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/jira/browse/SIMSBIOHUB-855

## Description of Changes

- Add ClamAV as a Helm subchart under `infrastructure/clamav/` (chart name: `biohub-platform-clamav`) with Deployment and Service, using namespace/license plate **a0ec71** (biohub-platform) and image `a0ec71-tools/clamav:latest`.
- Add `clamav` dependency to the biohub-platform umbrella chart with condition `clamav.enabled`.
- Enable ClamAV in dev, test, and prod; disable ClamAV deployment in PR previews (PRs use the shared DEV ClamAV instance).
- Pass ClamAV config (`enabled`, `host: clamav`, `port: 3310`) into the API and queue subcharts in all environment value files so the API and queue workers can reach the ClamAV service.
- Replicates the ClamAV Helm approach from bcgov/biohubbc PR #1594, adapted for this repo's chart naming and namespace.

## Testing Notes

- Run `helm dependency update` in `infrastructure/biohub-platform` and `helm template biohub-platform . -f values.yaml -f values-dev.yaml` to confirm ClamAV Deployment and Service render in namespace `a0ec71-dev` with the expected image and resources.
- Ensure the ClamAV image is built and available in the **a0ec71-tools** namespace (e.g. from https://github.com/bcgov/clamav) before deploying.