### PR TITLE
SIMSBIOHUB-893: Add Default Pagination & Increase Max Limit

### DIFF
--- a/api/src/openapi/schemas/pagination.ts
+++ b/api/src/openapi/schemas/pagination.ts
@@ -12,7 +12,8 @@ export const paginationRequestQueryParamSchema: OpenAPIV3.ParameterObject[] = [
     schema: {
       type: 'integer',
       minimum: 1,
-      description: 'The current page number to be fetched'
+      default: 1,
+      description: 'The current page number to be fetched. Defaults to 1 when omitted.'
     }
   },
   {
@@ -22,8 +23,9 @@ export const paginationRequestQueryParamSchema: OpenAPIV3.ParameterObject[] = [
     schema: {
       type: 'integer',
       minimum: 1,
-      maximum: 100,
-      description: 'The number of records to show per page'
+      maximum: 2000,
+      default: 25,
+      description: 'The number of records to show per page. Defaults to 25 when omitted.'
     }
   },
   {
@@ -63,7 +65,7 @@ export const paginationRequestBodySchema: OpenAPIV3.SchemaObject = {
     limit: {
       type: 'integer',
       minimum: 1,
-      maximum: 100,
+      maximum: 2000,
       default: 25,
       description: 'The number of records to return per page'
     },

--- a/api/src/openapi/schemas/pagination.ts
+++ b/api/src/openapi/schemas/pagination.ts
@@ -23,7 +23,7 @@ export const paginationRequestQueryParamSchema: OpenAPIV3.ParameterObject[] = [
     schema: {
       type: 'integer',
       minimum: 1,
-      maximum: 2000,
+      maximum: 200,
       default: 25,
       description: 'The number of records to show per page. Defaults to 25 when omitted.'
     }
@@ -65,7 +65,7 @@ export const paginationRequestBodySchema: OpenAPIV3.SchemaObject = {
     limit: {
       type: 'integer',
       minimum: 1,
-      maximum: 2000,
+      maximum: 200,
       default: 25,
       description: 'The number of records to return per page'
     },

--- a/api/src/paths/administrative/policies/index.ts
+++ b/api/src/paths/administrative/policies/index.ts
@@ -13,11 +13,7 @@ import {
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { PolicyService } from '../../../services/access-policy/policy-service';
 import { getLogger } from '../../../utils/logger';
-import {
-  ensureCompletePaginationOptions,
-  makePaginationOptionsFromRequest,
-  makePaginationResponse
-} from '../../../utils/pagination';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/administrative/policies');
 
@@ -84,7 +80,7 @@ export function getPolicies(): RequestHandler {
       const filters = { search };
       const pagination = makePaginationOptionsFromRequest(req);
       const [policies, count] = await Promise.all([
-        policyService.getPoliciesWithStatements(filters, ensureCompletePaginationOptions(pagination)),
+        policyService.getPoliciesWithStatements(filters, pagination),
         policyService.getPoliciesCount(filters)
       ]);
 

--- a/api/src/paths/administrative/team-policies/index.ts
+++ b/api/src/paths/administrative/team-policies/index.ts
@@ -13,11 +13,7 @@ import {
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamPolicyService } from '../../../services/access-policy/team-policy-service';
 import { getLogger } from '../../../utils/logger';
-import {
-  ensureCompletePaginationOptions,
-  makePaginationOptionsFromRequest,
-  makePaginationResponse
-} from '../../../utils/pagination';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/administrative/team-policies');
 
@@ -83,7 +79,7 @@ export function getTeamPolicies(): RequestHandler {
       const filters = { search };
       const pagination = makePaginationOptionsFromRequest(req);
       const [teamPolicies, count] = await Promise.all([
-        teamPolicyService.getAllTeamPolicies(filters, ensureCompletePaginationOptions(pagination)),
+        teamPolicyService.getAllTeamPolicies(filters, pagination),
         teamPolicyService.getAllTeamPoliciesCount(filters)
       ]);
 

--- a/api/src/paths/administrative/teams/index.ts
+++ b/api/src/paths/administrative/teams/index.ts
@@ -9,11 +9,7 @@ import { CreateTeamRequestSchema, TeamSchema, TeamsListResponseSchema } from '..
 import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
 import { TeamService } from '../../../services/access-policy/team-service';
 import { getLogger } from '../../../utils/logger';
-import {
-  ensureCompletePaginationOptions,
-  makePaginationOptionsFromRequest,
-  makePaginationResponse
-} from '../../../utils/pagination';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/administrative/teams');
 
@@ -74,7 +70,7 @@ export function getTeams(): RequestHandler {
       const pagination = makePaginationOptionsFromRequest(req);
 
       const [teams, count] = await Promise.all([
-        teamService.getTeams(filters, ensureCompletePaginationOptions(pagination)),
+        teamService.getTeams(filters, pagination),
         teamService.getTeamsCount(filters)
       ]);
 

--- a/api/src/paths/administrative/teams/{teamId}/member/index.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.ts
@@ -13,11 +13,7 @@ import {
 import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
 import { TeamMemberService } from '../../../../../services/access-policy/team-member-service';
 import { getLogger } from '../../../../../utils/logger';
-import {
-  ensureCompletePaginationOptions,
-  makePaginationOptionsFromRequest,
-  makePaginationResponse
-} from '../../../../../utils/pagination';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../../../utils/pagination';
 
 const defaultLog = getLogger('paths/administrative/teams/{teamId}/member');
 
@@ -77,7 +73,7 @@ export function getTeamMembers(): RequestHandler {
       const teamMemberService = new TeamMemberService(connection);
 
       const [members, count] = await Promise.all([
-        teamMemberService.getTeamMembersWithUsers(teamId, ensureCompletePaginationOptions(pagination)),
+        teamMemberService.getTeamMembersWithUsers(teamId, pagination),
         teamMemberService.getTeamMembersWithUsersCount(teamId)
       ]);
       await connection.commit();

--- a/api/src/paths/search/feature/index.test.ts
+++ b/api/src/paths/search/feature/index.test.ts
@@ -311,7 +311,7 @@ describe('searchFeatures', () => {
       features: mockResults,
       pagination: {
         total: 1,
-        per_page: 1,
+        per_page: 25,
         current_page: 1,
         last_page: 1,
         sort: undefined,

--- a/api/src/paths/search/feature/index.ts
+++ b/api/src/paths/search/feature/index.ts
@@ -9,11 +9,7 @@ import {
 import { SearchFeatureService } from '../../../services/search-feature-service';
 import { ISearchFeaturesFilters } from '../../../services/search-feature-service.interface';
 import { getLogger } from '../../../utils/logger';
-import {
-  ensureCompletePaginationOptions,
-  makePaginationOptionsFromBody,
-  makePaginationResponse
-} from '../../../utils/pagination';
+import { makePaginationOptionsFromBody, makePaginationResponse } from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/search/feature');
 
@@ -53,7 +49,7 @@ export function searchFeatures(): RequestHandler {
       const pagination = makePaginationOptionsFromBody(req);
 
       const [features, count] = await Promise.all([
-        service.searchFeatures(filters, ensureCompletePaginationOptions(pagination)),
+        service.searchFeatures(filters, pagination),
         service.getSearchFeaturesCount(filters)
       ]);
       await connection.commit();

--- a/api/src/paths/search/index.test.ts
+++ b/api/src/paths/search/index.test.ts
@@ -5,7 +5,6 @@ import sinonChai from 'sinon-chai';
 import * as db from '../../database/db';
 import { SearchService } from '../../services/search-service';
 import { SearchResponseWithCounts } from '../../services/search-service.interface';
-import { ensureCompletePaginationOptions } from '../../utils/pagination';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
 import * as search from './index';
 
@@ -31,7 +30,7 @@ describe('search', () => {
     taxonomy: { data: [], total: 0 }
   };
 
-  const defaultPaginationNumbers = { page: 1, limit: 2 };
+  const defaultPaginationNumbers = { page: 1, limit: 2, sort: undefined, order: undefined };
 
   afterEach(() => {
     sinon.restore();
@@ -56,7 +55,7 @@ describe('search', () => {
 
     expect(mockSearch).to.have.been.calledOnceWith(
       { keyword: 'moose habitat', feature_type_name: undefined },
-      ensureCompletePaginationOptions(defaultPaginationNumbers)
+      defaultPaginationNumbers
     );
 
     expect(mockRes.statusValue).to.equal(200);
@@ -82,7 +81,7 @@ describe('search', () => {
 
     expect(mockSearch).to.have.been.calledOnceWith(
       { keyword: 'moose', feature_type_name: 'dataset' },
-      ensureCompletePaginationOptions(defaultPaginationNumbers)
+      defaultPaginationNumbers
     );
 
     expect(mockRes.statusValue).to.equal(200);
@@ -90,7 +89,7 @@ describe('search', () => {
   });
 
   it('should return search results with custom pagination', async () => {
-    const customNumbers = { page: 2, limit: 5 };
+    const customNumbers = { page: 2, limit: 5, sort: undefined, order: undefined };
     const dbConnectionObj = getMockDBConnection({
       open: sinon.stub().resolves(),
       commit: sinon.stub().resolves(),
@@ -109,7 +108,7 @@ describe('search', () => {
 
     expect(mockSearch).to.have.been.calledOnceWith(
       { keyword: 'wildlife', feature_type_name: undefined },
-      ensureCompletePaginationOptions(customNumbers)
+      customNumbers
     );
 
     expect(mockRes.statusValue).to.equal(200);
@@ -135,7 +134,7 @@ describe('search', () => {
 
     expect(mockSearch).to.have.been.calledOnceWith(
       { keyword: '', feature_type_name: undefined },
-      ensureCompletePaginationOptions(defaultPaginationNumbers)
+      defaultPaginationNumbers
     );
 
     expect(mockRes.statusValue).to.equal(200);

--- a/api/src/paths/search/index.ts
+++ b/api/src/paths/search/index.ts
@@ -7,7 +7,7 @@ import { searchAllResponseSchema } from '../../openapi/schemas/search/search-all
 import { SearchService } from '../../services/search-service';
 import { SearchParams } from '../../services/search-service.interface';
 import { getLogger } from '../../utils/logger';
-import { ensureCompletePaginationOptions, makePaginationOptionsFromRequest } from '../../utils/pagination';
+import { makePaginationOptionsFromRequest } from '../../utils/pagination';
 
 const defaultLog = getLogger('paths/search/index');
 
@@ -63,7 +63,7 @@ export function searchAll(): RequestHandler {
       const filters = parseQueryParams(req);
       const paginationOptions = makePaginationOptionsFromRequest(req);
 
-      const result = await searchService.search(filters, ensureCompletePaginationOptions(paginationOptions));
+      const result = await searchService.search(filters, paginationOptions);
 
       await connection.commit();
 

--- a/api/src/paths/search/property/index.test.ts
+++ b/api/src/paths/search/property/index.test.ts
@@ -203,7 +203,7 @@ describe('searchProperties', () => {
       properties: mockResultsWithData,
       pagination: {
         total: 2,
-        per_page: 2,
+        per_page: 25,
         current_page: 1,
         last_page: 1,
         sort: undefined,

--- a/api/src/paths/search/property/index.ts
+++ b/api/src/paths/search/property/index.ts
@@ -9,11 +9,7 @@ import {
 import { PropertySearchService } from '../../../services/property-search-service';
 import { ISearchPropertyFilters } from '../../../services/property-search-service.interface';
 import { getLogger } from '../../../utils/logger';
-import {
-  ensureCompletePaginationOptions,
-  makePaginationOptionsFromBody,
-  makePaginationResponse
-} from '../../../utils/pagination';
+import { makePaginationOptionsFromBody, makePaginationResponse } from '../../../utils/pagination';
 
 const defaultLog = getLogger('paths/search/property');
 
@@ -53,7 +49,7 @@ export function searchProperties(): RequestHandler {
       const pagination = makePaginationOptionsFromBody(req);
 
       const [properties, count] = await Promise.all([
-        service.searchProperty(filters, ensureCompletePaginationOptions(pagination)),
+        service.searchProperty(filters, pagination),
         service.getSearchPropertyCount(filters)
       ]);
       await connection.commit();

--- a/api/src/paths/submission/{submissionId}/features/index.ts
+++ b/api/src/paths/submission/{submissionId}/features/index.ts
@@ -7,11 +7,7 @@ import { paginationRequestQueryParamSchema, paginationResponseSchema } from '../
 import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
 import { SubmissionService } from '../../../../services/submission-service';
 import { getLogger } from '../../../../utils/logger';
-import {
-  ensureCompletePaginationOptions,
-  makePaginationOptionsFromRequest,
-  makePaginationResponse
-} from '../../../../utils/pagination';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../../utils/pagination';
 
 const defaultLog = getLogger('paths/submission/{submissionId}');
 
@@ -110,7 +106,7 @@ export function getSubmissionFeatures(): RequestHandler {
 
       // Service method must support pagination options
       const [features, count] = await Promise.all([
-        submissionService.getSubmissionFeatures(submissionId, ensureCompletePaginationOptions(paginationOptions)),
+        submissionService.getSubmissionFeatures(submissionId, paginationOptions),
         submissionService.getSubmissionFeaturesCount(submissionId)
       ]);
 

--- a/api/src/services/cart-submission-feature-service.ts
+++ b/api/src/services/cart-submission-feature-service.ts
@@ -1,7 +1,7 @@
 import { IDBConnection } from '../database/db';
 import { CartFeatureListResponse, CartSubmissionFeature } from '../models/cart';
 import { CartSubmissionFeatureRepository } from '../repositories/cart-submission-feature-repository';
-import { ensureCompletePaginationOptions, makePaginationResponse } from '../utils/pagination';
+import { makePaginationResponse } from '../utils/pagination';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { PolicyService } from './access-policy/policy-service';
 import { DBService } from './db-service';
@@ -109,16 +109,16 @@ export class CartSubmissionFeatureService extends DBService {
    * Returns cart features and pagination payload in the same shape used by cart feature endpoints.
    *
    * @param {string} cartId - The ID of the cart
-   * @param {Partial<ApiPaginationOptions>} pagination - Requested pagination parameters
+   * @param {ApiPaginationOptions} pagination - Requested pagination parameters
    * @return {Promise<CartFeatureListResponse>}
    * @memberof CartSubmissionFeatureService
    */
   async getPaginatedCartFeaturesResponse(
     cartId: string,
-    pagination: Partial<ApiPaginationOptions>
+    pagination: ApiPaginationOptions
   ): Promise<CartFeatureListResponse> {
     const [features, count] = await Promise.all([
-      this.getCartSubmissionFeatures(cartId, ensureCompletePaginationOptions(pagination)),
+      this.getCartSubmissionFeatures(cartId, pagination),
       this.getCartSubmissionFeatureCount(cartId)
     ]);
 

--- a/api/src/utils/pagination.test.ts
+++ b/api/src/utils/pagination.test.ts
@@ -11,13 +11,13 @@ import {
 
 describe('pagination', () => {
   describe('makePaginationOptionsFromRequest', () => {
-    it('should return undefined options if query params are missing', () => {
+    it('should return default options if query params are missing', () => {
       const mockRequest = { query: {} } as unknown as Request;
 
       const result = makePaginationOptionsFromRequest(mockRequest);
       expect(result).to.eql({
-        limit: undefined,
-        page: undefined,
+        limit: 25,
+        page: 1,
         sort: undefined,
         order: undefined
       });
@@ -44,13 +44,13 @@ describe('pagination', () => {
   });
 
   describe('makePaginationOptionsFromBody', () => {
-    it('should return undefined options if pagination is missing in body', () => {
+    it('should return default options if pagination is missing in body', () => {
       const mockRequest = { body: {} } as unknown as Request;
 
       const result = makePaginationOptionsFromBody(mockRequest);
       expect(result).to.eql({
-        limit: undefined,
-        page: undefined,
+        limit: 25,
+        page: 1,
         sort: undefined,
         order: undefined
       });
@@ -90,9 +90,9 @@ describe('pagination', () => {
       const result = makePaginationResponse(101, mockPagination);
       expect(result).to.eql({
         total: 101,
-        per_page: 101, // fallback to total
+        per_page: 25,
         current_page: 1,
-        last_page: 1,
+        last_page: 5,
         sort: undefined,
         order: undefined
       });
@@ -138,7 +138,7 @@ describe('pagination', () => {
   });
 
   describe('ensureCompletePaginationOptions', () => {
-    it('should return undefined if limit is undefined', () => {
+    it('should default limit when limit is undefined', () => {
       const mockPagination: Partial<ApiPaginationOptions> = {
         limit: undefined,
         page: 1,
@@ -147,10 +147,15 @@ describe('pagination', () => {
       };
 
       const result = ensureCompletePaginationOptions(mockPagination);
-      expect(result).to.equal(undefined);
+      expect(result).to.eql({
+        limit: 25,
+        page: 1,
+        sort: 'name',
+        order: 'desc'
+      });
     });
 
-    it('should return undefined if page is undefined', () => {
+    it('should default page when page is undefined', () => {
       const mockPagination: Partial<ApiPaginationOptions> = {
         limit: 15,
         page: undefined,
@@ -159,7 +164,12 @@ describe('pagination', () => {
       };
 
       const result = ensureCompletePaginationOptions(mockPagination);
-      expect(result).to.equal(undefined);
+      expect(result).to.eql({
+        limit: 15,
+        page: 1,
+        sort: 'name',
+        order: 'desc'
+      });
     });
 
     it('should return pagination if page and limit are defined', () => {

--- a/api/src/utils/pagination.test.ts
+++ b/api/src/utils/pagination.test.ts
@@ -79,10 +79,10 @@ describe('pagination', () => {
   });
 
   describe('makePaginationResponse', () => {
-    it('should handle undefined pagination params and default last_page to 1', () => {
-      const mockPagination: Partial<ApiPaginationOptions> = {
-        limit: undefined,
-        page: undefined,
+    it('should calculate last_page with default pagination options', () => {
+      const mockPagination: ApiPaginationOptions = {
+        limit: 25,
+        page: 1,
         sort: undefined,
         order: undefined
       };
@@ -99,7 +99,7 @@ describe('pagination', () => {
     });
 
     it('should calculate last page correctly when all params are defined', () => {
-      const mockPagination: Partial<ApiPaginationOptions> = {
+      const mockPagination: ApiPaginationOptions = {
         limit: 15,
         page: 3,
         sort: 'name',
@@ -118,7 +118,7 @@ describe('pagination', () => {
     });
 
     it('should handle zero total records', () => {
-      const mockPagination: Partial<ApiPaginationOptions> = {
+      const mockPagination: ApiPaginationOptions = {
         limit: 20,
         page: 1,
         sort: 'name',

--- a/api/src/utils/pagination.ts
+++ b/api/src/utils/pagination.ts
@@ -4,34 +4,36 @@ import { ApiPaginationOptions, ApiPaginationResults } from '../zod-schema/pagina
 export const DEFAULT_PAGINATION_PAGE = 1;
 export const DEFAULT_PAGINATION_LIMIT = 25;
 
-const toNumber = (value: unknown): number | undefined =>
-  typeof value === 'string' || typeof value === 'number' ? Number(value) : undefined;
+const toNumber = (value: unknown): number | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  return typeof value === 'number' ? value : Number(value);
+};
 
 /**
  * Shared pagination extractor from a generic object.
  * Works with query params or body params.
  *
  * @param {Record<string, unknown>} source - Object containing pagination keys
- * @return {Partial<ApiPaginationOptions>}
+ * @return {ApiPaginationOptions}
  */
-const makePaginationOptionsFromSource = (source: Record<string, unknown>): Partial<ApiPaginationOptions> => {
+const makePaginationOptionsFromSource = (source: Record<string, unknown>): ApiPaginationOptions => {
   const page = toNumber(source.page);
   const limit = toNumber(source.limit);
 
-  const order =
-    typeof source.order === 'string' && (source.order.toLowerCase() === 'asc' || source.order.toLowerCase() === 'desc')
-      ? (source.order.toLowerCase() as 'asc' | 'desc')
-      : undefined;
-
   const sort = typeof source.sort === 'string' ? source.sort : undefined;
+  const orderRaw = typeof source.order === 'string' ? source.order.toLowerCase() : undefined;
+  const order = orderRaw === 'asc' || orderRaw === 'desc' ? (orderRaw as 'asc' | 'desc') : undefined;
 
-  return { page, limit, sort, order };
+  return ensureCompletePaginationOptions({ page, limit, sort, order });
 };
 
 /**
- * Normalizes partial pagination options to include default page and limit values.
+ * Returns complete pagination options by applying runtime defaults for omitted values.
  */
-export const normalizePaginationOptions = (
+export const ensureCompletePaginationOptions = (
   pagination: Partial<ApiPaginationOptions> = {}
 ): ApiPaginationOptions => ({
   page: pagination.page ?? DEFAULT_PAGINATION_PAGE,
@@ -43,14 +45,14 @@ export const normalizePaginationOptions = (
 /**
  * Extracts pagination from query parameters
  */
-export const makePaginationOptionsFromRequest = (request: Request): Partial<ApiPaginationOptions> => {
+export const makePaginationOptionsFromRequest = (request: Request): ApiPaginationOptions => {
   return makePaginationOptionsFromSource(request.query);
 };
 
 /**
  * Extracts pagination from request body
  */
-export const makePaginationOptionsFromBody = (request: Request): Partial<ApiPaginationOptions> => {
+export const makePaginationOptionsFromBody = (request: Request): ApiPaginationOptions => {
   return makePaginationOptionsFromSource(request.body.pagination ?? {});
 };
 
@@ -67,28 +69,14 @@ export const makePaginationResponse = (
   total: number,
   pagination?: Partial<ApiPaginationOptions>
 ): ApiPaginationResults => {
-  const normalizedPagination = normalizePaginationOptions(pagination);
-  const effectiveLimit = normalizedPagination.limit;
+  const { page, limit, sort, order } = ensureCompletePaginationOptions(pagination);
 
   return {
     total,
-    per_page: effectiveLimit,
-    current_page: normalizedPagination.page,
-    last_page: Math.max(1, Math.ceil(total / effectiveLimit)),
-    sort: normalizedPagination.sort,
-    order: normalizedPagination.order
+    per_page: limit,
+    current_page: page,
+    last_page: Math.max(1, Math.ceil(total / limit)),
+    sort,
+    order
   };
 };
-
-/**
- * Returns `ApiPaginationOptions` if the given pagination object contains all of the necessary request params needed to
- * facilitate pagination, otherwise returns `undefined`.
- *
- * Used in conjunction with the output of `makePaginationOptionsFromRequest`.
- *
- * @param {Partial<ApiPaginationOptions>} pagination
- * @returns {boolean}
- */
-export const ensureCompletePaginationOptions = (
-  pagination?: Partial<ApiPaginationOptions>
-): ApiPaginationOptions => normalizePaginationOptions(pagination);

--- a/api/src/utils/pagination.ts
+++ b/api/src/utils/pagination.ts
@@ -1,6 +1,9 @@
 import { Request } from 'express';
 import { ApiPaginationOptions, ApiPaginationResults } from '../zod-schema/pagination';
 
+export const DEFAULT_PAGINATION_PAGE = 1;
+export const DEFAULT_PAGINATION_LIMIT = 25;
+
 const toNumber = (value: unknown): number | undefined =>
   typeof value === 'string' || typeof value === 'number' ? Number(value) : undefined;
 
@@ -24,6 +27,18 @@ const makePaginationOptionsFromSource = (source: Record<string, unknown>): Parti
 
   return { page, limit, sort, order };
 };
+
+/**
+ * Normalizes partial pagination options to include default page and limit values.
+ */
+export const normalizePaginationOptions = (
+  pagination: Partial<ApiPaginationOptions> = {}
+): ApiPaginationOptions => ({
+  page: pagination.page ?? DEFAULT_PAGINATION_PAGE,
+  limit: pagination.limit ?? DEFAULT_PAGINATION_LIMIT,
+  sort: pagination.sort,
+  order: pagination.order
+});
 
 /**
  * Extracts pagination from query parameters
@@ -52,13 +67,16 @@ export const makePaginationResponse = (
   total: number,
   pagination?: Partial<ApiPaginationOptions>
 ): ApiPaginationResults => {
+  const normalizedPagination = normalizePaginationOptions(pagination);
+  const effectiveLimit = normalizedPagination.limit;
+
   return {
     total,
-    per_page: pagination?.limit ?? total,
-    current_page: pagination?.page ?? 1,
-    last_page: pagination?.limit ? Math.max(1, Math.ceil(total / pagination.limit)) : 1,
-    sort: pagination?.sort,
-    order: pagination?.order
+    per_page: effectiveLimit,
+    current_page: normalizedPagination.page,
+    last_page: Math.max(1, Math.ceil(total / effectiveLimit)),
+    sort: normalizedPagination.sort,
+    order: normalizedPagination.order
   };
 };
 
@@ -72,17 +90,5 @@ export const makePaginationResponse = (
  * @returns {boolean}
  */
 export const ensureCompletePaginationOptions = (
-  pagination: Partial<ApiPaginationOptions>
-): ApiPaginationOptions | undefined => {
-  // Type guard: ensures both properties exist
-  if (pagination.limit !== undefined && pagination.page !== undefined) {
-    return {
-      limit: pagination.limit,
-      page: pagination.page,
-      order: pagination.order,
-      sort: pagination.sort
-    };
-  }
-
-  return undefined;
-};
+  pagination?: Partial<ApiPaginationOptions>
+): ApiPaginationOptions => normalizePaginationOptions(pagination);

--- a/api/src/utils/pagination.ts
+++ b/api/src/utils/pagination.ts
@@ -25,7 +25,7 @@ const makePaginationOptionsFromSource = (source: Record<string, unknown>): ApiPa
 
   const sort = typeof source.sort === 'string' ? source.sort : undefined;
   const orderRaw = typeof source.order === 'string' ? source.order.toLowerCase() : undefined;
-  const order = orderRaw === 'asc' || orderRaw === 'desc' ? (orderRaw as 'asc' | 'desc') : undefined;
+  const order = orderRaw === 'asc' || orderRaw === 'desc' ? orderRaw : undefined;
 
   return ensureCompletePaginationOptions({ page, limit, sort, order });
 };

--- a/api/src/utils/pagination.ts
+++ b/api/src/utils/pagination.ts
@@ -59,17 +59,15 @@ export const makePaginationOptionsFromBody = (request: Request): ApiPaginationOp
 /**
  * Generates the pagination response object from the given pagination request params.
  *
- * Used in conjunction with a the output of `makePaginationOptionsFromRequest`.
+ * Used with complete pagination options from `makePaginationOptionsFromRequest` or
+ * `makePaginationOptionsFromBody`.
  *
  * @param {number} total
- * @param {Partial<ApiPaginationOptions>} [pagination]
+ * @param {ApiPaginationOptions} pagination
  * @returns
  */
-export const makePaginationResponse = (
-  total: number,
-  pagination?: Partial<ApiPaginationOptions>
-): ApiPaginationResults => {
-  const { page, limit, sort, order } = ensureCompletePaginationOptions(pagination);
+export const makePaginationResponse = (total: number, pagination: ApiPaginationOptions): ApiPaginationResults => {
+  const { page, limit, sort, order } = pagination;
 
   return {
     total,


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-893

## Description of Changes

- Changes the `per_page` property in the pagination response to always match the `limit` query param (previously, per_page was the number of rows returned)
- For API endpoints that support pagination, `limit` defaults to 25 and `page` defaults to 1
- Maximum limit of 2000 instead of 100.
