### PR TITLE
SIMSBIOHUB-885: API Improvements for Policies, Teams, and Team-Policy Assignments

### DIFF
--- a/api/src/models/count.ts
+++ b/api/src/models/count.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const CountResult = z.object({
+  count: z.number()
+});
+
+export type CountResult = z.infer<typeof CountResult>;

--- a/api/src/models/policy.ts
+++ b/api/src/models/policy.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import { PolicyEffect } from './policy-statement';
+import { PolicyConditionOperator } from './policy-statement-condition';
 
 export const Policy = z.object({
   policy_id: z.string().uuid(),
@@ -17,4 +19,26 @@ export interface UpdatePolicy {
   name?: string;
   description?: string;
   record_end_date?: string;
+}
+
+export interface PolicyStatementRequest {
+  effect: PolicyEffect;
+  submission_feature_urn: string;
+  conditions?: {
+    operator: PolicyConditionOperator;
+    key: string;
+    value: unknown;
+  }[];
+}
+
+export interface CreatePolicyRequest {
+  name: string;
+  description?: string;
+  statements: PolicyStatementRequest[];
+}
+
+export interface UpdatePolicyRequest {
+  name: string;
+  description?: string;
+  statements: PolicyStatementRequest[];
 }

--- a/api/src/models/team-member.ts
+++ b/api/src/models/team-member.ts
@@ -8,9 +8,27 @@ export const TeamMember = z.object({
 
 export type TeamMember = z.infer<typeof TeamMember>;
 
+export const TeamMemberWithUser = z.object({
+  team_member_id: z.string().uuid(),
+  system_user_id: z.number().int(),
+  user_identifier: z.string(),
+  email: z.string().nullable()
+});
+
+export type TeamMemberWithUser = z.infer<typeof TeamMemberWithUser>;
+
 export interface CreateTeamMember {
   system_user_id: number;
   team_id: string;
+}
+
+export interface TeamMemberByUserRequest {
+  system_user_id: number;
+}
+
+export interface TeamMemberByUserFilter {
+  team_id: string;
+  system_user_id: number;
 }
 
 export interface UpdateTeamMember {

--- a/api/src/models/team-policy.ts
+++ b/api/src/models/team-policy.ts
@@ -24,6 +24,10 @@ export interface CreateTeamPolicy {
   policy_id: string;
 }
 
+export interface CreateTeamPoliciesRequest {
+  policies: string[];
+}
+
 export interface UpdateTeamPolicy {
   record_end_date?: string;
 }

--- a/api/src/models/team.ts
+++ b/api/src/models/team.ts
@@ -20,3 +20,9 @@ export interface UpdateTeam {
   description?: string;
   record_end_date?: string;
 }
+
+export interface UpdateTeamRequest {
+  name?: string;
+  description?: string;
+  system_user_ids?: number[];
+}

--- a/api/src/models/team.ts
+++ b/api/src/models/team.ts
@@ -19,6 +19,7 @@ export interface UpdateTeam {
   name?: string;
   description?: string;
   record_end_date?: string;
+  system_user_ids?: number[];
 }
 
 export interface UpdateTeamRequest {

--- a/api/src/models/team.ts
+++ b/api/src/models/team.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 export const Team = z.object({
   team_id: z.string().uuid(),
   name: z.string().max(250),
-  description: z.string().max(1000).nullable()
+  description: z.string().max(1000).nullable(),
+  member_count: z.number().int()
 });
 
 export type Team = z.infer<typeof Team>;
@@ -11,6 +12,7 @@ export type Team = z.infer<typeof Team>;
 export interface CreateTeam {
   name: string;
   description?: string;
+  system_user_ids?: number[];
 }
 
 export interface UpdateTeam {

--- a/api/src/openapi/schemas/team-member.ts
+++ b/api/src/openapi/schemas/team-member.ts
@@ -1,0 +1,98 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { paginationResponseSchema } from './pagination';
+
+/**
+ * Schema for a team member with user details.
+ */
+export const TeamMemberSchema: OpenAPIV3.SchemaObject = {
+  title: 'TeamMember',
+  type: 'object',
+  required: ['team_member_id', 'system_user_id', 'user_identifier', 'email'],
+  properties: {
+    team_member_id: {
+      type: 'string',
+      format: 'uuid',
+      description: 'Unique identifier for the team membership'
+    },
+    system_user_id: {
+      type: 'integer',
+      description: 'The system user ID of the team member'
+    },
+    user_identifier: {
+      type: 'string',
+      description: 'Username or identifier from identity provider'
+    },
+    email: {
+      type: 'string',
+      nullable: true,
+      description: 'Email for the user'
+    }
+  }
+};
+
+/**
+ * Schema for paginated team member list response.
+ */
+export const TeamMembersListResponseSchema: OpenAPIV3.SchemaObject = {
+  title: 'TeamMembersListResponse',
+  type: 'object',
+  required: ['members', 'pagination'],
+  properties: {
+    members: {
+      type: 'array',
+      items: TeamMemberSchema,
+      description: 'List of members for the team'
+    },
+    pagination: paginationResponseSchema
+  }
+};
+
+/**
+ * Schema for add/remove team member by system user id.
+ */
+export const TeamMemberByUserRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'TeamMemberByUserRequest',
+  type: 'object',
+  required: ['system_user_id'],
+  properties: {
+    system_user_id: {
+      type: 'integer',
+      description: 'System user ID to add/remove as a team member'
+    }
+  }
+};
+
+/**
+ * Schema for an available user (for team membership selection).
+ */
+export const AvailableUserSchema: OpenAPIV3.SchemaObject = {
+  title: 'AvailableUser',
+  type: 'object',
+  required: ['system_user_id', 'user_identifier'],
+  properties: {
+    system_user_id: {
+      type: 'integer',
+      description: 'Unique identifier for the system user'
+    },
+    user_identifier: {
+      type: 'string',
+      description: 'Username or identifier from identity provider'
+    }
+  }
+};
+
+/**
+ * Schema for available users list response.
+ */
+export const AvailableUsersListResponseSchema: OpenAPIV3.SchemaObject = {
+  title: 'AvailableUsersListResponse',
+  type: 'object',
+  required: ['users'],
+  properties: {
+    users: {
+      type: 'array',
+      items: AvailableUserSchema,
+      description: 'List of available users for team membership'
+    }
+  }
+};

--- a/api/src/openapi/schemas/team-policy.ts
+++ b/api/src/openapi/schemas/team-policy.ts
@@ -80,6 +80,25 @@ export const CreateTeamPolicyRequestSchema: OpenAPIV3.SchemaObject = {
 };
 
 /**
+ * Schema for create team-policies batch request body.
+ */
+export const CreateTeamPoliciesRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'CreateTeamPoliciesRequest',
+  type: 'object',
+  required: ['policies'],
+  properties: {
+    policies: {
+      type: 'array',
+      items: {
+        type: 'string',
+        format: 'uuid'
+      },
+      description: 'List of policy IDs to associate with a team'
+    }
+  }
+};
+
+/**
  * Schema for created team-policy response (basic, without names).
  */
 export const TeamPolicySchema: OpenAPIV3.SchemaObject = {
@@ -101,6 +120,22 @@ export const TeamPolicySchema: OpenAPIV3.SchemaObject = {
       type: 'string',
       format: 'uuid',
       description: 'ID of the policy'
+    }
+  }
+};
+
+/**
+ * Schema for create team-policies batch response.
+ */
+export const TeamPoliciesBatchSchema: OpenAPIV3.SchemaObject = {
+  title: 'TeamPoliciesBatch',
+  type: 'object',
+  required: ['team_policies'],
+  properties: {
+    team_policies: {
+      type: 'array',
+      items: TeamPolicySchema,
+      description: 'Processed team-policy associations for this request'
     }
   }
 };

--- a/api/src/openapi/schemas/team-policy.ts
+++ b/api/src/openapi/schemas/team-policy.ts
@@ -127,7 +127,7 @@ export const TeamPolicySchema: OpenAPIV3.SchemaObject = {
 /**
  * Schema for create team-policies batch response.
  */
-export const TeamPoliciesBatchSchema: OpenAPIV3.SchemaObject = {
+export const TeamPoliciesSchema: OpenAPIV3.SchemaObject = {
   title: 'TeamPoliciesBatch',
   type: 'object',
   required: ['team_policies'],

--- a/api/src/openapi/schemas/team.ts
+++ b/api/src/openapi/schemas/team.ts
@@ -8,30 +8,6 @@ import { OpenAPIV3 } from 'openapi-types';
 import { paginationResponseSchema } from './pagination';
 
 /**
- * Schema for a team member with user details.
- */
-export const TeamMemberWithUserSchema: OpenAPIV3.SchemaObject = {
-  title: 'TeamMemberWithUser',
-  type: 'object',
-  required: ['team_member_id', 'system_user_id', 'user_identifier'],
-  properties: {
-    team_member_id: {
-      type: 'string',
-      format: 'uuid',
-      description: 'Unique identifier for the team membership'
-    },
-    system_user_id: {
-      type: 'integer',
-      description: 'The system user ID of the team member'
-    },
-    user_identifier: {
-      type: 'string',
-      description: 'Username or identifier from identity provider'
-    }
-  }
-};
-
-/**
  * Schema for a team (without members).
  */
 export const TeamSchema: OpenAPIV3.SchemaObject = {
@@ -59,12 +35,12 @@ export const TeamSchema: OpenAPIV3.SchemaObject = {
 };
 
 /**
- * Schema for a team with its members.
+ * Schema for a team with member count.
  */
-export const TeamWithMembersSchema: OpenAPIV3.SchemaObject = {
-  title: 'TeamWithMembers',
+export const TeamWithMemberCountSchema: OpenAPIV3.SchemaObject = {
+  title: 'TeamWithMemberCount',
   type: 'object',
-  required: ['team_id', 'name', 'members'],
+  required: ['team_id', 'name', 'member_count'],
   properties: {
     team_id: {
       type: 'string',
@@ -82,10 +58,9 @@ export const TeamWithMembersSchema: OpenAPIV3.SchemaObject = {
       nullable: true,
       description: 'Description of the team'
     },
-    members: {
-      type: 'array',
-      items: TeamMemberWithUserSchema,
-      description: 'List of team members with user details'
+    member_count: {
+      type: 'integer',
+      description: 'Number of active members in the team'
     }
   }
 };
@@ -100,8 +75,8 @@ export const TeamsListResponseSchema: OpenAPIV3.SchemaObject = {
   properties: {
     teams: {
       type: 'array',
-      items: TeamWithMembersSchema,
-      description: 'List of teams with members'
+      items: TeamWithMemberCountSchema,
+      description: 'List of teams with member counts'
     },
     pagination: paginationResponseSchema
   }
@@ -125,7 +100,7 @@ export const CreateTeamRequestSchema: OpenAPIV3.SchemaObject = {
       maxLength: 1000,
       description: 'Description of the team'
     },
-    member_user_ids: {
+    system_user_ids: {
       type: 'array',
       items: { type: 'integer' },
       description: 'System user IDs to add as team members'
@@ -150,45 +125,10 @@ export const UpdateTeamRequestSchema: OpenAPIV3.SchemaObject = {
       maxLength: 1000,
       description: 'Description of the team'
     },
-    member_user_ids: {
+    system_user_ids: {
       type: 'array',
       items: { type: 'integer' },
       description: 'Complete list of system user IDs (replaces existing members)'
-    }
-  }
-};
-
-/**
- * Schema for an available user (for team membership selection).
- */
-export const AvailableUserSchema: OpenAPIV3.SchemaObject = {
-  title: 'AvailableUser',
-  type: 'object',
-  required: ['system_user_id', 'user_identifier'],
-  properties: {
-    system_user_id: {
-      type: 'integer',
-      description: 'Unique identifier for the system user'
-    },
-    user_identifier: {
-      type: 'string',
-      description: 'Username or identifier from identity provider'
-    }
-  }
-};
-
-/**
- * Schema for available users list response.
- */
-export const AvailableUsersListResponseSchema: OpenAPIV3.SchemaObject = {
-  title: 'AvailableUsersListResponse',
-  type: 'object',
-  required: ['users'],
-  properties: {
-    users: {
-      type: 'array',
-      items: AvailableUserSchema,
-      description: 'List of available users for team membership'
     }
   }
 };

--- a/api/src/openapi/schemas/team.ts
+++ b/api/src/openapi/schemas/team.ts
@@ -8,37 +8,10 @@ import { OpenAPIV3 } from 'openapi-types';
 import { paginationResponseSchema } from './pagination';
 
 /**
- * Schema for a team (without members).
+ * Schema for a team.
  */
 export const TeamSchema: OpenAPIV3.SchemaObject = {
   title: 'Team',
-  type: 'object',
-  required: ['team_id', 'name'],
-  properties: {
-    team_id: {
-      type: 'string',
-      format: 'uuid',
-      description: 'Unique identifier for the team'
-    },
-    name: {
-      type: 'string',
-      maxLength: 250,
-      description: 'Name of the team'
-    },
-    description: {
-      type: 'string',
-      maxLength: 1000,
-      nullable: true,
-      description: 'Description of the team'
-    }
-  }
-};
-
-/**
- * Schema for a team with member count.
- */
-export const TeamWithMemberCountSchema: OpenAPIV3.SchemaObject = {
-  title: 'TeamWithMemberCount',
   type: 'object',
   required: ['team_id', 'name', 'member_count'],
   properties: {
@@ -75,7 +48,7 @@ export const TeamsListResponseSchema: OpenAPIV3.SchemaObject = {
   properties: {
     teams: {
       type: 'array',
-      items: TeamWithMemberCountSchema,
+      items: TeamSchema,
       description: 'List of teams with member counts'
     },
     pagination: paginationResponseSchema

--- a/api/src/paths/administrative/policies/index.test.ts
+++ b/api/src/paths/administrative/policies/index.test.ts
@@ -39,7 +39,7 @@ describe('paths/administrative/policies/index', () => {
       }
     });
 
-    it('should call service.getPoliciesWithStatements and return policies with pagination', async () => {
+    it('should call service methods and return policies with pagination', async () => {
       const dbConnectionObj = getMockDBConnection({
         commit: sinon.stub(),
         rollback: sinon.stub(),
@@ -48,21 +48,23 @@ describe('paths/administrative/policies/index', () => {
 
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
+      const mockPolicies = [
+        {
+          policy_id: '1',
+          name: 'Test Policy',
+          description: 'Test description',
+          statements: []
+        }
+      ];
       const mockPoliciesResponse = {
-        policies: [
-          {
-            policy_id: '1',
-            name: 'Test Policy',
-            description: 'Test description',
-            statements: []
-          }
-        ],
-        pagination: { total: 1, per_page: 10, current_page: 1, last_page: 1 }
+        policies: mockPolicies,
+        pagination: { total: 1, per_page: 10, current_page: 1, last_page: 1, sort: undefined, order: undefined }
       };
 
       const getPoliciesWithStatementsStub = sinon
         .stub(PolicyService.prototype, 'getPoliciesWithStatements')
-        .resolves(mockPoliciesResponse);
+        .resolves(mockPolicies);
+      const getPoliciesCountStub = sinon.stub(PolicyService.prototype, 'getPoliciesCount').resolves(1);
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -75,17 +77,21 @@ describe('paths/administrative/policies/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(undefined, {
-        page: 1,
-        limit: 10,
-        sort: undefined,
-        order: undefined
-      });
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(
+        { search: undefined },
+        {
+          page: 1,
+          limit: 10,
+          sort: undefined,
+          order: undefined
+        }
+      );
+      expect(getPoliciesCountStub).to.have.been.calledOnceWith({ search: undefined });
       expect(mockRes.statusValue).to.equal(200);
       expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
     });
 
-    it('should call service.getPoliciesWithStatements with search parameter', async () => {
+    it('should call service methods with search parameter', async () => {
       const dbConnectionObj = getMockDBConnection({
         commit: sinon.stub(),
         rollback: sinon.stub(),
@@ -94,14 +100,10 @@ describe('paths/administrative/policies/index', () => {
 
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
-      const mockPoliciesResponse = {
-        policies: [],
-        pagination: { total: 0, per_page: 25, current_page: 2, last_page: 1 }
-      };
-
       const getPoliciesWithStatementsStub = sinon
         .stub(PolicyService.prototype, 'getPoliciesWithStatements')
-        .resolves(mockPoliciesResponse);
+        .resolves([]);
+      const getPoliciesCountStub = sinon.stub(PolicyService.prototype, 'getPoliciesCount').resolves(0);
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -115,14 +117,21 @@ describe('paths/administrative/policies/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith('test', {
-        page: 2,
-        limit: 25,
-        sort: undefined,
-        order: undefined
-      });
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(
+        { search: 'test' },
+        {
+          page: 2,
+          limit: 25,
+          sort: undefined,
+          order: undefined
+        }
+      );
+      expect(getPoliciesCountStub).to.have.been.calledOnceWith({ search: 'test' });
       expect(mockRes.statusValue).to.equal(200);
-      expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
+      expect(mockRes.jsonValue).to.eql({
+        policies: [],
+        pagination: { total: 0, per_page: 25, current_page: 2, last_page: 1, sort: undefined, order: undefined }
+      });
     });
 
     it('should call service.getPoliciesWithStatements with sort ascending', async () => {
@@ -144,7 +153,8 @@ describe('paths/administrative/policies/index', () => {
 
       const getPoliciesWithStatementsStub = sinon
         .stub(PolicyService.prototype, 'getPoliciesWithStatements')
-        .resolves(mockPoliciesResponse);
+        .resolves(mockPoliciesResponse.policies);
+      const getPoliciesCountStub = sinon.stub(PolicyService.prototype, 'getPoliciesCount').resolves(2);
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -159,12 +169,16 @@ describe('paths/administrative/policies/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(undefined, {
-        page: 1,
-        limit: 10,
-        sort: 'name',
-        order: 'asc'
-      });
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(
+        { search: undefined },
+        {
+          page: 1,
+          limit: 10,
+          sort: 'name',
+          order: 'asc'
+        }
+      );
+      expect(getPoliciesCountStub).to.have.been.calledOnceWith({ search: undefined });
       expect(mockRes.statusValue).to.equal(200);
       expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
     });
@@ -188,7 +202,8 @@ describe('paths/administrative/policies/index', () => {
 
       const getPoliciesWithStatementsStub = sinon
         .stub(PolicyService.prototype, 'getPoliciesWithStatements')
-        .resolves(mockPoliciesResponse);
+        .resolves(mockPoliciesResponse.policies);
+      const getPoliciesCountStub = sinon.stub(PolicyService.prototype, 'getPoliciesCount').resolves(2);
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -203,12 +218,16 @@ describe('paths/administrative/policies/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(undefined, {
-        page: 1,
-        limit: 10,
-        sort: 'name',
-        order: 'desc'
-      });
+      expect(getPoliciesWithStatementsStub).to.have.been.calledOnceWith(
+        { search: undefined },
+        {
+          page: 1,
+          limit: 10,
+          sort: 'name',
+          order: 'desc'
+        }
+      );
+      expect(getPoliciesCountStub).to.have.been.calledOnceWith({ search: undefined });
       expect(mockRes.statusValue).to.equal(200);
       expect(mockRes.jsonValue).to.eql(mockPoliciesResponse);
     });

--- a/api/src/paths/administrative/policies/index.test.ts
+++ b/api/src/paths/administrative/policies/index.test.ts
@@ -308,7 +308,7 @@ describe('paths/administrative/policies/index', () => {
       expect(mockRes.jsonValue).to.eql(mockCreatedPolicy);
     });
 
-    it('should call service.createPolicyWithStatements with empty statements array', async () => {
+    it('should call service.createPolicyWithStatements with provided empty statements array', async () => {
       const dbConnectionObj = getMockDBConnection({
         commit: sinon.stub(),
         rollback: sinon.stub(),
@@ -331,7 +331,8 @@ describe('paths/administrative/policies/index', () => {
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
       mockReq.body = {
-        name: 'Empty Policy'
+        name: 'Empty Policy',
+        statements: []
       };
 
       const requestHandler = createPolicy();

--- a/api/src/paths/administrative/policies/index.ts
+++ b/api/src/paths/administrative/policies/index.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
+import { CreatePolicyRequest } from '../../../models/policy';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
 import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
 import {
@@ -153,13 +154,13 @@ export function createPolicy(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req['keycloak_token']);
 
-    const { name, description, statements } = req.body;
+    const { name, description, statements } = req.body as CreatePolicyRequest;
 
     try {
       await connection.open();
 
       const policyService = new PolicyService(connection);
-      const response = await policyService.createPolicyWithStatements({ name, description }, statements || []);
+      const response = await policyService.createPolicyWithStatements({ name, description }, statements);
 
       await connection.commit();
 

--- a/api/src/paths/administrative/policies/index.ts
+++ b/api/src/paths/administrative/policies/index.ts
@@ -12,7 +12,11 @@ import {
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { PolicyService } from '../../../services/access-policy/policy-service';
 import { getLogger } from '../../../utils/logger';
-import { ApiPaginationOptions } from '../../../zod-schema/pagination';
+import {
+  ensureCompletePaginationOptions,
+  makePaginationOptionsFromRequest,
+  makePaginationResponse
+} from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/administrative/policies');
 
@@ -71,22 +75,21 @@ export function getPolicies(): RequestHandler {
     const connection = getDBConnection(req['keycloak_token']);
 
     const search = req.query.search as string | undefined;
-    const pagination: ApiPaginationOptions = {
-      page: Number(req.query.page) || 1,
-      limit: Math.min(Number(req.query.limit) || 10, 100),
-      sort: req.query.sort as string | undefined,
-      order: req.query.order as 'asc' | 'desc' | undefined
-    };
 
     try {
       await connection.open();
 
       const policyService = new PolicyService(connection);
-      const response = await policyService.getPoliciesWithStatements(search, pagination);
+      const filters = { search };
+      const pagination = makePaginationOptionsFromRequest(req);
+      const [policies, count] = await Promise.all([
+        policyService.getPoliciesWithStatements(filters, ensureCompletePaginationOptions(pagination)),
+        policyService.getPoliciesCount(filters)
+      ]);
 
       await connection.commit();
 
-      return res.status(200).json(response);
+      return res.status(200).json({ policies, pagination: makePaginationResponse(count, pagination) });
     } catch (error) {
       defaultLog.error({ label: 'getPolicies', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/administrative/policies/{policyId}/index.test.ts
+++ b/api/src/paths/administrative/policies/{policyId}/index.test.ts
@@ -162,7 +162,7 @@ describe('paths/administrative/policies/{policyId}/index', () => {
       expect(mockRes.jsonValue).to.eql(mockUpdatedPolicy);
     });
 
-    it('should call service.updatePolicyWithStatements with empty statements array', async () => {
+    it('should call service.updatePolicyWithStatements with provided empty statements array', async () => {
       const dbConnectionObj = getMockDBConnection({
         commit: sinon.stub(),
         rollback: sinon.stub(),
@@ -188,7 +188,8 @@ describe('paths/administrative/policies/{policyId}/index', () => {
         policyId: '123'
       };
       mockReq.body = {
-        name: 'Policy No Statements'
+        name: 'Policy No Statements',
+        statements: []
       };
 
       const requestHandler = updatePolicy();

--- a/api/src/paths/administrative/policies/{policyId}/index.ts
+++ b/api/src/paths/administrative/policies/{policyId}/index.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../constants/roles';
 import { getDBConnection } from '../../../../database/db';
+import { UpdatePolicyRequest } from '../../../../models/policy';
 import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
 import { PolicyWithStatementsSchema, UpdatePolicyRequestSchema } from '../../../../openapi/schemas/policy';
 import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
@@ -153,17 +154,13 @@ export function updatePolicy(): RequestHandler {
     const connection = getDBConnection(req['keycloak_token']);
 
     const policyId = req.params.policyId;
-    const { name, description, statements } = req.body;
+    const { name, description, statements } = req.body as UpdatePolicyRequest;
 
     try {
       await connection.open();
 
       const policyService = new PolicyService(connection);
-      const response = await policyService.updatePolicyWithStatements(
-        policyId,
-        { name, description },
-        statements || []
-      );
+      const response = await policyService.updatePolicyWithStatements(policyId, { name, description }, statements);
 
       await connection.commit();
 

--- a/api/src/paths/administrative/team-policies/index.test.ts
+++ b/api/src/paths/administrative/team-policies/index.test.ts
@@ -36,10 +36,11 @@ describe('team-policies', () => {
 
       const mockResponse = {
         team_policies: mockTeamPolicies,
-        pagination: { total: 1, per_page: 10, current_page: 1, last_page: 1 }
+        pagination: { total: 1, per_page: 10, current_page: 1, last_page: 1, sort: undefined, order: undefined }
       };
 
-      sinon.stub(TeamPolicyService.prototype, 'getAllTeamPoliciesWithPagination').resolves(mockResponse);
+      sinon.stub(TeamPolicyService.prototype, 'getAllTeamPolicies').resolves(mockTeamPolicies);
+      sinon.stub(TeamPolicyService.prototype, 'getAllTeamPoliciesCount').resolves(1);
 
       const requestHandler = teamPolicies.getTeamPolicies();
 
@@ -57,23 +58,25 @@ describe('team-policies', () => {
 
       sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
 
-      const mockResponse = {
-        team_policies: [],
-        pagination: { total: 0, per_page: 10, current_page: 1, last_page: 1, sort: 'team_name', order: 'desc' as const }
-      };
-
-      const stub = sinon.stub(TeamPolicyService.prototype, 'getAllTeamPoliciesWithPagination').resolves(mockResponse);
+      const getAllTeamPoliciesStub = sinon.stub(TeamPolicyService.prototype, 'getAllTeamPolicies').resolves([]);
+      const getAllTeamPoliciesCountStub = sinon
+        .stub(TeamPolicyService.prototype, 'getAllTeamPoliciesCount')
+        .resolves(0);
 
       const requestHandler = teamPolicies.getTeamPolicies();
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(stub).to.have.been.calledWith({
-        page: 1,
-        limit: 10,
-        sort: 'team_name',
-        order: 'desc'
-      });
+      expect(getAllTeamPoliciesStub).to.have.been.calledWith(
+        { search: undefined },
+        {
+          page: 1,
+          limit: 10,
+          sort: 'team_name',
+          order: 'desc'
+        }
+      );
+      expect(getAllTeamPoliciesCountStub).to.have.been.calledWith({ search: undefined });
     });
   });
 

--- a/api/src/paths/administrative/team-policies/index.ts
+++ b/api/src/paths/administrative/team-policies/index.ts
@@ -12,7 +12,11 @@ import {
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamPolicyService } from '../../../services/access-policy/team-policy-service';
 import { getLogger } from '../../../utils/logger';
-import { ApiPaginationOptions } from '../../../zod-schema/pagination';
+import {
+  ensureCompletePaginationOptions,
+  makePaginationOptionsFromRequest,
+  makePaginationResponse
+} from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/administrative/team-policies');
 
@@ -38,7 +42,16 @@ GET.apiDoc = {
       Bearer: []
     }
   ],
-  parameters: [...paginationRequestQueryParamSchema],
+  parameters: [
+    ...paginationRequestQueryParamSchema,
+    {
+      in: 'query',
+      name: 'search',
+      required: false,
+      schema: { type: 'string' },
+      description: 'Search term to filter by team or policy name'
+    }
+  ],
   responses: {
     200: {
       description: 'List of team-policy associations.',
@@ -60,23 +73,24 @@ GET.apiDoc = {
 export function getTeamPolicies(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req['keycloak_token']);
-
-    const pagination: ApiPaginationOptions = {
-      page: Number(req.query.page) || 1,
-      limit: Math.min(Number(req.query.limit) || 10, 100),
-      sort: req.query.sort as string | undefined,
-      order: req.query.order as 'asc' | 'desc' | undefined
-    };
+    const search = req.query.search as string | undefined;
 
     try {
       await connection.open();
 
       const teamPolicyService = new TeamPolicyService(connection);
-      const response = await teamPolicyService.getAllTeamPoliciesWithPagination(pagination);
+      const filters = { search };
+      const pagination = makePaginationOptionsFromRequest(req);
+      const [teamPolicies, count] = await Promise.all([
+        teamPolicyService.getAllTeamPolicies(filters, ensureCompletePaginationOptions(pagination)),
+        teamPolicyService.getAllTeamPoliciesCount(filters)
+      ]);
 
       await connection.commit();
 
-      return res.status(200).json(response);
+      return res
+        .status(200)
+        .json({ team_policies: teamPolicies, pagination: makePaginationResponse(count, pagination) });
     } catch (error) {
       defaultLog.error({ label: 'getTeamPolicies', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/administrative/team-policies/index.ts
+++ b/api/src/paths/administrative/team-policies/index.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
+import { CreateTeamPolicy } from '../../../models/team-policy';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
 import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
 import {
@@ -154,7 +155,7 @@ export function createTeamPolicy(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req['keycloak_token']);
 
-    const { team_id, policy_id } = req.body;
+    const { team_id, policy_id } = req.body as CreateTeamPolicy;
 
     try {
       await connection.open();

--- a/api/src/paths/administrative/teams/index.test.ts
+++ b/api/src/paths/administrative/teams/index.test.ts
@@ -3,6 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as db from '../../../database/db';
+import { Team } from '../../../models/team';
 import { TeamService } from '../../../services/access-policy/team-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
 import { createTeam, getTeams } from './index';
@@ -37,14 +38,18 @@ describe('getTeams', () => {
   });
 
   it('should return 200 with paginated teams', async () => {
-    const mockTeams = {
-      teams: [{ team_id: 'team-1', name: 'Team Alpha', description: 'First', members: [] }],
-      pagination: { total: 1, per_page: 50, current_page: 1, last_page: 1 }
+    const mockTeams: Team[] = [
+      { team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34', name: 'Team Alpha', description: 'First', member_count: 0 }
+    ];
+    const mockResponse = {
+      teams: mockTeams,
+      pagination: { total: 1, per_page: 50, current_page: 1, last_page: 1, sort: undefined, order: undefined }
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    sinon.stub(TeamService.prototype, 'getTeamsWithMembers').resolves(mockTeams);
+    sinon.stub(TeamService.prototype, 'getTeams').resolves(mockTeams);
+    sinon.stub(TeamService.prototype, 'getTeamsCount').resolves(1);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.query = { page: '1', limit: '50' };
@@ -53,16 +58,14 @@ describe('getTeams', () => {
     await requestHandler(mockReq, mockRes, mockNext);
 
     expect(mockRes.statusValue).to.equal(200);
-    expect(mockRes.jsonValue).to.eql(mockTeams);
+    expect(mockRes.jsonValue).to.eql(mockResponse);
   });
 
   it('should filter by search parameter', async () => {
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const getTeamsStub = sinon.stub(TeamService.prototype, 'getTeamsWithMembers').resolves({
-      teams: [],
-      pagination: { total: 0, per_page: 50, current_page: 1, last_page: 1 }
-    });
+    const getTeamsStub = sinon.stub(TeamService.prototype, 'getTeams').resolves([]);
+    const getTeamsCountStub = sinon.stub(TeamService.prototype, 'getTeamsCount').resolves(0);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.query = { page: '1', limit: '50', search: 'Research' };
@@ -70,21 +73,23 @@ describe('getTeams', () => {
     const requestHandler = getTeams();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(getTeamsStub).to.have.been.calledWith('Research', {
-      page: 1,
-      limit: 50,
-      sort: undefined,
-      order: undefined
-    });
+    expect(getTeamsStub).to.have.been.calledWith(
+      { search: 'Research' },
+      {
+        page: 1,
+        limit: 50,
+        sort: undefined,
+        order: undefined
+      }
+    );
+    expect(getTeamsCountStub).to.have.been.calledWith({ search: 'Research' });
   });
 
-  it('should cap limit at 100', async () => {
+  it('should pass through limit from query params', async () => {
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const getTeamsStub = sinon.stub(TeamService.prototype, 'getTeamsWithMembers').resolves({
-      teams: [],
-      pagination: { total: 0, per_page: 100, current_page: 1, last_page: 1 }
-    });
+    const getTeamsStub = sinon.stub(TeamService.prototype, 'getTeams').resolves([]);
+    sinon.stub(TeamService.prototype, 'getTeamsCount').resolves(0);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.query = { page: '1', limit: '500' };
@@ -92,12 +97,15 @@ describe('getTeams', () => {
     const requestHandler = getTeams();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(getTeamsStub).to.have.been.calledWith(undefined, {
-      page: 1,
-      limit: 100,
-      sort: undefined,
-      order: undefined
-    });
+    expect(getTeamsStub).to.have.been.calledWith(
+      { search: undefined },
+      {
+        page: 1,
+        limit: 500,
+        sort: undefined,
+        order: undefined
+      }
+    );
   });
 });
 
@@ -129,60 +137,65 @@ describe('createTeam', () => {
   });
 
   it('should return 201 with created team', async () => {
-    const mockTeam = {
-      team_id: 'new-team',
+    const mockTeam: Team = {
+      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
       name: 'New Team',
       description: 'A new team',
-      members: []
+      member_count: 0
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves(mockTeam);
+    const createStub = sinon.stub(TeamService.prototype, 'createTeam').resolves(mockTeam);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-    mockReq.body = { name: 'New Team', description: 'A new team', member_user_ids: [] };
+    mockReq.body = { name: 'New Team', description: 'A new team', system_user_ids: [] };
 
     const requestHandler = createTeam();
     await requestHandler(mockReq, mockRes, mockNext);
 
+    expect(createStub).to.have.been.calledWith({ name: 'New Team', description: 'A new team', system_user_ids: [] });
     expect(mockRes.statusValue).to.equal(201);
     expect(mockRes.jsonValue).to.eql(mockTeam);
   });
 
   it('should create team with members', async () => {
-    const mockTeam = {
-      team_id: 'new-team',
+    const mockTeam: Team = {
+      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
       name: 'Team with Members',
       description: null,
-      members: [{ team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' }]
+      member_count: 1
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const createStub = sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves(mockTeam);
+    const createStub = sinon.stub(TeamService.prototype, 'createTeam').resolves(mockTeam);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-    mockReq.body = { name: 'Team with Members', member_user_ids: [1] };
+    mockReq.body = { name: 'Team with Members', system_user_ids: [1] };
 
     const requestHandler = createTeam();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(createStub).to.have.been.calledWith({ name: 'Team with Members', description: undefined }, [1]);
+    expect(createStub).to.have.been.calledWith({
+      name: 'Team with Members',
+      description: undefined,
+      system_user_ids: [1]
+    });
     expect(mockRes.statusValue).to.equal(201);
   });
 
-  it('should default member_user_ids to empty array when not provided', async () => {
-    const mockTeam = {
-      team_id: 'new-team',
+  it('should default system_user_ids to empty array when not provided', async () => {
+    const mockTeam: Team = {
+      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
       name: 'Empty Team',
       description: null,
-      members: []
+      member_count: 0
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const createStub = sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves(mockTeam);
+    const createStub = sinon.stub(TeamService.prototype, 'createTeam').resolves(mockTeam);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.body = { name: 'Empty Team' };
@@ -190,6 +203,10 @@ describe('createTeam', () => {
     const requestHandler = createTeam();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(createStub).to.have.been.calledWith({ name: 'Empty Team', description: undefined }, []);
+    expect(createStub).to.have.been.calledWith({
+      name: 'Empty Team',
+      description: undefined,
+      system_user_ids: undefined
+    });
   });
 });

--- a/api/src/paths/administrative/teams/index.test.ts
+++ b/api/src/paths/administrative/teams/index.test.ts
@@ -184,29 +184,4 @@ describe('createTeam', () => {
     });
     expect(mockRes.statusValue).to.equal(201);
   });
-
-  it('should default system_user_ids to empty array when not provided', async () => {
-    const mockTeam: Team = {
-      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
-      name: 'Empty Team',
-      description: null,
-      member_count: 0
-    };
-
-    const mockDBConnection = getMockDBConnection();
-    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const createStub = sinon.stub(TeamService.prototype, 'createTeam').resolves(mockTeam);
-
-    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-    mockReq.body = { name: 'Empty Team' };
-
-    const requestHandler = createTeam();
-    await requestHandler(mockReq, mockRes, mockNext);
-
-    expect(createStub).to.have.been.calledWith({
-      name: 'Empty Team',
-      description: undefined,
-      system_user_ids: undefined
-    });
-  });
 });

--- a/api/src/paths/administrative/teams/index.ts
+++ b/api/src/paths/administrative/teams/index.ts
@@ -2,13 +2,10 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
+import { CreateTeam } from '../../../models/team';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
 import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
-import {
-  CreateTeamRequestSchema,
-  TeamsListResponseSchema,
-  TeamWithMemberCountSchema
-} from '../../../openapi/schemas/team';
+import { CreateTeamRequestSchema, TeamSchema, TeamsListResponseSchema } from '../../../openapi/schemas/team';
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamService } from '../../../services/access-policy/team-service';
 import { getLogger } from '../../../utils/logger';
@@ -24,7 +21,7 @@ export const GET: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]
@@ -98,7 +95,7 @@ export const POST: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]
@@ -123,7 +120,7 @@ POST.apiDoc = {
       description: 'Team created',
       content: {
         'application/json': {
-          schema: TeamWithMemberCountSchema
+          schema: TeamSchema
         }
       }
     },
@@ -139,7 +136,7 @@ POST.apiDoc = {
 export function createTeam(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
-    const { name, description, system_user_ids } = req.body;
+    const { name, description, system_user_ids } = req.body as CreateTeam;
 
     try {
       await connection.open();

--- a/api/src/paths/administrative/teams/index.ts
+++ b/api/src/paths/administrative/teams/index.ts
@@ -4,23 +4,36 @@ import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
 import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
-import { CreateTeamRequestSchema, TeamsListResponseSchema, TeamWithMembersSchema } from '../../../openapi/schemas/team';
+import {
+  CreateTeamRequestSchema,
+  TeamsListResponseSchema,
+  TeamWithMemberCountSchema
+} from '../../../openapi/schemas/team';
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamService } from '../../../services/access-policy/team-service';
 import { getLogger } from '../../../utils/logger';
-import { ApiPaginationOptions } from '../../../zod-schema/pagination';
+import {
+  ensureCompletePaginationOptions,
+  makePaginationOptionsFromRequest,
+  makePaginationResponse
+} from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/administrative/teams');
 
 export const GET: Operation = [
   authorizeRequestHandler(() => ({
-    and: [{ validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR], discriminator: 'SystemRole' }]
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
   })),
   getTeams()
 ];
 
 GET.apiDoc = {
-  description: 'Get all teams with optional pagination and search.',
+  description: 'Get all teams with optional pagination and search (includes member_count only).',
   tags: ['admin'],
   security: [{ Bearer: [] }],
   parameters: [
@@ -35,8 +48,12 @@ GET.apiDoc = {
   ],
   responses: {
     200: {
-      description: 'List of teams with members',
-      content: { 'application/json': { schema: TeamsListResponseSchema } }
+      description: 'List of teams with member counts',
+      content: {
+        'application/json': {
+          schema: TeamsListResponseSchema
+        }
+      }
     },
     ...defaultErrorResponses
   }
@@ -50,21 +67,23 @@ GET.apiDoc = {
 export function getTeams(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
-
     const search = req.query.search as string | undefined;
-    const pagination: ApiPaginationOptions = {
-      page: Number(req.query.page) || 1,
-      limit: Math.min(Number(req.query.limit) || 10, 100),
-      sort: req.query.sort as string | undefined,
-      order: req.query.order as 'asc' | 'desc' | undefined
-    };
 
     try {
       await connection.open();
+
       const teamService = new TeamService(connection);
-      const result = await teamService.getTeamsWithMembers(search, pagination);
+      const filters = { search };
+      const pagination = makePaginationOptionsFromRequest(req);
+
+      const [teams, count] = await Promise.all([
+        teamService.getTeams(filters, ensureCompletePaginationOptions(pagination)),
+        teamService.getTeamsCount(filters)
+      ]);
+
       await connection.commit();
-      return res.status(200).json(result);
+
+      return res.status(200).json({ teams, pagination: makePaginationResponse(count, pagination) });
     } catch (error) {
       defaultLog.error({ label: 'getTeams', message: 'error', error });
       await connection.rollback();
@@ -77,42 +96,55 @@ export function getTeams(): RequestHandler {
 
 export const POST: Operation = [
   authorizeRequestHandler(() => ({
-    and: [{ validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR], discriminator: 'SystemRole' }]
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
   })),
   createTeam()
 ];
 
 POST.apiDoc = {
-  description: 'Create a new team with members.',
+  description: 'Create a new team.',
   tags: ['admin'],
   security: [{ Bearer: [] }],
   requestBody: {
     required: true,
-    content: { 'application/json': { schema: CreateTeamRequestSchema } }
+    content: {
+      'application/json': {
+        schema: CreateTeamRequestSchema
+      }
+    }
   },
   responses: {
     201: {
       description: 'Team created',
-      content: { 'application/json': { schema: TeamWithMembersSchema } }
+      content: {
+        'application/json': {
+          schema: TeamWithMemberCountSchema
+        }
+      }
     },
     ...defaultErrorResponses
   }
 };
 
 /**
- * Create a new team with members.
+ * Create a new team.
  *
  * @returns {RequestHandler}
  */
 export function createTeam(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
-    const { name, description, member_user_ids } = req.body;
+    const { name, description, system_user_ids } = req.body;
 
     try {
       await connection.open();
       const teamService = new TeamService(connection);
-      const result = await teamService.createTeamWithMembers({ name, description }, member_user_ids || []);
+      const result = await teamService.createTeam({ name, description, system_user_ids });
       await connection.commit();
       return res.status(201).json(result);
     } catch (error) {

--- a/api/src/paths/administrative/teams/{teamId}/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.test.ts
@@ -4,8 +4,6 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as db from '../../../../database/db';
 import { Team } from '../../../../models/team';
-import { TeamMemberWithUser } from '../../../../models/team-member';
-import { TeamMemberService } from '../../../../services/access-policy/team-member-service';
 import { TeamService } from '../../../../services/access-policy/team-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
 import { deleteTeam, getTeam, updateTeam } from './index';
@@ -61,7 +59,6 @@ describe('getTeam', () => {
     expect(mockRes.jsonValue).to.eql(mockTeam);
   });
 });
-
 describe('updateTeam', () => {
   afterEach(() => {
     sinon.restore();
@@ -84,7 +81,7 @@ describe('updateTeam', () => {
 
     try {
       await requestHandler(mockReq, mockRes, mockNext);
-      expect.fail();
+      expect.fail('Expected error to be thrown');
     } catch (actualError) {
       expect((actualError as Error).message).to.equal('test error');
     }
@@ -97,29 +94,23 @@ describe('updateTeam', () => {
       description: 'Updated description',
       member_count: 0
     };
-    const mockTeamMember: TeamMemberWithUser = {
-      team_member_id: 'bff717d7-6ff2-45fd-ab17-5b3144029f4f',
-      system_user_id: 1,
-      user_identifier: 'user1',
-      email: 'user1@test.com'
-    };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
     const updateStub = sinon.stub(TeamService.prototype, 'updateTeam').resolves(mockTeam);
-    sinon.stub(TeamService.prototype, 'getTeam').resolves(mockTeam);
-    sinon.stub(TeamMemberService.prototype, 'getTeamMembers').resolves([]);
-    sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(mockTeamMember);
-    sinon.stub(TeamMemberService.prototype, 'deleteTeamMember').resolves();
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.params = { teamId: 'team-1' };
-    mockReq.body = { name: 'Updated Team', description: 'Updated description', system_user_ids: [] };
+    mockReq.body = { name: 'Updated Team', description: 'Updated description', system_user_ids: [1, 2] };
 
     const requestHandler = updateTeam();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(updateStub).to.have.been.calledWith('team-1', { name: 'Updated Team', description: 'Updated description' });
+    expect(updateStub).to.have.been.calledWith('team-1', {
+      name: 'Updated Team',
+      description: 'Updated description',
+      system_user_ids: [1, 2]
+    });
     expect(mockRes.statusValue).to.equal(200);
     expect(mockRes.jsonValue).to.eql(mockTeam);
   });
@@ -128,32 +119,28 @@ describe('updateTeam', () => {
     const mockTeam: Team = {
       team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
       name: 'Updated Team',
-      description: null,
+      description: 'Some description',
       member_count: 0
-    };
-    const mockTeamMember: TeamMemberWithUser = {
-      team_member_id: 'bff717d7-6ff2-45fd-ab17-5b3144029f4f',
-      system_user_id: 1,
-      user_identifier: 'user1',
-      email: 'user1@test.com'
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
     const updateStub = sinon.stub(TeamService.prototype, 'updateTeam').resolves(mockTeam);
-    sinon.stub(TeamService.prototype, 'getTeam').resolves(mockTeam);
-    sinon.stub(TeamMemberService.prototype, 'getTeamMembers').resolves([]);
-    sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(mockTeamMember);
-    sinon.stub(TeamMemberService.prototype, 'deleteTeamMember').resolves();
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.params = { teamId: 'team-1' };
-    mockReq.body = { name: 'Updated Team' };
+    mockReq.body = { name: 'Updated Team', description: 'Some description' };
 
     const requestHandler = updateTeam();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(updateStub).to.have.been.calledWith('team-1', { name: 'Updated Team', description: undefined });
+    expect(updateStub).to.have.been.calledWith('team-1', {
+      name: 'Updated Team',
+      description: 'Some description',
+      system_user_ids: undefined
+    });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockTeam);
   });
 });
 

--- a/api/src/paths/administrative/teams/{teamId}/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.test.ts
@@ -114,34 +114,6 @@ describe('updateTeam', () => {
     expect(mockRes.statusValue).to.equal(200);
     expect(mockRes.jsonValue).to.eql(mockTeam);
   });
-
-  it('should default system_user_ids to empty array when not provided', async () => {
-    const mockTeam: Team = {
-      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
-      name: 'Updated Team',
-      description: 'Some description',
-      member_count: 0
-    };
-
-    const mockDBConnection = getMockDBConnection();
-    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const updateStub = sinon.stub(TeamService.prototype, 'updateTeam').resolves(mockTeam);
-
-    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-    mockReq.params = { teamId: 'team-1' };
-    mockReq.body = { name: 'Updated Team', description: 'Some description' };
-
-    const requestHandler = updateTeam();
-    await requestHandler(mockReq, mockRes, mockNext);
-
-    expect(updateStub).to.have.been.calledWith('team-1', {
-      name: 'Updated Team',
-      description: 'Some description',
-      system_user_ids: undefined
-    });
-    expect(mockRes.statusValue).to.equal(200);
-    expect(mockRes.jsonValue).to.eql(mockTeam);
-  });
 });
 
 describe('deleteTeam', () => {

--- a/api/src/paths/administrative/teams/{teamId}/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as db from '../../../../database/db';
 import { Team } from '../../../../models/team';
-import { TeamMemberWithUser } from '../../../../repositories/authorization/team-member-repository';
+import { TeamMemberWithUser } from '../../../../models/team-member';
 import { TeamMemberService } from '../../../../services/access-policy/team-member-service';
 import { TeamService } from '../../../../services/access-policy/team-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';

--- a/api/src/paths/administrative/teams/{teamId}/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.test.ts
@@ -3,6 +3,9 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as db from '../../../../database/db';
+import { Team } from '../../../../models/team';
+import { TeamMemberWithUser } from '../../../../repositories/authorization/team-member-repository';
+import { TeamMemberService } from '../../../../services/access-policy/team-member-service';
 import { TeamService } from '../../../../services/access-policy/team-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
 import { deleteTeam, getTeam, updateTeam } from './index';
@@ -36,17 +39,17 @@ describe('getTeam', () => {
     }
   });
 
-  it('should return 200 with team and members', async () => {
-    const mockTeam = {
-      team_id: 'team-1',
+  it('should return 200 with team details', async () => {
+    const mockTeam: Team = {
+      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
       name: 'Test Team',
       description: 'A test team',
-      members: [{ team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' }]
+      member_count: 1
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    sinon.stub(TeamService.prototype, 'getTeamWithMembers').resolves(mockTeam);
+    sinon.stub(TeamService.prototype, 'getTeam').resolves(mockTeam);
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.params = { teamId: 'team-1' };
@@ -88,44 +91,60 @@ describe('updateTeam', () => {
   });
 
   it('should return 200 with updated team', async () => {
-    const mockTeam = {
-      team_id: 'team-1',
+    const mockTeam: Team = {
+      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
       name: 'Updated Team',
       description: 'Updated description',
-      members: []
+      member_count: 0
+    };
+    const mockTeamMember: TeamMemberWithUser = {
+      team_member_id: 'bff717d7-6ff2-45fd-ab17-5b3144029f4f',
+      system_user_id: 1,
+      user_identifier: 'user1',
+      email: 'user1@test.com'
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const updateStub = sinon.stub(TeamService.prototype, 'updateTeamWithMembers').resolves(mockTeam);
+    const updateStub = sinon.stub(TeamService.prototype, 'updateTeam').resolves(mockTeam);
+    sinon.stub(TeamService.prototype, 'getTeam').resolves(mockTeam);
+    sinon.stub(TeamMemberService.prototype, 'getTeamMembers').resolves([]);
+    sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(mockTeamMember);
+    sinon.stub(TeamMemberService.prototype, 'deleteTeamMember').resolves();
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.params = { teamId: 'team-1' };
-    mockReq.body = { name: 'Updated Team', description: 'Updated description', member_user_ids: [] };
+    mockReq.body = { name: 'Updated Team', description: 'Updated description', system_user_ids: [] };
 
     const requestHandler = updateTeam();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(updateStub).to.have.been.calledWith(
-      'team-1',
-      { name: 'Updated Team', description: 'Updated description' },
-      []
-    );
+    expect(updateStub).to.have.been.calledWith('team-1', { name: 'Updated Team', description: 'Updated description' });
     expect(mockRes.statusValue).to.equal(200);
     expect(mockRes.jsonValue).to.eql(mockTeam);
   });
 
-  it('should default member_user_ids to empty array when not provided', async () => {
-    const mockTeam = {
-      team_id: 'team-1',
+  it('should default system_user_ids to empty array when not provided', async () => {
+    const mockTeam: Team = {
+      team_id: '5d92f13c-fefa-49f3-9fb9-4e4611c67a34',
       name: 'Updated Team',
       description: null,
-      members: []
+      member_count: 0
+    };
+    const mockTeamMember: TeamMemberWithUser = {
+      team_member_id: 'bff717d7-6ff2-45fd-ab17-5b3144029f4f',
+      system_user_id: 1,
+      user_identifier: 'user1',
+      email: 'user1@test.com'
     };
 
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const updateStub = sinon.stub(TeamService.prototype, 'updateTeamWithMembers').resolves(mockTeam);
+    const updateStub = sinon.stub(TeamService.prototype, 'updateTeam').resolves(mockTeam);
+    sinon.stub(TeamService.prototype, 'getTeam').resolves(mockTeam);
+    sinon.stub(TeamMemberService.prototype, 'getTeamMembers').resolves([]);
+    sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(mockTeamMember);
+    sinon.stub(TeamMemberService.prototype, 'deleteTeamMember').resolves();
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.params = { teamId: 'team-1' };
@@ -134,7 +153,7 @@ describe('updateTeam', () => {
     const requestHandler = updateTeam();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(updateStub).to.have.been.calledWith('team-1', { name: 'Updated Team', description: undefined }, []);
+    expect(updateStub).to.have.been.calledWith('team-1', { name: 'Updated Team', description: undefined });
   });
 });
 

--- a/api/src/paths/administrative/teams/{teamId}/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.ts
@@ -2,8 +2,9 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../constants/roles';
 import { getDBConnection } from '../../../../database/db';
+import { UpdateTeamRequest } from '../../../../models/team';
 import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
-import { TeamWithMemberCountSchema, UpdateTeamRequestSchema } from '../../../../openapi/schemas/team';
+import { TeamSchema, UpdateTeamRequestSchema } from '../../../../openapi/schemas/team';
 import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
 import { TeamMemberService } from '../../../../services/access-policy/team-member-service';
 import { TeamService } from '../../../../services/access-policy/team-service';
@@ -15,7 +16,7 @@ export const GET: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]
@@ -41,7 +42,7 @@ GET.apiDoc = {
       description: 'Team',
       content: {
         'application/json': {
-          schema: TeamWithMemberCountSchema
+          schema: TeamSchema
         }
       }
     },
@@ -79,7 +80,7 @@ export const PUT: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]
@@ -113,7 +114,7 @@ PUT.apiDoc = {
       description: 'Team updated',
       content: {
         'application/json': {
-          schema: TeamWithMemberCountSchema
+          schema: TeamSchema
         }
       }
     },
@@ -130,7 +131,7 @@ export function updateTeam(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
     const teamId = req.params.teamId;
-    const { name, description, system_user_ids } = req.body;
+    const { name, description, system_user_ids } = req.body as UpdateTeamRequest;
 
     try {
       await connection.open();
@@ -139,23 +140,25 @@ export function updateTeam(): RequestHandler {
 
       await teamService.updateTeam(teamId, { name, description });
 
-      const currentMembers = await teamMemberService.getTeamMembers(teamId);
-      const currentUserIds = new Set(currentMembers.map((member) => member.system_user_id));
-      const newUserIds = new Set(system_user_ids || []);
+      if (system_user_ids) {
+        const currentMembers = await teamMemberService.getTeamMembers(teamId);
+        const currentUserIds = new Set(currentMembers.map((member) => member.system_user_id));
+        const newUserIds = new Set(system_user_ids);
 
-      const toAdd = (system_user_ids || []).filter((userId: number) => !currentUserIds.has(userId));
-      const toRemove = currentMembers.filter((member) => !newUserIds.has(member.system_user_id));
+        const toAdd = system_user_ids.filter((userId) => !currentUserIds.has(userId));
+        const toRemove = currentMembers.filter((member) => !newUserIds.has(member.system_user_id));
 
-      await Promise.all(
-        toAdd.map((userId: number) =>
-          teamMemberService.createTeamMember({
-            team_id: teamId,
-            system_user_id: userId
-          })
-        )
-      );
+        await Promise.all(
+          toAdd.map((userId) =>
+            teamMemberService.createTeamMember({
+              team_id: teamId,
+              system_user_id: userId
+            })
+          )
+        );
 
-      await Promise.all(toRemove.map((member) => teamMemberService.deleteTeamMember(member.team_member_id)));
+        await Promise.all(toRemove.map((member) => teamMemberService.deleteTeamMember(member.team_member_id)));
+      }
 
       const result = await teamService.getTeam(teamId);
       await connection.commit();
@@ -174,7 +177,7 @@ export const DELETE: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]

--- a/api/src/paths/administrative/teams/{teamId}/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.ts
@@ -6,7 +6,6 @@ import { UpdateTeamRequest } from '../../../../models/team';
 import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
 import { TeamSchema, UpdateTeamRequestSchema } from '../../../../openapi/schemas/team';
 import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
-import { TeamMemberService } from '../../../../services/access-policy/team-member-service';
 import { TeamService } from '../../../../services/access-policy/team-service';
 import { getLogger } from '../../../../utils/logger';
 
@@ -131,38 +130,16 @@ export function updateTeam(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
     const teamId = req.params.teamId;
-    const { name, description, system_user_ids } = req.body as UpdateTeamRequest;
+    const payload = req.body as UpdateTeamRequest;
 
     try {
       await connection.open();
       const teamService = new TeamService(connection);
-      const teamMemberService = new TeamMemberService(connection);
 
-      await teamService.updateTeam(teamId, { name, description });
+      const team = await teamService.updateTeam(teamId, payload);
 
-      if (system_user_ids) {
-        const currentMembers = await teamMemberService.getTeamMembers(teamId);
-        const currentUserIds = new Set(currentMembers.map((member) => member.system_user_id));
-        const newUserIds = new Set(system_user_ids);
-
-        const toAdd = system_user_ids.filter((userId) => !currentUserIds.has(userId));
-        const toRemove = currentMembers.filter((member) => !newUserIds.has(member.system_user_id));
-
-        await Promise.all(
-          toAdd.map((userId) =>
-            teamMemberService.createTeamMember({
-              team_id: teamId,
-              system_user_id: userId
-            })
-          )
-        );
-
-        await Promise.all(toRemove.map((member) => teamMemberService.deleteTeamMember(member.team_member_id)));
-      }
-
-      const result = await teamService.getTeam(teamId);
       await connection.commit();
-      return res.status(200).json(result);
+      return res.status(200).json(team);
     } catch (error) {
       defaultLog.error({ label: 'updateTeam', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/administrative/teams/{teamId}/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/index.ts
@@ -3,8 +3,9 @@ import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../constants/roles';
 import { getDBConnection } from '../../../../database/db';
 import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
-import { TeamWithMembersSchema, UpdateTeamRequestSchema } from '../../../../openapi/schemas/team';
+import { TeamWithMemberCountSchema, UpdateTeamRequestSchema } from '../../../../openapi/schemas/team';
 import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
+import { TeamMemberService } from '../../../../services/access-policy/team-member-service';
 import { TeamService } from '../../../../services/access-policy/team-service';
 import { getLogger } from '../../../../utils/logger';
 
@@ -23,7 +24,7 @@ export const GET: Operation = [
 ];
 
 GET.apiDoc = {
-  description: 'Get a team by ID with its members.',
+  description: 'Get a team by ID.',
   tags: ['admin'],
   security: [{ Bearer: [] }],
   parameters: [
@@ -37,15 +38,19 @@ GET.apiDoc = {
   ],
   responses: {
     200: {
-      description: 'Team with members',
-      content: { 'application/json': { schema: TeamWithMembersSchema } }
+      description: 'Team',
+      content: {
+        'application/json': {
+          schema: TeamWithMemberCountSchema
+        }
+      }
     },
     ...defaultErrorResponses
   }
 };
 
 /**
- * Get a team by ID with its members.
+ * Get a team by ID.
  *
  * @returns {RequestHandler}
  */
@@ -57,7 +62,7 @@ export function getTeam(): RequestHandler {
     try {
       await connection.open();
       const teamService = new TeamService(connection);
-      const result = await teamService.getTeamWithMembers(teamId);
+      const result = await teamService.getTeam(teamId);
       await connection.commit();
       return res.status(200).json(result);
     } catch (error) {
@@ -72,7 +77,12 @@ export function getTeam(): RequestHandler {
 
 export const PUT: Operation = [
   authorizeRequestHandler(() => ({
-    and: [{ validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR], discriminator: 'SystemRole' }]
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
   })),
   updateTeam()
 ];
@@ -92,12 +102,20 @@ PUT.apiDoc = {
   ],
   requestBody: {
     required: true,
-    content: { 'application/json': { schema: UpdateTeamRequestSchema } }
+    content: {
+      'application/json': {
+        schema: UpdateTeamRequestSchema
+      }
+    }
   },
   responses: {
     200: {
       description: 'Team updated',
-      content: { 'application/json': { schema: TeamWithMembersSchema } }
+      content: {
+        'application/json': {
+          schema: TeamWithMemberCountSchema
+        }
+      }
     },
     ...defaultErrorResponses
   }
@@ -112,12 +130,34 @@ export function updateTeam(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
     const teamId = req.params.teamId;
-    const { name, description, member_user_ids } = req.body;
+    const { name, description, system_user_ids } = req.body;
 
     try {
       await connection.open();
       const teamService = new TeamService(connection);
-      const result = await teamService.updateTeamWithMembers(teamId, { name, description }, member_user_ids || []);
+      const teamMemberService = new TeamMemberService(connection);
+
+      await teamService.updateTeam(teamId, { name, description });
+
+      const currentMembers = await teamMemberService.getTeamMembers(teamId);
+      const currentUserIds = new Set(currentMembers.map((member) => member.system_user_id));
+      const newUserIds = new Set(system_user_ids || []);
+
+      const toAdd = (system_user_ids || []).filter((userId: number) => !currentUserIds.has(userId));
+      const toRemove = currentMembers.filter((member) => !newUserIds.has(member.system_user_id));
+
+      await Promise.all(
+        toAdd.map((userId: number) =>
+          teamMemberService.createTeamMember({
+            team_id: teamId,
+            system_user_id: userId
+          })
+        )
+      );
+
+      await Promise.all(toRemove.map((member) => teamMemberService.deleteTeamMember(member.team_member_id)));
+
+      const result = await teamService.getTeam(teamId);
       await connection.commit();
       return res.status(200).json(result);
     } catch (error) {
@@ -132,7 +172,12 @@ export function updateTeam(): RequestHandler {
 
 export const DELETE: Operation = [
   authorizeRequestHandler(() => ({
-    and: [{ validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR], discriminator: 'SystemRole' }]
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
   })),
   deleteTeam()
 ];

--- a/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as db from '../../../../../database/db';
-import { TeamMemberWithUser } from '../../../../../repositories/authorization/team-member-repository';
+import { TeamMemberWithUser } from '../../../../../models/team-member';
 import { TeamMemberService } from '../../../../../services/access-policy/team-member-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
 import { createTeamMember, deleteTeamMember, getTeamMembers } from './index';
@@ -101,7 +101,7 @@ describe('getTeamMembers', () => {
   it('should delete team member by system_user_id on DELETE', async () => {
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const deleteStub = sinon.stub(TeamMemberService.prototype, 'deleteTeamMember').resolves();
+    const deleteStub = sinon.stub(TeamMemberService.prototype, 'deleteTeamMemberByUser').resolves();
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.params = { teamId: 'team-1' };
@@ -110,7 +110,7 @@ describe('getTeamMembers', () => {
     const requestHandler = deleteTeamMember();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(deleteStub).to.have.been.calledOnceWith('team-1', 42);
+    expect(deleteStub).to.have.been.calledOnceWith({ team_id: 'team-1', system_user_id: 42 });
     expect(mockRes.statusValue).to.equal(204);
   });
 });

--- a/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
@@ -1,0 +1,116 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import * as db from '../../../../../database/db';
+import { TeamMemberWithUser } from '../../../../../repositories/authorization/team-member-repository';
+import { TeamMemberService } from '../../../../../services/access-policy/team-member-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
+import { createTeamMember, deleteTeamMember, getTeamMembers } from './index';
+
+chai.use(sinonChai);
+
+describe('getTeamMembers', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { teamId: 'team-1' };
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getTeamMembers();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with paginated team members', async () => {
+    const mockMembers: TeamMemberWithUser[] = [
+      { team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice', email: 'a@test.com' }
+    ];
+    const mockResponse = {
+      members: mockMembers,
+      pagination: { total: 1, per_page: 50, current_page: 1, last_page: 1, sort: undefined, order: undefined }
+    };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const getMembersStub = sinon.stub(TeamMemberService.prototype, 'getTeamMembersWithUsers').resolves(mockMembers);
+    const getMembersCountStub = sinon.stub(TeamMemberService.prototype, 'getTeamMembersWithUsersCount').resolves(1);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { teamId: 'team-1' };
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getTeamMembers();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getMembersStub).to.have.been.calledWith('team-1', {
+      page: 1,
+      limit: 50,
+      sort: undefined,
+      order: undefined
+    });
+    expect(getMembersCountStub).to.have.been.calledWith('team-1');
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockResponse);
+  });
+
+  it('should add team member', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const createdTeamMember: TeamMemberWithUser = {
+      team_member_id: 'tm-1',
+      system_user_id: 42,
+      user_identifier: 'user_42',
+      email: 'user_42@test.com'
+    };
+    const createStub = sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(createdTeamMember);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { teamId: 'team-1' };
+    mockReq.body = { system_user_id: 42 };
+
+    const requestHandler = createTeamMember();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledOnceWith({ team_id: 'team-1', system_user_id: 42 });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql({
+      team_member_id: 'tm-1',
+      system_user_id: 42,
+      user_identifier: 'user_42',
+      email: 'user_42@test.com'
+    });
+  });
+
+  it('should delete team member by system_user_id on DELETE', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const deleteStub = sinon.stub(TeamMemberService.prototype, 'deleteTeamMember').resolves();
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { teamId: 'team-1' };
+    mockReq.body = { system_user_id: 42 };
+
+    const requestHandler = deleteTeamMember();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(deleteStub).to.have.been.calledOnceWith('team-1', 42);
+    expect(mockRes.statusValue).to.equal(204);
+  });
+});

--- a/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
@@ -6,7 +6,7 @@ import * as db from '../../../../../database/db';
 import { TeamMemberWithUser } from '../../../../../models/team-member';
 import { TeamMemberService } from '../../../../../services/access-policy/team-member-service';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
-import { createTeamMember, deleteTeamMember, getTeamMembers } from './index';
+import { createTeamMember, deleteAllTeamMembers, getTeamMembers } from './index';
 
 chai.use(sinonChai);
 
@@ -89,7 +89,7 @@ describe('getTeamMembers', () => {
     await requestHandler(mockReq, mockRes, mockNext);
 
     expect(createStub).to.have.been.calledOnceWith({ team_id: 'team-1', system_user_id: 42 });
-    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.statusValue).to.equal(201);
     expect(mockRes.jsonValue).to.eql({
       team_member_id: 'tm-1',
       system_user_id: 42,
@@ -98,19 +98,20 @@ describe('getTeamMembers', () => {
     });
   });
 
-  it('should delete team member by system_user_id on DELETE', async () => {
+  it('should delete all team members for a team', async () => {
     const mockDBConnection = getMockDBConnection();
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
-    const deleteStub = sinon.stub(TeamMemberService.prototype, 'deleteTeamMemberByUser').resolves();
+
+    // Stub the new service method
+    const deleteAllStub = sinon.stub(TeamMemberService.prototype, 'deleteAllTeamMembers').resolves();
 
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
     mockReq.params = { teamId: 'team-1' };
-    mockReq.body = { system_user_id: 42 };
 
-    const requestHandler = deleteTeamMember();
+    const requestHandler = deleteAllTeamMembers();
     await requestHandler(mockReq, mockRes, mockNext);
 
-    expect(deleteStub).to.have.been.calledOnceWith({ team_id: 'team-1', system_user_id: 42 });
+    expect(deleteAllStub).to.have.been.calledOnceWith('team-1');
     expect(mockRes.statusValue).to.equal(204);
   });
 });

--- a/api/src/paths/administrative/teams/{teamId}/member/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../../constants/roles';
 import { getDBConnection } from '../../../../../database/db';
+import { TeamMemberByUserRequest } from '../../../../../models/team-member';
 import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
 import { paginationRequestQueryParamSchema } from '../../../../../openapi/schemas/pagination';
 import {
@@ -24,7 +25,7 @@ export const GET: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]
@@ -95,7 +96,7 @@ export const POST: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]
@@ -141,7 +142,7 @@ export const DELETE: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]
@@ -185,7 +186,7 @@ export function createTeamMember(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
     const teamId = req.params.teamId;
-    const { system_user_id } = req.body;
+    const { system_user_id } = req.body as TeamMemberByUserRequest;
 
     try {
       await connection.open();
@@ -213,12 +214,12 @@ export function deleteTeamMember(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
     const teamId = req.params.teamId;
-    const { system_user_id } = req.body;
+    const { system_user_id } = req.body as TeamMemberByUserRequest;
 
     try {
       await connection.open();
       const teamMemberService = new TeamMemberService(connection);
-      await teamMemberService.deleteTeamMember(teamId, system_user_id);
+      await teamMemberService.deleteTeamMemberByUser({ team_id: teamId, system_user_id });
 
       await connection.commit();
       return res.status(204).send();

--- a/api/src/paths/administrative/teams/{teamId}/member/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.ts
@@ -126,7 +126,7 @@ POST.apiDoc = {
     }
   },
   responses: {
-    200: {
+    201: {
       description: 'Team member association',
       content: {
         'application/json': {
@@ -147,7 +147,7 @@ export const DELETE: Operation = [
       }
     ]
   })),
-  deleteTeamMember()
+  deleteAllTeamMembers()
 ];
 
 DELETE.apiDoc = {
@@ -194,7 +194,7 @@ export function createTeamMember(): RequestHandler {
       const created = await teamMemberService.createTeamMember({ team_id: teamId, system_user_id });
 
       await connection.commit();
-      return res.status(200).json(created);
+      return res.status(201).json(created);
     } catch (error) {
       defaultLog.error({ label: 'createTeamMember', message: 'error', error });
       await connection.rollback();
@@ -210,16 +210,15 @@ export function createTeamMember(): RequestHandler {
  *
  * @returns {RequestHandler}
  */
-export function deleteTeamMember(): RequestHandler {
+export function deleteAllTeamMembers(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
     const teamId = req.params.teamId;
-    const { system_user_id } = req.body as TeamMemberByUserRequest;
 
     try {
       await connection.open();
       const teamMemberService = new TeamMemberService(connection);
-      await teamMemberService.deleteTeamMemberByUser({ team_id: teamId, system_user_id });
+      await teamMemberService.deleteAllTeamMembers(teamId);
 
       await connection.commit();
       return res.status(204).send();

--- a/api/src/paths/administrative/teams/{teamId}/member/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.ts
@@ -1,0 +1,233 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../../constants/roles';
+import { getDBConnection } from '../../../../../database/db';
+import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema } from '../../../../../openapi/schemas/pagination';
+import {
+  TeamMemberByUserRequestSchema,
+  TeamMemberSchema,
+  TeamMembersListResponseSchema
+} from '../../../../../openapi/schemas/team-member';
+import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
+import { TeamMemberService } from '../../../../../services/access-policy/team-member-service';
+import { getLogger } from '../../../../../utils/logger';
+import {
+  ensureCompletePaginationOptions,
+  makePaginationOptionsFromRequest,
+  makePaginationResponse
+} from '../../../../../utils/pagination';
+
+const defaultLog = getLogger('paths/administrative/teams/{teamId}/member');
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  getTeamMembers()
+];
+
+GET.apiDoc = {
+  description: 'Get paginated members for a team by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      in: 'path',
+      name: 'teamId',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+      description: 'Team ID'
+    },
+    ...paginationRequestQueryParamSchema
+  ],
+  responses: {
+    200: {
+      description: 'Paginated team members',
+      content: {
+        'application/json': {
+          schema: TeamMembersListResponseSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get paginated members for a team by ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function getTeamMembers(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const teamId = req.params.teamId;
+    const pagination = makePaginationOptionsFromRequest(req);
+
+    try {
+      await connection.open();
+
+      const teamMemberService = new TeamMemberService(connection);
+
+      const [members, count] = await Promise.all([
+        teamMemberService.getTeamMembersWithUsers(teamId, ensureCompletePaginationOptions(pagination)),
+        teamMemberService.getTeamMembersWithUsersCount(teamId)
+      ]);
+      await connection.commit();
+      return res.status(200).json({ members, pagination: makePaginationResponse(count, pagination) });
+    } catch (error) {
+      defaultLog.error({ label: 'getTeamMembers', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const POST: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  createTeamMember()
+];
+
+POST.apiDoc = {
+  description: 'Add a member to a team by system user ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      in: 'path',
+      name: 'teamId',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+      description: 'Team ID'
+    }
+  ],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: TeamMemberByUserRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Team member association',
+      content: {
+        'application/json': {
+          schema: TeamMemberSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+export const DELETE: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  deleteTeamMember()
+];
+
+DELETE.apiDoc = {
+  description: 'Remove a member from a team by system user ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      in: 'path',
+      name: 'teamId',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+      description: 'Team ID'
+    }
+  ],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: TeamMemberByUserRequestSchema
+      }
+    }
+  },
+  responses: {
+    204: { description: 'Team member removed' },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Add a member to a team by system user ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function createTeamMember(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const teamId = req.params.teamId;
+    const { system_user_id } = req.body;
+
+    try {
+      await connection.open();
+      const teamMemberService = new TeamMemberService(connection);
+      const created = await teamMemberService.createTeamMember({ team_id: teamId, system_user_id });
+
+      await connection.commit();
+      return res.status(200).json(created);
+    } catch (error) {
+      defaultLog.error({ label: 'createTeamMember', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+/**
+ * Remove a member from a team by system user id.
+ *
+ * @returns {RequestHandler}
+ */
+export function deleteTeamMember(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const teamId = req.params.teamId;
+    const { system_user_id } = req.body;
+
+    try {
+      await connection.open();
+      const teamMemberService = new TeamMemberService(connection);
+      await teamMemberService.deleteTeamMember(teamId, system_user_id);
+
+      await connection.commit();
+      return res.status(204).send();
+    } catch (error) {
+      defaultLog.error({ label: 'deleteTeamMember', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/teams/{teamId}/member/{teamMemberId}/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/{teamMemberId}/index.test.ts
@@ -1,0 +1,31 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import * as db from '../../../../../../database/db';
+import { TeamMemberService } from '../../../../../../services/access-policy/team-member-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
+import { deleteTeamMember } from './index';
+
+chai.use(sinonChai);
+
+describe('teams/{teamId}/member/{teamMemberId}', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should delete a team member', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const deleteStub = sinon.stub(TeamMemberService.prototype, 'deleteTeamMember').resolves();
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { teamId: 'team-1', teamMemberId: 'tm-1' };
+
+    const requestHandler = deleteTeamMember();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(deleteStub).to.have.been.calledOnceWith('tm-1');
+    expect(mockRes.statusValue).to.equal(204);
+  });
+});

--- a/api/src/paths/administrative/teams/{teamId}/member/{teamMemberId}/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/{teamMemberId}/index.ts
@@ -13,7 +13,7 @@ export const DELETE: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]

--- a/api/src/paths/administrative/teams/{teamId}/member/{teamMemberId}/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/{teamMemberId}/index.ts
@@ -1,0 +1,75 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../../../constants/roles';
+import { getDBConnection } from '../../../../../../database/db';
+import { defaultErrorResponses } from '../../../../../../openapi/schemas/http-responses';
+import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
+import { TeamMemberService } from '../../../../../../services/access-policy/team-member-service';
+import { getLogger } from '../../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/administrative/teams/{teamId}/member/{teamMemberId}');
+
+export const DELETE: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  deleteTeamMember()
+];
+
+DELETE.apiDoc = {
+  description: 'Delete a team member association by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      in: 'path',
+      name: 'teamId',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+      description: 'Team ID'
+    },
+    {
+      in: 'path',
+      name: 'teamMemberId',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+      description: 'Team member ID'
+    }
+  ],
+  responses: {
+    204: { description: 'Team member deleted' },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Delete a team member association.
+ *
+ * @returns {RequestHandler}
+ */
+export function deleteTeamMember(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const teamMemberId = req.params.teamMemberId;
+
+    try {
+      await connection.open();
+      const teamMemberService = new TeamMemberService(connection);
+      await teamMemberService.deleteTeamMember(teamMemberId);
+
+      await connection.commit();
+      return res.status(204).send();
+    } catch (error) {
+      defaultLog.error({ label: 'deleteTeamMember', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/teams/{teamId}/policy/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/policy/index.test.ts
@@ -53,12 +53,12 @@ describe('teams/{teamId}/policy', () => {
     expect(mockRes.jsonValue).to.eql({ team_policies: mockResponse });
   });
 
-  it('should default policies to an empty array when omitted', async () => {
+  it('should pass through an explicitly provided empty policies array', async () => {
     const mockDBConnection = getMockDBConnection();
     const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
     mockReq.params = { teamId: '22222222-2222-2222-2222-222222222222' };
-    mockReq.body = {};
+    mockReq.body = { policies: [] };
 
     sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
     const createStub = sinon.stub(TeamPolicyService.prototype, 'createTeamPolicies').resolves([]);

--- a/api/src/paths/administrative/teams/{teamId}/policy/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/policy/index.test.ts
@@ -1,0 +1,73 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import * as db from '../../../../../database/db';
+import { TeamPolicy } from '../../../../../models/team-policy';
+import { TeamPolicyService } from '../../../../../services/access-policy/team-policy-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
+import { createTeamPolicies } from './index';
+
+chai.use(sinonChai);
+
+describe('teams/{teamId}/policy', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should create team policies in bulk and return 201 on success', async () => {
+    const mockDBConnection = getMockDBConnection();
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.params = { teamId: '22222222-2222-2222-2222-222222222222' };
+    mockReq.body = {
+      policies: ['33333333-3333-3333-3333-333333333333', '44444444-4444-4444-4444-444444444444']
+    };
+
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+
+    const mockResponse: TeamPolicy[] = [
+      {
+        team_policy_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      },
+      {
+        team_policy_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '44444444-4444-4444-4444-444444444444'
+      }
+    ];
+
+    const createStub = sinon.stub(TeamPolicyService.prototype, 'createTeamPolicies').resolves(mockResponse);
+
+    const requestHandler = createTeamPolicies();
+
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledWith('22222222-2222-2222-2222-222222222222', [
+      '33333333-3333-3333-3333-333333333333',
+      '44444444-4444-4444-4444-444444444444'
+    ]);
+    expect(mockRes.statusValue).to.equal(201);
+    expect(mockRes.jsonValue).to.eql({ team_policies: mockResponse });
+  });
+
+  it('should default policies to an empty array when omitted', async () => {
+    const mockDBConnection = getMockDBConnection();
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.params = { teamId: '22222222-2222-2222-2222-222222222222' };
+    mockReq.body = {};
+
+    sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
+    const createStub = sinon.stub(TeamPolicyService.prototype, 'createTeamPolicies').resolves([]);
+
+    const requestHandler = createTeamPolicies();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222', []);
+    expect(mockRes.statusValue).to.equal(201);
+    expect(mockRes.jsonValue).to.eql({ team_policies: [] });
+  });
+});

--- a/api/src/paths/administrative/teams/{teamId}/policy/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/policy/index.ts
@@ -1,0 +1,88 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../../constants/roles';
+import { getDBConnection } from '../../../../../database/db';
+import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
+import { CreateTeamPoliciesRequestSchema, TeamPoliciesBatchSchema } from '../../../../../openapi/schemas/team-policy';
+import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
+import { TeamPolicyService } from '../../../../../services/access-policy/team-policy-service';
+import { getLogger } from '../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/administrative/teams/{teamId}/policy');
+
+export const POST: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  createTeamPolicies()
+];
+
+POST.apiDoc = {
+  description: 'Create team-policy associations in bulk for a team.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      in: 'path',
+      name: 'teamId',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+      description: 'Team ID'
+    }
+  ],
+  requestBody: {
+    description: 'Policy IDs to assign to the team.',
+    required: true,
+    content: {
+      'application/json': {
+        schema: CreateTeamPoliciesRequestSchema
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Processed team-policy associations for this request.',
+      content: {
+        'application/json': {
+          schema: TeamPoliciesBatchSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Create team-policy associations in bulk.
+ *
+ * @returns {RequestHandler}
+ */
+export function createTeamPolicies(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const teamId = req.params.teamId;
+    const { policies } = req.body;
+
+    try {
+      await connection.open();
+
+      const teamPolicyService = new TeamPolicyService(connection);
+      const teamPolicies = await teamPolicyService.createTeamPolicies(teamId, policies || []);
+
+      await connection.commit();
+
+      return res.status(201).json({ team_policies: teamPolicies });
+    } catch (error) {
+      defaultLog.error({ label: 'createTeamPolicies', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/teams/{teamId}/policy/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/policy/index.ts
@@ -2,8 +2,9 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../../constants/roles';
 import { getDBConnection } from '../../../../../database/db';
+import { CreateTeamPoliciesRequest } from '../../../../../models/team-policy';
 import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
-import { CreateTeamPoliciesRequestSchema, TeamPoliciesBatchSchema } from '../../../../../openapi/schemas/team-policy';
+import { CreateTeamPoliciesRequestSchema, TeamPoliciesSchema } from '../../../../../openapi/schemas/team-policy';
 import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
 import { TeamPolicyService } from '../../../../../services/access-policy/team-policy-service';
 import { getLogger } from '../../../../../utils/logger';
@@ -49,7 +50,7 @@ POST.apiDoc = {
       description: 'Processed team-policy associations for this request.',
       content: {
         'application/json': {
-          schema: TeamPoliciesBatchSchema
+          schema: TeamPoliciesSchema
         }
       }
     },
@@ -66,13 +67,13 @@ export function createTeamPolicies(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
     const teamId = req.params.teamId;
-    const { policies } = req.body;
+    const { policies } = req.body as CreateTeamPoliciesRequest;
 
     try {
       await connection.open();
 
       const teamPolicyService = new TeamPolicyService(connection);
-      const teamPolicies = await teamPolicyService.createTeamPolicies(teamId, policies || []);
+      const teamPolicies = await teamPolicyService.createTeamPolicies(teamId, policies);
 
       await connection.commit();
 

--- a/api/src/paths/administrative/users/index.ts
+++ b/api/src/paths/administrative/users/index.ts
@@ -14,7 +14,7 @@ export const GET: Operation = [
   authorizeRequestHandler(() => ({
     and: [
       {
-        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
         discriminator: 'SystemRole'
       }
     ]

--- a/api/src/paths/administrative/users/index.ts
+++ b/api/src/paths/administrative/users/index.ts
@@ -3,7 +3,7 @@ import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../constants/roles';
 import { getDBConnection } from '../../../database/db';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
-import { AvailableUsersListResponseSchema } from '../../../openapi/schemas/team';
+import { AvailableUsersListResponseSchema } from '../../../openapi/schemas/team-member';
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { UserService } from '../../../services/user-service';
 import { getLogger } from '../../../utils/logger';
@@ -12,7 +12,12 @@ const defaultLog = getLogger('paths/administrative/users');
 
 export const GET: Operation = [
   authorizeRequestHandler(() => ({
-    and: [{ validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR], discriminator: 'SystemRole' }]
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN, SYSTEM_ROLE.DATA_ADMINISTRATOR],
+        discriminator: 'SystemRole'
+      }
+    ]
   })),
   getAvailableUsers()
 ];
@@ -32,7 +37,11 @@ GET.apiDoc = {
   responses: {
     200: {
       description: 'List of available users',
-      content: { 'application/json': { schema: AvailableUsersListResponseSchema } }
+      content: {
+        'application/json': {
+          schema: AvailableUsersListResponseSchema
+        }
+      }
     },
     ...defaultErrorResponses
   }

--- a/api/src/repositories/authorization/policy-repository.test.ts
+++ b/api/src/repositories/authorization/policy-repository.test.ts
@@ -102,54 +102,84 @@ describe('PolicyRepository', () => {
     });
   });
 
-  describe('getPoliciesWithPagination', () => {
-    it('returns paginated policies with total count', async () => {
+  describe('getPolicies', () => {
+    it('returns paginated policies', async () => {
       const mockPolicies: Policy[] = [
         { policy_id: '11111111-1111-1111-1111-111111111111', name: 'Policy1', description: 'Test1' },
         { policy_id: '22222222-2222-2222-2222-222222222222', name: 'Policy2', description: 'Test2' }
       ];
 
-      const knexStub = sinon.stub();
-      knexStub.onFirstCall().resolves({ rows: [{ count: '5' }] });
-      knexStub.onSecondCall().resolves({ rows: mockPolicies });
+      const mockResponse = {
+        rowCount: 2,
+        rows: mockPolicies
+      } as unknown as Promise<QueryResult<any>>;
 
-      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new PolicyRepository(mockDBConnection);
-      const result = await repository.getPoliciesWithPagination(undefined, { page: 1, limit: 2 });
+      const result = await repository.getPolicies(undefined, { page: 1, limit: 2 });
 
-      expect(result.policies).to.eql(mockPolicies);
-      expect(result.total).to.equal(5);
+      expect(result).to.eql(mockPolicies);
     });
 
     it('filters by search term', async () => {
       const mockPolicies = [{ policy_id: '1', name: 'Telemetry Policy', description: 'Test' }];
 
-      const knexStub = sinon.stub();
-      knexStub.onFirstCall().resolves({ rows: [{ count: '1' }] });
-      knexStub.onSecondCall().resolves({ rows: mockPolicies });
+      const mockResponse = {
+        rowCount: 1,
+        rows: mockPolicies
+      } as unknown as Promise<QueryResult<any>>;
 
-      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new PolicyRepository(mockDBConnection);
-      const result = await repository.getPoliciesWithPagination('Telemetry', { page: 1, limit: 50 });
+      const result = await repository.getPolicies({ search: 'Telemetry' }, { page: 1, limit: 50 });
 
-      expect(result.policies).to.eql(mockPolicies);
-      expect(result.total).to.equal(1);
+      expect(result).to.eql(mockPolicies);
     });
 
     it('returns empty array when no policies exist', async () => {
-      const knexStub = sinon.stub();
-      knexStub.onFirstCall().resolves({ rows: [{ count: '0' }] });
-      knexStub.onSecondCall().resolves({ rows: [] });
+      const mockResponse = {
+        rowCount: 0,
+        rows: []
+      } as unknown as Promise<QueryResult<any>>;
 
-      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new PolicyRepository(mockDBConnection);
-      const result = await repository.getPoliciesWithPagination(undefined, { page: 1, limit: 50 });
+      const result = await repository.getPolicies(undefined, { page: 1, limit: 50 });
 
-      expect(result.policies).to.eql([]);
-      expect(result.total).to.equal(0);
+      expect(result).to.eql([]);
+    });
+  });
+
+  describe('getPoliciesCount', () => {
+    it('returns count for matching policies', async () => {
+      const mockResponse = {
+        rowCount: 1,
+        rows: [{ count: 2 }]
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
+
+      const repository = new PolicyRepository(mockDBConnection);
+      const result = await repository.getPoliciesCount();
+
+      expect(result).to.equal(2);
+    });
+
+    it('returns zero when no rows are returned', async () => {
+      const mockResponse = {
+        rowCount: 1,
+        rows: [{ count: 0 }]
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
+
+      const repository = new PolicyRepository(mockDBConnection);
+      const result = await repository.getPoliciesCount({ search: 'none' });
+
+      expect(result).to.equal(0);
     });
   });
 

--- a/api/src/repositories/authorization/policy-repository.ts
+++ b/api/src/repositories/authorization/policy-repository.ts
@@ -1,9 +1,12 @@
+import { Knex } from 'knex';
 import SQL from 'sql-template-strings';
 import { getKnex } from '../../database/db';
 import { FeatureUrn } from '../../database/urn-utils.interface';
 import { ApiExecuteSQLError } from '../../errors/api-error';
+import { CountResult } from '../../models/count';
 import { CreatePolicy, Policy, UpdatePolicy } from '../../models/policy';
 import { PolicyEffect } from '../../models/policy-statement';
+import { PolicyFilters } from '../../services/access-policy/policy-service.interface';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
@@ -53,72 +56,57 @@ export class PolicyRepository extends BaseRepository {
    * @memberof PolicyRepository
    */
   async getPolicy(policyId: string): Promise<Policy> {
-    const knex = getKnex();
-    const query = knex.table('policy').select(['policy_id', 'name', 'description']).where('policy_id', policyId);
+    const response = await this.getPolicies({ policyId });
 
-    const response = await this.connection.knex(query, Policy);
-
-    if (response.rowCount !== 1) {
+    if (response.length !== 1) {
       throw new ApiExecuteSQLError('Failed to get policy', [
         'PolicyRepository->getPolicy',
         'rowCount was null or undefined, expected rowCount = 1'
       ]);
     }
 
-    return response.rows[0];
+    return response[0];
   }
 
   /**
-   * Get all policy records.
+   * Get policies with optional search and pagination.
    *
-   * @return {Promise<Policy[]>} - A list of all policy records.
+   * @param {PolicyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<Policy[]>}
    * @memberof PolicyRepository
    */
-  async getPolicies(): Promise<Policy[]> {
+  async getPolicies(filters?: PolicyFilters, pagination?: ApiPaginationOptions): Promise<Policy[]> {
     const knex = getKnex();
-    const query = knex.table('policy').select(['policy_id', 'name', 'description']);
+    const query = this.applyFilters(knex.table('policy').whereNull('record_end_date'), filters).select([
+      'policy_id',
+      'name',
+      'description'
+    ]);
+
+    if (pagination) {
+      this.applyPagination(query, pagination);
+    }
 
     const response = await this.connection.knex(query, Policy);
-
     return response.rows;
   }
 
   /**
-   * Get policies with pagination and optional search.
+   * Get count of policies matching optional filters.
    *
-   * @param {string} [search] - Optional search term to filter by policy name.
-   * @param {ApiPaginationOptions} pagination - Pagination options.
-   * @return {Promise<{ policies: Policy[]; total: number }>} - Paginated policies and total count.
+   * @param {PolicyFilters} [filters] - Optional filter set.
+   * @return {Promise<number>}
    * @memberof PolicyRepository
    */
-  async getPoliciesWithPagination(
-    search: string | undefined,
-    pagination: ApiPaginationOptions
-  ): Promise<{ policies: Policy[]; total: number }> {
+  async getPoliciesCount(filters?: PolicyFilters): Promise<number> {
     const knex = getKnex();
+    const query = this.applyFilters(knex.table('policy').whereNull('record_end_date'), filters)
+      .select(knex.raw('coalesce(count(*), 0)::integer as count'))
+      .first();
 
-    let baseQuery = knex.table('policy').where('record_end_date', null);
-
-    if (search) {
-      baseQuery = baseQuery.whereILike('name', `%${search}%`);
-    }
-
-    // Get total count
-    const countQuery = baseQuery.clone().count('* as count').first();
-    const countResult = await this.connection.knex(countQuery);
-    const total = Number(countResult.rows[0]?.count || 0);
-
-    // Get paginated results (page is 1-indexed, so offset = (page - 1) * limit)
-    const paginatedQuery = baseQuery
-      .clone()
-      .select(['policy_id', 'name', 'description'])
-      .orderBy(pagination.sort || 'name', pagination.order || 'asc')
-      .offset((pagination.page - 1) * pagination.limit)
-      .limit(pagination.limit);
-
-    const response = await this.connection.knex(paginatedQuery, Policy);
-
-    return { policies: response.rows, total };
+    const response = await this.connection.knex(query, CountResult);
+    return response.rows[0].count;
   }
 
   /**
@@ -222,5 +210,28 @@ export class PolicyRepository extends BaseRepository {
         'rowCount was null or undefined, expected rowCount = 1'
       ]);
     }
+  }
+
+  /**
+   * Apply policy list filters to the provided query.
+   *
+   * @param {Knex.QueryBuilder} query - Base query to filter.
+   * @param {PolicyFilters} [filters] - Optional filter set.
+   * @return {Knex.QueryBuilder} Filtered query.
+   */
+  private applyFilters(query: Knex.QueryBuilder, filters?: PolicyFilters): Knex.QueryBuilder {
+    if (!filters) {
+      return query;
+    }
+
+    if (filters.search) {
+      query.whereILike('name', `%${filters.search}%`);
+    }
+
+    if (filters.policyId) {
+      query.where('policy_id', filters.policyId);
+    }
+
+    return query;
   }
 }

--- a/api/src/repositories/authorization/team-member-repository.test.ts
+++ b/api/src/repositories/authorization/team-member-repository.test.ts
@@ -170,4 +170,37 @@ describe('TeamMemberRepository', () => {
       }
     });
   });
+
+  describe('deleteAllTeamMembers', () => {
+    it('soft deletes all team members successfully', async () => {
+      const mockResponse = {
+        rowCount: 1,
+        rows: [{ team_id: 'team-1' }]
+      } as unknown as Promise<QueryResult<any>>;
+
+      const knexStub = sinon.stub().resolves(mockResponse);
+      const mockConnection = getMockDBConnection({
+        knex: knexStub
+      });
+
+      const repository = new TeamMemberRepository(mockConnection);
+      await repository.deleteAllTeamMembers('team-1');
+
+      expect(knexStub).to.have.been.calledOnce;
+    });
+
+    it('throws error if delete fails', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+
+      const repository = new TeamMemberRepository(mockConnection);
+
+      try {
+        await repository.deleteAllTeamMembers('1');
+        expect.fail();
+      } catch (error) {
+        expect((error as ApiExecuteSQLError).message).to.equal('Failed to delete all team members');
+      }
+    });
+  });
 });

--- a/api/src/repositories/authorization/team-member-repository.ts
+++ b/api/src/repositories/authorization/team-member-repository.ts
@@ -1,21 +1,14 @@
-import { z } from 'zod';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
-import { CreateTeamMember, TeamMember, UpdateTeamMember } from '../../models/team-member';
+import {
+  CreateTeamMember,
+  TeamMember,
+  TeamMemberByUserFilter,
+  TeamMemberWithUser,
+  UpdateTeamMember
+} from '../../models/team-member';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
-
-/**
- * A team member with user details.
- */
-export const TeamMemberWithUser = z.object({
-  team_member_id: z.string().uuid(),
-  system_user_id: z.number(),
-  user_identifier: z.string(),
-  email: z.string().nullable()
-});
-
-export type TeamMemberWithUser = z.infer<typeof TeamMemberWithUser>;
 
 /**
  * A repository class for accessing team member data.
@@ -195,18 +188,39 @@ export class TeamMemberRepository extends BaseRepository {
    * @return {Promise<TeamMemberWithUser | null>}
    * @memberof TeamMemberRepository
    */
-  async getTeamMemberWithUser(teamId: string, systemUserId: number): Promise<TeamMemberWithUser | null> {
+  async getTeamMemberWithUser(teamMemberData: TeamMemberByUserFilter): Promise<TeamMemberWithUser | null> {
     const knex = getKnex();
     const query = knex
       .table('team_member as tm')
       .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier', 'su.email'])
       .innerJoin('system_user as su', 'tm.system_user_id', 'su.system_user_id')
-      .where('tm.team_id', teamId)
-      .where('tm.system_user_id', systemUserId)
+      .where('tm.team_id', teamMemberData.team_id)
+      .where('tm.system_user_id', teamMemberData.system_user_id)
       .whereNull('tm.record_end_date')
       .first();
 
     const response = await this.connection.knex(query, TeamMemberWithUser);
+    return response.rows[0] ?? null;
+  }
+
+  /**
+   * Get a single active team member for a team and system user.
+   *
+   * @param {TeamMemberByUserFilter} teamMemberData - Team and system user identifiers.
+   * @return {Promise<TeamMember | null>}
+   * @memberof TeamMemberRepository
+   */
+  async getTeamMemberByTeamAndUser(teamMemberData: TeamMemberByUserFilter): Promise<TeamMember | null> {
+    const knex = getKnex();
+    const query = knex
+      .table('team_member')
+      .select(['team_member_id', 'system_user_id', 'team_id'])
+      .where('team_id', teamMemberData.team_id)
+      .where('system_user_id', teamMemberData.system_user_id)
+      .whereNull('record_end_date')
+      .first();
+
+    const response = await this.connection.knex(query, TeamMember);
     return response.rows[0] ?? null;
   }
 

--- a/api/src/repositories/authorization/team-member-repository.ts
+++ b/api/src/repositories/authorization/team-member-repository.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { CreateTeamMember, TeamMember, UpdateTeamMember } from '../../models/team-member';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
 /**
@@ -10,7 +11,8 @@ import { BaseRepository } from '../base-repository';
 export const TeamMemberWithUser = z.object({
   team_member_id: z.string().uuid(),
   system_user_id: z.number(),
-  user_identifier: z.string()
+  user_identifier: z.string(),
+  email: z.string().nullable()
 });
 
 export type TeamMemberWithUser = z.infer<typeof TeamMemberWithUser>;
@@ -90,7 +92,8 @@ export class TeamMemberRepository extends BaseRepository {
     const query = knex
       .table('team_member')
       .select(['team_member_id', 'system_user_id', 'team_id'])
-      .where('team_id', teamId);
+      .where('team_id', teamId)
+      .whereNull('record_end_date');
 
     const response = await this.connection.knex(query, TeamMember);
 
@@ -161,17 +164,70 @@ export class TeamMemberRepository extends BaseRepository {
    * @return {Promise<TeamMemberWithUser[]>}
    * @memberof TeamMemberRepository
    */
-  async getTeamMembersWithUsers(teamId: string): Promise<TeamMemberWithUser[]> {
+  async getTeamMembersWithUsers(teamId: string, pagination?: ApiPaginationOptions): Promise<TeamMemberWithUser[]> {
     const knex = getKnex();
+    const sortFieldMap: Record<string, string> = {
+      user_identifier: 'su.user_identifier',
+      system_user_id: 'tm.system_user_id'
+    };
+    const sortField = sortFieldMap[pagination?.sort || ''] || 'su.user_identifier';
     const query = knex
       .table('team_member as tm')
-      .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier'])
+      .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier', 'su.email'])
       .innerJoin('system_user as su', 'tm.system_user_id', 'su.system_user_id')
       .where('tm.team_id', teamId)
       .whereNull('tm.record_end_date')
-      .orderBy('su.user_identifier', 'asc');
+      .orderBy(sortField, pagination?.order || 'asc');
+
+    if (pagination) {
+      query.offset((pagination.page - 1) * pagination.limit).limit(pagination.limit);
+    }
 
     const response = await this.connection.knex(query, TeamMemberWithUser);
     return response.rows;
+  }
+
+  /**
+   * Get a single team member with user details for a team and system user.
+   *
+   * @param {string} teamId - The ID of the team.
+   * @param {number} systemUserId - The system user ID.
+   * @return {Promise<TeamMemberWithUser | null>}
+   * @memberof TeamMemberRepository
+   */
+  async getTeamMemberWithUser(teamId: string, systemUserId: number): Promise<TeamMemberWithUser | null> {
+    const knex = getKnex();
+    const query = knex
+      .table('team_member as tm')
+      .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier', 'su.email'])
+      .innerJoin('system_user as su', 'tm.system_user_id', 'su.system_user_id')
+      .where('tm.team_id', teamId)
+      .where('tm.system_user_id', systemUserId)
+      .whereNull('tm.record_end_date')
+      .first();
+
+    const response = await this.connection.knex(query, TeamMemberWithUser);
+    return response.rows[0] ?? null;
+  }
+
+  /**
+   * Get count of active team members for a given team.
+   *
+   * @param {string} teamId - The ID of the team.
+   * @return {Promise<number>}
+   * @memberof TeamMemberRepository
+   */
+  async getTeamMembersWithUsersCount(teamId: string): Promise<number> {
+    const knex = getKnex();
+    const query = knex
+      .table('team_member as tm')
+      .innerJoin('system_user as su', 'tm.system_user_id', 'su.system_user_id')
+      .where('tm.team_id', teamId)
+      .whereNull('tm.record_end_date')
+      .count('* as count')
+      .first();
+
+    const response = await this.connection.knex(query);
+    return Number(response.rows[0]?.count || 0);
   }
 }

--- a/api/src/repositories/authorization/team-member-repository.ts
+++ b/api/src/repositories/authorization/team-member-repository.ts
@@ -151,6 +151,33 @@ export class TeamMemberRepository extends BaseRepository {
   }
 
   /**
+   * Soft delete all team members for a team
+   *
+   * @param {string} teamId
+   * @return {Promise<void>}
+   * @memberof TeamMemberRepository
+   */
+  async deleteAllTeamMembers(teamId: string): Promise<void> {
+    const knex = getKnex();
+    const query = knex
+      .table('team_member')
+      .update({
+        record_end_date: knex.fn.now()
+      })
+      .where('team_id', teamId)
+      .returning(['team_id']);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to delete all team members', [
+        'TeamMemberRepository->deleteAllTeamMembers',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+  }
+
+  /**
    * Get team members with user details for a given team.
    *
    * @param {string} teamId - The ID of the team.

--- a/api/src/repositories/authorization/team-policy-repository.test.ts
+++ b/api/src/repositories/authorization/team-policy-repository.test.ts
@@ -78,10 +78,9 @@ describe('TeamPolicyRepository', () => {
 
   describe('getTeamPolicies', () => {
     it('returns all team policies', async () => {
-      const mockTeamId = '11';
       const mockRows = [
-        { team_policy_id: 1, team_id: mockTeamId, policy_id: '123abc' },
-        { team_policy_id: 2, team_id: mockTeamId, policy_id: '456xyz' }
+        { team_policy_id: 1, team_id: '11', policy_id: '123abc', team_name: 'Team 1', policy_name: 'Policy A' },
+        { team_policy_id: 2, team_id: '11', policy_id: '456xyz', team_name: 'Team 1', policy_name: 'Policy B' }
       ];
       const mockResponse = {
         rowCount: 2,
@@ -91,7 +90,7 @@ describe('TeamPolicyRepository', () => {
       const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new TeamPolicyRepository(mockConnection);
-      const result = await repository.getTeamPolicies(mockTeamId);
+      const result = await repository.getTeamPolicies();
 
       expect(result).to.eql(mockRows);
     });
@@ -101,14 +100,11 @@ describe('TeamPolicyRepository', () => {
       const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new TeamPolicyRepository(mockConnection);
-      const result = await repository.getTeamPolicies('15');
+      const result = await repository.getTeamPolicies();
 
       expect(result).to.eql([]);
     });
-  });
-
-  describe('getAllTeamPolicies', () => {
-    it('returns all team-policy associations with names', async () => {
+    it('returns all active team-policy associations with pagination options', async () => {
       const mockRows = [
         {
           team_policy_id: '11111111-1111-1111-1111-111111111111',
@@ -124,21 +120,62 @@ describe('TeamPolicyRepository', () => {
       } as unknown as Promise<QueryResult<any>>;
 
       const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
-
       const repository = new TeamPolicyRepository(mockConnection);
-      const result = await repository.getAllTeamPolicies();
+
+      const result = await repository.getTeamPolicies({ search: 'Test' }, { page: 1, limit: 10 });
+
+      expect(result).to.eql(mockRows);
+    });
+  });
+
+  describe('getPoliciesByTeamId', () => {
+    it('returns active team policies for a team filtered by policy ids', async () => {
+      const mockRows = [
+        {
+          team_policy_id: '11111111-1111-1111-1111-111111111111',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '33333333-3333-3333-3333-333333333333',
+          team_name: 'Test Team',
+          policy_name: 'Test Policy'
+        }
+      ];
+      const mockResponse = {
+        rowCount: 1,
+        rows: mockRows
+      } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new TeamPolicyRepository(mockConnection);
+
+      const result = await repository.getPoliciesByTeamId('22222222-2222-2222-2222-222222222222', {
+        policyIds: ['33333333-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555']
+      });
 
       expect(result).to.eql(mockRows);
     });
 
-    it('returns empty array if no team-policy associations exist', async () => {
-      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
-      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+    it('does not apply policy id filter when policyIds is empty', async () => {
+      const mockRows = [
+        {
+          team_policy_id: '11111111-1111-1111-1111-111111111111',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '33333333-3333-3333-3333-333333333333',
+          team_name: 'Test Team',
+          policy_name: 'Test Policy'
+        }
+      ];
+      const mockResponse = {
+        rowCount: 1,
+        rows: mockRows
+      } as unknown as Promise<QueryResult<any>>;
 
+      const knexStub = sinon.stub().resolves(mockResponse);
+      const mockConnection = getMockDBConnection({ knex: knexStub });
       const repository = new TeamPolicyRepository(mockConnection);
-      const result = await repository.getAllTeamPolicies();
 
-      expect(result).to.eql([]);
+      const result = await repository.getPoliciesByTeamId('22222222-2222-2222-2222-222222222222', { policyIds: [] });
+
+      expect(result).to.eql(mockRows);
+      expect(knexStub).to.have.been.calledOnce;
     });
   });
 

--- a/api/src/repositories/authorization/team-policy-repository.ts
+++ b/api/src/repositories/authorization/team-policy-repository.ts
@@ -1,6 +1,9 @@
+import { Knex } from 'knex';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
+import { CountResult } from '../../models/count';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
+import { TeamPolicyFilters } from '../../services/access-policy/team-policy-service.interface';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
@@ -68,29 +71,49 @@ export class TeamPolicyRepository extends BaseRepository {
   }
 
   /**
-   * Get all team policy records for a specific team.
+   * Get active team policy records with optional filters and pagination.
    *
-   * @param {string} teamId - The ID of the team whose policies to fetch.
-   * @return {Promise<TeamPolicy[]>} - A list of team policy records for the team.
+   * @param {TeamPolicyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<TeamPolicyDetails[]>} - A list of matching active team policy records.
    * @memberof TeamPolicyRepository
    */
-  async getTeamPolicies(teamId: string): Promise<TeamPolicy[]> {
+  async getTeamPolicies(filters?: TeamPolicyFilters, pagination?: ApiPaginationOptions): Promise<TeamPolicyDetails[]> {
     const knex = getKnex();
-    const query = knex.table('team_policy').select(['team_policy_id', 'team_id', 'policy_id']).where('team_id', teamId);
+    const query = knex
+      .select(['tp.team_policy_id', 'tp.team_id', 'tp.policy_id', 't.name as team_name', 'p.name as policy_name'])
+      .from('team_policy as tp')
+      .innerJoin('team as t', 'tp.team_id', 't.team_id')
+      .innerJoin('policy as p', 'tp.policy_id', 'p.policy_id')
+      .whereNull('tp.record_end_date')
+      .whereNull('t.record_end_date')
+      .whereNull('p.record_end_date');
 
-    const response = await this.connection.knex(query, TeamPolicy);
+    this.applyFilters(query, filters);
+
+    if (pagination) {
+      this.applyPagination(query, pagination);
+    }
+
+    const response = await this.connection.knex(query, TeamPolicyDetails);
 
     return response.rows;
   }
 
   /**
-   * Get all active team-policy associations with team and policy names.
-   * Follows SIMS pattern of returning display-ready data.
+   * Get active team policy records for a specific team with optional filters and pagination.
    *
-   * @return {Promise<TeamPolicyDetails[]>} - List of team policy records with names.
+   * @param {string} teamId - Team ID.
+   * @param {TeamPolicyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<TeamPolicyDetails[]>} - A list of matching active team policy records.
    * @memberof TeamPolicyRepository
    */
-  async getAllTeamPolicies(): Promise<TeamPolicyDetails[]> {
+  async getPoliciesByTeamId(
+    teamId: string,
+    filters?: TeamPolicyFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<TeamPolicyDetails[]> {
     const knex = getKnex();
     const query = knex
       .select(['tp.team_policy_id', 'tp.team_id', 'tp.policy_id', 't.name as team_name', 'p.name as policy_name'])
@@ -100,8 +123,13 @@ export class TeamPolicyRepository extends BaseRepository {
       .whereNull('tp.record_end_date')
       .whereNull('t.record_end_date')
       .whereNull('p.record_end_date')
-      .orderBy('t.name')
-      .orderBy('p.name');
+      .where('tp.team_id', teamId);
+
+    this.applyFilters(query, filters);
+
+    if (pagination) {
+      this.applyPagination(query, pagination);
+    }
 
     const response = await this.connection.knex(query, TeamPolicyDetails);
 
@@ -109,46 +137,28 @@ export class TeamPolicyRepository extends BaseRepository {
   }
 
   /**
-   * Get all active team-policy associations with pagination support.
+   * Get count of active team-policy associations matching optional filters.
    *
-   * @param {ApiPaginationOptions} options - Pagination options.
-   * @return {Promise<{ teamPolicies: TeamPolicyDetails[]; total: number }>}
+   * @param {TeamPolicyFilters} [filters] - Optional filter set.
+   * @return {Promise<number>}
    * @memberof TeamPolicyRepository
    */
-  async getAllTeamPoliciesWithPagination(
-    options: ApiPaginationOptions
-  ): Promise<{ teamPolicies: TeamPolicyDetails[]; total: number }> {
+  async getAllTeamPoliciesCount(filters?: TeamPolicyFilters): Promise<number> {
     const knex = getKnex();
+    const query = knex
+      .from('team_policy as tp')
+      .innerJoin('team as t', 'tp.team_id', 't.team_id')
+      .innerJoin('policy as p', 'tp.policy_id', 'p.policy_id')
+      .whereNull('tp.record_end_date')
+      .whereNull('t.record_end_date')
+      .whereNull('p.record_end_date')
+      .select(knex.raw('coalesce(count(*), 0)::integer as count'))
+      .first();
 
-    // Base query for filtering
-    const baseQuery = () =>
-      knex
-        .from('team_policy as tp')
-        .innerJoin('team as t', 'tp.team_id', 't.team_id')
-        .innerJoin('policy as p', 'tp.policy_id', 'p.policy_id')
-        .whereNull('tp.record_end_date')
-        .whereNull('t.record_end_date')
-        .whereNull('p.record_end_date');
+    this.applyFilters(query, filters);
 
-    // Get total count
-    const countQuery = baseQuery().count('* as count').first();
-    const countResult = await this.connection.knex(countQuery);
-    const total = Number(countResult.rows[0]?.count ?? 0);
-
-    // Determine sort column (map frontend field names to SQL columns)
-    const sortColumn = options.sort === 'team_name' ? 't.name' : options.sort === 'policy_name' ? 'p.name' : 't.name';
-    const sortOrder = options.order || 'asc';
-
-    // Get paginated results (page is 1-indexed, so offset = (page - 1) * limit)
-    const dataQuery = baseQuery()
-      .select(['tp.team_policy_id', 'tp.team_id', 'tp.policy_id', 't.name as team_name', 'p.name as policy_name'])
-      .orderBy(sortColumn, sortOrder)
-      .offset((options.page - 1) * options.limit)
-      .limit(options.limit);
-
-    const response = await this.connection.knex(dataQuery, TeamPolicyDetails);
-
-    return { teamPolicies: response.rows, total };
+    const response = await this.connection.knex(query, CountResult);
+    return response.rows[0].count;
   }
 
   /**
@@ -206,5 +216,30 @@ export class TeamPolicyRepository extends BaseRepository {
         'rowCount was null or undefined, expected rowCount = 1'
       ]);
     }
+  }
+
+  /**
+   * Apply team-policy list filters to the provided query.
+   *
+   * @param {Knex.QueryBuilder} query - Base query to filter.
+   * @param {TeamPolicyFilters} [filters] - Optional filter set.
+   * @return {Knex.QueryBuilder} Filtered query.
+   */
+  private applyFilters(query: Knex.QueryBuilder, filters?: TeamPolicyFilters): Knex.QueryBuilder {
+    if (!filters) {
+      return query;
+    }
+
+    if (filters.policyIds?.length) {
+      query.whereIn('tp.policy_id', filters.policyIds);
+    }
+
+    if (filters.search) {
+      query.where((builder) => {
+        builder.whereILike('t.name', `%${filters.search}%`).orWhereILike('p.name', `%${filters.search}%`);
+      });
+    }
+
+    return query;
   }
 }

--- a/api/src/repositories/authorization/team-repository.test.ts
+++ b/api/src/repositories/authorization/team-repository.test.ts
@@ -4,7 +4,6 @@ import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { ApiExecuteSQLError } from '../../errors/api-error';
-import { Team } from '../../models/team';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamRepository } from './team-repository';
 
@@ -47,7 +46,7 @@ describe('TeamRepository', () => {
 
   describe('getTeam', () => {
     it('returns a team by ID', async () => {
-      const mockRows = [{ team_id: 1, name: 'Team A', description: 'Description A' }];
+      const mockRows = [{ team_id: 1, name: 'Team A', description: 'Description A', member_count: 3 }];
       const mockResponse = {
         rowCount: 1,
         rows: mockRows
@@ -75,10 +74,10 @@ describe('TeamRepository', () => {
   });
 
   describe('getTeams', () => {
-    it('returns all teams', async () => {
+    it('returns all teams with member_count', async () => {
       const mockRows = [
-        { team_id: 1, name: 'Team A', description: 'Description A' },
-        { team_id: 2, name: 'Team B', description: 'Description B' }
+        { team_id: 1, name: 'Team A', description: 'Description A', member_count: 0 },
+        { team_id: 2, name: 'Team B', description: 'Description B', member_count: 2 }
       ];
       const mockResponse = {
         rowCount: 2,
@@ -93,7 +92,10 @@ describe('TeamRepository', () => {
     });
 
     it('returns empty array if no teams', async () => {
-      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockResponse = {
+        rowCount: 0,
+        rows: []
+      } as unknown as Promise<QueryResult<any>>;
       const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
       const repository = new TeamRepository(mockConnection);
 
@@ -102,92 +104,128 @@ describe('TeamRepository', () => {
     });
   });
 
-  describe('getTeamsWithPagination', () => {
-    it('returns paginated teams with total count', async () => {
-      const mockTeams: Team[] = [
-        { team_id: '11111111-1111-1111-1111-111111111111', name: 'Team Alpha', description: 'First team' },
-        { team_id: '22222222-2222-2222-2222-222222222222', name: 'Team Beta', description: 'Second team' }
+  describe('getTeams with pagination', () => {
+    it('returns paginated teams', async () => {
+      const mockTeams = [
+        {
+          team_id: '11111111-1111-1111-1111-111111111111',
+          name: 'Team Alpha',
+          description: 'First team',
+          member_count: 1
+        },
+        {
+          team_id: '22222222-2222-2222-2222-222222222222',
+          name: 'Team Beta',
+          description: 'Second team',
+          member_count: 0
+        }
       ];
 
-      // First call returns count, second returns teams
-      const knexStub = sinon.stub();
-      knexStub.onFirstCall().resolves({ rows: [{ count: '5' }] });
-      knexStub.onSecondCall().resolves({ rows: mockTeams });
+      const mockResponse = {
+        rowCount: 2,
+        rows: mockTeams
+      } as unknown as Promise<QueryResult<any>>;
 
-      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination(undefined, { page: 1, limit: 2 });
+      const result = await repository.getTeams(undefined, { page: 1, limit: 2 });
 
-      expect(result.teams).to.eql(mockTeams);
-      expect(result.total).to.equal(5);
+      expect(result).to.eql(mockTeams);
     });
 
     it('filters by search term', async () => {
       const mockTeams = [{ team_id: 'uuid-1', name: 'Research Team', description: 'Research group' }];
 
-      const knexStub = sinon.stub();
-      knexStub.onFirstCall().resolves({ rows: [{ count: '1' }] });
-      knexStub.onSecondCall().resolves({ rows: mockTeams });
+      const mockResponse = {
+        rowCount: 1,
+        rows: mockTeams
+      } as unknown as Promise<QueryResult<any>>;
 
-      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination('Research', { page: 1, limit: 50 });
+      const result = await repository.getTeams({ search: 'Research' }, { page: 1, limit: 50 });
 
-      expect(result.teams).to.eql(mockTeams);
-      expect(result.total).to.equal(1);
+      expect(result).to.eql(mockTeams);
     });
 
     it('returns empty array when no teams exist', async () => {
-      const knexStub = sinon.stub();
-      knexStub.onFirstCall().resolves({ rows: [{ count: '0' }] });
-      knexStub.onSecondCall().resolves({ rows: [] });
+      const mockResponse = {
+        rowCount: 0,
+        rows: []
+      } as unknown as Promise<QueryResult<any>>;
 
-      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination(undefined, { page: 1, limit: 50 });
+      const result = await repository.getTeams(undefined, { page: 1, limit: 50 });
 
-      expect(result.teams).to.eql([]);
-      expect(result.total).to.equal(0);
+      expect(result).to.eql([]);
     });
 
     it('calculates correct offset for page > 1', async () => {
       const mockTeams = [{ team_id: 'uuid-3', name: 'Team Gamma', description: 'Third team' }];
 
-      const knexStub = sinon.stub();
-      knexStub.onFirstCall().resolves({ rows: [{ count: '10' }] });
-      knexStub.onSecondCall().resolves({ rows: mockTeams });
+      const mockResponse = {
+        rowCount: 1,
+        rows: mockTeams
+      } as unknown as Promise<QueryResult<any>>;
 
-      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
 
       const repository = new TeamRepository(mockDBConnection);
-      const result = await repository.getTeamsWithPagination(undefined, { page: 2, limit: 3 });
+      const result = await repository.getTeams(undefined, { page: 2, limit: 3 });
 
-      // Page 2 with limit 3 should offset by 3 ((2-1) * 3) for 1-indexed pagination
-      expect(result.teams).to.eql(mockTeams);
-      expect(result.total).to.equal(10);
+      expect(result).to.eql(mockTeams);
+    });
+  });
+
+  describe('getTeamsCount', () => {
+    it('returns count for matching teams', async () => {
+      const mockResponse = {
+        rowCount: 1,
+        rows: [{ count: 2 }]
+      } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new TeamRepository(mockConnection);
+
+      const result = await repository.getTeamsCount();
+
+      expect(result).to.equal(2);
+    });
+
+    it('returns 0 when count query has no rows', async () => {
+      const mockResponse = {
+        rowCount: 1,
+        rows: [{ count: 0 }]
+      } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new TeamRepository(mockConnection);
+
+      const result = await repository.getTeamsCount({ search: 'Research' });
+
+      expect(result).to.equal(0);
     });
   });
 
   describe('updateTeam', () => {
-    it('returns updated team record', async () => {
-      const mockRows = [{ team_id: 1, name: 'Team A Updated', description: 'Updated Desc' }];
+    it('updates team record', async () => {
       const mockResponse = {
-        rowCount: 1,
-        rows: mockRows
+        rowCount: 1
       } as unknown as Promise<QueryResult<any>>;
 
-      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const knexStub = sinon.stub().resolves(mockResponse);
+      const mockConnection = getMockDBConnection({ knex: knexStub });
       const repository = new TeamRepository(mockConnection);
 
-      const result = await repository.updateTeam('1', {
+      await repository.updateTeam('1', {
         name: 'Team A Updated',
         description: 'Updated Desc',
         record_end_date: new Date().toISOString()
       });
-      expect(result).to.eql(mockRows[0]);
+
+      expect(knexStub).to.have.been.calledOnce;
     });
 
     it('throws error if update fails', async () => {

--- a/api/src/repositories/authorization/team-repository.ts
+++ b/api/src/repositories/authorization/team-repository.ts
@@ -1,6 +1,9 @@
+import { Knex } from 'knex';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
+import { CountResult } from '../../models/count';
 import { CreateTeam, Team, UpdateTeam } from '../../models/team';
+import { TeamFilters } from '../../services/access-policy/team-service.interface';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
@@ -27,7 +30,7 @@ export class TeamRepository extends BaseRepository {
         name: teamData.name,
         description: teamData.description
       })
-      .returning(['team_id', 'name', 'description']);
+      .returning(['team_id', 'name', 'description', knex.raw('0::int as member_count')]);
 
     const response = await this.connection.knex(query, Team);
 
@@ -51,14 +54,18 @@ export class TeamRepository extends BaseRepository {
   async getTeam(teamId: string): Promise<Team> {
     const knex = getKnex();
     const query = knex
-      .table('team')
-      .select(['team_id', 'name', 'description'])
-      .where('team_id', teamId)
-      .whereNull('record_end_date');
+      .from('team as t')
+      .leftJoin('team_member as tm', function () {
+        this.on('t.team_id', '=', 'tm.team_id').andOnNull('tm.record_end_date');
+      })
+      .select(['t.team_id', 't.name', 't.description', knex.raw('COUNT(tm.team_member_id)::int as member_count')])
+      .whereNull('t.record_end_date')
+      .where('t.team_id', teamId)
+      .groupBy(['t.team_id', 't.name', 't.description']);
 
     const response = await this.connection.knex(query, Team);
 
-    if (response.rowCount !== 1) {
+    if (response.rows.length !== 1) {
       throw new ApiExecuteSQLError('Failed to get team', [
         'TeamRepository->getTeam',
         'rowCount was null or undefined, expected rowCount = 1'
@@ -69,14 +76,28 @@ export class TeamRepository extends BaseRepository {
   }
 
   /**
-   * Get all team records.
+   * Get teams with optional search and pagination, including active member count.
    *
-   * @return {Promise<Team[]>} - A list of all team records.
+   * @param {TeamFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<Team[]>}
    * @memberof TeamRepository
    */
-  async getTeams(): Promise<Team[]> {
+  async getTeams(filters?: TeamFilters, pagination?: ApiPaginationOptions): Promise<Team[]> {
     const knex = getKnex();
-    const query = knex.table('team').select(['team_id', 'name', 'description']).whereNull('record_end_date');
+    const baseQuery = this.applyFilters(knex.table('team as t').whereNull('t.record_end_date'), filters);
+
+    const query = baseQuery
+      .clone()
+      .leftJoin('team_member as tm', function () {
+        this.on('t.team_id', '=', 'tm.team_id').andOnNull('tm.record_end_date');
+      })
+      .select(['t.team_id', 't.name', 't.description', knex.raw('COUNT(tm.team_member_id)::int as member_count')])
+      .groupBy(['t.team_id', 't.name', 't.description']);
+
+    if (pagination) {
+      this.applyPagination(query, pagination);
+    }
 
     const response = await this.connection.knex(query, Team);
 
@@ -84,44 +105,19 @@ export class TeamRepository extends BaseRepository {
   }
 
   /**
-   * Get teams with pagination and optional search.
+   * Get count of teams matching optional search criteria.
    *
-   * @param {string} [search] - Optional search term to filter by team name.
-   * @param {ApiPaginationOptions} pagination - Pagination options.
-   * @return {Promise<{ teams: Team[]; total: number }>}
+   * @param {TeamFilters} [filters] - Optional filter set.
+   * @return {Promise<number>}
    * @memberof TeamRepository
    */
-  async getTeamsWithPagination(
-    search: string | undefined,
-    pagination: ApiPaginationOptions
-  ): Promise<{ teams: Team[]; total: number }> {
+  async getTeamsCount(filters?: TeamFilters): Promise<number> {
     const knex = getKnex();
+    const baseQuery = this.applyFilters(knex.table('team as t').whereNull('t.record_end_date'), filters);
 
-    let baseQuery = knex.table('team').whereNull('record_end_date');
-
-    if (search) {
-      baseQuery = baseQuery.whereILike('name', `%${search}%`);
-    }
-
-    // Build count query
-    const countQuery = baseQuery.clone().count('* as count').first();
-
-    // Build paginated query (1-indexed pagination)
-    const paginatedQuery = baseQuery
-      .clone()
-      .select(['team_id', 'name', 'description'])
-      .orderBy(pagination.sort || 'name', pagination.order || 'asc')
-      .offset((pagination.page - 1) * pagination.limit)
-      .limit(pagination.limit);
-
-    // Execute both queries in parallel
-    const [countResult, response] = await Promise.all([
-      this.connection.knex(countQuery),
-      this.connection.knex(paginatedQuery, Team)
-    ]);
-    const total = Number(countResult.rows[0]?.count || 0);
-
-    return { teams: response.rows, total };
+    const countQuery = baseQuery.clone().select(knex.raw('coalesce(count(*), 0)::integer as count')).first();
+    const countResult = await this.connection.knex(countQuery, CountResult);
+    return countResult.rows[0].count;
   }
 
   /**
@@ -129,10 +125,10 @@ export class TeamRepository extends BaseRepository {
    *
    * @param {string} teamId - The ID of the team to update.
    * @param {UpdateTeam} teamData - The data to update.
-   * @return {Promise<Team>} - The updated team record.
+   * @return {Promise<void>}
    * @memberof TeamRepository
    */
-  async updateTeam(teamId: string, teamData: UpdateTeam): Promise<Team> {
+  async updateTeam(teamId: string, teamData: UpdateTeam): Promise<void> {
     const knex = getKnex();
     const query = knex
       .table('team')
@@ -141,10 +137,9 @@ export class TeamRepository extends BaseRepository {
         description: teamData.description,
         record_end_date: teamData.record_end_date
       })
-      .where('team_id', teamId)
-      .returning(['team_id', 'name', 'description']);
+      .where('team_id', teamId);
 
-    const response = await this.connection.knex(query, Team);
+    const response = await this.connection.knex(query);
 
     if (response.rowCount !== 1) {
       throw new ApiExecuteSQLError('Failed to update team', [
@@ -152,8 +147,6 @@ export class TeamRepository extends BaseRepository {
         'rowCount was null or undefined, expected rowCount = 1'
       ]);
     }
-
-    return response.rows[0];
   }
 
   /**
@@ -181,5 +174,24 @@ export class TeamRepository extends BaseRepository {
         'rowCount was null or undefined, expected rowCount = 1'
       ]);
     }
+  }
+
+  /**
+   * Apply team list filters to the provided query.
+   *
+   * @param {Knex.QueryBuilder} query - Base query to filter.
+   * @param {TeamFilters} [filters] - Optional filter set.
+   * @return {Knex.QueryBuilder} Filtered query.
+   */
+  private applyFilters(query: Knex.QueryBuilder, filters?: TeamFilters): Knex.QueryBuilder {
+    if (!filters) {
+      return query;
+    }
+
+    if (filters.search) {
+      query.whereILike('t.name', `%${filters.search}%`);
+    }
+
+    return query;
   }
 }

--- a/api/src/services/access-policy/policy-service.interface.ts
+++ b/api/src/services/access-policy/policy-service.interface.ts
@@ -3,6 +3,21 @@ import { PolicyEffect, PolicyStatement } from '../../models/policy-statement';
 import { PolicyConditionOperator, PolicyStatementCondition } from '../../models/policy-statement-condition';
 
 /**
+ * Optional filters when querying policies.
+ */
+export interface PolicyFilters {
+  /**
+   * Optional policy id filter.
+   */
+  policyId?: string;
+
+  /**
+   * Optional policy-name search term.
+   */
+  search?: string;
+}
+
+/**
  * A policy statement with its conditions.
  */
 export interface PolicyStatementWithConditions extends PolicyStatement {

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -56,9 +56,23 @@ describe('PolicyService', () => {
       const getPolicyStub = sinon.stub(PolicyRepository.prototype, 'getPolicies').resolves(mockPolicy);
 
       const result = await policyService.getPolicies();
+      const filters = undefined;
+      const pagination = undefined;
 
-      expect(getPolicyStub).to.have.been.called;
+      expect(getPolicyStub).to.have.been.calledOnce;
+      expect(getPolicyStub).to.have.been.calledWith(filters, pagination);
       expect(result).to.eql(mockPolicy);
+    });
+  });
+
+  describe('getPoliciesCount', () => {
+    it('should call repository.getPoliciesCount and return count', async () => {
+      const getPoliciesCountStub = sinon.stub(PolicyRepository.prototype, 'getPoliciesCount').resolves(2);
+
+      const result = await policyService.getPoliciesCount({ search: 'Telemetry' });
+
+      expect(getPoliciesCountStub).to.have.been.calledWith({ search: 'Telemetry' });
+      expect(result).to.equal(2);
     });
   });
 
@@ -109,7 +123,7 @@ describe('PolicyService', () => {
   });
 
   describe('getPoliciesWithStatements', () => {
-    it('should call repository.getPoliciesWithPagination and return policies with statements', async () => {
+    it('should call repository.getPolicies and return policies with statements', async () => {
       const mockPolicies: Policy[] = [
         { policy_id: '1', name: 'Policy 1', description: 'Desc 1' },
         { policy_id: '2', name: 'Policy 2', description: 'Desc 2' }
@@ -127,9 +141,7 @@ describe('PolicyService', () => {
         }
       ];
 
-      const getPoliciesWithPaginationStub = sinon
-        .stub(PolicyRepository.prototype, 'getPoliciesWithPagination')
-        .resolves({ policies: mockPolicies, total: 2 });
+      const getPoliciesStub = sinon.stub(PolicyRepository.prototype, 'getPolicies').resolves(mockPolicies);
       const getPolicyStatementsStub = sinon
         .stub(PolicyStatementRepository.prototype, 'getPolicyStatements')
         .resolves(mockStatements);
@@ -139,30 +151,22 @@ describe('PolicyService', () => {
 
       const result = await policyService.getPoliciesWithStatements(undefined, { page: 1, limit: 10 });
 
-      expect(getPoliciesWithPaginationStub).to.have.been.calledWith(undefined, { page: 1, limit: 10 });
+      expect(getPoliciesStub).to.have.been.calledWith(undefined, { page: 1, limit: 10 });
       expect(getPolicyStatementsStub).to.have.been.called;
       expect(getConditionsStub).to.have.been.called;
-      expect(result).to.eql({
-        policies: [
-          { ...mockPolicies[0], statements: [{ ...mockStatements[0], conditions: mockConditions }] },
-          { ...mockPolicies[1], statements: [{ ...mockStatements[0], conditions: mockConditions }] }
-        ],
-        pagination: { total: 2, per_page: 10, current_page: 1, last_page: 1, sort: undefined, order: undefined }
-      });
+      expect(result).to.eql([
+        { ...mockPolicies[0], statements: [{ ...mockStatements[0], conditions: mockConditions }] },
+        { ...mockPolicies[1], statements: [{ ...mockStatements[0], conditions: mockConditions }] }
+      ]);
     });
 
-    it('should call repository.getPoliciesWithPagination and return empty array when no policies exist', async () => {
-      const getPoliciesWithPaginationStub = sinon
-        .stub(PolicyRepository.prototype, 'getPoliciesWithPagination')
-        .resolves({ policies: [], total: 0 });
+    it('should call repository.getPolicies and return empty array when no policies exist', async () => {
+      const getPoliciesStub = sinon.stub(PolicyRepository.prototype, 'getPolicies').resolves([]);
 
       const result = await policyService.getPoliciesWithStatements(undefined, { page: 1, limit: 10 });
 
-      expect(getPoliciesWithPaginationStub).to.have.been.calledWith(undefined, { page: 1, limit: 10 });
-      expect(result).to.eql({
-        policies: [],
-        pagination: { total: 0, per_page: 10, current_page: 1, last_page: 1, sort: undefined, order: undefined }
-      });
+      expect(getPoliciesStub).to.have.been.calledWith(undefined, { page: 1, limit: 10 });
+      expect(result).to.eql([]);
     });
   });
 

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -2,11 +2,11 @@ import { IDBConnection } from '../../database/db';
 import { parseFeatureUrn } from '../../database/urn-utils';
 import { CreatePolicy, Policy, UpdatePolicy } from '../../models/policy';
 import { PolicyRepository } from '../../repositories/authorization/policy-repository';
-import { makePaginationResponse } from '../../utils/pagination';
-import { ApiPaginationOptions, ApiPaginationResults } from '../../zod-schema/pagination';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 import {
   CreatePolicyStatementInput,
+  PolicyFilters,
   PolicyStatementWithConditions,
   PolicyWithStatements
 } from './policy-service.interface';
@@ -48,13 +48,26 @@ export class PolicyService extends DBService {
   }
 
   /**
-   * Retrieve policies
+   * Retrieve policies with optional filters and pagination.
    *
+   * @param {PolicyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
    * @return {Promise<Policy[]>}
    * @memberof PolicyService
    */
-  getPolicies(): Promise<Policy[]> {
-    return this.policyRepository.getPolicies();
+  getPolicies(filters?: PolicyFilters, pagination?: ApiPaginationOptions): Promise<Policy[]> {
+    return this.policyRepository.getPolicies(filters, pagination);
+  }
+
+  /**
+   * Retrieve count of policies matching optional filters.
+   *
+   * @param {PolicyFilters} [filters] - Optional filter set.
+   * @return {Promise<number>}
+   * @memberof PolicyService
+   */
+  getPoliciesCount(filters?: PolicyFilters): Promise<number> {
+    return this.policyRepository.getPoliciesCount(filters);
   }
 
   /**
@@ -94,21 +107,18 @@ export class PolicyService extends DBService {
   }
 
   /**
-   * Get all policies with their statements, with pagination and search.
+   * Get policies with their statements and conditions.
    *
-   * @param {string} [search] - Optional search term to filter by policy name.
-   * @param {ApiPaginationOptions} pagination - Pagination options.
-   * @return {Promise<{ policies: PolicyWithStatements[]; pagination: ApiPaginationResults }>}
+   * @param {PolicyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<PolicyWithStatements[]>}
    * @memberof PolicyService
    */
   async getPoliciesWithStatements(
-    search: string | undefined,
-    pagination: ApiPaginationOptions
-  ): Promise<{
-    policies: PolicyWithStatements[];
-    pagination: ApiPaginationResults;
-  }> {
-    const { policies, total } = await this.policyRepository.getPoliciesWithPagination(search, pagination);
+    filters?: PolicyFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<PolicyWithStatements[]> {
+    const policies = await this.policyRepository.getPolicies(filters, pagination);
 
     const policiesWithStatements = await Promise.all(
       policies.map(async (policy) => ({
@@ -117,10 +127,7 @@ export class PolicyService extends DBService {
       }))
     );
 
-    return {
-      policies: policiesWithStatements,
-      pagination: makePaginationResponse(total, pagination)
-    };
+    return policiesWithStatements;
   }
 
   /**

--- a/api/src/services/access-policy/team-member-service.test.ts
+++ b/api/src/services/access-policy/team-member-service.test.ts
@@ -2,8 +2,14 @@ import chai, { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { CreateTeamMember, TeamMember, UpdateTeamMember } from '../../models/team-member';
-import { TeamMemberRepository, TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
+import {
+  CreateTeamMember,
+  TeamMember,
+  TeamMemberByUserFilter,
+  TeamMemberWithUser,
+  UpdateTeamMember
+} from '../../models/team-member';
+import { TeamMemberRepository } from '../../repositories/authorization/team-member-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamMemberService } from './team-member-service';
 
@@ -52,7 +58,10 @@ describe('TeamMemberService', () => {
       const result = await service.createTeamMember(input);
 
       expect(insertStub).to.have.been.calledWith(input);
-      expect(getWithUserStub).to.have.been.calledWith('22222222-2222-2222-2222-222222222222', 1);
+      expect(getWithUserStub).to.have.been.calledWith({
+        team_id: '22222222-2222-2222-2222-222222222222',
+        system_user_id: 1
+      });
       expect(result).to.eql(mockTeamMemberWithUser);
     });
 
@@ -151,25 +160,31 @@ describe('TeamMemberService', () => {
     });
 
     it('should find and delete by teamId and systemUserId', async () => {
-      sinon.stub(TeamMemberRepository.prototype, 'getTeamMembersByTeamId').resolves([
-        {
-          team_member_id: '11111111-1111-1111-1111-111111111111',
-          system_user_id: 2,
-          team_id: '22222222-2222-2222-2222-222222222222'
-        } as TeamMember
-      ]);
+      const teamMemberFilter: TeamMemberByUserFilter = {
+        team_id: '22222222-2222-2222-2222-222222222222',
+        system_user_id: 2
+      };
+      sinon.stub(TeamMemberRepository.prototype, 'getTeamMemberByTeamAndUser').resolves({
+        team_member_id: '11111111-1111-1111-1111-111111111111',
+        system_user_id: 2,
+        team_id: '22222222-2222-2222-2222-222222222222'
+      });
       const deleteStub = sinon.stub(TeamMemberRepository.prototype, 'deleteTeamMember').resolves();
 
-      await service.deleteTeamMember('22222222-2222-2222-2222-222222222222', 2);
+      await service.deleteTeamMemberByUser(teamMemberFilter);
 
       expect(deleteStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
     });
 
     it('should no-op when deleting by teamId and systemUserId if no member exists', async () => {
-      sinon.stub(TeamMemberRepository.prototype, 'getTeamMembersByTeamId').resolves([]);
+      const teamMemberFilter: TeamMemberByUserFilter = {
+        team_id: '22222222-2222-2222-2222-222222222222',
+        system_user_id: 2
+      };
+      sinon.stub(TeamMemberRepository.prototype, 'getTeamMemberByTeamAndUser').resolves(null);
       const deleteStub = sinon.stub(TeamMemberRepository.prototype, 'deleteTeamMember').resolves();
 
-      await service.deleteTeamMember('22222222-2222-2222-2222-222222222222', 2);
+      await service.deleteTeamMemberByUser(teamMemberFilter);
 
       expect(deleteStub).to.not.have.been.called;
     });

--- a/api/src/services/access-policy/team-member-service.test.ts
+++ b/api/src/services/access-policy/team-member-service.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { CreateTeamMember, TeamMember, UpdateTeamMember } from '../../models/team-member';
-import { TeamMemberRepository } from '../../repositories/authorization/team-member-repository';
+import { TeamMemberRepository, TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamMemberService } from './team-member-service';
 
@@ -29,8 +29,20 @@ describe('TeamMemberService', () => {
         system_user_id: 1,
         team_id: '22222222-2222-2222-2222-222222222222'
       };
+      const mockTeamMemberWithUser: TeamMemberWithUser = {
+        team_member_id: '11111111-1111-1111-1111-111111111111',
+        system_user_id: 1,
+        user_identifier: 'user_1',
+        email: 'user_1@test.com'
+      };
 
-      const stub = sinon.stub(TeamMemberRepository.prototype, 'insertTeamMember').resolves(mockTeamMember);
+      const getWithUserStub = sinon
+        .stub(TeamMemberRepository.prototype, 'getTeamMemberWithUser')
+        .onFirstCall()
+        .resolves(null)
+        .onSecondCall()
+        .resolves(mockTeamMemberWithUser);
+      const insertStub = sinon.stub(TeamMemberRepository.prototype, 'insertTeamMember').resolves(mockTeamMember);
 
       const input: CreateTeamMember = {
         system_user_id: 1,
@@ -39,8 +51,31 @@ describe('TeamMemberService', () => {
 
       const result = await service.createTeamMember(input);
 
-      expect(stub).to.have.been.calledWith(input);
-      expect(result).to.eql(mockTeamMember);
+      expect(insertStub).to.have.been.calledWith(input);
+      expect(getWithUserStub).to.have.been.calledWith('22222222-2222-2222-2222-222222222222', 1);
+      expect(result).to.eql(mockTeamMemberWithUser);
+    });
+
+    it('should return existing team member when association already exists', async () => {
+      const existingTeamMember: TeamMemberWithUser = {
+        team_member_id: '11111111-1111-1111-1111-111111111111',
+        system_user_id: 1,
+        user_identifier: 'user_1',
+        email: 'user_1@test.com'
+      };
+
+      sinon.stub(TeamMemberRepository.prototype, 'getTeamMemberWithUser').resolves(existingTeamMember);
+      const insertStub = sinon.stub(TeamMemberRepository.prototype, 'insertTeamMember').resolves({} as TeamMember);
+
+      const input: CreateTeamMember = {
+        system_user_id: 1,
+        team_id: '22222222-2222-2222-2222-222222222222'
+      };
+
+      const result = await service.createTeamMember(input);
+
+      expect(insertStub).to.not.have.been.called;
+      expect(result).to.eql(existingTeamMember);
     });
   });
 
@@ -107,12 +142,36 @@ describe('TeamMemberService', () => {
   });
 
   describe('deleteTeamMember', () => {
-    it('should call repository.deleteTeamMember', async () => {
-      const stub = sinon.stub(TeamMemberRepository.prototype, 'deleteTeamMember').resolves();
+    it('should call repository.deleteTeamMember when teamMemberId is provided', async () => {
+      const deleteStub = sinon.stub(TeamMemberRepository.prototype, 'deleteTeamMember').resolves();
 
       await service.deleteTeamMember('11111111-1111-1111-1111-111111111111');
 
-      expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+      expect(deleteStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('should find and delete by teamId and systemUserId', async () => {
+      sinon.stub(TeamMemberRepository.prototype, 'getTeamMembersByTeamId').resolves([
+        {
+          team_member_id: '11111111-1111-1111-1111-111111111111',
+          system_user_id: 2,
+          team_id: '22222222-2222-2222-2222-222222222222'
+        } as TeamMember
+      ]);
+      const deleteStub = sinon.stub(TeamMemberRepository.prototype, 'deleteTeamMember').resolves();
+
+      await service.deleteTeamMember('22222222-2222-2222-2222-222222222222', 2);
+
+      expect(deleteStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('should no-op when deleting by teamId and systemUserId if no member exists', async () => {
+      sinon.stub(TeamMemberRepository.prototype, 'getTeamMembersByTeamId').resolves([]);
+      const deleteStub = sinon.stub(TeamMemberRepository.prototype, 'deleteTeamMember').resolves();
+
+      await service.deleteTeamMember('22222222-2222-2222-2222-222222222222', 2);
+
+      expect(deleteStub).to.not.have.been.called;
     });
   });
 });

--- a/api/src/services/access-policy/team-member-service.ts
+++ b/api/src/services/access-policy/team-member-service.ts
@@ -1,6 +1,12 @@
 import { IDBConnection } from '../../database/db';
-import { CreateTeamMember, TeamMember, UpdateTeamMember } from '../../models/team-member';
-import { TeamMemberRepository, TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
+import {
+  CreateTeamMember,
+  TeamMember,
+  TeamMemberByUserFilter,
+  TeamMemberWithUser,
+  UpdateTeamMember
+} from '../../models/team-member';
+import { TeamMemberRepository } from '../../repositories/authorization/team-member-repository';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 
@@ -20,10 +26,7 @@ export class TeamMemberService extends DBService {
    * @memberof TeamMemberService
    */
   async createTeamMember(teamMemberData: CreateTeamMember): Promise<TeamMemberWithUser> {
-    const existing = await this.teamMemberRepository.getTeamMemberWithUser(
-      teamMemberData.team_id,
-      teamMemberData.system_user_id
-    );
+    const existing = await this.teamMemberRepository.getTeamMemberWithUser(teamMemberData);
 
     if (existing) {
       return existing;
@@ -31,10 +34,7 @@ export class TeamMemberService extends DBService {
 
     await this.teamMemberRepository.insertTeamMember(teamMemberData);
 
-    const created = await this.teamMemberRepository.getTeamMemberWithUser(
-      teamMemberData.team_id,
-      teamMemberData.system_user_id
-    );
+    const created = await this.teamMemberRepository.getTeamMemberWithUser(teamMemberData);
 
     if (!created) {
       throw new Error('Failed to create team member');
@@ -80,19 +80,23 @@ export class TeamMemberService extends DBService {
   /**
    * Delete a team member record.
    *
-   * @param {string} id - Team member ID (or team ID when systemUserId is provided).
-   * @param {number} [systemUserId] - Optional system user ID for delete-by-team-and-user.
+   * @param {string} teamMemberId - Team member ID.
    * @return {Promise<void>}
    * @memberof TeamMemberService
    */
-  async deleteTeamMember(id: string, systemUserId?: number): Promise<void> {
-    if (systemUserId === undefined) {
-      await this.teamMemberRepository.deleteTeamMember(id);
-      return;
-    }
+  async deleteTeamMember(teamMemberId: string): Promise<void> {
+    await this.teamMemberRepository.deleteTeamMember(teamMemberId);
+  }
 
-    const teamMembers = await this.teamMemberRepository.getTeamMembersByTeamId(id);
-    const existing = teamMembers.find((member) => member.system_user_id === systemUserId);
+  /**
+   * Delete a team member association by team and system user IDs.
+   *
+   * @param {TeamMemberByUserFilter} teamMemberData - Team and user identifiers.
+   * @return {Promise<void>}
+   * @memberof TeamMemberService
+   */
+  async deleteTeamMemberByUser(teamMemberData: TeamMemberByUserFilter): Promise<void> {
+    const existing = await this.teamMemberRepository.getTeamMemberByTeamAndUser(teamMemberData);
 
     if (!existing) {
       return;

--- a/api/src/services/access-policy/team-member-service.ts
+++ b/api/src/services/access-policy/team-member-service.ts
@@ -106,6 +106,17 @@ export class TeamMemberService extends DBService {
   }
 
   /**
+   * Delete all members for a team
+   *
+   * @param {string} teamId
+   * @return {Promise<void>}
+   * @memberof TeamMemberService
+   */
+  async deleteAllTeamMembers(teamId: string): Promise<void> {
+    await this.teamMemberRepository.deleteAllTeamMembers(teamId);
+  }
+
+  /**
    * Retrieve team members with user details for a given team.
    *
    * @param {string} teamId - The ID of the team to fetch members for.

--- a/api/src/services/access-policy/team-member-service.ts
+++ b/api/src/services/access-policy/team-member-service.ts
@@ -1,6 +1,7 @@
 import { IDBConnection } from '../../database/db';
 import { CreateTeamMember, TeamMember, UpdateTeamMember } from '../../models/team-member';
-import { TeamMemberRepository } from '../../repositories/authorization/team-member-repository';
+import { TeamMemberRepository, TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 
 export class TeamMemberService extends DBService {
@@ -15,11 +16,31 @@ export class TeamMemberService extends DBService {
    * Create a new team member record.
    *
    * @param {CreateTeamMember} teamMemberData - Data required to create a new team member.
-   * @return {Promise<TeamMember>} - The created team member record.
+   * @return {Promise<TeamMemberWithUser>} - The created team member with user details, or existing record if associated.
    * @memberof TeamMemberService
    */
-  createTeamMember(teamMemberData: CreateTeamMember): Promise<TeamMember> {
-    return this.teamMemberRepository.insertTeamMember(teamMemberData);
+  async createTeamMember(teamMemberData: CreateTeamMember): Promise<TeamMemberWithUser> {
+    const existing = await this.teamMemberRepository.getTeamMemberWithUser(
+      teamMemberData.team_id,
+      teamMemberData.system_user_id
+    );
+
+    if (existing) {
+      return existing;
+    }
+
+    await this.teamMemberRepository.insertTeamMember(teamMemberData);
+
+    const created = await this.teamMemberRepository.getTeamMemberWithUser(
+      teamMemberData.team_id,
+      teamMemberData.system_user_id
+    );
+
+    if (!created) {
+      throw new Error('Failed to create team member');
+    }
+
+    return created;
   }
 
   /**
@@ -59,11 +80,47 @@ export class TeamMemberService extends DBService {
   /**
    * Delete a team member record.
    *
-   * @param {string} teamMemberId - The id of the team member to delete
+   * @param {string} id - Team member ID (or team ID when systemUserId is provided).
+   * @param {number} [systemUserId] - Optional system user ID for delete-by-team-and-user.
    * @return {Promise<void>}
    * @memberof TeamMemberService
    */
-  async deleteTeamMember(teamMemberId: string): Promise<void> {
-    await this.teamMemberRepository.deleteTeamMember(teamMemberId);
+  async deleteTeamMember(id: string, systemUserId?: number): Promise<void> {
+    if (systemUserId === undefined) {
+      await this.teamMemberRepository.deleteTeamMember(id);
+      return;
+    }
+
+    const teamMembers = await this.teamMemberRepository.getTeamMembersByTeamId(id);
+    const existing = teamMembers.find((member) => member.system_user_id === systemUserId);
+
+    if (!existing) {
+      return;
+    }
+
+    await this.teamMemberRepository.deleteTeamMember(existing.team_member_id);
+  }
+
+  /**
+   * Retrieve team members with user details for a given team.
+   *
+   * @param {string} teamId - The ID of the team to fetch members for.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<TeamMemberWithUser[]>}
+   * @memberof TeamMemberService
+   */
+  getTeamMembersWithUsers(teamId: string, pagination?: ApiPaginationOptions): Promise<TeamMemberWithUser[]> {
+    return this.teamMemberRepository.getTeamMembersWithUsers(teamId, pagination);
+  }
+
+  /**
+   * Retrieve count of team members with user details for a given team.
+   *
+   * @param {string} teamId - The ID of the team to fetch member count for.
+   * @return {Promise<number>}
+   * @memberof TeamMemberService
+   */
+  getTeamMembersWithUsersCount(teamId: string): Promise<number> {
+    return this.teamMemberRepository.getTeamMembersWithUsersCount(teamId);
   }
 }

--- a/api/src/services/access-policy/team-policy-service.interface.ts
+++ b/api/src/services/access-policy/team-policy-service.interface.ts
@@ -1,0 +1,14 @@
+/**
+ * Optional filters when querying team-policy assignments.
+ */
+export interface TeamPolicyFilters {
+  /**
+   * Optional list of policy ids to filter by.
+   */
+  policyIds?: string[];
+
+  /**
+   * Optional search term applied to team or policy name.
+   */
+  search?: string;
+}

--- a/api/src/services/access-policy/team-policy-service.test.ts
+++ b/api/src/services/access-policy/team-policy-service.test.ts
@@ -61,9 +61,41 @@ describe('TeamPolicyService', () => {
     });
   });
 
-  describe('getTeamPolicies', () => {
-    it('should call repository.getTeamPolicies and return the records for a team', async () => {
-      const mockTeamPolicies: TeamPolicy[] = [
+  describe('createTeamPolicies', () => {
+    it('should create unique policies in bulk when none exist', async () => {
+      const getExistingStub = sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
+
+      const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy');
+      insertStub.onCall(0).resolves({
+        team_policy_id: '11111111-1111-1111-1111-111111111111',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
+      insertStub.onCall(1).resolves({
+        team_policy_id: '44444444-4444-4444-4444-444444444444',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '55555555-5555-5555-5555-555555555555'
+      });
+
+      const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
+        '33333333-3333-3333-3333-333333333333',
+        '55555555-5555-5555-5555-555555555555'
+      ]);
+
+      expect(getExistingStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222', {
+        policyIds: ['33333333-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555']
+      });
+
+      expect(insertStub).to.have.been.calledTwice;
+      expect(insertStub.firstCall).to.have.been.calledWith({
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
+      expect(insertStub.secondCall).to.have.been.calledWith({
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '55555555-5555-5555-5555-555555555555'
+      });
+      expect(result).to.eql([
         {
           team_policy_id: '11111111-1111-1111-1111-111111111111',
           team_id: '22222222-2222-2222-2222-222222222222',
@@ -74,11 +106,71 @@ describe('TeamPolicyService', () => {
           team_id: '22222222-2222-2222-2222-222222222222',
           policy_id: '55555555-5555-5555-5555-555555555555'
         }
+      ]);
+    });
+
+    it('should skip policies that already exist and de-duplicate input policy ids', async () => {
+      const getExistingStub = sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([
+        {
+          team_policy_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '33333333-3333-3333-3333-333333333333',
+          team_name: 'Team 1',
+          policy_name: 'Policy A'
+        }
+      ]);
+
+      const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves({
+        team_policy_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '55555555-5555-5555-5555-555555555555'
+      });
+
+      const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
+        '33333333-3333-3333-3333-333333333333',
+        '33333333-3333-3333-3333-333333333333',
+        '55555555-5555-5555-5555-555555555555'
+      ]);
+
+      expect(getExistingStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222', {
+        policyIds: ['33333333-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555']
+      });
+      expect(insertStub).to.have.been.calledOnceWith({
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '55555555-5555-5555-5555-555555555555'
+      });
+      expect(result).to.eql([
+        {
+          team_policy_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '55555555-5555-5555-5555-555555555555'
+        }
+      ]);
+    });
+  });
+
+  describe('getPoliciesByTeamId', () => {
+    it('should call repository.getPoliciesByTeamId and return the records for a team', async () => {
+      const mockTeamPolicies: TeamPolicyDetails[] = [
+        {
+          team_policy_id: '11111111-1111-1111-1111-111111111111',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '33333333-3333-3333-3333-333333333333',
+          team_name: 'Team 1',
+          policy_name: 'Policy A'
+        },
+        {
+          team_policy_id: '44444444-4444-4444-4444-444444444444',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '55555555-5555-5555-5555-555555555555',
+          team_name: 'Team 1',
+          policy_name: 'Policy B'
+        }
       ];
 
-      const stub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(mockTeamPolicies);
+      const stub = sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves(mockTeamPolicies);
 
-      const result = await service.getTeamPolicies('22222222-2222-2222-2222-222222222222');
+      const result = await service.getPoliciesByTeamId('22222222-2222-2222-2222-222222222222');
 
       expect(stub).to.have.been.calledWith('22222222-2222-2222-2222-222222222222');
       expect(result).to.eql(mockTeamPolicies);
@@ -86,7 +178,7 @@ describe('TeamPolicyService', () => {
   });
 
   describe('getAllTeamPolicies', () => {
-    it('should call repository.getAllTeamPolicies and return all team-policy associations with names', async () => {
+    it('should call repository.getTeamPolicies and return all team-policy associations with names', async () => {
       const mockTeamPolicies: TeamPolicyDetails[] = [
         {
           team_policy_id: '11111111-1111-1111-1111-111111111111',
@@ -97,12 +189,25 @@ describe('TeamPolicyService', () => {
         }
       ];
 
-      const stub = sinon.stub(TeamPolicyRepository.prototype, 'getAllTeamPolicies').resolves(mockTeamPolicies);
+      const stub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(mockTeamPolicies);
 
       const result = await service.getAllTeamPolicies();
+      const filters = undefined;
+      const pagination = undefined;
 
       expect(stub).to.have.been.calledOnce;
+      expect(stub).to.have.been.calledWith(filters, pagination);
       expect(result).to.eql(mockTeamPolicies);
+    });
+  });
+
+  describe('getAllTeamPoliciesCount', () => {
+    it('should call repository.getAllTeamPoliciesCount and return count', async () => {
+      const stub = sinon.stub(TeamPolicyRepository.prototype, 'getAllTeamPoliciesCount').resolves(2);
+      const result = await service.getAllTeamPoliciesCount({ search: 'Team' });
+
+      expect(stub).to.have.been.calledWith({ search: 'Team' });
+      expect(result).to.equal(2);
     });
   });
 

--- a/api/src/services/access-policy/team-policy-service.ts
+++ b/api/src/services/access-policy/team-policy-service.ts
@@ -1,9 +1,9 @@
 import { IDBConnection } from '../../database/db';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
 import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
-import { makePaginationResponse } from '../../utils/pagination';
-import { ApiPaginationOptions, ApiPaginationResults } from '../../zod-schema/pagination';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
+import { TeamPolicyFilters } from './team-policy-service.interface';
 
 export class TeamPolicyService extends DBService {
   teamPolicyRepository: TeamPolicyRepository;
@@ -25,6 +25,32 @@ export class TeamPolicyService extends DBService {
   }
 
   /**
+   * Create team-policy records in bulk for a single team.
+   *
+   * @param {string} teamId - Team ID.
+   * @param {string[]} policyIds - Policy IDs to associate with the team.
+   * @return {Promise<TeamPolicy[]>}
+   * @memberof TeamPolicyService
+   */
+  async createTeamPolicies(teamId: string, policyIds: string[]): Promise<TeamPolicy[]> {
+    const uniquePolicyIds = [...new Set(policyIds)];
+    if (!uniquePolicyIds.length) {
+      return [];
+    }
+
+    const existingPolicies = await this.teamPolicyRepository.getPoliciesByTeamId(teamId, {
+      policyIds: uniquePolicyIds
+    });
+    const existingPolicyIds = new Set(existingPolicies.map((teamPolicy) => teamPolicy.policy_id));
+
+    const policyIdsToCreate = uniquePolicyIds.filter((policyId) => !existingPolicyIds.has(policyId));
+
+    return Promise.all(
+      policyIdsToCreate.map((policyId) => this.createTeamPolicy({ team_id: teamId, policy_id: policyId }))
+    );
+  }
+
+  /**
    * Retrieve a team policy record
    *
    * @param {string} teamPolicyId - The ID of the team policy to fetch.
@@ -39,39 +65,38 @@ export class TeamPolicyService extends DBService {
    * Retrieve all team policy records for a specific team.
    *
    * @param {string} teamId - The ID of the team whose policies to fetch.
-   * @return {Promise<TeamPolicy[]>} - The list of team policy records.
+   * @return {Promise<TeamPolicyDetails[]>} - The list of team policy records.
    * @memberof TeamPolicyService
    */
-  getTeamPolicies(teamId: string): Promise<TeamPolicy[]> {
-    return this.teamPolicyRepository.getTeamPolicies(teamId);
+  getPoliciesByTeamId(
+    teamId: string,
+    filters?: TeamPolicyFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<TeamPolicyDetails[]> {
+    return this.teamPolicyRepository.getPoliciesByTeamId(teamId, filters, pagination);
   }
 
   /**
    * Get all team-policy associations with team and policy names for display.
    *
+   * @param {TeamPolicyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
    * @return {Promise<TeamPolicyDetails[]>} - List of team policy records with names.
    * @memberof TeamPolicyService
    */
-  getAllTeamPolicies(): Promise<TeamPolicyDetails[]> {
-    return this.teamPolicyRepository.getAllTeamPolicies();
+  getAllTeamPolicies(filters?: TeamPolicyFilters, pagination?: ApiPaginationOptions): Promise<TeamPolicyDetails[]> {
+    return this.teamPolicyRepository.getTeamPolicies(filters, pagination);
   }
 
   /**
-   * Get all team-policy associations with pagination support.
+   * Get count of team-policy associations matching optional filters.
    *
-   * @param {ApiPaginationOptions} options - Pagination options.
-   * @return {Promise<{ team_policies: TeamPolicyDetails[]; pagination: ApiPaginationResults }>}
+   * @param {TeamPolicyFilters} [filters] - Optional filter set.
+   * @return {Promise<number>}
    * @memberof TeamPolicyService
    */
-  async getAllTeamPoliciesWithPagination(
-    options: ApiPaginationOptions
-  ): Promise<{ team_policies: TeamPolicyDetails[]; pagination: ApiPaginationResults }> {
-    const { teamPolicies, total } = await this.teamPolicyRepository.getAllTeamPoliciesWithPagination(options);
-
-    return {
-      team_policies: teamPolicies,
-      pagination: makePaginationResponse(total, options)
-    };
+  getAllTeamPoliciesCount(filters?: TeamPolicyFilters): Promise<number> {
+    return this.teamPolicyRepository.getAllTeamPoliciesCount(filters);
   }
 
   /**

--- a/api/src/services/access-policy/team-service.interface.ts
+++ b/api/src/services/access-policy/team-service.interface.ts
@@ -1,0 +1,9 @@
+/**
+ * Optional filters when querying teams.
+ */
+export interface TeamFilters {
+  /**
+   * Optional team name search term.
+   */
+  search?: string;
+}

--- a/api/src/services/access-policy/team-service.test.ts
+++ b/api/src/services/access-policy/team-service.test.ts
@@ -2,11 +2,11 @@ import chai, { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { CreateTeam, Team, UpdateTeam } from '../../models/team';
-import { TeamMember } from '../../models/team-member';
-import { TeamMemberRepository, TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
+import { Team } from '../../models/team';
+import { TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
 import { TeamRepository } from '../../repositories/authorization/team-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
+import { TeamMemberService } from './team-member-service';
 import { TeamService } from './team-service';
 
 chai.use(sinonChai);
@@ -24,219 +24,153 @@ describe('TeamService', () => {
     sinon.restore();
   });
 
-  describe('createTeam', () => {
-    it('should call repository.insertTeam and return the created record', async () => {
-      const mockTeam: Team = {
+  it('createTeam inserts team and returns refreshed team', async () => {
+    const mockTeam: Team = {
+      team_id: '11111111-1111-1111-1111-111111111111',
+      name: 'Engineering',
+      description: 'Team description',
+      member_count: 0
+    };
+
+    const insertStub = sinon.stub(TeamRepository.prototype, 'insertTeam').resolves(mockTeam);
+    const getStub = sinon.stub(TeamRepository.prototype, 'getTeam').resolves(mockTeam);
+    const result = await service.createTeam({ name: 'Engineering', description: 'Team description' });
+
+    expect(insertStub).to.have.been.calledWith({ name: 'Engineering', description: 'Team description' });
+    expect(getStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+    expect(result).to.eql(mockTeam);
+  });
+
+  it('createTeam creates team members when system_user_ids are provided', async () => {
+    const insertedTeam: Team = {
+      team_id: '11111111-1111-1111-1111-111111111111',
+      name: 'Engineering',
+      description: 'Team description',
+      member_count: 0
+    };
+
+    const refreshedTeam: Team = {
+      ...insertedTeam,
+      member_count: 2
+    };
+
+    const createdMember: TeamMemberWithUser = {
+      team_member_id: '22222222-2222-2222-2222-222222222222',
+      system_user_id: 1,
+      user_identifier: 'user_1',
+      email: 'user_1@test.com'
+    };
+
+    sinon.stub(TeamRepository.prototype, 'insertTeam').resolves(insertedTeam);
+    const getTeamStub = sinon.stub(TeamRepository.prototype, 'getTeam').resolves(refreshedTeam);
+    const createTeamMemberStub = sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(createdMember);
+
+    const result = await service.createTeam({
+      name: 'Engineering',
+      description: 'Team description',
+      system_user_ids: [1, 2]
+    });
+
+    expect(createTeamMemberStub).to.have.been.calledTwice;
+    expect(createTeamMemberStub.firstCall).to.have.been.calledWith({
+      team_id: '11111111-1111-1111-1111-111111111111',
+      system_user_id: 1
+    });
+    expect(createTeamMemberStub.secondCall).to.have.been.calledWith({
+      team_id: '11111111-1111-1111-1111-111111111111',
+      system_user_id: 2
+    });
+    expect(getTeamStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+    expect(result).to.eql(refreshedTeam);
+  });
+
+  it('getTeam calls repository.getTeam', async () => {
+    const mockTeam: Team = {
+      team_id: '11111111-1111-1111-1111-111111111111',
+      name: 'Engineering',
+      description: 'Team description',
+      member_count: 2
+    };
+
+    const stub = sinon.stub(TeamRepository.prototype, 'getTeam').resolves(mockTeam);
+    const result = await service.getTeam('11111111-1111-1111-1111-111111111111');
+
+    expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+    expect(result).to.eql(mockTeam);
+  });
+
+  it('getTeams without pagination returns array', async () => {
+    const mockTeams: Team[] = [
+      {
         team_id: '11111111-1111-1111-1111-111111111111',
         name: 'Engineering',
-        description: 'Team description'
-      };
+        description: 'Team description',
+        member_count: 1
+      }
+    ];
 
-      const stub = sinon.stub(TeamRepository.prototype, 'insertTeam').resolves(mockTeam);
+    const stub = sinon.stub(TeamRepository.prototype, 'getTeams').resolves(mockTeams);
+    const result = await service.getTeams();
+    const filters = undefined;
+    const pagination = undefined;
 
-      const input: CreateTeam = {
-        name: 'Engineering',
-        description: 'Team description'
-      };
-
-      const result = await service.createTeam(input);
-
-      expect(stub).to.have.been.calledWith(input);
-      expect(result).to.eql(mockTeam);
-    });
+    expect(stub).to.have.been.calledOnce;
+    expect(stub).to.have.been.calledWith(filters, pagination);
+    expect(result).to.eql(mockTeams);
   });
 
-  describe('getTeam', () => {
-    it('should call repository.getTeam and return the record', async () => {
-      const mockTeam: Team = {
+  it('getTeams with pagination returns array', async () => {
+    const mockTeams: Team[] = [
+      {
         team_id: '11111111-1111-1111-1111-111111111111',
         name: 'Engineering',
-        description: 'Team description'
-      };
+        description: 'Team description',
+        member_count: 1
+      }
+    ];
 
-      const stub = sinon.stub(TeamRepository.prototype, 'getTeam').resolves(mockTeam);
+    const getTeamsStub = sinon.stub(TeamRepository.prototype, 'getTeams').resolves(mockTeams);
+    const result = await service.getTeams({ search: 'Eng' }, { page: 1, limit: 50 });
 
-      const result = await service.getTeam('11111111-1111-1111-1111-111111111111');
-
-      expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
-      expect(result).to.eql(mockTeam);
-    });
+    expect(getTeamsStub).to.have.been.calledWith({ search: 'Eng' }, { page: 1, limit: 50 });
+    expect(result).to.eql(mockTeams);
   });
 
-  describe('getTeams', () => {
-    it('should call repository.getTeams and return all records', async () => {
-      const mockTeams: Team[] = [
-        {
-          team_id: '11111111-1111-1111-1111-111111111111',
-          name: 'Engineering',
-          description: 'Team description'
-        },
-        {
-          team_id: '22222222-2222-2222-2222-222222222222',
-          name: 'Telemetry',
-          description: 'Telemetry team description'
-        }
-      ];
+  it('getTeamsCount calls repository.getTeamsCount', async () => {
+    const stub = sinon.stub(TeamRepository.prototype, 'getTeamsCount').resolves(3);
+    const result = await service.getTeamsCount({ search: 'Eng' });
 
-      const stub = sinon.stub(TeamRepository.prototype, 'getTeams').resolves(mockTeams);
-
-      const result = await service.getTeams();
-
-      expect(stub).to.have.been.calledOnce;
-      expect(result).to.eql(mockTeams);
-    });
+    expect(stub).to.have.been.calledWith({ search: 'Eng' });
+    expect(result).to.equal(3);
   });
 
-  describe('updateTeam', () => {
-    it('should call repository.updateTeam and return the updated record', async () => {
-      const mockTeam: Team = {
-        team_id: '11111111-1111-1111-1111-111111111111',
-        name: 'Engineering',
-        description: 'Team description'
-      };
+  it('updateTeam calls repository.updateTeam and then getTeam', async () => {
+    const mockTeam: Team = {
+      team_id: '11111111-1111-1111-1111-111111111111',
+      name: 'Engineering',
+      description: 'Team description',
+      member_count: 2
+    };
 
-      const stub = sinon.stub(TeamRepository.prototype, 'updateTeam').resolves(mockTeam);
+    const updateStub = sinon.stub(TeamRepository.prototype, 'updateTeam').resolves();
+    const getStub = sinon.stub(TeamRepository.prototype, 'getTeam').resolves(mockTeam);
 
-      const updateData: UpdateTeam = {
-        name: 'Engineering',
-        description: 'Team description'
-      };
-
-      const result = await service.updateTeam('11111111-1111-1111-1111-111111111111', updateData);
-
-      expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111', updateData);
-      expect(result).to.eql(mockTeam);
+    const result = await service.updateTeam('11111111-1111-1111-1111-111111111111', {
+      name: 'Engineering',
+      description: 'Team description'
     });
+
+    expect(updateStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111', {
+      name: 'Engineering',
+      description: 'Team description'
+    });
+    expect(getStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+    expect(result).to.eql(mockTeam);
   });
 
-  describe('deleteTeam', () => {
-    it('should call repository.deleteTeam', async () => {
-      const stub = sinon.stub(TeamRepository.prototype, 'deleteTeam').resolves();
-
-      await service.deleteTeam('11111111-1111-1111-1111-111111111111');
-
-      expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
-    });
-  });
-
-  describe('getTeamsWithMembers', () => {
-    it('should return paginated teams with members', async () => {
-      const mockTeams: Team[] = [
-        { team_id: 'team-1', name: 'Team Alpha', description: 'First team' },
-        { team_id: 'team-2', name: 'Team Beta', description: 'Second team' }
-      ];
-      const mockMembers: TeamMemberWithUser[] = [
-        { team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' }
-      ];
-
-      sinon.stub(TeamRepository.prototype, 'getTeamsWithPagination').resolves({ teams: mockTeams, total: 2 });
-      sinon.stub(service.connection, 'knex').resolves({ rows: mockMembers } as any);
-
-      const result = await service.getTeamsWithMembers(undefined, { page: 1, limit: 50 });
-
-      expect(result.pagination).to.eql({
-        total: 2,
-        per_page: 50,
-        current_page: 1,
-        last_page: 1,
-        sort: undefined,
-        order: undefined
-      });
-      expect(result.teams).to.have.length(2);
-      expect(result.teams[0].members).to.eql(mockMembers);
-    });
-
-    it('should return empty array when no teams exist', async () => {
-      sinon.stub(TeamRepository.prototype, 'getTeamsWithPagination').resolves({ teams: [], total: 0 });
-
-      const result = await service.getTeamsWithMembers(undefined, { page: 1, limit: 50 });
-
-      expect(result.teams).to.eql([]);
-      expect(result.pagination).to.eql({
-        total: 0,
-        per_page: 50,
-        current_page: 1,
-        last_page: 1,
-        sort: undefined,
-        order: undefined
-      });
-    });
-  });
-
-  describe('getTeamWithMembers', () => {
-    it('should return team with its members', async () => {
-      const mockTeam: Team = { team_id: 'team-1', name: 'Test Team', description: 'A test team' };
-      const mockMembers: TeamMemberWithUser[] = [{ team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'bob' }];
-
-      sinon.stub(TeamRepository.prototype, 'getTeam').resolves(mockTeam);
-      sinon.stub(service.connection, 'knex').resolves({ rows: mockMembers } as any);
-
-      const result = await service.getTeamWithMembers('team-1');
-
-      expect(result).to.eql({ ...mockTeam, members: mockMembers });
-    });
-  });
-
-  describe('createTeamWithMembers', () => {
-    it('should create team and add members', async () => {
-      const mockTeam: Team = { team_id: 'new-team', name: 'New Team', description: 'A new team' };
-      const mockMembers: TeamMemberWithUser[] = [
-        { team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' },
-        { team_member_id: 'tm-2', system_user_id: 2, user_identifier: 'bob' }
-      ];
-
-      sinon.stub(TeamRepository.prototype, 'insertTeam').resolves(mockTeam);
-      sinon.stub(TeamMemberRepository.prototype, 'insertTeamMember').resolves({} as TeamMember);
-      sinon.stub(service.connection, 'knex').resolves({ rows: mockMembers } as any);
-
-      const result = await service.createTeamWithMembers({ name: 'New Team', description: 'A new team' }, [1, 2]);
-
-      expect(result.team_id).to.equal('new-team');
-      expect(result.members).to.eql(mockMembers);
-    });
-
-    it('should create team with no members when none provided', async () => {
-      const mockTeam: Team = { team_id: 'empty-team', name: 'Empty Team', description: null };
-
-      sinon.stub(TeamRepository.prototype, 'insertTeam').resolves(mockTeam);
-      sinon.stub(service.connection, 'knex').resolves({ rows: [] } as any);
-
-      const result = await service.createTeamWithMembers({ name: 'Empty Team' }, []);
-
-      expect(result.members).to.eql([]);
-    });
-  });
-
-  describe('updateTeamWithMembers', () => {
-    it('should update team and sync members', async () => {
-      const mockTeam: Team = { team_id: 'team-1', name: 'Updated Team', description: 'Updated' };
-      const existingMembers: TeamMember[] = [
-        { team_member_id: 'tm-1', team_id: 'team-1', system_user_id: 1 },
-        { team_member_id: 'tm-2', team_id: 'team-1', system_user_id: 2 }
-      ];
-      const newMembers: TeamMemberWithUser[] = [
-        { team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' },
-        { team_member_id: 'tm-3', system_user_id: 3, user_identifier: 'charlie' }
-      ];
-
-      sinon.stub(TeamRepository.prototype, 'updateTeam').resolves(mockTeam);
-      sinon.stub(TeamMemberRepository.prototype, 'getTeamMembersByTeamId').resolves(existingMembers);
-      const insertStub = sinon.stub(TeamMemberRepository.prototype, 'insertTeamMember').resolves({} as TeamMember);
-      const deleteStub = sinon.stub(TeamMemberRepository.prototype, 'deleteTeamMember').resolves();
-      sinon.stub(service.connection, 'knex').resolves({ rows: newMembers } as any);
-
-      // Update with users 1 and 3 (remove 2, keep 1, add 3)
-      const result = await service.updateTeamWithMembers(
-        'team-1',
-        { name: 'Updated Team', description: 'Updated' },
-        [1, 3]
-      );
-
-      // Should add user 3 (new)
-      expect(insertStub).to.have.been.calledOnce;
-      // Should remove user 2 (no longer in list)
-      expect(deleteStub).to.have.been.calledOnce;
-      expect(result.members).to.eql(newMembers);
-    });
+  it('deleteTeam calls repository.deleteTeam', async () => {
+    const stub = sinon.stub(TeamRepository.prototype, 'deleteTeam').resolves();
+    await service.deleteTeam('11111111-1111-1111-1111-111111111111');
+    expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
   });
 });

--- a/api/src/services/access-policy/team-service.test.ts
+++ b/api/src/services/access-policy/team-service.test.ts
@@ -2,6 +2,7 @@ import chai, { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { IDBConnection } from '../../database/db';
 import { Team } from '../../models/team';
 import { TeamMemberWithUser } from '../../models/team-member';
 import { TeamRepository } from '../../repositories/authorization/team-repository';
@@ -12,7 +13,7 @@ import { TeamService } from './team-service';
 chai.use(sinonChai);
 
 describe('TeamService', () => {
-  let mockDBConnection: any;
+  let mockDBConnection: IDBConnection;
   let service: TeamService;
 
   beforeEach(() => {
@@ -144,7 +145,7 @@ describe('TeamService', () => {
     expect(result).to.equal(3);
   });
 
-  it('updateTeam calls repository.updateTeam and then getTeam', async () => {
+  it('updateTeam calls repository.updateTeam, creates team members, and then getTeam', async () => {
     const mockTeam: Team = {
       team_id: '11111111-1111-1111-1111-111111111111',
       name: 'Engineering',
@@ -152,18 +153,34 @@ describe('TeamService', () => {
       member_count: 2
     };
 
+    const systemUserIds = [101, 102];
+
     const updateStub = sinon.stub(TeamRepository.prototype, 'updateTeam').resolves();
     const getStub = sinon.stub(TeamRepository.prototype, 'getTeam').resolves(mockTeam);
+    const createMemberStub = sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves();
 
     const result = await service.updateTeam('11111111-1111-1111-1111-111111111111', {
       name: 'Engineering',
-      description: 'Team description'
+      description: 'Team description',
+      system_user_ids: systemUserIds
     });
 
     expect(updateStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111', {
       name: 'Engineering',
-      description: 'Team description'
+      description: 'Team description',
+      system_user_ids: systemUserIds
     });
+
+    expect(createMemberStub).to.have.been.calledTwice;
+    expect(createMemberStub.getCall(0)).to.have.been.calledWith({
+      team_id: '11111111-1111-1111-1111-111111111111',
+      system_user_id: 101
+    });
+    expect(createMemberStub.getCall(1)).to.have.been.calledWith({
+      team_id: '11111111-1111-1111-1111-111111111111',
+      system_user_id: 102
+    });
+
     expect(getStub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
     expect(result).to.eql(mockTeam);
   });

--- a/api/src/services/access-policy/team-service.test.ts
+++ b/api/src/services/access-policy/team-service.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { Team } from '../../models/team';
-import { TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
+import { TeamMemberWithUser } from '../../models/team-member';
 import { TeamRepository } from '../../repositories/authorization/team-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamMemberService } from './team-member-service';

--- a/api/src/services/access-policy/team-service.ts
+++ b/api/src/services/access-policy/team-service.ts
@@ -1,202 +1,109 @@
 import { IDBConnection } from '../../database/db';
 import { CreateTeam, Team, UpdateTeam } from '../../models/team';
-import { TeamMemberRepository, TeamMemberWithUser } from '../../repositories/authorization/team-member-repository';
 import { TeamRepository } from '../../repositories/authorization/team-repository';
-import { makePaginationResponse } from '../../utils/pagination';
-import { ApiPaginationOptions, ApiPaginationResults } from '../../zod-schema/pagination';
+import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
+import { TeamMemberService } from './team-member-service';
+import { TeamFilters } from './team-service.interface';
 
 /**
- * A team with its members.
+ * Service for managing teams.
+ *
+ * Note: Team members are managed by `TeamMemberService` and are not returned by this service.
  */
-export interface TeamWithMembers extends Team {
-  members: TeamMemberWithUser[];
-}
-
 export class TeamService extends DBService {
   teamRepository: TeamRepository;
-  teamMemberRepository: TeamMemberRepository;
+  teamMemberService: TeamMemberService;
 
+  /**
+   * Creates a TeamService instance.
+   *
+   * @param {IDBConnection} connection - The active database connection.
+   */
   constructor(connection: IDBConnection) {
     super(connection);
     this.teamRepository = new TeamRepository(connection);
-    this.teamMemberRepository = new TeamMemberRepository(connection);
+    this.teamMemberService = new TeamMemberService(connection);
   }
 
   /**
-   * Create a new team record.
+   * Create a team record.
    *
-   * @param {CreateTeam} teamData - Data required to create a new team.
-   * @return {Promise<Team>} - The created team record.
-   * @memberof TeamService
+   * @param {CreateTeam} teamData - Team fields required to create the team.
+   * @return {Promise<Team>} The created team (includes `member_count`).
    */
-  createTeam(teamData: CreateTeam): Promise<Team> {
-    return this.teamRepository.insertTeam(teamData);
+  async createTeam(teamData: CreateTeam): Promise<Team> {
+    const team = await this.teamRepository.insertTeam({
+      name: teamData.name,
+      description: teamData.description
+    });
+
+    const systemUserIds = teamData.system_user_ids ?? [];
+
+    if (systemUserIds.length > 0) {
+      await Promise.all(
+        systemUserIds.map((systemUserId) =>
+          this.teamMemberService.createTeamMember({
+            team_id: team.team_id,
+            system_user_id: systemUserId
+          })
+        )
+      );
+    }
+
+    return this.teamRepository.getTeam(team.team_id);
   }
 
   /**
-   * Retrieve a team record
+   * Get a single team by ID.
    *
-   * @param {string} teamId - The ID of the team to fetch.
-   * @return {Promise<Team>} - The team record.
-   * @memberof TeamService
+   * @param {string} teamId - Team identifier.
+   * @return {Promise<Team>} Team record including `member_count`.
    */
   getTeam(teamId: string): Promise<Team> {
     return this.teamRepository.getTeam(teamId);
   }
 
   /**
-   * Retrieve multiple team records
+   * Get teams with optional search and optional pagination.
    *
-   * @return {Promise<Team[]>} - The team records.
-   * @memberof TeamService
+   * @param {TeamFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<Team[]>} Team list response.
    */
-  getTeams(): Promise<Team[]> {
-    return this.teamRepository.getTeams();
+  getTeams(filters?: TeamFilters, pagination?: ApiPaginationOptions): Promise<Team[]> {
+    return this.teamRepository.getTeams(filters, pagination);
   }
 
   /**
-   * Update an existing team record.
+   * Get total count of teams matching optional filters.
    *
-   * @param {string} teamId - The ID of the team to update.
-   * @param {UpdateTeam} teamData - Partial data to update the team record.
-   * @return {Promise<Team>} - The updated team record.
-   * @memberof TeamService
+   * @param {TeamFilters} [filters] - Optional filter set.
+   * @return {Promise<number>} Count of matching teams.
    */
-  updateTeam(teamId: string, teamData: UpdateTeam): Promise<Team> {
-    return this.teamRepository.updateTeam(teamId, teamData);
+  getTeamsCount(filters?: TeamFilters): Promise<number> {
+    return this.teamRepository.getTeamsCount(filters);
   }
 
   /**
-   * Delete a team record.
+   * Update a team record by ID.
    *
-   * @param {string} teamId - The id of the team to delete
+   * @param {string} teamId - Team identifier.
+   * @param {UpdateTeam} teamData - Partial team fields to update.
+   * @return {Promise<Team>} Updated team including current `member_count`.
+   */
+  async updateTeam(teamId: string, teamData: UpdateTeam): Promise<Team> {
+    await this.teamRepository.updateTeam(teamId, teamData);
+    return this.teamRepository.getTeam(teamId);
+  }
+
+  /**
+   * Soft-delete a team by ID.
+   *
+   * @param {string} teamId - Team identifier.
    * @return {Promise<void>}
-   * @memberof TeamService
    */
   async deleteTeam(teamId: string): Promise<void> {
     await this.teamRepository.deleteTeam(teamId);
-  }
-
-  /**
-   * Get all teams with their members, with pagination and search.
-   *
-   * @param {string} [search] - Optional search term to filter by team name.
-   * @param {ApiPaginationOptions} pagination - Pagination options.
-   * @return {Promise<{ teams: TeamWithMembers[]; pagination: ApiPaginationResults }>}
-   * @memberof TeamService
-   */
-  async getTeamsWithMembers(
-    search: string | undefined,
-    pagination: ApiPaginationOptions
-  ): Promise<{
-    teams: TeamWithMembers[];
-    pagination: ApiPaginationResults;
-  }> {
-    const { teams, total } = await this.teamRepository.getTeamsWithPagination(search, pagination);
-
-    const teamsWithMembers = await Promise.all(
-      teams.map(async (team) => ({
-        ...team,
-        members: await this.getTeamMembersWithUsers(team.team_id)
-      }))
-    );
-
-    return {
-      teams: teamsWithMembers,
-      pagination: makePaginationResponse(total, pagination)
-    };
-  }
-
-  /**
-   * Get a single team with its members.
-   *
-   * @param {string} teamId - The ID of the team to fetch.
-   * @return {Promise<TeamWithMembers>}
-   * @memberof TeamService
-   */
-  async getTeamWithMembers(teamId: string): Promise<TeamWithMembers> {
-    const [team, members] = await Promise.all([
-      this.teamRepository.getTeam(teamId),
-      this.getTeamMembersWithUsers(teamId)
-    ]);
-    return { ...team, members };
-  }
-
-  /**
-   * Get team members with user details.
-   *
-   * @param {string} teamId - The ID of the team.
-   * @return {Promise<TeamMemberWithUser[]>}
-   * @memberof TeamService
-   */
-  async getTeamMembersWithUsers(teamId: string): Promise<TeamMemberWithUser[]> {
-    return this.teamMemberRepository.getTeamMembersWithUsers(teamId);
-  }
-
-  /**
-   * Create a team with members.
-   *
-   * @param {CreateTeam} teamData - Data required to create a new team.
-   * @param {number[]} memberUserIds - System user IDs to add as members.
-   * @return {Promise<TeamWithMembers>}
-   * @memberof TeamService
-   */
-  async createTeamWithMembers(teamData: CreateTeam, memberUserIds: number[]): Promise<TeamWithMembers> {
-    const team = await this.createTeam(teamData);
-
-    // Add members
-    await Promise.all(
-      memberUserIds.map((userId) =>
-        this.teamMemberRepository.insertTeamMember({
-          team_id: team.team_id,
-          system_user_id: userId
-        })
-      )
-    );
-
-    const members = await this.getTeamMembersWithUsers(team.team_id);
-    return { ...team, members };
-  }
-
-  /**
-   * Update a team and sync its members.
-   * Strategy: Compare new member list with existing, add new, remove old.
-   *
-   * @param {string} teamId - The ID of the team to update.
-   * @param {UpdateTeam} teamData - Partial data to update the team record.
-   * @param {number[]} memberUserIds - New complete member list (user IDs).
-   * @return {Promise<TeamWithMembers>}
-   * @memberof TeamService
-   */
-  async updateTeamWithMembers(teamId: string, teamData: UpdateTeam, memberUserIds: number[]): Promise<TeamWithMembers> {
-    const team = await this.updateTeam(teamId, teamData);
-
-    // Get current members
-    const currentMembers = await this.teamMemberRepository.getTeamMembersByTeamId(teamId);
-    const currentUserIds = new Set(currentMembers.map((m) => m.system_user_id));
-    const newUserIds = new Set(memberUserIds);
-
-    // Find members to add (in new list but not current)
-    const toAdd = memberUserIds.filter((id) => !currentUserIds.has(id));
-
-    // Find members to remove (in current but not new list)
-    const toRemove = currentMembers.filter((m) => !newUserIds.has(m.system_user_id));
-
-    // Add new members
-    await Promise.all(
-      toAdd.map((userId) =>
-        this.teamMemberRepository.insertTeamMember({
-          team_id: teamId,
-          system_user_id: userId
-        })
-      )
-    );
-
-    // Soft-delete removed members
-    await Promise.all(toRemove.map((member) => this.teamMemberRepository.deleteTeamMember(member.team_member_id)));
-
-    const members = await this.getTeamMembersWithUsers(teamId);
-    return { ...team, members };
   }
 }

--- a/api/src/services/access-policy/team-service.ts
+++ b/api/src/services/access-policy/team-service.ts
@@ -94,6 +94,20 @@ export class TeamService extends DBService {
    */
   async updateTeam(teamId: string, teamData: UpdateTeam): Promise<Team> {
     await this.teamRepository.updateTeam(teamId, teamData);
+
+    const systemUserIds = teamData.system_user_ids ?? [];
+
+    if (systemUserIds.length > 0) {
+      await Promise.all(
+        systemUserIds.map((systemUserId) =>
+          this.teamMemberService.createTeamMember({
+            team_id: teamId,
+            system_user_id: systemUserId
+          })
+        )
+      );
+    }
+
     return this.teamRepository.getTeam(teamId);
   }
 

--- a/api/src/services/cart-service.test.ts
+++ b/api/src/services/cart-service.test.ts
@@ -244,11 +244,11 @@ describe('CartService', () => {
       const createDownloadStub = sinon
         .stub(DownloadService.prototype, 'createDownload')
         .resolves({ download_id: 'dl-uuid' });
-      const teamWithMembersStub = sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves({
+      const createTeamStub = sinon.stub(TeamService.prototype, 'createTeam').resolves({
         team_id: 'team-1',
         name: 'team',
         description: 'description',
-        members: [{ system_user_id: 42, team_member_id: 'team-id', user_identifier: 'guid' }]
+        member_count: 0
       });
       const createFeaturesStub = sinon.stub(DownloadService.prototype, 'createDownloadFeatures').resolves();
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart').resolves();
@@ -268,10 +268,11 @@ describe('CartService', () => {
         checkout_user: 42
       });
       expect(publishStub).to.have.been.calledOnceWith(mockDBConnection, { downloadId: 'dl-uuid' });
-      expect(teamWithMembersStub).to.have.been.calledOnceWith(
-        { name: `Team for cart cart-1`, description: 'Team automatically created for cart checkout' },
-        [42]
-      );
+      expect(createTeamStub).to.have.been.calledOnceWith({
+        name: `Team for cart cart-1`,
+        description: 'Team automatically created for cart checkout',
+        system_user_ids: [42]
+      });
     });
 
     it('should not create a team for anonymous carts', async () => {
@@ -282,11 +283,11 @@ describe('CartService', () => {
       const createDownloadStub = sinon
         .stub(DownloadService.prototype, 'createDownload')
         .resolves({ download_id: 'dl-uuid' });
-      const teamWithMembersStub = sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves({
+      const createTeamStub = sinon.stub(TeamService.prototype, 'createTeam').resolves({
         team_id: 'team-1',
         name: 'team',
         description: 'description',
-        members: [{ system_user_id: 42, team_member_id: 'team-id', user_identifier: 'guid' }]
+        member_count: 0
       });
       sinon.stub(DownloadService.prototype, 'createDownloadFeatures').resolves();
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart').resolves();
@@ -300,7 +301,7 @@ describe('CartService', () => {
         checkout_date: sinon.match.string,
         checkout_user: null
       });
-      expect(teamWithMembersStub).to.not.have.been.called;
+      expect(createTeamStub).to.not.have.been.called;
     });
 
     it('should throw HTTP400 when cart is empty', async () => {
@@ -309,11 +310,11 @@ describe('CartService', () => {
 
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureIds').resolves([]);
 
-      const teamWithMembersStub = sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves({
+      const createTeamStub = sinon.stub(TeamService.prototype, 'createTeam').resolves({
         team_id: 'team-1',
         name: 'team',
         description: 'description',
-        members: [{ system_user_id: 42, team_member_id: 'team-id', user_identifier: 'guid' }]
+        member_count: 0
       });
       const createDownloadStub = sinon.stub(DownloadService.prototype, 'createDownload');
       const createFeaturesStub = sinon.stub(DownloadService.prototype, 'createDownloadFeatures');
@@ -332,7 +333,7 @@ describe('CartService', () => {
       expect(createFeaturesStub).to.not.have.been.called;
       expect(updateCartStub).to.not.have.been.called;
       expect(publishStub).to.not.have.been.called;
-      expect(teamWithMembersStub).to.not.have.been.called;
+      expect(createTeamStub).to.not.have.been.called;
     });
 
     it('should forward systemUserId for authenticated users', async () => {
@@ -344,11 +345,11 @@ describe('CartService', () => {
         .stub(DownloadService.prototype, 'createDownload')
         .resolves({ download_id: 'dl-uuid' });
       sinon.stub(DownloadService.prototype, 'createDownloadFeatures').resolves();
-      sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves({
+      sinon.stub(TeamService.prototype, 'createTeam').resolves({
         team_id: 'team-1',
         name: 'team',
         description: 'description',
-        members: [{ system_user_id: 42, team_member_id: 'team-id', user_identifier: 'guid' }]
+        member_count: 0
       });
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart').resolves();
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
@@ -372,7 +373,7 @@ describe('CartService', () => {
         .stub(DownloadService.prototype, 'createDownload')
         .resolves({ download_id: 'dl-uuid' });
       sinon.stub(DownloadService.prototype, 'createDownloadFeatures').resolves();
-      sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves();
+      const createTeamStub = sinon.stub(TeamService.prototype, 'createTeam');
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart').resolves();
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
 
@@ -384,6 +385,7 @@ describe('CartService', () => {
         checkout_date: sinon.match.string,
         checkout_user: null
       });
+      expect(createTeamStub).to.not.have.been.called;
     });
 
     it('should propagate errors and not call subsequent steps', async () => {
@@ -392,11 +394,11 @@ describe('CartService', () => {
 
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureIds').resolves([1, 2]);
       sinon.stub(DownloadService.prototype, 'createDownload').rejects(new Error('DB error'));
-      sinon.stub(TeamService.prototype, 'createTeamWithMembers').resolves({
+      sinon.stub(TeamService.prototype, 'createTeam').resolves({
         team_id: 'team-1',
         name: 'team',
         description: 'description',
-        members: [{ system_user_id: 42, team_member_id: 'team-id', user_identifier: 'guid' }]
+        member_count: 0
       });
       const createFeaturesStub = sinon.stub(DownloadService.prototype, 'createDownloadFeatures');
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart');

--- a/api/src/services/cart-service.ts
+++ b/api/src/services/cart-service.ts
@@ -146,13 +146,11 @@ export class CartService extends DBService {
     let teamId: string | null = null;
 
     if (systemUserId) {
-      const team = await this.teamService.createTeamWithMembers(
-        {
-          name: `Team for cart ${cartId}`,
-          description: 'Team automatically created for cart checkout'
-        },
-        [systemUserId]
-      );
+      const team = await this.teamService.createTeam({
+        name: `Team for cart ${cartId}`,
+        description: 'Team automatically created for cart checkout',
+        system_user_ids: [systemUserId]
+      });
 
       teamId = team.team_id ?? null;
     }

--- a/api/src/services/data-request-service.test.ts
+++ b/api/src/services/data-request-service.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { CreateDataRequest, DataRequest, FlatDataRequestWithStatus, UpdateDataRequest } from '../models/data-request';
 import { DataRequestStatus, DataRequestStatusEnum } from '../models/data-request-status';
-import { TeamMemberWithUser } from '../repositories/authorization/team-member-repository';
+import { TeamMemberWithUser } from '../models/team-member';
 import { DataRequestRepository } from '../repositories/data-request-repository';
 import { getMockDBConnection } from '../__mocks__/db';
 import { TeamMemberService } from './access-policy/team-member-service';

--- a/api/src/services/data-request-service.test.ts
+++ b/api/src/services/data-request-service.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { CreateDataRequest, DataRequest, FlatDataRequestWithStatus, UpdateDataRequest } from '../models/data-request';
 import { DataRequestStatus, DataRequestStatusEnum } from '../models/data-request-status';
-import { TeamMember } from '../models/team-member';
+import { TeamMemberWithUser } from '../repositories/authorization/team-member-repository';
 import { DataRequestRepository } from '../repositories/data-request-repository';
 import { getMockDBConnection } from '../__mocks__/db';
 import { TeamMemberService } from './access-policy/team-member-service';
@@ -43,10 +43,11 @@ describe('DataRequestService', () => {
     request_status: 'REQUESTED'
   };
 
-  const mockTeamMember: TeamMember = {
+  const mockTeamMember: TeamMemberWithUser = {
     team_member_id: 'd4e5f6a7-b8c9-0123-defa-234567890123',
     system_user_id: 1,
-    team_id: mockDataRequest.team_id
+    user_identifier: 'user_1',
+    email: 'user_1@test.com'
   };
 
   describe('findDataRequestById', () => {
@@ -176,7 +177,7 @@ describe('DataRequestService', () => {
       const newTeamId = 'e5f6a7b8-c9d0-1234-efab-345678901234';
       const teamStub = sinon
         .stub(TeamService.prototype, 'createTeam')
-        .resolves({ team_id: newTeamId, name: 'test', description: null });
+        .resolves({ team_id: newTeamId, name: 'test', description: null, member_count: 0 });
       const memberStub = sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(mockTeamMember);
       sinon.stub(DataRequestRepository.prototype, 'createDataRequest').resolves({
         ...mockDataRequest,

--- a/api/src/services/security-service.test.ts
+++ b/api/src/services/security-service.test.ts
@@ -211,7 +211,7 @@ describe('SecurityService', () => {
         expect(deleteSecurityRuleFromArtifactStub).to.have.been.calledOnceWith(1, 3);
 
         expect(applySecurityRulesToArtifactStub).to.have.callCount(2);
-        expect(applySecurityRulesToArtifactStub).to.have.been.calledWith(1, 1);
+        expect(applySecurityRulesToArtifactStub.firstCall.args).to.eql([1, 1]);
         expect(applySecurityRulesToArtifactStub).to.have.been.calledWith(1, 2);
       });
     });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2914,6 +2914,27 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3142,6 +3163,14 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3287,7 +3316,6 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3343,6 +3371,14 @@
         "@types/geojson": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -4769,6 +4805,14 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -4777,6 +4821,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -7103,6 +7157,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7139,6 +7204,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7276,6 +7354,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -8078,6 +8167,44 @@
           "optional": true
         }
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -9830,7 +9957,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2914,27 +2914,6 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3163,14 +3142,6 @@
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3316,6 +3287,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3371,14 +3343,6 @@
         "@types/geojson": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -4805,14 +4769,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -4821,16 +4777,6 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -7157,17 +7103,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7204,19 +7139,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7354,17 +7276,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -8167,44 +8078,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -9957,7 +9830,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/app/src/features/admin/policies/ManagePoliciesPage.test.tsx
+++ b/app/src/features/admin/policies/ManagePoliciesPage.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { useApi } from 'hooks/useApi';
 import { IPolicy } from 'interfaces/usePoliciesApi.interface';
 import { ITeamPolicyDetails } from 'interfaces/useTeamPoliciesApi.interface';
-import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
+import { ITeam } from 'interfaces/useTeamsApi.interface';
 import { MemoryRouter } from 'react-router';
 import { render } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
@@ -16,14 +16,14 @@ interface MockActivePoliciesListProps {
 }
 
 interface MockTeamsContainerProps {
-  teams: ITeamWithMembers[];
+  teams: ITeam[];
   onSelectTeam: (id: string | null) => void;
   selectedTeamId: string | null;
 }
 
 interface MockTeamPoliciesContainerProps {
   teamPolicies: ITeamPolicyDetails[];
-  selectedTeam: ITeamWithMembers | null;
+  selectedTeam: ITeam | null;
   selectedPolicy: IPolicy | null;
 }
 
@@ -91,8 +91,8 @@ const mockPolicies = [
 ];
 
 const mockTeams = [
-  { team_id: 't1', name: 'Team Alpha', description: 'First team', members: [] },
-  { team_id: 't2', name: 'Team Beta', description: 'Second team', members: [] }
+  { team_id: 't1', name: 'Team Alpha', description: 'First team', member_count: 0 },
+  { team_id: 't2', name: 'Team Beta', description: 'Second team', member_count: 0 }
 ];
 
 const mockTeamPolicies = [

--- a/app/src/features/admin/policies/components/AddTeamForm.test.tsx
+++ b/app/src/features/admin/policies/components/AddTeamForm.test.tsx
@@ -42,7 +42,7 @@ describe('AddTeamForm', () => {
     const initialValues = {
       name: 'Test Team',
       description: 'A test description',
-      member_user_ids: []
+      system_user_ids: []
     };
 
     const { getByLabelText } = renderWithFormik(initialValues);
@@ -57,13 +57,13 @@ describe('AddTeamForm', () => {
     expect(AddTeamFormInitialValues).toEqual({
       name: '',
       description: '',
-      member_user_ids: []
+      system_user_ids: []
     });
   });
 
   describe('validation schema', () => {
     it('requires team name', async () => {
-      const result = await AddTeamFormYupSchema.validate({ name: '', description: '', member_user_ids: [] }).catch(
+      const result = await AddTeamFormYupSchema.validate({ name: '', description: '', system_user_ids: [] }).catch(
         (err) => err
       );
 
@@ -75,7 +75,7 @@ describe('AddTeamForm', () => {
       const result = await AddTeamFormYupSchema.validate({
         name: longName,
         description: '',
-        member_user_ids: []
+        system_user_ids: []
       }).catch((err) => err);
 
       expect(result.message).toBe('Team name must be 250 characters or less');
@@ -85,7 +85,7 @@ describe('AddTeamForm', () => {
       const result = await AddTeamFormYupSchema.validate({
         name: 'Valid Team Name',
         description: '',
-        member_user_ids: []
+        system_user_ids: []
       });
 
       expect(result.name).toBe('Valid Team Name');
@@ -96,7 +96,7 @@ describe('AddTeamForm', () => {
       const result = await AddTeamFormYupSchema.validate({
         name: 'Team',
         description: longDescription,
-        member_user_ids: []
+        system_user_ids: []
       }).catch((err) => err);
 
       expect(result.message).toBe('Description must be 1000 characters or less');
@@ -106,7 +106,7 @@ describe('AddTeamForm', () => {
       const result = await AddTeamFormYupSchema.validate({
         name: 'Team',
         description: '',
-        member_user_ids: []
+        system_user_ids: []
       });
 
       expect(result.description).toBe('');
@@ -116,10 +116,10 @@ describe('AddTeamForm', () => {
       const result = await AddTeamFormYupSchema.validate({
         name: 'Team',
         description: '',
-        member_user_ids: [1, 2, 3]
+        system_user_ids: [1, 2, 3]
       });
 
-      expect(result.member_user_ids).toEqual([1, 2, 3]);
+      expect(result.system_user_ids).toEqual([1, 2, 3]);
     });
   });
 });

--- a/app/src/features/admin/policies/components/AddTeamForm.tsx
+++ b/app/src/features/admin/policies/components/AddTeamForm.tsx
@@ -14,7 +14,7 @@ export interface IAddTeamFormValues {
   /** Optional description */
   description: string;
   /** Array of system user IDs for team members */
-  member_user_ids: number[];
+  system_user_ids: number[];
 }
 
 /**
@@ -31,7 +31,7 @@ export interface IAddTeamFormProps {
 export const AddTeamFormInitialValues: IAddTeamFormValues = {
   name: '',
   description: '',
-  member_user_ids: []
+  system_user_ids: []
 };
 
 /**
@@ -40,7 +40,7 @@ export const AddTeamFormInitialValues: IAddTeamFormValues = {
 export const AddTeamFormYupSchema = yup.object().shape({
   name: yup.string().required('Team name is required').max(250, 'Team name must be 250 characters or less'),
   description: yup.string().max(1000, 'Description must be 1000 characters or less'),
-  member_user_ids: yup.array().of(yup.number())
+  system_user_ids: yup.array().of(yup.number())
 });
 
 /**
@@ -81,8 +81,8 @@ export const AddTeamForm = ({ initialUsers }: IAddTeamFormProps) => {
       />
 
       <TeamMemberSelect
-        selectedUserIds={values.member_user_ids}
-        onChange={(userIds) => setFieldValue('member_user_ids', userIds)}
+        selectedUserIds={values.system_user_ids}
+        onChange={(userIds) => setFieldValue('system_user_ids', userIds)}
         initialUsers={initialUsers}
       />
     </Box>

--- a/app/src/features/admin/policies/components/TeamPoliciesContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamPoliciesContainer.test.tsx
@@ -3,7 +3,7 @@ import { GridColDef } from '@mui/x-data-grid';
 import { useApi } from 'hooks/useApi';
 import { IPolicy } from 'interfaces/usePoliciesApi.interface';
 import { ITeamPolicyDetails } from 'interfaces/useTeamPoliciesApi.interface';
-import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
+import { ITeam } from 'interfaces/useTeamsApi.interface';
 import { MemoryRouter } from 'react-router';
 import { cleanup, render, waitFor } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
@@ -56,10 +56,10 @@ const mockTeamPolicies: ITeamPolicyDetails[] = [
   }
 ];
 
-const mockTeams: ITeamWithMembers[] = [
-  { team_id: 'team-1', name: 'Alpha Team', description: 'First team', members: [] },
-  { team_id: 'team-2', name: 'Beta Team', description: 'Second team', members: [] },
-  { team_id: 'team-3', name: 'Gamma Team', description: 'Third team', members: [] }
+const mockTeams: ITeam[] = [
+  { team_id: 'team-1', name: 'Alpha Team', description: 'First team', member_count: 0 },
+  { team_id: 'team-2', name: 'Beta Team', description: 'Second team', member_count: 0 },
+  { team_id: 'team-3', name: 'Gamma Team', description: 'Third team', member_count: 0 }
 ];
 
 const mockPolicies: IPolicy[] = [

--- a/app/src/features/admin/policies/components/TeamPoliciesContainer.tsx
+++ b/app/src/features/admin/policies/components/TeamPoliciesContainer.tsx
@@ -14,7 +14,7 @@ import { useApi } from 'hooks/useApi';
 import { useDialogContext } from 'hooks/useContext';
 import { IPolicy } from 'interfaces/usePoliciesApi.interface';
 import { ITeamPolicyDetails } from 'interfaces/useTeamPoliciesApi.interface';
-import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
+import { ITeam } from 'interfaces/useTeamsApi.interface';
 import { useState } from 'react';
 
 /**
@@ -34,7 +34,7 @@ export interface ITeamPoliciesContainerProps {
   /** Callback when sort changes */
   setSortModel: (model: GridSortModel) => void;
   /** Currently selected team from TeamsContainer (null if none selected) */
-  selectedTeam: ITeamWithMembers | null;
+  selectedTeam: ITeam | null;
   /** Currently selected policy from ActivePoliciesList (null if none selected) */
   selectedPolicy: IPolicy | null;
   /** Callback to refresh the team-policies list after create/delete */

--- a/app/src/features/admin/policies/components/TeamsContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent } from '@testing-library/react';
 import { GridColDef } from '@mui/x-data-grid';
 import { useApi } from 'hooks/useApi';
-import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
+import { ITeam } from 'interfaces/useTeamsApi.interface';
 import { MemoryRouter } from 'react-router';
 import { cleanup, render, waitFor } from 'test-helpers/test-utils';
 import { Mock } from 'vitest';
@@ -9,7 +9,7 @@ import { ITeamsContainerProps, TeamsContainer } from './TeamsContainer';
 
 // Types for DataGrid mock
 interface MockDataGridProps {
-  rows: ITeamWithMembers[];
+  rows: ITeam[];
   columns: GridColDef[];
   localeText?: { noRowsLabel?: string };
 }
@@ -25,7 +25,7 @@ vi.mock('@mui/x-data-grid', () => ({
           <div key={row.team_id} data-testid={`row-${row.team_id}`}>
             <span>{row.name}</span>
             <span>{row.description || '-'}</span>
-            <span>{row.members?.length ?? 0}</span>
+            <span>{row.member_count}</span>
             {/* Render actions column */}
             {columns.find((c) => c.field === 'actions')?.renderCell?.({ row } as never)}
           </div>
@@ -38,21 +38,18 @@ vi.mock('@mui/x-data-grid', () => ({
 vi.mock('../../../../hooks/useApi');
 const mockBiohubApi = useApi as Mock;
 
-const mockTeams: ITeamWithMembers[] = [
+const mockTeams: ITeam[] = [
   {
     team_id: 'team-1',
     name: 'Alpha Team',
     description: 'First team',
-    members: [{ team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' }]
+    member_count: 1
   },
   {
     team_id: 'team-2',
     name: 'Beta Team',
     description: null,
-    members: [
-      { team_member_id: 'tm-2', system_user_id: 2, user_identifier: 'bob' },
-      { team_member_id: 'tm-3', system_user_id: 3, user_identifier: 'charlie' }
-    ]
+    member_count: 2
   }
 ];
 
@@ -191,7 +188,7 @@ describe('TeamsContainer', () => {
         expect(mockCreateTeam).toHaveBeenCalledWith({
           name: 'New Team',
           description: 'A new team',
-          member_user_ids: []
+          system_user_ids: []
         });
       });
 
@@ -274,7 +271,7 @@ describe('TeamsContainer', () => {
         expect(mockUpdateTeam).toHaveBeenCalledWith('team-1', {
           name: 'Updated Team',
           description: 'First team',
-          member_user_ids: [1]
+          system_user_ids: []
         });
       });
 

--- a/app/src/features/admin/policies/components/TeamsContainer.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.tsx
@@ -16,7 +16,7 @@ import { ISnackbarProps } from 'contexts/dialogContext';
 import { APIError } from 'hooks/api/useAxios';
 import { useApi } from 'hooks/useApi';
 import { useDialogContext } from 'hooks/useContext';
-import { ITeamWithMembers } from 'interfaces/useTeamsApi.interface';
+import { ITeam } from 'interfaces/useTeamsApi.interface';
 import { IServerPaginationProps } from 'types/pagination';
 import { useState } from 'react';
 import { AddTeamForm, AddTeamFormInitialValues, AddTeamFormYupSchema, IAddTeamFormValues } from './AddTeamForm';
@@ -26,7 +26,7 @@ import { AddTeamForm, AddTeamFormInitialValues, AddTeamFormYupSchema, IAddTeamFo
  */
 export interface ITeamsContainerProps extends IServerPaginationProps {
   /** Array of teams to display in the table */
-  teams: ITeamWithMembers[];
+  teams: ITeam[];
   /** Callback to refresh the teams list after create/update/delete */
   refresh: () => void;
   /** Current search term for filtering teams */
@@ -73,7 +73,7 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
   // Dialog state
   const [openAddTeamDialog, setOpenAddTeamDialog] = useState(false);
   const [openEditTeamDialog, setOpenEditTeamDialog] = useState(false);
-  const [editingTeam, setEditingTeam] = useState<ITeamWithMembers | null>(null);
+  const [editingTeam, setEditingTeam] = useState<ITeam | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   /**
@@ -106,9 +106,9 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
   /**
    * Open confirmation dialog to delete a team.
    *
-   * @param {ITeamWithMembers} team - The team to delete
+   * @param {ITeam} team - The team to delete
    */
-  const handleDeleteTeamClick = (team: ITeamWithMembers) => {
+  const handleDeleteTeamClick = (team: ITeam) => {
     dialogContext.setYesNoDialog({
       dialogTitle: 'Delete team?',
       dialogContent: (
@@ -137,10 +137,10 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
   /**
    * Delete a team via API.
    *
-   * @param {ITeamWithMembers} team - The team to delete
+   * @param {ITeam} team - The team to delete
    * @returns {Promise<void>}
    */
-  const deleteTeam = async (team: ITeamWithMembers) => {
+  const deleteTeam = async (team: ITeam) => {
     if (!team?.team_id) {
       return;
     }
@@ -184,9 +184,9 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
   /**
    * Open the edit dialog for a team.
    *
-   * @param {ITeamWithMembers} team - The team to edit
+   * @param {ITeam} team - The team to edit
    */
-  const handleEditTeamClick = (team: ITeamWithMembers) => {
+  const handleEditTeamClick = (team: ITeam) => {
     setEditingTeam(team);
     setOpenEditTeamDialog(true);
   };
@@ -204,7 +204,7 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
       await biohubApi.teams.createTeam({
         name: values.name,
         description: values.description || undefined,
-        member_user_ids: values.member_user_ids
+        system_user_ids: values.system_user_ids
       });
 
       setOpenAddTeamDialog(false);
@@ -255,7 +255,7 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
       await biohubApi.teams.updateTeam(editingTeam.team_id, {
         name: values.name,
         description: values.description || undefined,
-        member_user_ids: values.member_user_ids
+        system_user_ids: values.system_user_ids
       });
 
       setOpenEditTeamDialog(false);
@@ -302,12 +302,12 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
     return {
       name: editingTeam.name,
       description: editingTeam.description || '',
-      member_user_ids: editingTeam.members.map((m) => m.system_user_id)
+      system_user_ids: []
     };
   };
 
   // DataGrid columns
-  const columns: GridColDef<ITeamWithMembers>[] = [
+  const columns: GridColDef<ITeam>[] = [
     {
       field: 'name',
       headerName: 'Name',
@@ -322,11 +322,10 @@ export const TeamsContainer: React.FC<ITeamsContainerProps> = (props) => {
       valueGetter: (value) => value || '-'
     },
     {
-      field: 'members',
+      field: 'member_count',
       headerName: 'Members',
       width: 100,
-      sortable: false,
-      valueGetter: (_value, row) => row.members?.length ?? 0
+      valueGetter: (_value, row) => row.member_count
     },
     {
       field: 'actions',

--- a/app/src/hooks/api/useTeamsApi.ts
+++ b/app/src/hooks/api/useTeamsApi.ts
@@ -1,10 +1,11 @@
 import { AxiosInstance } from 'axios';
 import {
-  ITeamWithMembers,
+  ITeam,
   ITeamsResponse,
   ICreateTeamRequest,
   IUpdateTeamRequest,
-  IAvailableUsersResponse
+  IAvailableUsersResponse,
+  ITeamMembersResponse
 } from 'interfaces/useTeamsApi.interface';
 import { ApiPaginationRequestOptions, ApiSearchParams } from 'types/pagination';
 
@@ -36,9 +37,9 @@ export const useTeamsApi = (axios: AxiosInstance) => {
    * Get a single team by ID.
    *
    * @param {string} teamId
-   * @return {*} {Promise<ITeamWithMembers>}
+   * @return {*} {Promise<ITeam>}
    */
-  const getTeam = async (teamId: string): Promise<ITeamWithMembers> => {
+  const getTeam = async (teamId: string): Promise<ITeam> => {
     const { data } = await axios.get(`/api/administrative/teams/${teamId}`);
 
     return data;
@@ -48,9 +49,9 @@ export const useTeamsApi = (axios: AxiosInstance) => {
    * Create a new team.
    *
    * @param {ICreateTeamRequest} team
-   * @return {*} {Promise<ITeamWithMembers>}
+   * @return {*} {Promise<ITeam>}
    */
-  const createTeam = async (team: ICreateTeamRequest): Promise<ITeamWithMembers> => {
+  const createTeam = async (team: ICreateTeamRequest): Promise<ITeam> => {
     const { data } = await axios.post('/api/administrative/teams', team);
 
     return data;
@@ -61,9 +62,9 @@ export const useTeamsApi = (axios: AxiosInstance) => {
    *
    * @param {string} teamId
    * @param {IUpdateTeamRequest} team
-   * @return {*} {Promise<ITeamWithMembers>}
+   * @return {*} {Promise<ITeam>}
    */
-  const updateTeam = async (teamId: string, team: IUpdateTeamRequest): Promise<ITeamWithMembers> => {
+  const updateTeam = async (teamId: string, team: IUpdateTeamRequest): Promise<ITeam> => {
     const { data } = await axios.put(`/api/administrative/teams/${teamId}`, team);
 
     return data;
@@ -93,12 +94,27 @@ export const useTeamsApi = (axios: AxiosInstance) => {
     return data;
   };
 
+  /**
+   * Get members for a team.
+   *
+   * @param {string} teamId
+   * @return {*} {Promise<ITeamMembersResponse>}
+   */
+  const getTeamMembers = async (teamId: string): Promise<ITeamMembersResponse> => {
+    const { data } = await axios.get(`/api/administrative/teams/${teamId}/member`, {
+      params: { page: 1, limit: 1000 }
+    });
+
+    return data;
+  };
+
   return {
     getTeams,
     getTeam,
     createTeam,
     updateTeam,
     deleteTeam,
-    getAvailableUsers
+    getAvailableUsers,
+    getTeamMembers
   };
 };

--- a/app/src/interfaces/useTeamsApi.interface.ts
+++ b/app/src/interfaces/useTeamsApi.interface.ts
@@ -7,23 +7,24 @@ export interface ITeamMember {
   team_member_id: string;
   system_user_id: number;
   user_identifier: string;
+  email?: string | null;
 }
 
 /**
- * Team with its members.
+ * Team summary.
  */
-export interface ITeamWithMembers {
+export interface ITeam {
   team_id: string;
   name: string;
   description: string | null;
-  members: ITeamMember[];
+  member_count: number;
 }
 
 /**
  * Paginated teams response.
  */
 export interface ITeamsResponse {
-  teams: ITeamWithMembers[];
+  teams: ITeam[];
   pagination: ApiPaginationResponseParams;
 }
 
@@ -33,7 +34,7 @@ export interface ITeamsResponse {
 export interface ICreateTeamRequest {
   name: string;
   description?: string;
-  member_user_ids?: number[];
+  system_user_ids?: number[];
 }
 
 /**
@@ -42,7 +43,7 @@ export interface ICreateTeamRequest {
 export interface IUpdateTeamRequest {
   name?: string;
   description?: string;
-  member_user_ids?: number[];
+  system_user_ids?: number[];
 }
 
 /**
@@ -58,4 +59,11 @@ export interface IAvailableUser {
  */
 export interface IAvailableUsersResponse {
   users: IAvailableUser[];
+}
+
+/**
+ * Team members response.
+ */
+export interface ITeamMembersResponse {
+  members: ITeamMember[];
 }


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-885

## Description of Changes

- Adds endpoints for managing team members under `/administrative/teams/{teamId}/member`
- Removes `members` arrays from Team responses; member data retrieved via dedicated endpoints
- Updates team creation to accept `system_user_ids` and create memberships in the service layer
- Updates cart checkout to use `TeamService.createTeam`, removing duplicate membership logic
- Consolidates and simplifies repository and service methods
- Aligns pagination and filtering patterns across team, policy, and team-policy services
- Updates frontend team types to match API changes

## Testing Notes

- Backend half of https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-869
- App changes in this PR are limited to type alignment so the app continues to function