### PR TITLE
SIMSBIOHUB-868: Fix access policy seed failing in test

### DIFF
--- a/database/src/seeds/07_access_policy.ts
+++ b/database/src/seeds/07_access_policy.ts
@@ -109,7 +109,7 @@ export async function seed(knex: Knex): Promise<void> {
   await knex.raw(
     `
     INSERT INTO team_member (system_user_id, team_id, create_user)
-    SELECT su.system_user_id, $1::uuid, (SELECT system_user_id FROM "system_user" WHERE record_end_date IS NULL LIMIT 1)
+    SELECT su.system_user_id, ?, (SELECT system_user_id FROM "system_user" WHERE record_end_date IS NULL LIMIT 1)
     FROM "system_user" su
     WHERE su.user_identity_source_id IN (
       SELECT user_identity_source_id
@@ -118,7 +118,7 @@ export async function seed(knex: Knex): Promise<void> {
     )
     AND NOT EXISTS (
       SELECT 1 FROM team_member tm
-      WHERE tm.system_user_id = su.system_user_id AND tm.team_id = $2::uuid
+      WHERE tm.system_user_id = su.system_user_id AND tm.team_id = ?
     );
   `,
     [telemetryTeam.team_id, telemetryTeam.team_id]


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-868](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-868)

## Description of Changes

- The seed failed with `Expected 2 bindings, saw 0` on the team_member raw insert. The query used `$1` and `$2` in the string; Knex expects `?` for bindings and then substitutes the right placeholders. Switched to `?` and left the bindings array as-is so the two team_id values are applied correctly.

## Testing Notes

- Run migrate + seed twice against the same DB (or run once in test where the data might already exist). Seed should finish without the policy_nuk1 or bindings error. Fresh DB should still get the same policies and teams as before.