### PR TITLE
SIMSBIOHUB-847: Storing Feature Content Array

### DIFF
--- a/api/src/repositories/submission-repository.test.ts
+++ b/api/src/repositories/submission-repository.test.ts
@@ -1661,8 +1661,8 @@ describe('SubmissionRepository', () => {
       const submissionRepository = new SubmissionRepository(mockDBConnection);
 
       await submissionRepository.insertSubmissionFeatureRelationships([
-        { parent_submission_feature_id: 1, child_submission_feature_id: 2 },
-        { parent_submission_feature_id: 1, child_submission_feature_id: 3 }
+        { parent_feature_id: 1, child_feature_id: 2 },
+        { parent_feature_id: 1, child_feature_id: 3 }
       ]);
 
       expect(sqlStub).to.have.been.calledOnce;
@@ -1690,11 +1690,11 @@ describe('SubmissionRepository', () => {
 
     it('should return parent and child IDs for a feature', async () => {
       const mockParentResponse = {
-        rows: [{ parent_submission_feature_id: 10 }],
+        rows: [{ parent_feature_id: 10 }],
         rowCount: 1
       };
       const mockChildResponse = {
-        rows: [{ child_submission_feature_id: 2 }, { child_submission_feature_id: 3 }],
+        rows: [{ child_feature_id: 2 }, { child_feature_id: 3 }],
         rowCount: 2
       };
 

--- a/api/src/repositories/submission-repository.test.ts
+++ b/api/src/repositories/submission-repository.test.ts
@@ -1694,10 +1694,7 @@ describe('SubmissionRepository', () => {
         rowCount: 1
       };
       const mockChildResponse = {
-        rows: [
-          { child_submission_feature_id: 2 },
-          { child_submission_feature_id: 3 }
-        ],
+        rows: [{ child_submission_feature_id: 2 }, { child_submission_feature_id: 3 }],
         rowCount: 2
       };
 

--- a/api/src/repositories/submission-repository.test.ts
+++ b/api/src/repositories/submission-repository.test.ts
@@ -1644,7 +1644,7 @@ describe('SubmissionRepository', () => {
 
       expect(sqlStub).to.have.been.calledOnce;
       const calledSql = sqlStub.args[0][0];
-      expect(calledSql.text).to.include('submission_feature__feature');
+      expect(calledSql.text).to.include('submission_feature_feature');
       expect(calledSql.text).to.include('submission_id');
     });
   });
@@ -1661,13 +1661,13 @@ describe('SubmissionRepository', () => {
       const submissionRepository = new SubmissionRepository(mockDBConnection);
 
       await submissionRepository.insertSubmissionFeatureRelationships([
-        { parent_feature_id: 1, child_feature_id: 2 },
-        { parent_feature_id: 1, child_feature_id: 3 }
+        { source_feature_id: 1, target_feature_id: 2 },
+        { source_feature_id: 1, target_feature_id: 3 }
       ]);
 
       expect(sqlStub).to.have.been.calledOnce;
       const calledSql = sqlStub.args[0][0];
-      expect(calledSql.text).to.include('submission_feature__feature');
+      expect(calledSql.text).to.include('submission_feature_feature');
       expect(calledSql.text).to.include('ON CONFLICT');
     });
 
@@ -1688,13 +1688,13 @@ describe('SubmissionRepository', () => {
       sinon.restore();
     });
 
-    it('should return parent and child IDs for a feature', async () => {
+    it('should return source and target IDs for a feature', async () => {
       const mockParentResponse = {
-        rows: [{ parent_feature_id: 10 }],
+        rows: [{ source_feature_id: 10 }],
         rowCount: 1
       };
       const mockChildResponse = {
-        rows: [{ child_feature_id: 2 }, { child_feature_id: 3 }],
+        rows: [{ target_feature_id: 2 }, { target_feature_id: 3 }],
         rowCount: 2
       };
 
@@ -1711,8 +1711,8 @@ describe('SubmissionRepository', () => {
 
       const result = await submissionRepository.getRelatedSubmissionFeatureIds(1);
 
-      expect(result.parentIds).to.deep.equal([10]);
-      expect(result.childIds).to.deep.equal([2, 3]);
+      expect(result.sourceIds).to.deep.equal([10]);
+      expect(result.targetIds).to.deep.equal([2, 3]);
       expect(sqlStub).to.have.been.calledTwice;
     });
   });

--- a/api/src/repositories/submission-repository.test.ts
+++ b/api/src/repositories/submission-repository.test.ts
@@ -1620,4 +1620,103 @@ describe('SubmissionRepository', () => {
       expect(sqlStub).to.have.been.calledOnce;
     });
   });
+
+  describe('deleteSubmissionFeatureRelationships', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should delete relationship rows for features belonging to the submission', async () => {
+      const mockQueryResponse: QueryResult<never> = {
+        rowCount: 5,
+        rows: [],
+        command: '',
+        oid: 0,
+        fields: []
+      };
+
+      const sqlStub = sinon.stub().resolves(mockQueryResponse);
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const submissionRepository = new SubmissionRepository(mockDBConnection);
+
+      await submissionRepository.deleteSubmissionFeatureRelationships(1);
+
+      expect(sqlStub).to.have.been.calledOnce;
+      const calledSql = sqlStub.args[0][0];
+      expect(calledSql.text).to.include('submission_feature__feature');
+      expect(calledSql.text).to.include('submission_id');
+    });
+  });
+
+  describe('insertSubmissionFeatureRelationships', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should insert relationship pairs', async () => {
+      const sqlStub = sinon.stub().resolves({ rowCount: 2, rows: [] });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const submissionRepository = new SubmissionRepository(mockDBConnection);
+
+      await submissionRepository.insertSubmissionFeatureRelationships([
+        { parent_submission_feature_id: 1, child_submission_feature_id: 2 },
+        { parent_submission_feature_id: 1, child_submission_feature_id: 3 }
+      ]);
+
+      expect(sqlStub).to.have.been.calledOnce;
+      const calledSql = sqlStub.args[0][0];
+      expect(calledSql.text).to.include('submission_feature__feature');
+      expect(calledSql.text).to.include('ON CONFLICT');
+    });
+
+    it('should not execute SQL when pairs array is empty', async () => {
+      const sqlStub = sinon.stub().resolves({ rowCount: 0, rows: [] });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const submissionRepository = new SubmissionRepository(mockDBConnection);
+
+      await submissionRepository.insertSubmissionFeatureRelationships([]);
+
+      expect(sqlStub).not.to.have.been.called;
+    });
+  });
+
+  describe('getRelatedSubmissionFeatureIds', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return parent and child IDs for a feature', async () => {
+      const mockParentResponse = {
+        rows: [{ parent_submission_feature_id: 10 }],
+        rowCount: 1
+      };
+      const mockChildResponse = {
+        rows: [
+          { child_submission_feature_id: 2 },
+          { child_submission_feature_id: 3 }
+        ],
+        rowCount: 2
+      };
+
+      const sqlStub = sinon
+        .stub()
+        .onFirstCall()
+        .resolves(mockParentResponse)
+        .onSecondCall()
+        .resolves(mockChildResponse);
+
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const submissionRepository = new SubmissionRepository(mockDBConnection);
+
+      const result = await submissionRepository.getRelatedSubmissionFeatureIds(1);
+
+      expect(result.parentIds).to.deep.equal([10]);
+      expect(result.childIds).to.deep.equal([2, 3]);
+      expect(sqlStub).to.have.been.calledTwice;
+    });
+  });
 });

--- a/api/src/repositories/submission-repository.ts
+++ b/api/src/repositories/submission-repository.ts
@@ -491,10 +491,10 @@ export class SubmissionRepository extends BaseRepository {
   async deleteSubmissionFeatureRelationships(submissionId: number): Promise<void> {
     const sqlStatement = SQL`
       DELETE FROM submission_feature__feature
-      WHERE parent_submission_feature_id IN (
+      WHERE parent_feature_id IN (
         SELECT submission_feature_id FROM submission_feature WHERE submission_id = ${submissionId}
       )
-      OR child_submission_feature_id IN (
+      OR child_feature_id IN (
         SELECT submission_feature_id FROM submission_feature WHERE submission_id = ${submissionId}
       );
     `;
@@ -506,27 +506,27 @@ export class SubmissionRepository extends BaseRepository {
    * Insert submission feature relationships (parent-child from content array).
    * Uses ON CONFLICT DO NOTHING to avoid failures on duplicate pairs.
    *
-   * @param {Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }>} pairs The pairs to insert.
+   * @param {Array<{ parent_feature_id: number; child_feature_id: number }>} pairs The pairs to insert.
    * @return {Promise<void>}
    * @memberof SubmissionRepository
    */
   async insertSubmissionFeatureRelationships(
-    pairs: Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }>
+    pairs: Array<{ parent_feature_id: number; child_feature_id: number }>
   ): Promise<void> {
     if (pairs.length === 0) {
       return;
     }
 
-    const parentIds = pairs.map((p) => p.parent_submission_feature_id);
-    const childIds = pairs.map((p) => p.child_submission_feature_id);
+    const parentIds = pairs.map((p) => p.parent_feature_id);
+    const childIds = pairs.map((p) => p.child_feature_id);
 
     const sqlStatement = SQL`
-      INSERT INTO submission_feature__feature (parent_submission_feature_id, child_submission_feature_id)
+      INSERT INTO submission_feature__feature (parent_feature_id, child_feature_id)
       SELECT parent_id, child_id FROM unnest(
         ${parentIds}::integer[],
         ${childIds}::integer[]
       ) AS t(parent_id, child_id)
-      ON CONFLICT (parent_submission_feature_id, child_submission_feature_id) DO NOTHING;
+      ON CONFLICT (parent_feature_id, child_feature_id) DO NOTHING;
     `;
 
     await this.connection.sql(sqlStatement);
@@ -543,25 +543,25 @@ export class SubmissionRepository extends BaseRepository {
     submissionFeatureId: number
   ): Promise<{ parentIds: number[]; childIds: number[] }> {
     const parentSqlStatement = SQL`
-      SELECT parent_submission_feature_id
+      SELECT parent_feature_id
       FROM submission_feature__feature
-      WHERE child_submission_feature_id = ${submissionFeatureId};
+      WHERE child_feature_id = ${submissionFeatureId};
     `;
 
     const childSqlStatement = SQL`
-      SELECT child_submission_feature_id
+      SELECT child_feature_id
       FROM submission_feature__feature
-      WHERE parent_submission_feature_id = ${submissionFeatureId};
+      WHERE parent_feature_id = ${submissionFeatureId};
     `;
 
     const [parentResult, childResult] = await Promise.all([
-      this.connection.sql<{ parent_submission_feature_id: number }>(parentSqlStatement),
-      this.connection.sql<{ child_submission_feature_id: number }>(childSqlStatement)
+      this.connection.sql<{ parent_feature_id: number }>(parentSqlStatement),
+      this.connection.sql<{ child_feature_id: number }>(childSqlStatement)
     ]);
 
     return {
-      parentIds: parentResult.rows.map((r) => r.parent_submission_feature_id),
-      childIds: childResult.rows.map((r) => r.child_submission_feature_id)
+      parentIds: parentResult.rows.map((r) => r.parent_feature_id),
+      childIds: childResult.rows.map((r) => r.child_feature_id)
     };
   }
 

--- a/api/src/repositories/submission-repository.ts
+++ b/api/src/repositories/submission-repository.ts
@@ -481,6 +481,91 @@ export class SubmissionRepository extends BaseRepository {
   }
 
   /**
+   * Delete all submission feature relationships for features belonging to a submission.
+   * Used for idempotency - allows job retries to start fresh.
+   *
+   * @param {number} submissionId The submission ID.
+   * @return {Promise<void>}
+   * @memberof SubmissionRepository
+   */
+  async deleteSubmissionFeatureRelationships(submissionId: number): Promise<void> {
+    const sqlStatement = SQL`
+      DELETE FROM submission_feature__feature
+      WHERE parent_submission_feature_id IN (
+        SELECT submission_feature_id FROM submission_feature WHERE submission_id = ${submissionId}
+      )
+      OR child_submission_feature_id IN (
+        SELECT submission_feature_id FROM submission_feature WHERE submission_id = ${submissionId}
+      );
+    `;
+
+    await this.connection.sql(sqlStatement);
+  }
+
+  /**
+   * Insert submission feature relationships (parent-child from content array).
+   * Uses ON CONFLICT DO NOTHING to avoid failures on duplicate pairs.
+   *
+   * @param {Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }>} pairs The pairs to insert.
+   * @return {Promise<void>}
+   * @memberof SubmissionRepository
+   */
+  async insertSubmissionFeatureRelationships(
+    pairs: Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }>
+  ): Promise<void> {
+    if (pairs.length === 0) {
+      return;
+    }
+
+    const parentIds = pairs.map((p) => p.parent_submission_feature_id);
+    const childIds = pairs.map((p) => p.child_submission_feature_id);
+
+    const sqlStatement = SQL`
+      INSERT INTO submission_feature__feature (parent_submission_feature_id, child_submission_feature_id)
+      SELECT parent_id, child_id FROM unnest(
+        ${parentIds}::integer[],
+        ${childIds}::integer[]
+      ) AS t(parent_id, child_id)
+      ON CONFLICT (parent_submission_feature_id, child_submission_feature_id) DO NOTHING;
+    `;
+
+    await this.connection.sql(sqlStatement);
+  }
+
+  /**
+   * Get all related submission feature IDs for a given feature (parents and children).
+   *
+   * @param {number} submissionFeatureId The submission feature ID.
+   * @return {Promise<{ parentIds: number[]; childIds: number[] }>}
+   * @memberof SubmissionRepository
+   */
+  async getRelatedSubmissionFeatureIds(
+    submissionFeatureId: number
+  ): Promise<{ parentIds: number[]; childIds: number[] }> {
+    const parentSqlStatement = SQL`
+      SELECT parent_submission_feature_id
+      FROM submission_feature__feature
+      WHERE child_submission_feature_id = ${submissionFeatureId};
+    `;
+
+    const childSqlStatement = SQL`
+      SELECT child_submission_feature_id
+      FROM submission_feature__feature
+      WHERE parent_submission_feature_id = ${submissionFeatureId};
+    `;
+
+    const [parentResult, childResult] = await Promise.all([
+      this.connection.sql<{ parent_submission_feature_id: number }>(parentSqlStatement),
+      this.connection.sql<{ child_submission_feature_id: number }>(childSqlStatement)
+    ]);
+
+    return {
+      parentIds: parentResult.rows.map((r) => r.parent_submission_feature_id),
+      childIds: childResult.rows.map((r) => r.child_submission_feature_id)
+    };
+  }
+
+  /**
    * Get feature type id by name.
    *
    * @param {string} name

--- a/api/src/repositories/submission-repository.ts
+++ b/api/src/repositories/submission-repository.ts
@@ -490,11 +490,11 @@ export class SubmissionRepository extends BaseRepository {
    */
   async deleteSubmissionFeatureRelationships(submissionId: number): Promise<void> {
     const sqlStatement = SQL`
-      DELETE FROM submission_feature__feature
-      WHERE parent_feature_id IN (
+      DELETE FROM submission_feature_feature
+      WHERE source_feature_id IN (
         SELECT submission_feature_id FROM submission_feature WHERE submission_id = ${submissionId}
       )
-      OR child_feature_id IN (
+      OR target_feature_id IN (
         SELECT submission_feature_id FROM submission_feature WHERE submission_id = ${submissionId}
       );
     `;
@@ -503,65 +503,66 @@ export class SubmissionRepository extends BaseRepository {
   }
 
   /**
-   * Insert submission feature relationships (parent-child from content array).
+   * Insert submission feature relationships (source-target from content array).
    * Uses ON CONFLICT DO NOTHING to avoid failures on duplicate pairs.
    *
-   * @param {Array<{ parent_feature_id: number; child_feature_id: number }>} pairs The pairs to insert.
+   * @param {Array<{ source_feature_id: number; target_feature_id: number }>} pairs The pairs to insert.
    * @return {Promise<void>}
    * @memberof SubmissionRepository
    */
   async insertSubmissionFeatureRelationships(
-    pairs: Array<{ parent_feature_id: number; child_feature_id: number }>
+    pairs: Array<{ source_feature_id: number; target_feature_id: number }>
   ): Promise<void> {
     if (pairs.length === 0) {
       return;
     }
 
-    const parentIds = pairs.map((p) => p.parent_feature_id);
-    const childIds = pairs.map((p) => p.child_feature_id);
+    const sourceIds = pairs.map((p) => p.source_feature_id);
+    const targetIds = pairs.map((p) => p.target_feature_id);
 
     const sqlStatement = SQL`
-      INSERT INTO submission_feature__feature (parent_feature_id, child_feature_id)
-      SELECT parent_id, child_id FROM unnest(
-        ${parentIds}::integer[],
-        ${childIds}::integer[]
-      ) AS t(parent_id, child_id)
-      ON CONFLICT (parent_feature_id, child_feature_id) DO NOTHING;
+      INSERT INTO submission_feature_feature (source_feature_id, target_feature_id)
+      SELECT source_id, target_id FROM unnest(
+        ${sourceIds}::integer[],
+        ${targetIds}::integer[]
+      ) AS t(source_id, target_id)
+      ON CONFLICT (source_feature_id, target_feature_id) DO NOTHING;
     `;
 
     await this.connection.sql(sqlStatement);
   }
 
   /**
-   * Get all related submission feature IDs for a given feature (parents and children).
+   * Get all related submission feature IDs for a given feature (sources and targets).
+   * sourceIds = features that reference this one; targetIds = features this one references.
    *
    * @param {number} submissionFeatureId The submission feature ID.
-   * @return {Promise<{ parentIds: number[]; childIds: number[] }>}
+   * @return {Promise<{ sourceIds: number[]; targetIds: number[] }>}
    * @memberof SubmissionRepository
    */
   async getRelatedSubmissionFeatureIds(
     submissionFeatureId: number
-  ): Promise<{ parentIds: number[]; childIds: number[] }> {
+  ): Promise<{ sourceIds: number[]; targetIds: number[] }> {
     const parentSqlStatement = SQL`
-      SELECT parent_feature_id
-      FROM submission_feature__feature
-      WHERE child_feature_id = ${submissionFeatureId};
+      SELECT source_feature_id
+      FROM submission_feature_feature
+      WHERE target_feature_id = ${submissionFeatureId};
     `;
 
     const childSqlStatement = SQL`
-      SELECT child_feature_id
-      FROM submission_feature__feature
-      WHERE parent_feature_id = ${submissionFeatureId};
+      SELECT target_feature_id
+      FROM submission_feature_feature
+      WHERE source_feature_id = ${submissionFeatureId};
     `;
 
     const [parentResult, childResult] = await Promise.all([
-      this.connection.sql<{ parent_feature_id: number }>(parentSqlStatement),
-      this.connection.sql<{ child_feature_id: number }>(childSqlStatement)
+      this.connection.sql<{ source_feature_id: number }>(parentSqlStatement),
+      this.connection.sql<{ target_feature_id: number }>(childSqlStatement)
     ]);
 
     return {
-      parentIds: parentResult.rows.map((r) => r.parent_feature_id),
-      childIds: childResult.rows.map((r) => r.child_feature_id)
+      sourceIds: parentResult.rows.map((r) => r.source_feature_id),
+      targetIds: childResult.rows.map((r) => r.target_feature_id)
     };
   }
 

--- a/api/src/services/feature-ingestion-service.test.ts
+++ b/api/src/services/feature-ingestion-service.test.ts
@@ -697,9 +697,7 @@ describe('FeatureIngestionService', () => {
       expect(deleteRelationshipsStub).to.have.been.calledOnceWith(1);
       expect(insertStub).to.have.been.calledTwice;
       expect(updateParentStub).to.have.been.calledOnceWith(101, 100);
-      expect(insertRelationshipsStub).to.have.been.calledOnceWith([
-        { parent_feature_id: 100, child_feature_id: 101 }
-      ]);
+      expect(insertRelationshipsStub).to.have.been.calledOnceWith([{ parent_feature_id: 100, child_feature_id: 101 }]);
     });
 
     it('should return all errors when validation fails', async () => {

--- a/api/src/services/feature-ingestion-service.test.ts
+++ b/api/src/services/feature-ingestion-service.test.ts
@@ -698,7 +698,7 @@ describe('FeatureIngestionService', () => {
       expect(insertStub).to.have.been.calledTwice;
       expect(updateParentStub).to.have.been.calledOnceWith(101, 100);
       expect(insertRelationshipsStub).to.have.been.calledOnceWith([
-        { parent_submission_feature_id: 100, child_submission_feature_id: 101 }
+        { parent_feature_id: 100, child_feature_id: 101 }
       ]);
     });
 
@@ -1155,9 +1155,9 @@ describe('FeatureIngestionService', () => {
       await service.ingestFeatures(1, features);
 
       expect(insertRelationshipsStub).to.have.been.calledOnceWith([
-        { parent_submission_feature_id: 10, child_submission_feature_id: 20 },
-        { parent_submission_feature_id: 10, child_submission_feature_id: 30 },
-        { parent_submission_feature_id: 10, child_submission_feature_id: 40 }
+        { parent_feature_id: 10, child_feature_id: 20 },
+        { parent_feature_id: 10, child_feature_id: 30 },
+        { parent_feature_id: 10, child_feature_id: 40 }
       ]);
     });
 

--- a/api/src/services/feature-ingestion-service.test.ts
+++ b/api/src/services/feature-ingestion-service.test.ts
@@ -1087,6 +1087,7 @@ describe('FeatureIngestionService', () => {
       expect(callOrder[2]).to.equal('insert');
       expect(deleteStub).to.have.been.calledOnceWith(1);
       expect(deleteRelationshipsStub).to.have.been.calledOnceWith(1);
+      expect(insertStub).to.have.been.calledOnce;
     });
 
     it('should not call insertSubmissionFeatureRelationships when all features have empty content', async () => {
@@ -1117,6 +1118,7 @@ describe('FeatureIngestionService', () => {
 
       await service.ingestFeatures(1, features);
 
+      expect(insertStub).to.have.been.calledTwice;
       expect(insertRelationshipsStub).to.not.have.been.called;
     });
 

--- a/api/src/services/feature-ingestion-service.test.ts
+++ b/api/src/services/feature-ingestion-service.test.ts
@@ -670,12 +670,19 @@ describe('FeatureIngestionService', () => {
         .resolves(mockFeatureTypeWithProperties);
 
       const deleteStub = sinon.stub(SubmissionRepository.prototype, 'deleteSubmissionFeatures').resolves();
+      const deleteRelationshipsStub = sinon
+        .stub(SubmissionRepository.prototype, 'deleteSubmissionFeatureRelationships')
+        .resolves();
 
       const insertStub = sinon.stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRecord');
       insertStub.onFirstCall().resolves({ submission_feature_id: 100 });
       insertStub.onSecondCall().resolves({ submission_feature_id: 101 });
 
       const updateParentStub = sinon.stub(SubmissionRepository.prototype, 'updateSubmissionFeatureParent').resolves();
+
+      const insertRelationshipsStub = sinon
+        .stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRelationships')
+        .resolves();
 
       const features: IFlattenedBlock[] = [
         createValidFeature({ id: 'uuid-1', content: ['uuid-2'] }),
@@ -687,8 +694,12 @@ describe('FeatureIngestionService', () => {
       expect(result.valid).to.be.true;
       expect(result.errors).to.have.length(0);
       expect(deleteStub).to.have.been.calledOnceWith(1);
+      expect(deleteRelationshipsStub).to.have.been.calledOnceWith(1);
       expect(insertStub).to.have.been.calledTwice;
       expect(updateParentStub).to.have.been.calledOnceWith(101, 100);
+      expect(insertRelationshipsStub).to.have.been.calledOnceWith([
+        { parent_submission_feature_id: 100, child_submission_feature_id: 101 }
+      ]);
     });
 
     it('should return all errors when validation fails', async () => {
@@ -1037,7 +1048,7 @@ describe('FeatureIngestionService', () => {
       expect(insertStub.secondCall.args[4]).to.deep.equal(propsMinimal);
     });
 
-    it('should call deleteSubmissionFeatures before inserting', async () => {
+    it('should call deleteSubmissionFeatures and deleteSubmissionFeatureRelationships before inserting', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new FeatureIngestionService(mockDBConnection);
 
@@ -1051,6 +1062,12 @@ describe('FeatureIngestionService', () => {
         callOrder.push('delete');
       });
 
+      const deleteRelationshipsStub = sinon
+        .stub(SubmissionRepository.prototype, 'deleteSubmissionFeatureRelationships')
+        .callsFake(async () => {
+          callOrder.push('deleteRelationships');
+        });
+
       const insertStub = sinon
         .stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRecord')
         .callsFake(async () => {
@@ -1059,14 +1076,87 @@ describe('FeatureIngestionService', () => {
         });
 
       sinon.stub(SubmissionRepository.prototype, 'updateSubmissionFeatureParent').resolves();
+      sinon.stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRelationships').resolves();
 
       const features: IFlattenedBlock[] = [createValidFeature()];
 
       await service.ingestFeatures(1, features);
 
       expect(callOrder[0]).to.equal('delete');
-      expect(callOrder[1]).to.equal('insert');
-      expect(deleteStub).to.have.been.calledBefore(insertStub);
+      expect(callOrder[1]).to.equal('deleteRelationships');
+      expect(callOrder[2]).to.equal('insert');
+      expect(deleteStub).to.have.been.calledOnceWith(1);
+      expect(deleteRelationshipsStub).to.have.been.calledOnceWith(1);
+    });
+
+    it('should not call insertSubmissionFeatureRelationships when all features have empty content', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new FeatureIngestionService(mockDBConnection);
+
+      sinon
+        .stub(ValidationRepository.prototype, 'getFeatureTypeWithProperties')
+        .resolves(mockFeatureTypeWithProperties);
+
+      sinon.stub(SubmissionRepository.prototype, 'deleteSubmissionFeatures').resolves();
+      sinon.stub(SubmissionRepository.prototype, 'deleteSubmissionFeatureRelationships').resolves();
+
+      const insertStub = sinon
+        .stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRecord')
+        .resolves({ submission_feature_id: 1 });
+
+      sinon.stub(SubmissionRepository.prototype, 'updateSubmissionFeatureParent').resolves();
+
+      const insertRelationshipsStub = sinon
+        .stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRelationships')
+        .resolves();
+
+      const features: IFlattenedBlock[] = [
+        createValidFeature({ id: 'uuid-1', content: [], parent: null }),
+        createValidFeature({ id: 'uuid-2', content: [], parent: 'uuid-1' })
+      ];
+
+      await service.ingestFeatures(1, features);
+
+      expect(insertRelationshipsStub).to.not.have.been.called;
+    });
+
+    it('should insert relationship rows for parent with multiple children', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new FeatureIngestionService(mockDBConnection);
+
+      sinon
+        .stub(ValidationRepository.prototype, 'getFeatureTypeWithProperties')
+        .resolves(mockFeatureTypeWithProperties);
+
+      sinon.stub(SubmissionRepository.prototype, 'deleteSubmissionFeatures').resolves();
+      sinon.stub(SubmissionRepository.prototype, 'deleteSubmissionFeatureRelationships').resolves();
+
+      const insertStub = sinon.stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRecord');
+      insertStub.onFirstCall().resolves({ submission_feature_id: 10 });
+      insertStub.onSecondCall().resolves({ submission_feature_id: 20 });
+      insertStub.onThirdCall().resolves({ submission_feature_id: 30 });
+      insertStub.onCall(3).resolves({ submission_feature_id: 40 });
+
+      sinon.stub(SubmissionRepository.prototype, 'updateSubmissionFeatureParent').resolves();
+
+      const insertRelationshipsStub = sinon
+        .stub(SubmissionRepository.prototype, 'insertSubmissionFeatureRelationships')
+        .resolves();
+
+      const features: IFlattenedBlock[] = [
+        createValidFeature({ id: 'parent', parent: null, content: ['child-1', 'child-2', 'child-3'] }),
+        createValidFeature({ id: 'child-1', parent: 'parent', content: [] }),
+        createValidFeature({ id: 'child-2', parent: 'parent', content: [] }),
+        createValidFeature({ id: 'child-3', parent: 'parent', content: [] })
+      ];
+
+      await service.ingestFeatures(1, features);
+
+      expect(insertRelationshipsStub).to.have.been.calledOnceWith([
+        { parent_submission_feature_id: 10, child_submission_feature_id: 20 },
+        { parent_submission_feature_id: 10, child_submission_feature_id: 30 },
+        { parent_submission_feature_id: 10, child_submission_feature_id: 40 }
+      ]);
     });
 
     it('should insert all features before updating any parent references', async () => {

--- a/api/src/services/feature-ingestion-service.test.ts
+++ b/api/src/services/feature-ingestion-service.test.ts
@@ -697,7 +697,7 @@ describe('FeatureIngestionService', () => {
       expect(deleteRelationshipsStub).to.have.been.calledOnceWith(1);
       expect(insertStub).to.have.been.calledTwice;
       expect(updateParentStub).to.have.been.calledOnceWith(101, 100);
-      expect(insertRelationshipsStub).to.have.been.calledOnceWith([{ parent_feature_id: 100, child_feature_id: 101 }]);
+      expect(insertRelationshipsStub).to.have.been.calledOnceWith([{ source_feature_id: 100, target_feature_id: 101 }]);
     });
 
     it('should return all errors when validation fails', async () => {
@@ -1153,9 +1153,9 @@ describe('FeatureIngestionService', () => {
       await service.ingestFeatures(1, features);
 
       expect(insertRelationshipsStub).to.have.been.calledOnceWith([
-        { parent_feature_id: 10, child_feature_id: 20 },
-        { parent_feature_id: 10, child_feature_id: 30 },
-        { parent_feature_id: 10, child_feature_id: 40 }
+        { source_feature_id: 10, target_feature_id: 20 },
+        { source_feature_id: 10, target_feature_id: 30 },
+        { source_feature_id: 10, target_feature_id: 40 }
       ]);
     });
 

--- a/api/src/services/feature-ingestion-service.ts
+++ b/api/src/services/feature-ingestion-service.ts
@@ -109,36 +109,36 @@ export class FeatureIngestionService extends DBService {
   }
 
   /**
-   * Build parent-child relationship pairs from features' content arrays.
+   * Build source-target relationship pairs from features' content arrays.
    *
    * @private
    * @param {IFlattenedBlock[]} features - Features with content references
    * @param {Map<string, number>} uuidToDbId - UUID to submission_feature_id mapping
-   * @return {Array<{ parent_feature_id: number; child_feature_id: number }>}
+   * @return {Array<{ source_feature_id: number; target_feature_id: number }>}
    * @memberof FeatureIngestionService
    */
   private buildContentRelationshipPairs(
     features: IFlattenedBlock[],
     uuidToDbId: Map<string, number>
-  ): Array<{ parent_feature_id: number; child_feature_id: number }> {
+  ): Array<{ source_feature_id: number; target_feature_id: number }> {
     const pairs: Array<{
-      parent_feature_id: number;
-      child_feature_id: number;
+      source_feature_id: number;
+      target_feature_id: number;
     }> = [];
     for (const feature of features) {
       if (!feature.content?.length) {
         continue;
       }
-      const parentDbId = uuidToDbId.get(feature.id);
-      if (parentDbId === undefined) {
+      const sourceDbId = uuidToDbId.get(feature.id);
+      if (sourceDbId === undefined) {
         continue;
       }
-      for (const childId of feature.content) {
-        const childDbId = uuidToDbId.get(childId);
-        if (childDbId !== undefined) {
+      for (const targetId of feature.content) {
+        const targetDbId = uuidToDbId.get(targetId);
+        if (targetDbId !== undefined) {
           pairs.push({
-            parent_feature_id: parentDbId,
-            child_feature_id: childDbId
+            source_feature_id: sourceDbId,
+            target_feature_id: targetDbId
           });
         }
       }

--- a/api/src/services/feature-ingestion-service.ts
+++ b/api/src/services/feature-ingestion-service.ts
@@ -102,29 +102,48 @@ export class FeatureIngestionService extends DBService {
     }
 
     // Pass 3: Insert content relationships (many-to-many)
-    const relationshipPairs: Array<{
+    const relationshipPairs = this.buildContentRelationshipPairs(features, uuidToDbId);
+    if (relationshipPairs.length > 0) {
+      await submissionRepository.insertSubmissionFeatureRelationships(relationshipPairs);
+    }
+  }
+
+  /**
+   * Build parent-child relationship pairs from features' content arrays.
+   *
+   * @private
+   * @param {IFlattenedBlock[]} features - Features with content references
+   * @param {Map<string, number>} uuidToDbId - UUID to submission_feature_id mapping
+   * @return {Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }>}
+   * @memberof FeatureIngestionService
+   */
+  private buildContentRelationshipPairs(
+    features: IFlattenedBlock[],
+    uuidToDbId: Map<string, number>
+  ): Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }> {
+    const pairs: Array<{
       parent_submission_feature_id: number;
       child_submission_feature_id: number;
     }> = [];
     for (const feature of features) {
-      if (feature.content && feature.content.length > 0) {
-        const parentDbId = uuidToDbId.get(feature.id);
-        if (parentDbId) {
-          for (const childId of feature.content) {
-            const childDbId = uuidToDbId.get(childId);
-            if (childDbId) {
-              relationshipPairs.push({
-                parent_submission_feature_id: parentDbId,
-                child_submission_feature_id: childDbId
-              });
-            }
-          }
+      if (!feature.content?.length) {
+        continue;
+      }
+      const parentDbId = uuidToDbId.get(feature.id);
+      if (parentDbId === undefined) {
+        continue;
+      }
+      for (const childId of feature.content) {
+        const childDbId = uuidToDbId.get(childId);
+        if (childDbId !== undefined) {
+          pairs.push({
+            parent_submission_feature_id: parentDbId,
+            child_submission_feature_id: childDbId
+          });
         }
       }
     }
-    if (relationshipPairs.length > 0) {
-      await submissionRepository.insertSubmissionFeatureRelationships(relationshipPairs);
-    }
+    return pairs;
   }
 
   // ============================================================================

--- a/api/src/services/feature-ingestion-service.ts
+++ b/api/src/services/feature-ingestion-service.ts
@@ -114,16 +114,16 @@ export class FeatureIngestionService extends DBService {
    * @private
    * @param {IFlattenedBlock[]} features - Features with content references
    * @param {Map<string, number>} uuidToDbId - UUID to submission_feature_id mapping
-   * @return {Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }>}
+   * @return {Array<{ parent_feature_id: number; child_feature_id: number }>}
    * @memberof FeatureIngestionService
    */
   private buildContentRelationshipPairs(
     features: IFlattenedBlock[],
     uuidToDbId: Map<string, number>
-  ): Array<{ parent_submission_feature_id: number; child_submission_feature_id: number }> {
+  ): Array<{ parent_feature_id: number; child_feature_id: number }> {
     const pairs: Array<{
-      parent_submission_feature_id: number;
-      child_submission_feature_id: number;
+      parent_feature_id: number;
+      child_feature_id: number;
     }> = [];
     for (const feature of features) {
       if (!feature.content?.length) {
@@ -137,8 +137,8 @@ export class FeatureIngestionService extends DBService {
         const childDbId = uuidToDbId.get(childId);
         if (childDbId !== undefined) {
           pairs.push({
-            parent_submission_feature_id: parentDbId,
-            child_submission_feature_id: childDbId
+            parent_feature_id: parentDbId,
+            child_feature_id: childDbId
           });
         }
       }

--- a/api/src/services/feature-ingestion-service.ts
+++ b/api/src/services/feature-ingestion-service.ts
@@ -52,20 +52,22 @@ export class FeatureIngestionService extends DBService {
       return validationResult;
     }
 
-    // 2. Delete existing features (idempotency for job retries)
+    // 2. Delete existing features and relationships (idempotency for job retries)
     const submissionRepository = new SubmissionRepository(this.connection);
     await submissionRepository.deleteSubmissionFeatures(submissionId);
+    await submissionRepository.deleteSubmissionFeatureRelationships(submissionId);
 
-    // 3. Insert features (two-pass for parent references)
+    // 3. Insert features (two-pass for parent references, Pass 3 for content relationships)
     await this.insertFlatFeatures(submissionId, features);
 
     return { valid: true, errors: [] };
   }
 
   /**
-   * Insert flat features using two-pass approach.
+   * Insert flat features using three-pass approach.
    * Pass 1: Insert all features with parent = NULL
    * Pass 2: Update parent references using UUID → ID mapping
+   * Pass 3: Insert content relationships (parent-child from content array)
    *
    * @private
    * @param {number} submissionId - The submission ID
@@ -97,6 +99,31 @@ export class FeatureIngestionService extends DBService {
           await submissionRepository.updateSubmissionFeatureParent(featureDbId, parentDbId);
         }
       }
+    }
+
+    // Pass 3: Insert content relationships (many-to-many)
+    const relationshipPairs: Array<{
+      parent_submission_feature_id: number;
+      child_submission_feature_id: number;
+    }> = [];
+    for (const feature of features) {
+      if (feature.content && feature.content.length > 0) {
+        const parentDbId = uuidToDbId.get(feature.id);
+        if (parentDbId) {
+          for (const childId of feature.content) {
+            const childDbId = uuidToDbId.get(childId);
+            if (childDbId) {
+              relationshipPairs.push({
+                parent_submission_feature_id: parentDbId,
+                child_submission_feature_id: childDbId
+              });
+            }
+          }
+        }
+      }
+    }
+    if (relationshipPairs.length > 0) {
+      await submissionRepository.insertSubmissionFeatureRelationships(relationshipPairs);
     }
   }
 

--- a/database/src/migrations/20260212000000_submission_feature_relationships.ts
+++ b/database/src/migrations/20260212000000_submission_feature_relationships.ts
@@ -17,36 +17,36 @@ export async function up(knex: Knex): Promise<void> {
     --------------------------------------------------------------------------------
 
     CREATE TABLE submission_feature__feature (
-      parent_submission_feature_id integer NOT NULL,
-      child_submission_feature_id integer NOT NULL,
+      parent_feature_id integer NOT NULL,
+      child_feature_id integer NOT NULL,
       create_date timestamptz(6) DEFAULT now() NOT NULL,
       create_user integer NOT NULL,
       update_date timestamptz(6),
       update_user integer,
       revision_count integer DEFAULT 0 NOT NULL,
       CONSTRAINT submission_feature__feature_pk
-        PRIMARY KEY (parent_submission_feature_id, child_submission_feature_id),
+        PRIMARY KEY (parent_feature_id, child_feature_id),
       CONSTRAINT submission_feature__feature_parent_fk
-        FOREIGN KEY (parent_submission_feature_id)
+        FOREIGN KEY (parent_feature_id)
         REFERENCES submission_feature(submission_feature_id)
         ON DELETE CASCADE,
       CONSTRAINT submission_feature__feature_child_fk
-        FOREIGN KEY (child_submission_feature_id)
+        FOREIGN KEY (child_feature_id)
         REFERENCES submission_feature(submission_feature_id)
         ON DELETE CASCADE,
       CONSTRAINT submission_feature__feature_no_self_loop
-        CHECK (parent_submission_feature_id != child_submission_feature_id)
+        CHECK (parent_feature_id != child_feature_id)
     );
 
     CREATE INDEX submission_feature__feature_parent_idx
-      ON submission_feature__feature(parent_submission_feature_id);
+      ON submission_feature__feature(parent_feature_id);
 
     CREATE INDEX submission_feature__feature_child_idx
-      ON submission_feature__feature(child_submission_feature_id);
+      ON submission_feature__feature(child_feature_id);
 
     COMMENT ON TABLE submission_feature__feature IS 'Many-to-many relationships between submission features (from content array in flat ingestion).';
-    COMMENT ON COLUMN submission_feature__feature.parent_submission_feature_id IS 'Foreign key to the parent submission feature.';
-    COMMENT ON COLUMN submission_feature__feature.child_submission_feature_id IS 'Foreign key to the child submission feature.';
+    COMMENT ON COLUMN submission_feature__feature.parent_feature_id IS 'Foreign key to the parent submission feature.';
+    COMMENT ON COLUMN submission_feature__feature.child_feature_id IS 'Foreign key to the child submission feature.';
     COMMENT ON COLUMN submission_feature__feature.create_date IS 'The datetime the record was created.';
     COMMENT ON COLUMN submission_feature__feature.create_user IS 'The id of the user who created the record.';
     COMMENT ON COLUMN submission_feature__feature.update_date IS 'The datetime the record was updated.';

--- a/database/src/migrations/20260212000000_submission_feature_relationships.ts
+++ b/database/src/migrations/20260212000000_submission_feature_relationships.ts
@@ -1,0 +1,77 @@
+import { Knex } from 'knex';
+
+/**
+ * Add submission_feature__feature junction table for many-to-many relationships
+ * between submission features (from content array in flat ingestion).
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- SUBMISSION_FEATURE__FEATURE (many-to-many feature relationships)
+    --------------------------------------------------------------------------------
+
+    CREATE TABLE submission_feature__feature (
+      parent_submission_feature_id integer NOT NULL,
+      child_submission_feature_id integer NOT NULL,
+      create_date timestamptz(6) DEFAULT now() NOT NULL,
+      create_user integer NOT NULL,
+      update_date timestamptz(6),
+      update_user integer,
+      revision_count integer DEFAULT 0 NOT NULL,
+      CONSTRAINT submission_feature__feature_pk
+        PRIMARY KEY (parent_submission_feature_id, child_submission_feature_id),
+      CONSTRAINT submission_feature__feature_parent_fk
+        FOREIGN KEY (parent_submission_feature_id)
+        REFERENCES submission_feature(submission_feature_id)
+        ON DELETE CASCADE,
+      CONSTRAINT submission_feature__feature_child_fk
+        FOREIGN KEY (child_submission_feature_id)
+        REFERENCES submission_feature(submission_feature_id)
+        ON DELETE CASCADE,
+      CONSTRAINT submission_feature__feature_no_self_loop
+        CHECK (parent_submission_feature_id != child_submission_feature_id)
+    );
+
+    CREATE INDEX submission_feature__feature_parent_idx
+      ON submission_feature__feature(parent_submission_feature_id);
+
+    CREATE INDEX submission_feature__feature_child_idx
+      ON submission_feature__feature(child_submission_feature_id);
+
+    COMMENT ON TABLE submission_feature__feature IS 'Many-to-many relationships between submission features (from content array in flat ingestion).';
+    COMMENT ON COLUMN submission_feature__feature.parent_submission_feature_id IS 'Foreign key to the parent submission feature.';
+    COMMENT ON COLUMN submission_feature__feature.child_submission_feature_id IS 'Foreign key to the child submission feature.';
+    COMMENT ON COLUMN submission_feature__feature.create_date IS 'The datetime the record was created.';
+    COMMENT ON COLUMN submission_feature__feature.create_user IS 'The id of the user who created the record.';
+    COMMENT ON COLUMN submission_feature__feature.update_date IS 'The datetime the record was updated.';
+    COMMENT ON COLUMN submission_feature__feature.update_user IS 'The id of the user who updated the record.';
+    COMMENT ON COLUMN submission_feature__feature.revision_count IS 'Revision count used for concurrency control.';
+
+    --------------------------------------------------------------------------------
+    -- AUDIT / JOURNAL TRIGGERS
+    --------------------------------------------------------------------------------
+
+    CREATE TRIGGER audit_submission_feature__feature
+      BEFORE INSERT OR UPDATE OR DELETE ON submission_feature__feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_audit_trigger();
+
+    CREATE TRIGGER journal_submission_feature__feature
+      AFTER INSERT OR UPDATE OR DELETE ON submission_feature__feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_journal_trigger();
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP TRIGGER IF EXISTS journal_submission_feature__feature ON submission_feature__feature;
+    DROP TRIGGER IF EXISTS audit_submission_feature__feature ON submission_feature__feature;
+
+    DROP TABLE IF EXISTS submission_feature__feature;
+  `);
+}

--- a/database/src/migrations/20260212000000_submission_feature_relationships.ts
+++ b/database/src/migrations/20260212000000_submission_feature_relationships.ts
@@ -1,8 +1,10 @@
 import { Knex } from 'knex';
 
 /**
- * Add submission_feature__feature junction table for many-to-many relationships
+ * Add submission_feature_feature junction table for many-to-many relationships
  * between submission features (from content array in flat ingestion).
+ * Uses source_feature_id/target_feature_id to support non-hierarchical relationships.
+ * Unique index on (LEAST, GREATEST) prevents inverse pairs (A→B and B→A).
  *
  * @export
  * @param {Knex} knex
@@ -13,65 +15,71 @@ export async function up(knex: Knex): Promise<void> {
     SET SEARCH_PATH = biohub, public;
 
     --------------------------------------------------------------------------------
-    -- SUBMISSION_FEATURE__FEATURE (many-to-many feature relationships)
+    -- SUBMISSION_FEATURE_FEATURE (many-to-many feature relationships)
     --------------------------------------------------------------------------------
 
-    CREATE TABLE submission_feature__feature (
-      parent_feature_id integer NOT NULL,
-      child_feature_id integer NOT NULL,
+    CREATE TABLE submission_feature_feature (
+      source_feature_id integer NOT NULL,
+      target_feature_id integer NOT NULL,
       create_date timestamptz(6) DEFAULT now() NOT NULL,
       create_user integer NOT NULL,
       update_date timestamptz(6),
       update_user integer,
       revision_count integer DEFAULT 0 NOT NULL,
-      CONSTRAINT submission_feature__feature_pk
-        PRIMARY KEY (parent_feature_id, child_feature_id),
-      CONSTRAINT submission_feature__feature_parent_fk
-        FOREIGN KEY (parent_feature_id)
+      CONSTRAINT submission_feature_feature_pk
+        PRIMARY KEY (source_feature_id, target_feature_id),
+      CONSTRAINT submission_feature_feature_source_fk
+        FOREIGN KEY (source_feature_id)
         REFERENCES submission_feature(submission_feature_id)
         ON DELETE CASCADE,
-      CONSTRAINT submission_feature__feature_child_fk
-        FOREIGN KEY (child_feature_id)
+      CONSTRAINT submission_feature_feature_target_fk
+        FOREIGN KEY (target_feature_id)
         REFERENCES submission_feature(submission_feature_id)
         ON DELETE CASCADE,
-      CONSTRAINT submission_feature__feature_no_self_loop
-        CHECK (parent_feature_id != child_feature_id)
+      CONSTRAINT submission_feature_feature_no_self_loop
+        CHECK (source_feature_id != target_feature_id)
     );
 
-    CREATE INDEX submission_feature__feature_parent_idx
-      ON submission_feature__feature(parent_feature_id);
+    CREATE INDEX submission_feature_feature_source_idx
+      ON submission_feature_feature(source_feature_id);
 
-    CREATE INDEX submission_feature__feature_child_idx
-      ON submission_feature__feature(child_feature_id);
+    CREATE INDEX submission_feature_feature_target_idx
+      ON submission_feature_feature(target_feature_id);
 
-    COMMENT ON TABLE submission_feature__feature IS 'Many-to-many relationships between submission features (from content array in flat ingestion).';
-    COMMENT ON COLUMN submission_feature__feature.parent_feature_id IS 'Foreign key to the parent submission feature.';
-    COMMENT ON COLUMN submission_feature__feature.child_feature_id IS 'Foreign key to the child submission feature.';
-    COMMENT ON COLUMN submission_feature__feature.create_date IS 'The datetime the record was created.';
-    COMMENT ON COLUMN submission_feature__feature.create_user IS 'The id of the user who created the record.';
-    COMMENT ON COLUMN submission_feature__feature.update_date IS 'The datetime the record was updated.';
-    COMMENT ON COLUMN submission_feature__feature.update_user IS 'The id of the user who updated the record.';
-    COMMENT ON COLUMN submission_feature__feature.revision_count IS 'Revision count used for concurrency control.';
+    CREATE UNIQUE INDEX submission_feature_feature_no_inverse_idx
+      ON submission_feature_feature (
+        LEAST(source_feature_id, target_feature_id),
+        GREATEST(source_feature_id, target_feature_id)
+      );
+
+    COMMENT ON TABLE submission_feature_feature IS 'Many-to-many relationships between submission features (from content array in flat ingestion).';
+    COMMENT ON COLUMN submission_feature_feature.source_feature_id IS 'Foreign key to the source submission feature (e.g. feature that has content array).';
+    COMMENT ON COLUMN submission_feature_feature.target_feature_id IS 'Foreign key to the target submission feature (e.g. feature referenced in content).';
+    COMMENT ON COLUMN submission_feature_feature.create_date IS 'The datetime the record was created.';
+    COMMENT ON COLUMN submission_feature_feature.create_user IS 'The id of the user who created the record.';
+    COMMENT ON COLUMN submission_feature_feature.update_date IS 'The datetime the record was updated.';
+    COMMENT ON COLUMN submission_feature_feature.update_user IS 'The id of the user who updated the record.';
+    COMMENT ON COLUMN submission_feature_feature.revision_count IS 'Revision count used for concurrency control.';
 
     --------------------------------------------------------------------------------
     -- AUDIT / JOURNAL TRIGGERS
     --------------------------------------------------------------------------------
 
-    CREATE TRIGGER audit_submission_feature__feature
-      BEFORE INSERT OR UPDATE OR DELETE ON submission_feature__feature
+    CREATE TRIGGER audit_submission_feature_feature
+      BEFORE INSERT OR UPDATE OR DELETE ON submission_feature_feature
       FOR EACH ROW EXECUTE PROCEDURE biohub.tr_audit_trigger();
 
-    CREATE TRIGGER journal_submission_feature__feature
-      AFTER INSERT OR UPDATE OR DELETE ON submission_feature__feature
+    CREATE TRIGGER journal_submission_feature_feature
+      AFTER INSERT OR UPDATE OR DELETE ON submission_feature_feature
       FOR EACH ROW EXECUTE PROCEDURE biohub.tr_journal_trigger();
   `);
 }
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
-    DROP TRIGGER IF EXISTS journal_submission_feature__feature ON submission_feature__feature;
-    DROP TRIGGER IF EXISTS audit_submission_feature__feature ON submission_feature__feature;
+    DROP TRIGGER IF EXISTS journal_submission_feature_feature ON submission_feature_feature;
+    DROP TRIGGER IF EXISTS audit_submission_feature_feature ON submission_feature_feature;
 
-    DROP TABLE IF EXISTS submission_feature__feature;
+    DROP TABLE IF EXISTS submission_feature_feature;
   `);
 }


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-870](https://quartech.atlassian.net/browse/SIMSBIOHUB-870)

## Description of Changes

- **Database:** New junction table `submission_feature_feature` with `source_feature_id` and `target_feature_id`, unique on the pair, FKs to `submission_feature`, and a check so source ≠ target. Unique index on `(LEAST(source_feature_id, target_feature_id), GREATEST(...))` to prevent inverse pairs (A→B and B→A). Indexes on both columns for lookups. Audit/journal triggers added to match other tables.
- **Ingestion:** When flat features are ingested, we clear any existing relationship rows for that submission (with the existing feature soft-delete) for idempotency. After inserting features and updating parent refs, we add a third pass: for each feature with a non-empty `content` array, we insert one row per referenced feature into the junction table (feature = source, each `content` ID = target). Features with no or empty `content` are unchanged.
- **Repository:** `SubmissionRepository` now has `deleteSubmissionFeatureRelationships(submissionId)`, `insertSubmissionFeatureRelationships(pairs)` (bulk insert with ON CONFLICT DO NOTHING; pairs use `source_feature_id` / `target_feature_id`), and `getRelatedSubmissionFeatureIds(submissionFeatureId)` returning `{ sourceIds, targetIds }` so you can reconstruct related features from the table.
- **Tests:** New/updated tests for the three repo methods and for ingestion (relationships created when `content` is present, not created when empty, delete-relationships step, and source-with-multiple-targets).

## Testing Notes

- Run migrations (`database`: `npm run migrate-latest`) before testing