### PR TITLE
SIMSBIOHUB-868: Fix access policy seed duplicate key error in TEST

### DIFF
--- a/database/src/seeds/07_access_policy.ts
+++ b/database/src/seeds/07_access_policy.ts
@@ -1,7 +1,8 @@
 import { Knex } from 'knex';
 
 /**
- * Inserts default access policies for accessing secured data
+ * Inserts default access policies for accessing secured data.
+ * Idempotent: safe to run when policies/teams already exist (e.g. re-run in test).
  *
  * @export
  * @param {Knex} knex
@@ -13,84 +14,193 @@ export async function seed(knex: Knex): Promise<void> {
     SET SEARCH_PATH = 'biohub','public';
   `);
 
+  // Resolve create_user for inserts (audit trigger may set it; fallback for environments where it does not)
+  const createUserRow = await knex('system_user')
+    .whereNull('record_end_date')
+    .select('system_user_id')
+    .first();
+  const createUser = createUserRow?.system_user_id ?? 1;
+
   /** ------------------------------------------------------------------
    * 1. TELEMETRY POLICY + TEAM
    * ------------------------------------------------------------------ */
-  const [telemetryPolicy] = await knex('policy')
-    .insert({
-      name: 'Telemetry Access',
-      description: 'Grants read access to all Telemetry submission features'
+  let telemetryPolicy = await knex('policy')
+    .where({ name: 'Telemetry Access' })
+    .whereNull('record_end_date')
+    .first();
+
+  if (!telemetryPolicy) {
+    const [inserted] = await knex('policy')
+      .insert({
+        name: 'Telemetry Access',
+        description: 'Grants read access to all Telemetry submission features',
+        create_user: createUser
+      })
+      .returning('*');
+    telemetryPolicy = inserted;
+  }
+
+  let telemetryTeam = await knex('team')
+    .where({ name: 'Telemetry Team' })
+    .whereNull('record_end_date')
+    .first();
+
+  if (!telemetryTeam) {
+    const [inserted] = await knex('team')
+      .insert({
+        name: 'Telemetry Team',
+        description: 'Team assigned to default Telemetry access policy',
+        create_user: createUser
+      })
+      .returning('*');
+    telemetryTeam = inserted;
+  }
+
+  const telemetryTeamPolicyExists = await knex('team_policy')
+    .where({
+      team_id: telemetryTeam.team_id,
+      policy_id: telemetryPolicy.policy_id
     })
-    .returning('*');
+    .whereNull('record_end_date')
+    .first();
 
-  const [telemetryTeam] = await knex('team')
-    .insert({
-      name: 'Telemetry Team',
-      description: 'Team assigned to default Telemetry access policy'
-    })
-    .returning('*');
+  if (!telemetryTeamPolicyExists) {
+    await knex('team_policy').insert({
+      team_id: telemetryTeam.team_id,
+      policy_id: telemetryPolicy.policy_id,
+      create_user: createUser
+    });
+  }
 
-  await knex('team_policy').insert({
-    team_id: telemetryTeam.team_id,
-    policy_id: telemetryPolicy.policy_id
-  });
-
-  const [telemetryStatement] = await knex('policy_statement')
-    .insert({
+  let telemetryStatement = await knex('policy_statement')
+    .where({
       policy_id: telemetryPolicy.policy_id,
       effect: 'allow',
       submission_feature_urn: 'urn:*:telemetry:*'
     })
-    .returning('*');
+    .whereNull('record_end_date')
+    .first();
 
-  await knex('policy_statement_condition').insert({
-    policy_statement_id: telemetryStatement.policy_statement_id,
-    operator: 'DateBefore',
-    key: 'start_date',
-    value: JSON.stringify(new Date().toISOString())
-  });
+  if (!telemetryStatement) {
+    const [inserted] = await knex('policy_statement')
+      .insert({
+        policy_id: telemetryPolicy.policy_id,
+        effect: 'allow',
+        submission_feature_urn: 'urn:*:telemetry:*',
+        create_user: createUser
+      })
+      .returning('*');
+    telemetryStatement = inserted;
+  }
 
-  // Add all non-system users (IDIR/BCEID) to Telemetry Team
-  await knex.raw(`
-    INSERT INTO team_member (system_user_id, team_id)
-    SELECT su.system_user_id, '${telemetryTeam.team_id}'
+  const telemetryConditionValue = JSON.stringify(new Date().toISOString());
+  const telemetryConditionExists = await knex('policy_statement_condition')
+    .where({
+      policy_statement_id: telemetryStatement.policy_statement_id,
+      operator: 'DateBefore',
+      key: 'start_date',
+      value: telemetryConditionValue
+    })
+    .whereNull('record_end_date')
+    .first();
+
+  if (!telemetryConditionExists) {
+    await knex('policy_statement_condition').insert({
+      policy_statement_id: telemetryStatement.policy_statement_id,
+      operator: 'DateBefore',
+      key: 'start_date',
+      value: telemetryConditionValue,
+      create_user: createUser
+    });
+  }
+
+  // Add all non-system users (IDIR/BCEID) to Telemetry Team (skip if already member)
+  await knex.raw(
+    `
+    INSERT INTO team_member (system_user_id, team_id, create_user)
+    SELECT su.system_user_id, $1::uuid, (SELECT system_user_id FROM "system_user" WHERE record_end_date IS NULL LIMIT 1)
     FROM "system_user" su
     WHERE su.user_identity_source_id IN (
       SELECT user_identity_source_id
       FROM user_identity_source
       WHERE LOWER(name) NOT IN ('system', 'database')
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM team_member tm
+      WHERE tm.system_user_id = su.system_user_id AND tm.team_id = $2::uuid
     );
-  `);
+  `,
+    [telemetryTeam.team_id, telemetryTeam.team_id]
+  );
 
   /** ------------------------------------------------------------------
    * 2. SAMPLING SITES TEAM
    * ------------------------------------------------------------------ */
-  const [adminPolicy] = await knex('policy')
-    .insert({
-      name: 'Secret Sampling Sites Access',
-      description: 'Grants unrestricted access to all submission features and data'
+  let adminPolicy = await knex('policy')
+    .where({ name: 'Secret Sampling Sites Access' })
+    .whereNull('record_end_date')
+    .first();
+
+  if (!adminPolicy) {
+    const [inserted] = await knex('policy')
+      .insert({
+        name: 'Secret Sampling Sites Access',
+        description: 'Grants unrestricted access to all submission features and data',
+        create_user: createUser
+      })
+      .returning('*');
+    adminPolicy = inserted;
+  }
+
+  let adminTeam = await knex('team')
+    .where({ name: 'Secret Sampling Sites Team' })
+    .whereNull('record_end_date')
+    .first();
+
+  if (!adminTeam) {
+    const [inserted] = await knex('team')
+      .insert({
+        name: 'Secret Sampling Sites Team',
+        description: 'Team assigned to unrestricted administrative access',
+        create_user: createUser
+      })
+      .returning('*');
+    adminTeam = inserted;
+  }
+
+  const adminTeamPolicyExists = await knex('team_policy')
+    .where({
+      team_id: adminTeam.team_id,
+      policy_id: adminPolicy.policy_id
     })
-    .returning('*');
+    .whereNull('record_end_date')
+    .first();
 
-  const [adminTeam] = await knex('team')
-    .insert({
-      name: 'Secret Sampling Sites Team',
-      description: 'Team assigned to unrestricted administrative access'
-    })
-    .returning('*');
+  if (!adminTeamPolicyExists) {
+    await knex('team_policy').insert({
+      team_id: adminTeam.team_id,
+      policy_id: adminPolicy.policy_id,
+      create_user: createUser
+    });
+  }
 
-  await knex('team_policy').insert({
-    team_id: adminTeam.team_id,
-    policy_id: adminPolicy.policy_id
-  });
-
-  await knex('policy_statement')
-    .insert({
+  const adminStatementExists = await knex('policy_statement')
+    .where({
       policy_id: adminPolicy.policy_id,
       effect: 'allow',
       submission_feature_urn: 'urn:*:sample_site:*'
     })
-    .returning('*');
+    .whereNull('record_end_date')
+    .first();
+
+  if (!adminStatementExists) {
+    await knex('policy_statement').insert({
+      policy_id: adminPolicy.policy_id,
+      effect: 'allow',
+      submission_feature_urn: 'urn:*:sample_site:*',
+      create_user: createUser
+    });
+  }
 
   // Do not add users to the sampling sites policy team, for confirming that only team members can access features covered by the policy
 }

--- a/database/src/seeds/07_access_policy.ts
+++ b/database/src/seeds/07_access_policy.ts
@@ -15,19 +15,13 @@ export async function seed(knex: Knex): Promise<void> {
   `);
 
   // Resolve create_user for inserts (audit trigger may set it; fallback for environments where it does not)
-  const createUserRow = await knex('system_user')
-    .whereNull('record_end_date')
-    .select('system_user_id')
-    .first();
+  const createUserRow = await knex('system_user').whereNull('record_end_date').select('system_user_id').first();
   const createUser = createUserRow?.system_user_id ?? 1;
 
   /** ------------------------------------------------------------------
    * 1. TELEMETRY POLICY + TEAM
    * ------------------------------------------------------------------ */
-  let telemetryPolicy = await knex('policy')
-    .where({ name: 'Telemetry Access' })
-    .whereNull('record_end_date')
-    .first();
+  let telemetryPolicy = await knex('policy').where({ name: 'Telemetry Access' }).whereNull('record_end_date').first();
 
   if (!telemetryPolicy) {
     const [inserted] = await knex('policy')
@@ -40,10 +34,7 @@ export async function seed(knex: Knex): Promise<void> {
     telemetryPolicy = inserted;
   }
 
-  let telemetryTeam = await knex('team')
-    .where({ name: 'Telemetry Team' })
-    .whereNull('record_end_date')
-    .first();
+  let telemetryTeam = await knex('team').where({ name: 'Telemetry Team' }).whereNull('record_end_date').first();
 
   if (!telemetryTeam) {
     const [inserted] = await knex('team')
@@ -152,10 +143,7 @@ export async function seed(knex: Knex): Promise<void> {
     adminPolicy = inserted;
   }
 
-  let adminTeam = await knex('team')
-    .where({ name: 'Secret Sampling Sites Team' })
-    .whereNull('record_end_date')
-    .first();
+  let adminTeam = await knex('team').where({ name: 'Secret Sampling Sites Team' }).whereNull('record_end_date').first();
 
   if (!adminTeam) {
     const [inserted] = await knex('team')


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-868](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-868)

## Description of Changes

- **Access policy seed is now idempotent.** The seed `07_access_policy.ts` was always inserting the same two policies ("Telemetry Access", "Secret Sampling Sites Access") and their teams. In test, when the seed runs against a DB that already had that data (e.g. re-run or existing test data), it blew up with:

  ```
  Error while executing ".../07_access_policy.ts" seed: insert into "policy" ("description", "name") values ($1, $2) returning * - duplicate key value violates unique constraint "policy_nuk1"
  ```

- **What changed:** We only insert when the row doesn’t already exist. For policies and teams we do a get-or-create (select by name; insert only if missing). For `team_policy`, `policy_statement`, and `policy_statement_condition` we check for an existing row with the same natural key before inserting. The bulk insert that adds non-system users to the Telemetry team now skips users who are already in that team via a `NOT EXISTS` check so we don’t hit the unique on `(system_user_id, team_id)`.

- **create_user:** The seed now resolves a valid `create_user` (first active system user, fallback 1) and passes it on all inserts so it still works in environments where the audit trigger doesn’t set it.

## Testing Notes

- Run the DB setup (migrate + seed) twice against the same database, or run it in the test environment where the access policy data may already exist. The seed should complete without the `policy_nuk1` (or related) duplicate key error. No change to behaviour when the DB is empty—the same policies and teams are created.