### PR TITLE
SIMSBIOHUB-884: Fix Malware Publish Edge Cases

### DIFF
--- a/api/.mocharc.system.json
+++ b/api/.mocharc.system.json
@@ -2,5 +2,6 @@
   "extension": ["ts"],
   "spec": "src/__integration__/system/*.integration.ts",
   "require": "ts-node/register",
+  "node-option": ["no-experimental-strip-types"],
   "timeout": 60000
 }

--- a/api/src/__integration__/system/malware-scan-worker.integration.ts
+++ b/api/src/__integration__/system/malware-scan-worker.integration.ts
@@ -6,6 +6,7 @@ import { expect } from 'chai';
 import { Knex, knex } from 'knex';
 import sinon from 'sinon';
 import * as tar from 'tar-stream';
+import { defaultPoolConfig, getAPIUserDBConnection, initDBPool } from '../../database/db';
 import { initPgBoss, stopPgBoss } from '../../queue/pg-boss-service';
 import * as publisher from '../../queue/publisher';
 import { BucketType, ObjectStorageService } from '../../services/object-storage/object-storage-service';
@@ -48,6 +49,8 @@ describe('Malware Scan Worker', function () {
   let db: Knex;
   let storageService: ObjectStorageService;
   const createdArtifactIds: number[] = [];
+  const createdUploadIds: string[] = [];
+  const createdSubmissionIds: number[] = [];
   const createdObjectKeys: string[] = [];
 
   before(async () => {
@@ -65,6 +68,7 @@ describe('Malware Scan Worker', function () {
     storageService = new ObjectStorageService();
     // Stub the downstream job publisher so the scan doesn't chain into validation
     sinon.stub(publisher, 'publishProcessSubmissionFeaturesJob').resolves();
+    initDBPool(defaultPoolConfig);
     await initPgBoss();
   });
 
@@ -80,7 +84,15 @@ describe('Malware Scan Worker', function () {
           )
           .del();
         await db('biohub.artifact_security').whereIn('artifact_id', createdArtifactIds).del();
+        await db('biohub.upload_archive').whereIn('artifact_id', createdArtifactIds).del();
         await db('biohub.artifact').whereIn('artifact_id', createdArtifactIds).del();
+      }
+      if (createdUploadIds.length > 0) {
+        await db('biohub.submission_upload').whereIn('upload_id', createdUploadIds).del();
+        await db('biohub.upload').whereIn('upload_id', createdUploadIds).del();
+      }
+      if (createdSubmissionIds.length > 0) {
+        await db('biohub.submission').whereIn('submission_id', createdSubmissionIds).del();
       }
       for (const key of createdObjectKeys) {
         try {
@@ -125,6 +137,44 @@ describe('Malware Scan Worker', function () {
       .returning('artifact_id');
     createdArtifactIds.push(artifact.artifact_id);
 
+    // Create upload + upload_archive + submission_upload (mirrors completeArchiveUpload)
+    const [upload] = await db('biohub.upload')
+      .insert({
+        upload_status: 'completed',
+        record_end_date: '9999-12-31',
+        create_user: SYSTEM_USER_ID
+      })
+      .returning('upload_id');
+    createdUploadIds.push(upload.upload_id);
+
+    await db('biohub.upload_archive')
+      .insert({
+        upload_id: upload.upload_id,
+        artifact_id: artifact.artifact_id,
+        archive_status: 'blocked',
+        create_user: SYSTEM_USER_ID
+      });
+
+    const [submission] = await db('biohub.submission')
+      .insert({
+        uuid: db.raw('gen_random_uuid()'),
+        system_user_id: SYSTEM_USER_ID,
+        source_system: 'SIMS',
+        name: 'integration-test',
+        description: 'integration-test',
+        comment: '',
+        create_user: SYSTEM_USER_ID
+      })
+      .returning('submission_id');
+    createdSubmissionIds.push(submission.submission_id);
+
+    await db('biohub.submission_upload')
+      .insert({
+        submission_id: submission.submission_id,
+        upload_id: upload.upload_id,
+        create_user: SYSTEM_USER_ID
+      });
+
     const [security] = await db('biohub.artifact_security')
       .insert({
         artifact_id: artifact.artifact_id,
@@ -133,7 +183,14 @@ describe('Malware Scan Worker', function () {
       })
       .returning('artifact_security_id');
 
-    await publisher.publishMalwareScanJob({ artifactSecurityId: security.artifact_security_id });
+    const connection = getAPIUserDBConnection();
+    try {
+      await connection.open();
+      await publisher.publishMalwareScanJob(connection, { artifactSecurityId: security.artifact_security_id });
+      await connection.commit();
+    } finally {
+      connection.release();
+    }
     const result = await waitForScanResult(db, security.artifact_security_id);
 
     return { result, objectKey };

--- a/api/src/__integration__/system/malware-scan-worker.integration.ts
+++ b/api/src/__integration__/system/malware-scan-worker.integration.ts
@@ -147,13 +147,12 @@ describe('Malware Scan Worker', function () {
       .returning('upload_id');
     createdUploadIds.push(upload.upload_id);
 
-    await db('biohub.upload_archive')
-      .insert({
-        upload_id: upload.upload_id,
-        artifact_id: artifact.artifact_id,
-        archive_status: 'blocked',
-        create_user: SYSTEM_USER_ID
-      });
+    await db('biohub.upload_archive').insert({
+      upload_id: upload.upload_id,
+      artifact_id: artifact.artifact_id,
+      archive_status: 'blocked',
+      create_user: SYSTEM_USER_ID
+    });
 
     const [submission] = await db('biohub.submission')
       .insert({
@@ -168,12 +167,11 @@ describe('Malware Scan Worker', function () {
       .returning('submission_id');
     createdSubmissionIds.push(submission.submission_id);
 
-    await db('biohub.submission_upload')
-      .insert({
-        submission_id: submission.submission_id,
-        upload_id: upload.upload_id,
-        create_user: SYSTEM_USER_ID
-      });
+    await db('biohub.submission_upload').insert({
+      submission_id: submission.submission_id,
+      upload_id: upload.upload_id,
+      create_user: SYSTEM_USER_ID
+    });
 
     const [security] = await db('biohub.artifact_security')
       .insert({

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -233,8 +233,9 @@ describe('publisher', () => {
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
 
+      const mockConnection = getMockDBConnection();
       const data = { artifactSecurityId: 'artifact-security-123' };
-      const result = await publishMalwareScanJob(data);
+      const result = await publishMalwareScanJob(mockConnection, data);
 
       expect(createQueueStub.calledOnce).to.be.true;
       expect(createQueueStub.firstCall.args[0]).to.equal(JobQueues.MALWARE_SCAN);
@@ -252,7 +253,7 @@ describe('publisher', () => {
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
 
-      await publishMalwareScanJob({ artifactSecurityId: 'artifact-security-456' });
+      await publishMalwareScanJob(getMockDBConnection(), { artifactSecurityId: 'artifact-security-456' });
 
       const options = sendStub.firstCall.args[2];
       expect(options.retryLimit).to.equal(3);
@@ -268,10 +269,24 @@ describe('publisher', () => {
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
 
-      await publishMalwareScanJob({ artifactSecurityId: '123' });
+      await publishMalwareScanJob(getMockDBConnection(), { artifactSecurityId: '123' });
 
       const options = sendStub.firstCall.args[2];
       expect(options.singletonKey).to.equal('artifact-security-123');
+    });
+
+    it('passes db option to boss.send for transactional publishing', async () => {
+      const sendStub = sinon.stub().resolves('scan-job-id');
+      const createQueueStub = sinon.stub().resolves();
+      const mockBoss = { send: sendStub, createQueue: createQueueStub };
+
+      sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
+
+      await publishMalwareScanJob(getMockDBConnection(), { artifactSecurityId: 'tx-test-123' });
+
+      const options = sendStub.firstCall.args[2];
+      expect(options.db).to.exist;
+      expect(options.db.executeSql).to.be.a('function');
     });
 
     it('returns duplicate status when send returns null', async () => {
@@ -281,7 +296,7 @@ describe('publisher', () => {
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
 
-      const result = await publishMalwareScanJob({ artifactSecurityId: 'artifact-security-999' });
+      const result = await publishMalwareScanJob(getMockDBConnection(), { artifactSecurityId: 'artifact-security-999' });
 
       expect(result.status).to.equal('duplicate');
       expect((result as { status: 'duplicate'; message: string }).message).to.equal(
@@ -292,7 +307,7 @@ describe('publisher', () => {
     it('returns error status when pg-boss throws', async () => {
       sinon.stub(pgBossService, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishMalwareScanJob({ artifactSecurityId: 'artifact-security-000' });
+      const result = await publishMalwareScanJob(getMockDBConnection(), { artifactSecurityId: 'artifact-security-000' });
 
       expect(result.status).to.equal('error');
       expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -296,7 +296,9 @@ describe('publisher', () => {
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
 
-      const result = await publishMalwareScanJob(getMockDBConnection(), { artifactSecurityId: 'artifact-security-999' });
+      const result = await publishMalwareScanJob(getMockDBConnection(), {
+        artifactSecurityId: 'artifact-security-999'
+      });
 
       expect(result.status).to.equal('duplicate');
       expect((result as { status: 'duplicate'; message: string }).message).to.equal(
@@ -307,7 +309,9 @@ describe('publisher', () => {
     it('returns error status when pg-boss throws', async () => {
       sinon.stub(pgBossService, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishMalwareScanJob(getMockDBConnection(), { artifactSecurityId: 'artifact-security-000' });
+      const result = await publishMalwareScanJob(getMockDBConnection(), {
+        artifactSecurityId: 'artifact-security-000'
+      });
 
       expect(result.status).to.equal('error');
       expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');

--- a/api/src/queue/publisher.ts
+++ b/api/src/queue/publisher.ts
@@ -181,11 +181,13 @@ export const publishProcessSubmissionFeaturesJob = async (
  *
  * Queues ClamAV scanning for an uploaded artifact.
  *
+ * @param {IDBConnection} connection Database connection for submission validation tracking
  * @param {IMalwareScanJobData} data Job data containing artifactSecurityId
  * @param {IPublishOptions} [options={}] Job options
  * @return {*}  {Promise<PublishJobResult>} Result indicating success, duplicate, or error
  */
 export const publishMalwareScanJob = async (
+  connection: IDBConnection,
   data: IMalwareScanJobData,
   options: IPublishOptions = {}
 ): Promise<PublishJobResult> => {
@@ -195,10 +197,18 @@ export const publishMalwareScanJob = async (
 
     await boss.createQueue(JobQueues.MALWARE_SCAN);
 
+    const db = {
+      executeSql: async (text: string, values: any[]) => {
+        const result = await connection.query(text, values);
+        return { rows: result.rows, rowCount: result.rowCount };
+      }
+    };
+
     // Use singletonKey to prevent duplicate concurrent jobs for the same artifact security record
     const jobId = await boss.send(JobQueues.MALWARE_SCAN, data, {
       ...mergedOptions,
-      singletonKey: `artifact-security-${data.artifactSecurityId}`
+      singletonKey: `artifact-security-${data.artifactSecurityId}`,
+      db
     });
 
     if (jobId) {

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -189,7 +189,7 @@ export class SubmissionUploadRepository extends BaseRepository {
    * @param {string} uploadId - The upload_id to look up.
    * @returns {Promise<SubmissionUpload | null>} - The submission_upload record, or null if not found.
    */
-  async findSubmissionUploadByUploadId(uploadId: string): Promise<SubmissionUpload | null> {
+  async getSubmissionUploadByUploadId(uploadId: string): Promise<SubmissionUpload> {
     const sqlStatement = SQL`
       SELECT
         submission_upload_id,
@@ -202,7 +202,15 @@ export class SubmissionUploadRepository extends BaseRepository {
     `;
 
     const response = await this.connection.sql(sqlStatement, SubmissionUpload);
-    return response.rows[0] ?? null;
+    
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to get submission upload record', [
+        'SubmissionUploadRepository->getSubmissionUploadByUploadId',
+        `rowCount was ${response.rowCount}, expected 1`
+      ]);
+    }
+    
+      return response.rows[0];
   }
 
   /**

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -202,15 +202,15 @@ export class SubmissionUploadRepository extends BaseRepository {
     `;
 
     const response = await this.connection.sql(sqlStatement, SubmissionUpload);
-    
+
     if (response.rowCount !== 1) {
       throw new ApiExecuteSQLError('Failed to get submission upload record', [
         'SubmissionUploadRepository->getSubmissionUploadByUploadId',
         `rowCount was ${response.rowCount}, expected 1`
       ]);
     }
-    
-      return response.rows[0];
+
+    return response.rows[0];
   }
 
   /**

--- a/api/src/repositories/upload/upload-archive-repository.ts
+++ b/api/src/repositories/upload/upload-archive-repository.ts
@@ -85,7 +85,7 @@ export class UploadArchiveRepository extends BaseRepository {
    * @param {string} artifactId - The ID of the artifact.
    * @returns {Promise<UploadArchive | null>} - The upload archive or null if not found.
    */
-  async getUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive | null> {
+  async getUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive> {
     const sqlStatement = SQL`
       SELECT
         upload_archive_id,
@@ -99,7 +99,16 @@ export class UploadArchiveRepository extends BaseRepository {
     `;
 
     const response = await this.connection.sql(sqlStatement, UploadArchive);
-    return response.rows[0] ?? null;
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to get upload archive record', [
+        'UploadArchiveRepository->getUploadArchiveByArtifactId',
+        `rowCount was ${response.rowCount}, expected 1`
+      ]);
+    }
+
+    return response.rows[0];
+    
   }
 
   /**

--- a/api/src/repositories/upload/upload-archive-repository.ts
+++ b/api/src/repositories/upload/upload-archive-repository.ts
@@ -108,7 +108,6 @@ export class UploadArchiveRepository extends BaseRepository {
     }
 
     return response.rows[0];
-    
   }
 
   /**

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -335,7 +335,16 @@ describe('ArtifactSecurityService', () => {
       expect(result.securityStatus).to.equal(SecurityStatusEnum.INFECTED);
     });
 
-    it('should call handleCleanScanResult on clean scan', async () => {
+    it('should call handleCleanScanResult and publishNextPipelineStep on clean scan', async () => {
+      // Verifies: clean scan triggers post-scan file handling and downstream job publishing
+
+      const mockUploadArchive: UploadArchive = {
+        upload_archive_id: 'archive-1',
+        upload_id: 'upload-1',
+        artifact_id: 'artifact-1',
+        archive_status: ProcessStatusStatusEnum.BLOCKED
+      };
+
       sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
       sinon.stub(ArtifactService.prototype, 'getArtifact').resolves(mockArtifact);
       sinon
@@ -356,11 +365,22 @@ describe('ArtifactSecurityService', () => {
       const promoteStub = sinon
         .stub(ObjectStorageService.prototype, 'promoteFromSecurity')
         .resolves({ key: 'test.tar' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(null);
+      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon.stub(UploadArchiveService.prototype, 'updateUploadArchive').resolves({ upload_archive_id: 'archive-1' });
+      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
+        submission_upload_id: 'su-1',
+        submission_id: 123,
+        upload_id: 'upload-1'
+      });
+      const publishStub = sinon
+        .stub(publisher, 'publishProcessSubmissionFeaturesJob')
+        .resolves({ status: 'published', jobId: 'job-1' });
 
       await service.executeScan('security-1');
 
       expect(promoteStub.calledOnceWith('uploads/test.tar')).to.be.true;
+      expect(publishStub.calledOnce).to.be.true;
+      expect(publishStub.firstCall.args[1]).to.deep.equal({ submissionId: 123 });
     });
 
     it('should update scan record to FAILED on error and rethrow', async () => {
@@ -391,69 +411,62 @@ describe('ArtifactSecurityService', () => {
   });
 
   describe('handleCleanScanResult', () => {
-    it('should promote file from security bucket to main bucket', async () => {
+    const mockUploadArchive: UploadArchive = {
+      upload_archive_id: 'archive-1',
+      upload_id: 'upload-1',
+      artifact_id: 'artifact-1',
+      archive_status: ProcessStatusStatusEnum.BLOCKED
+    };
+
+    it('should promote file and unblock archive, returning the upload archive record', async () => {
+      // Verifies: handleCleanScanResult promotes file, updates archive status, and returns the archive
+
+      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
       const promoteStub = sinon
         .stub(ObjectStorageService.prototype, 'promoteFromSecurity')
         .resolves({ key: 'test.tar' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(null);
-
-      await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
-
-      expect(promoteStub.calledOnceWith('uploads/test.tar')).to.be.true;
-    });
-
-    it('should update upload_archive status to PENDING if archive exists', async () => {
-      const mockUploadArchive: UploadArchive = {
-        upload_archive_id: 'archive-1',
-        upload_id: 'upload-1',
-        artifact_id: 'artifact-1',
-        archive_status: ProcessStatusStatusEnum.BLOCKED
-      };
-      sinon.stub(ObjectStorageService.prototype, 'promoteFromSecurity').resolves({ key: 'test.tar' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
       const updateArchiveStub = sinon.stub(UploadArchiveService.prototype, 'updateUploadArchive').resolves({
         upload_archive_id: 'archive-1'
       });
-      sinon.stub(SubmissionUploadService.prototype, 'findSubmissionUploadByUploadId').resolves({
-        submission_upload_id: 'su-1',
-        submission_id: 123,
-        upload_id: 'upload-1'
-      });
-      sinon.stub(publisher, 'publishProcessSubmissionFeaturesJob').resolves({ status: 'published', jobId: 'job-1' });
 
-      await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
+      const result = await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
 
+      expect(promoteStub.calledOnceWith('uploads/test.tar')).to.be.true;
       expect(updateArchiveStub.calledOnceWith('archive-1', { archive_status: ProcessStatusStatusEnum.PENDING })).to.be
         .true;
+      expect(result).to.eql(mockUploadArchive);
     });
 
-    it('should handle missing upload_archive gracefully', async () => {
-      sinon.stub(ObjectStorageService.prototype, 'promoteFromSecurity').resolves({ key: 'test.tar' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(null);
-      const updateArchiveStub = sinon.stub(UploadArchiveService.prototype, 'updateUploadArchive');
-      const publishStub = sinon
-        .stub(publisher, 'publishProcessSubmissionFeaturesJob')
-        .resolves({ status: 'published', jobId: 'job-1' });
+    it('should propagate error when upload_archive lookup throws', async () => {
+      // Verifies: missing upload_archive is data corruption — error propagates, no S3 promote
 
-      await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
+      sinon
+        .stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId')
+        .rejects(new Error('Failed to get upload archive record'));
+      const promoteStub = sinon.stub(ObjectStorageService.prototype, 'promoteFromSecurity');
 
-      expect(updateArchiveStub.called).to.be.false;
-      expect(publishStub.called).to.be.false;
+      try {
+        await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
+        expect.fail('Expected error not thrown');
+      } catch (err) {
+        expect((err as Error).message).to.equal('Failed to get upload archive record');
+        expect(promoteStub.called).to.be.false;
+      }
     });
+  });
+
+  describe('publishNextPipelineStep', () => {
+    const mockUploadArchive: UploadArchive = {
+      upload_archive_id: 'archive-1',
+      upload_id: 'upload-1',
+      artifact_id: 'artifact-1',
+      archive_status: ProcessStatusStatusEnum.PENDING
+    };
 
     it('should publish process-submission-features job with correct submissionId', async () => {
-      const mockUploadArchive: UploadArchive = {
-        upload_archive_id: 'archive-1',
-        upload_id: 'upload-1',
-        artifact_id: 'artifact-1',
-        archive_status: ProcessStatusStatusEnum.BLOCKED
-      };
-      sinon.stub(ObjectStorageService.prototype, 'promoteFromSecurity').resolves({ key: 'test.tar' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
-      sinon.stub(UploadArchiveService.prototype, 'updateUploadArchive').resolves({
-        upload_archive_id: 'archive-1'
-      });
-      sinon.stub(SubmissionUploadService.prototype, 'findSubmissionUploadByUploadId').resolves({
+      // Verifies: looks up submission via upload_id and publishes with correct submissionId
+
+      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
         submission_upload_id: 'su-1',
         submission_id: 999,
         upload_id: 'upload-1'
@@ -462,53 +475,24 @@ describe('ArtifactSecurityService', () => {
         .stub(publisher, 'publishProcessSubmissionFeaturesJob')
         .resolves({ status: 'published', jobId: 'job-1' });
 
-      await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
+      await service.publishNextPipelineStep(mockUploadArchive);
 
       expect(publishStub.calledOnce).to.be.true;
       expect(publishStub.firstCall.args[1]).to.deep.equal({ submissionId: 999 });
     });
 
-    it('should not publish job when submission_upload lookup returns null', async () => {
-      const mockUploadArchive: UploadArchive = {
-        upload_archive_id: 'archive-1',
-        upload_id: 'upload-1',
-        artifact_id: 'artifact-1',
-        archive_status: ProcessStatusStatusEnum.BLOCKED
-      };
-      sinon.stub(ObjectStorageService.prototype, 'promoteFromSecurity').resolves({ key: 'test.tar' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
-      sinon.stub(UploadArchiveService.prototype, 'updateUploadArchive').resolves({
-        upload_archive_id: 'archive-1'
-      });
-      sinon.stub(SubmissionUploadService.prototype, 'findSubmissionUploadByUploadId').resolves(null);
-      const publishStub = sinon
-        .stub(publisher, 'publishProcessSubmissionFeaturesJob')
-        .resolves({ status: 'published', jobId: 'job-1' });
+    it('should propagate error when submission_upload lookup throws', async () => {
+      // Verifies: missing submission_upload is data corruption — error propagates
 
-      await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
-
-      expect(publishStub.called).to.be.false;
-    });
-
-    it('should propagate error when submission_upload lookup fails', async () => {
-      const mockUploadArchive: UploadArchive = {
-        upload_archive_id: 'archive-1',
-        upload_id: 'upload-1',
-        artifact_id: 'artifact-1',
-        archive_status: ProcessStatusStatusEnum.BLOCKED
-      };
-      sinon.stub(ObjectStorageService.prototype, 'promoteFromSecurity').resolves({ key: 'test.tar' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
-      sinon.stub(UploadArchiveService.prototype, 'updateUploadArchive').resolves({
-        upload_archive_id: 'archive-1'
-      });
-      sinon.stub(SubmissionUploadService.prototype, 'findSubmissionUploadByUploadId').rejects(new Error('DB error'));
+      sinon
+        .stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId')
+        .rejects(new Error('Failed to get submission upload record'));
 
       try {
-        await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
+        await service.publishNextPipelineStep(mockUploadArchive);
         expect.fail('Expected error not thrown');
       } catch (err) {
-        expect((err as Error).message).to.equal('DB error');
+        expect((err as Error).message).to.equal('Failed to get submission upload record');
       }
     });
   });

--- a/api/src/services/upload/artifact-security-service.ts
+++ b/api/src/services/upload/artifact-security-service.ts
@@ -3,6 +3,7 @@ import { ArtifactStatusEnum } from '../../models/artifact';
 import { ArtifactSecurity, CreateArtifactSecurity, UpdateArtifactSecurity } from '../../models/artifact-security';
 import { ProcessStatusStatusEnum } from '../../models/process-status';
 import { SecurityStatusEnum } from '../../models/security-status';
+import { UploadArchive } from '../../models/upload-archive';
 import { publishProcessSubmissionFeaturesJob } from '../../queue/publisher';
 import { ArtifactSecurityRepository } from '../../repositories/upload/artifact-security-repository';
 import { getObjectStoreBucketName, getSecurityObjectStoreBucketName, _getClamAvScanner } from '../../utils/file-utils';
@@ -85,30 +86,38 @@ export class ArtifactSecurityService extends DBService {
    * @param {string} objectKey The S3 object key
    * @memberof ArtifactSecurityService
    */
-  async handleCleanScanResult(artifactId: string, objectKey: string): Promise<void> {
+  async handleCleanScanResult(artifactId: string, objectKey: string): Promise<UploadArchive> {
+    const uploadArchiveService = new UploadArchiveService(this.connection);
+    const uploadArchive = await uploadArchiveService.getUploadArchiveByArtifactId(artifactId);
+
     // 1. Copy file from security bucket to main bucket
     const storageService = new ObjectStorageService();
     await storageService.promoteFromSecurity(objectKey);
 
     // 2. Unblock the upload_archive for extraction
-    const uploadArchiveService = new UploadArchiveService(this.connection);
-    const uploadArchive = await uploadArchiveService.getUploadArchiveByArtifactId(artifactId);
+    await uploadArchiveService.updateUploadArchive(uploadArchive.upload_archive_id, {
+      archive_status: ProcessStatusStatusEnum.PENDING
+    });
 
-    if (uploadArchive) {
-      await uploadArchiveService.updateUploadArchive(uploadArchive.upload_archive_id, {
-        archive_status: ProcessStatusStatusEnum.PENDING
-      });
+    return uploadArchive;
+  }
 
-      // Look up submissionId and publish the process-submission-features job
-      const submissionUploadService = new SubmissionUploadService(this.connection);
-      const submissionUpload = await submissionUploadService.findSubmissionUploadByUploadId(uploadArchive.upload_id);
+  /**
+   * Publishes the downstream processing job after a clean scan.
+   *
+   * submission_upload is created atomically in completeArchiveUpload before the scan
+   * job is published — a missing record means data corruption, not a valid state.
+   *
+   * @param {UploadArchive} uploadArchive The upload archive record from handleCleanScanResult
+   * @memberof ArtifactSecurityService
+   */
+  async publishNextPipelineStep(uploadArchive: UploadArchive): Promise<void> {
+    const submissionUploadService = new SubmissionUploadService(this.connection);
+    const submissionUpload = await submissionUploadService.getSubmissionUploadByUploadId(uploadArchive.upload_id);
 
-      if (submissionUpload) {
-        await publishProcessSubmissionFeaturesJob(this.connection, {
-          submissionId: submissionUpload.submission_id
-        });
-      }
-    }
+    await publishProcessSubmissionFeaturesJob(this.connection, {
+      submissionId: submissionUpload.submission_id
+    });
   }
 
   /**
@@ -177,7 +186,8 @@ export class ArtifactSecurityService extends DBService {
 
       // 6. Handle post-scan actions for clean files
       if (scanOutcome.securityStatus === SecurityStatusEnum.CLEAN) {
-        await this.handleCleanScanResult(artifact.artifact_id, artifact.object_key);
+        const uploadArchive = await this.handleCleanScanResult(artifact.artifact_id, artifact.object_key);
+        await this.publishNextPipelineStep(uploadArchive);
       }
 
       return {

--- a/api/src/services/upload/submission-upload-service.ts
+++ b/api/src/services/upload/submission-upload-service.ts
@@ -55,11 +55,11 @@ export class SubmissionUploadService extends DBService {
    * Retrieves a submission_upload record by upload_id (reverse lookup).
    *
    * @param {string} uploadId The upload_id to look up
-   * @return {Promise<SubmissionUpload | null>} The submission upload record, or null if not found
+   * @return {Promise<SubmissionUpload | null>} The submission upload record
    * @memberof SubmissionUploadService
    */
-  async findSubmissionUploadByUploadId(uploadId: string): Promise<SubmissionUpload | null> {
-    return this.submissionUploadRepository.findSubmissionUploadByUploadId(uploadId);
+  async getSubmissionUploadByUploadId(uploadId: string): Promise<SubmissionUpload> {
+    return this.submissionUploadRepository.getSubmissionUploadByUploadId(uploadId);
   }
 
   /**

--- a/api/src/services/upload/upload-archive-service.ts
+++ b/api/src/services/upload/upload-archive-service.ts
@@ -81,7 +81,7 @@ export class UploadArchiveService extends DBService {
    * @return {Promise<UploadArchive | null>} The upload archive record or null if not found
    * @memberof UploadArchiveService
    */
-  async getUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive | null> {
+  async getUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive> {
     return this.uploadArchiveRepository.getUploadArchiveByArtifactId(artifactId);
   }
 

--- a/api/src/services/upload/upload-ingestion-service.test.ts
+++ b/api/src/services/upload/upload-ingestion-service.test.ts
@@ -226,8 +226,8 @@ describe('UploadIngestionService', () => {
 
       const publishStub = publisher.publishMalwareScanJob as sinon.SinonStub;
       expect(publishStub.callCount).to.equal(mockSecurityRecords.length);
-      expect(publishStub.firstCall.args[0]).to.deep.equal({ artifactSecurityId: 'artifact-security-1' });
-      expect(publishStub.secondCall.args[0]).to.deep.equal({ artifactSecurityId: 'artifact-security-2' });
+      expect(publishStub.firstCall.args[1]).to.deep.equal({ artifactSecurityId: 'artifact-security-1' });
+      expect(publishStub.secondCall.args[1]).to.deep.equal({ artifactSecurityId: 'artifact-security-2' });
       expect(s3ClientStub.send).to.have.been.calledOnce;
     });
 

--- a/api/src/services/upload/upload-ingestion-service.ts
+++ b/api/src/services/upload/upload-ingestion-service.ts
@@ -154,7 +154,9 @@ export class UploadIngestionService extends DBService {
 
     // 7. Publish malware scan jobs for each artifact_security record
     await Promise.all(
-      securityRecords.map((record) => publishMalwareScanJob(this.connection, { artifactSecurityId: record.artifact_security_id }))
+      securityRecords.map((record) =>
+        publishMalwareScanJob(this.connection, { artifactSecurityId: record.artifact_security_id })
+      )
     );
   }
 

--- a/api/src/services/upload/upload-ingestion-service.ts
+++ b/api/src/services/upload/upload-ingestion-service.ts
@@ -154,7 +154,7 @@ export class UploadIngestionService extends DBService {
 
     // 7. Publish malware scan jobs for each artifact_security record
     await Promise.all(
-      securityRecords.map((record) => publishMalwareScanJob({ artifactSecurityId: record.artifact_security_id }))
+      securityRecords.map((record) => publishMalwareScanJob(this.connection, { artifactSecurityId: record.artifact_security_id }))
     );
   }
 


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-884](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-884)[SIMSBIOHUB-884](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-884)

## Description of Changes

The malware scan publish flow has edge cases that pose a small risk of data inconsistency.

**Acceptance Criteria**

1. Throw on Missing Archive Record

WHEN `getUploadArchiveByArtifactId` is called with an `artifact_id` that has no `upload_archive` record,
THEN the repository should throw an `ApiExecuteSQLError` (matching the pattern in `getUploadArchive`),
AND the return type should be `Promise<UploadArchive>` (not `| null`),
AND callers should not need to null-check the result.

2. Update order

WHEN a malware scan completes with CLEAN status,
THEN `handleCleanScanResult` should validate the `upload_archive` record exists before the S3 promotion,
AND if the DB lookup throws, no irreversible S3 changes should be made.

3. Transactional Job Publishing

WHEN `publishMalwareScanJob` publishes a malware scan job,
THEN it should accept an `IDBConnection` parameter and use pg-boss's `db` option to enlist the job insert in the caller's transaction (matching the pattern in `publishProcessDownloadJob`),
AND this prevents ghost jobs and lost jobs.

## Testing Notes

- Verified via unit tests (operation ordering, throw-on-missing, transactional publish)
- **Missing archive now throws** instead of silently returning null
