### PR TITLE
SIMSBIOHUB-894: Bug fix to clear invalid cached carts 

### DIFF
--- a/api/src/models/cart.ts
+++ b/api/src/models/cart.ts
@@ -22,7 +22,8 @@ export type CartSubmissionFeature = z.infer<typeof CartSubmissionFeature>;
 export const Cart = z.object({
   cart_id: z.string(),
   system_user_id: z.number().nullable(),
-  cart_status: z.nativeEnum(CartStatus)
+  cart_status: z.nativeEnum(CartStatus),
+  record_end_date: z.string().nullable()
 });
 
 export type Cart = z.infer<typeof Cart>;

--- a/api/src/openapi/schemas/cart.ts
+++ b/api/src/openapi/schemas/cart.ts
@@ -59,7 +59,7 @@ export const GetCartSubmissionFeaturesSchema: OpenAPIV3.SchemaObject = {
 
 export const GetCartSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
-  required: ['cart_id', 'system_user_id', 'cart_status'],
+  required: ['cart_id', 'system_user_id', 'cart_status', 'record_end_date'],
   additionalProperties: false,
   properties: {
     cart_id: { type: 'string', format: 'uuid' },
@@ -67,7 +67,8 @@ export const GetCartSchema: OpenAPIV3.SchemaObject = {
     cart_status: {
       type: 'string',
       enum: ['active', 'checked_out', 'expired', 'abandoned']
-    }
+    },
+    record_end_date: { type: 'string', nullable: true }
   }
 };
 

--- a/api/src/paths/cart/index.test.ts
+++ b/api/src/paths/cart/index.test.ts
@@ -51,7 +51,8 @@ describe('cart', () => {
         cart: {
           cart_id: '1111-2222-3333-4444',
           system_user_id: 1,
-          cart_status: CartStatus.ACTIVE
+          cart_status: CartStatus.ACTIVE,
+          record_end_date: null
         },
         features: [],
         pagination: {
@@ -90,7 +91,8 @@ describe('cart', () => {
         cart: {
           cart_id: '1111-2222-3333-4444',
           system_user_id: null,
-          cart_status: CartStatus.ACTIVE
+          cart_status: CartStatus.ACTIVE,
+          record_end_date: null
         },
         features: [],
         pagination: {

--- a/api/src/paths/cart/{cartId}/index.test.ts
+++ b/api/src/paths/cart/{cartId}/index.test.ts
@@ -272,7 +272,7 @@ describe('cart/{cartId}', () => {
       });
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
       sinon.stub(CartService.prototype, 'getCartById').rejects(new Error('Cart not found'));
-      const featureStub = sinon.stub(CartSubmissionFeatureService.prototype, 'getPaginatedCartFeaturesResponse');
+      sinon.stub(CartSubmissionFeatureService.prototype, 'getPaginatedCartFeaturesResponse');
 
       const requestHandler = getCartWithFeaturesById();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -285,7 +285,6 @@ describe('cart/{cartId}', () => {
         expect.fail('Expected handler to throw');
       } catch (error) {
         expect((error as ApiError).message).to.equal('Cart not found');
-        expect(featureStub).to.not.have.been.called;
         expect(mockDBConnection.rollback).to.have.been.calledOnce;
         expect(mockDBConnection.release).to.have.been.calledOnce;
       }

--- a/api/src/paths/cart/{cartId}/index.test.ts
+++ b/api/src/paths/cart/{cartId}/index.test.ts
@@ -54,7 +54,8 @@ describe('cart/{cartId}', () => {
       const fakeCart = {
         cart_id: 'cart-123',
         system_user_id: null,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const fakePaginatedResponse = {
@@ -112,7 +113,8 @@ describe('cart/{cartId}', () => {
       const fakeCart = {
         cart_id: 'cart-123',
         system_user_id: null,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const fakePaginatedResponse = {
@@ -161,7 +163,8 @@ describe('cart/{cartId}', () => {
       const fakeCart = {
         cart_id: 'cart-123',
         system_user_id: null,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const fakePaginatedResponse = {
@@ -177,7 +180,7 @@ describe('cart/{cartId}', () => {
       };
 
       sinon.stub(CartService.prototype, 'getCartById').resolves(fakeCart);
-      sinon
+      const getPaginatedCartFeaturesResponseStub = sinon
         .stub(CartSubmissionFeatureService.prototype, 'getPaginatedCartFeaturesResponse')
         .resolves(fakePaginatedResponse);
 
@@ -189,9 +192,12 @@ describe('cart/{cartId}', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      // Check that default pagination is set in request
-      expect(mockReq.query.limit).to.equal('25');
-      expect(mockReq.query.page).to.equal('1');
+      expect(getPaginatedCartFeaturesResponseStub).to.have.been.calledOnceWith('cart-123', {
+        page: 1,
+        limit: 25,
+        sort: undefined,
+        order: undefined
+      });
       expect(mockDBConnection.commit).to.have.been.calledOnce;
       expect(mockDBConnection.release).to.have.been.calledOnce;
       expect(mockRes.statusValue).to.equal(200);
@@ -233,7 +239,8 @@ describe('cart/{cartId}', () => {
       const fakeCart = {
         cart_id: 'cart-123',
         system_user_id: null,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       sinon.stub(CartService.prototype, 'getCartById').resolves(fakeCart);

--- a/api/src/paths/cart/{cartId}/index.ts
+++ b/api/src/paths/cart/{cartId}/index.ts
@@ -119,9 +119,10 @@ export function getCartWithFeaturesById(): RequestHandler {
 
       const pagination = makePaginationOptionsFromRequest(req);
 
-      const cart = await cartService.getCartById(cartId);
-
-      const paginatedFeatures = await cartSubmissionFeatureService.getPaginatedCartFeaturesResponse(cartId, pagination);
+      const [cart, paginatedFeatures] = await Promise.all([
+        cartService.getCartById(cartId),
+        cartSubmissionFeatureService.getPaginatedCartFeaturesResponse(cartId, pagination)
+      ]);
 
       await connection.commit();
 

--- a/api/src/paths/cart/{cartId}/index.ts
+++ b/api/src/paths/cart/{cartId}/index.ts
@@ -117,10 +117,6 @@ export function getCartWithFeaturesById(): RequestHandler {
       const cartService = new CartService(connection);
       const cartSubmissionFeatureService = new CartSubmissionFeatureService(connection);
 
-      // Return first 25 features from page 1 if pagination not specified
-      req.query.limit = req.query.limit || '25';
-      req.query.page = req.query.page || '1';
-
       const pagination = makePaginationOptionsFromRequest(req);
 
       const cart = await cartService.getCartById(cartId);
@@ -129,7 +125,7 @@ export function getCartWithFeaturesById(): RequestHandler {
 
       await connection.commit();
 
-      res.status(200).json({
+      return res.status(200).json({
         ...paginatedFeatures,
         cart
       });

--- a/api/src/repositories/cart-repository.test.ts
+++ b/api/src/repositories/cart-repository.test.ts
@@ -19,7 +19,8 @@ describe('CartRepository', () => {
       const mockCart: Cart = {
         cart_id: 'cart-1',
         cart_status: CartStatus.ACTIVE,
-        system_user_id: 1
+        system_user_id: 1,
+        record_end_date: null
       };
 
       const mockQueryResponse = {
@@ -65,7 +66,8 @@ describe('CartRepository', () => {
       const mockCart: Cart = {
         cart_id: 'cart-1',
         cart_status: CartStatus.ABANDONED,
-        system_user_id: 1
+        system_user_id: 1,
+        record_end_date: null
       };
 
       const mockQueryResponse = {
@@ -107,7 +109,8 @@ describe('CartRepository', () => {
       const mockCart: Cart = {
         cart_id: 'cart-1',
         cart_status: CartStatus.ACTIVE,
-        system_user_id: 1
+        system_user_id: 1,
+        record_end_date: null
       };
 
       const mockQueryResponse = {

--- a/api/src/repositories/cart-repository.ts
+++ b/api/src/repositories/cart-repository.ts
@@ -20,7 +20,9 @@ export class CartRepository extends BaseRepository {
    */
   async findCartById(cartId: string): Promise<Cart | null> {
     const knex = getKnex();
-    const query = knex('cart').where('cart_id', cartId).select('cart_id', 'cart_status', 'system_user_id');
+    const query = knex('cart')
+      .where('cart_id', cartId)
+      .select('cart_id', 'cart_status', 'system_user_id', 'record_end_date');
 
     const response = await this.connection.knex(query, Cart);
 
@@ -36,7 +38,9 @@ export class CartRepository extends BaseRepository {
    */
   async getCartById(cartId: string): Promise<Cart> {
     const knex = getKnex();
-    const query = knex('cart').where('cart_id', cartId).select('cart_id', 'cart_status', 'system_user_id');
+    const query = knex('cart')
+      .where('cart_id', cartId)
+      .select('cart_id', 'cart_status', 'system_user_id', 'record_end_date');
 
     const response = await this.connection.knex(query, Cart);
 
@@ -68,7 +72,7 @@ export class CartRepository extends BaseRepository {
         system_user_id: systemUserId,
         cart_status: CartStatus.ACTIVE
       })
-      .returning(['cart_id', 'cart_status', 'system_user_id']);
+      .returning(['cart_id', 'cart_status', 'system_user_id', 'record_end_date']);
 
     const response = await this.connection.knex(query, Cart);
 

--- a/api/src/services/authorization/authorization-service.test.ts
+++ b/api/src/services/authorization/authorization-service.test.ts
@@ -541,7 +541,8 @@ describe('authorizeByCart', function () {
   const fakeCart: Cart = {
     cart_id: 'cart-1',
     cart_status: CartStatus.ACTIVE,
-    system_user_id: 1
+    system_user_id: 1,
+    record_end_date: null
   };
 
   const systemUser: SystemUser = {
@@ -569,7 +570,8 @@ describe('authorizeByCart', function () {
     const fakeCart: Cart = {
       cart_id: 'cart-1',
       system_user_id: 1,
-      cart_status: CartStatus.ACTIVE
+      cart_status: CartStatus.ACTIVE,
+      record_end_date: null
     };
 
     sinon.stub(CartService.prototype, 'findCartById').resolves(fakeCart);
@@ -592,7 +594,8 @@ describe('authorizeByCart', function () {
     const fakeCartWithDifferentOwner: Cart = {
       cart_id: 'cart-1',
       cart_status: CartStatus.ACTIVE,
-      system_user_id: 2
+      system_user_id: 2,
+      record_end_date: null
     };
     sinon.stub(CartService.prototype, 'findCartById').resolves(fakeCartWithDifferentOwner);
     sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
@@ -612,7 +615,8 @@ describe('authorizeByCart', function () {
     const fakeUnauthenticatedCart: Cart = {
       cart_id: 'cart-1',
       cart_status: CartStatus.ACTIVE,
-      system_user_id: null // No system_user_id, indicating it's unauthenticated
+      system_user_id: null, // No system_user_id, indicating it's unauthenticated
+      record_end_date: null
     };
     sinon.stub(CartService.prototype, 'findCartById').resolves(fakeUnauthenticatedCart);
     sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
@@ -655,6 +659,108 @@ describe('authorizeByCart', function () {
     });
 
     expect(result).to.be.false;
+  });
+
+  it('returns false if cart is checked out', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(CartService.prototype, 'findCartById').resolves({
+      cart_id: 'cart-1',
+      cart_status: CartStatus.CHECKED_OUT,
+      system_user_id: 1,
+      record_end_date: null
+    });
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByCart({
+      discriminator: 'Cart',
+      cartId: 'cart-1'
+    });
+
+    expect(result).to.be.false;
+  });
+
+  it('returns false if cart is expired', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(CartService.prototype, 'findCartById').resolves({
+      cart_id: 'cart-1',
+      cart_status: CartStatus.EXPIRED,
+      system_user_id: 1,
+      record_end_date: null
+    });
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByCart({
+      discriminator: 'Cart',
+      cartId: 'cart-1'
+    });
+
+    expect(result).to.be.false;
+  });
+
+  it('returns false if cart is abandoned', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(CartService.prototype, 'findCartById').resolves({
+      cart_id: 'cart-1',
+      cart_status: CartStatus.ABANDONED,
+      system_user_id: 1,
+      record_end_date: null
+    });
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByCart({
+      discriminator: 'Cart',
+      cartId: 'cart-1'
+    });
+
+    expect(result).to.be.false;
+  });
+
+  it('returns false if cart record_end_date is in the past', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(CartService.prototype, 'findCartById').resolves({
+      cart_id: 'cart-1',
+      cart_status: CartStatus.ACTIVE,
+      system_user_id: 1,
+      record_end_date: '2000-01-01T00:00:00.000Z'
+    });
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByCart({
+      discriminator: 'Cart',
+      cartId: 'cart-1'
+    });
+
+    expect(result).to.be.false;
+  });
+
+  it('returns true if cart record_end_date is in the future and user owns the cart', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(CartService.prototype, 'findCartById').resolves({
+      cart_id: 'cart-1',
+      cart_status: CartStatus.ACTIVE,
+      system_user_id: 1,
+      record_end_date: '2999-01-01T00:00:00.000Z'
+    });
+
+    const systemUser = { system_user_id: 1 } as SystemUserExtended;
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByCart({
+      discriminator: 'Cart',
+      cartId: 'cart-1'
+    });
+
+    expect(result).to.be.true;
   });
 });
 

--- a/api/src/services/authorization/authorization-service.ts
+++ b/api/src/services/authorization/authorization-service.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { SYSTEM_ROLE } from '../../constants/roles';
 import { IDBConnection } from '../../database/db';
 import { SystemUser, SystemUserExtended } from '../../repositories/user-repository';
@@ -257,6 +258,18 @@ export class AuthorizationService extends DBService {
 
     // Cart does not exist
     if (!cart) {
+      return false;
+    }
+
+    // Only active carts are accessible
+    if (cart.cart_status !== 'active') {
+      return false;
+    }
+
+    // Deny access to carts whose validity window has ended
+    const recordEndDate = cart.record_end_date ? dayjs(cart.record_end_date) : null;
+    const cartValidityEnded = recordEndDate !== null && (!recordEndDate.isValid() || !recordEndDate.isAfter(dayjs()));
+    if (cartValidityEnded) {
       return false;
     }
 

--- a/api/src/services/cart-service.test.ts
+++ b/api/src/services/cart-service.test.ts
@@ -27,7 +27,8 @@ describe('CartService', () => {
       const mockCart: Cart = {
         cart_id: 'cart-1',
         system_user_id: 1,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const mockFeatures: CartSubmissionFeature[] = [
@@ -57,7 +58,8 @@ describe('CartService', () => {
       const mockCart: Cart = {
         cart_id: 'cart-1',
         system_user_id: 1,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const stub = sinon.stub(CartRepository.prototype, 'getCartById').resolves(mockCart);
@@ -77,7 +79,8 @@ describe('CartService', () => {
       const mockCart: Cart = {
         cart_id: 'cart-123',
         system_user_id: 1,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const mockPaginationResponse: CartFeatureListResponse = {
@@ -113,7 +116,8 @@ describe('CartService', () => {
       const mockCart: Cart = {
         cart_id: 'cart-123',
         system_user_id: 1,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const mockFeatures: CartSubmissionFeature[] = [
@@ -163,7 +167,8 @@ describe('CartService', () => {
       const mockCart: Cart = {
         cart_id: 'cart-123',
         system_user_id: 1,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       const mockPaginationResponse: CartFeatureListResponse = {
@@ -215,7 +220,8 @@ describe('CartService', () => {
       const mockCart: Cart = {
         cart_id: 'cart-123',
         system_user_id: 1,
-        cart_status: CartStatus.ACTIVE
+        cart_status: CartStatus.ACTIVE,
+        record_end_date: null
       };
 
       sinon.stub(CartRepository.prototype, 'createCart').resolves(mockCart);

--- a/app/src/contexts/cartContext.test.tsx
+++ b/app/src/contexts/cartContext.test.tsx
@@ -148,11 +148,40 @@ describe('CartContextProvider', () => {
     });
   });
 
+  it.each([401, 403, 404])('clears stale cached cart id when getCartById returns a %s response', async (statusCode) => {
+    setStoredCartId('stale-cart-id');
+    mockCartApi.getCartById.mockRejectedValueOnce(makeApiError(statusCode, 'Cart unavailable'));
+
+    const { getContext } = await renderProvider(getMockAuthState({ base: SystemUserAuthState }));
+
+    await waitFor(() => {
+      expect(mockSetStoredCartId).toHaveBeenCalledWith(null);
+      expect(getContext().features).toEqual([]);
+      expect(getContext().pagination).toEqual({ total: 0, current_page: 1, last_page: 1 });
+      expect(getContext().error).toBeUndefined();
+      expect(getContext().isLoading).toBe(false);
+    });
+  });
+
+  it('does not clear cached cart id when getCartById returns a 500', async () => {
+    const loadError = makeApiError(500, 'Server error');
+    setStoredCartId('cart-err');
+    mockCartApi.getCartById.mockRejectedValueOnce(loadError);
+
+    const { getContext } = await renderProvider(getMockAuthState({ base: SystemUserAuthState }));
+
+    await waitFor(() => {
+      expect(getContext().error).toBe(loadError);
+      expect(getContext().isLoading).toBe(false);
+    });
+
+    expect(mockSetStoredCartId).not.toHaveBeenCalledWith(null);
+  });
+
   it('creates a cart when adding features with no existing cart', async () => {
     const searchFeature = createMockSearchFeature(1, 'Feature 1');
     const createdFeature = createMockFeature('saved-1', 1, 123, 456, 'Feature 1');
     mockCartApi.createCart.mockResolvedValueOnce(buildCartResponse('new-cart', [createdFeature]));
-    mockCartApi.getCartById.mockResolvedValueOnce(buildCartResponse('new-cart', [createdFeature]));
 
     const { getContext } = await renderProvider(getMockAuthState({ base: UnauthenticatedUserAuthState }));
 
@@ -163,6 +192,7 @@ describe('CartContextProvider', () => {
     expect(mockCartApi.createCart).toHaveBeenCalledTimes(1);
     expect(mockCartApi.createCart).toHaveBeenCalledWith({ features: [1] });
     expect(mockSetStoredCartId).toHaveBeenCalledWith('new-cart');
+    expect(mockCartApi.getCartById).not.toHaveBeenCalled();
 
     await waitFor(() => {
       expect(getContext().features).toHaveLength(1);
@@ -231,16 +261,15 @@ describe('CartContextProvider', () => {
     expect(mockCartApi.addCartFeatures).not.toHaveBeenCalled();
   });
 
-  it('retries addToCart by creating a new cart on 401/403 add failure', async () => {
+  it.each([401, 403, 404])('retries addToCart by creating a new cart on %s add failure', async (statusCode) => {
     const persistedFeature = createMockFeature('saved-1', 1, 101, 201, 'Existing');
     const newFeature = createMockSearchFeature(2, 'New');
+    const recreatedFeature = createMockFeature('saved-2', 2, 102, 202, 'New');
 
     setStoredCartId('cart-1');
     mockCartApi.getCartById.mockResolvedValueOnce(buildCartResponse('cart-1', [persistedFeature]));
-    mockCartApi.addCartFeatures.mockRejectedValueOnce(makeApiError(401));
-    mockCartApi.createCart.mockResolvedValueOnce(
-      buildCartResponse('cart-2', [createMockFeature('saved-2', 2, 102, 202, 'New')])
-    );
+    mockCartApi.addCartFeatures.mockRejectedValueOnce(makeApiError(statusCode));
+    mockCartApi.createCart.mockResolvedValueOnce(buildCartResponse('cart-2', [recreatedFeature]));
 
     const { getContext } = await renderProvider(getMockAuthState({ base: SystemUserAuthState }));
 
@@ -256,6 +285,13 @@ describe('CartContextProvider', () => {
     expect(mockCartApi.createCart).toHaveBeenCalledTimes(1);
     expect(mockCartApi.createCart).toHaveBeenCalledWith({ features: [2] });
     expect(mockSetStoredCartId).toHaveBeenCalledWith('cart-2');
+    expect(mockCartApi.getCartById).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(getContext().features).toEqual([recreatedFeature]);
+      expect(getContext().pagination.total).toBe(1);
+      expect(getContext().error).toBeUndefined();
+    });
   });
 
   it('rolls back addToCart and rethrows when add fails with a non-auth error', async () => {
@@ -283,6 +319,35 @@ describe('CartContextProvider', () => {
       expect(getContext().features).toEqual([persistedFeature]);
       expect(getContext().pagination.total).toBe(1);
     });
+  });
+
+  it('rolls back addToCart and rethrows when add fails with a non-recoverable 400 error', async () => {
+    const persistedFeature = createMockFeature('saved-1', 1, 101, 201, 'Existing');
+    const newFeature = createMockSearchFeature(2, 'New');
+    const addError = makeApiError(400, 'bad request');
+
+    setStoredCartId('cart-1');
+    mockCartApi.getCartById.mockResolvedValueOnce(buildCartResponse('cart-1', [persistedFeature]));
+    mockCartApi.addCartFeatures.mockRejectedValueOnce(addError);
+
+    const { getContext } = await renderProvider(getMockAuthState({ base: SystemUserAuthState }));
+
+    await waitFor(() => {
+      expect(getContext().features).toEqual([persistedFeature]);
+    });
+
+    await expect(
+      act(async () => {
+        await getContext().addToCart([newFeature]);
+      })
+    ).rejects.toBe(addError);
+
+    await waitFor(() => {
+      expect(getContext().features).toEqual([persistedFeature]);
+      expect(getContext().pagination.total).toBe(1);
+    });
+
+    expect(mockCartApi.createCart).not.toHaveBeenCalled();
   });
 
   it('removes persisted features by cart_submission_feature_id', async () => {

--- a/app/src/contexts/cartContext.tsx
+++ b/app/src/contexts/cartContext.tsx
@@ -190,14 +190,6 @@ const makeSnapshot = (state: CartState): CartSnapshot => ({
 });
 
 /**
- * Returns true when an API error indicates the current cart can no longer be used.
- */
-const isCartAccessError = (error: unknown): boolean => {
-  const status = (error as APIError)?.status;
-  return status === 401 || status === 403 || status === 404;
-};
-
-/**
  * Returns true when an API error indicates the cached cart ID is no longer valid.
  *
  * This handles stale session cart IDs that can happen after cart deletion,
@@ -476,7 +468,7 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
           dispatch({ type: 'ROLLBACK', payload: previousSnapshot });
         }
 
-        if (previousSnapshot && optimisticAdds.length > 0 && isCartAccessError(error)) {
+        if (previousSnapshot && optimisticAdds.length > 0 && isInvalidCachedCartError(error)) {
           operationInProgress.current = false;
           await _createCart({ features: optimisticAdds });
           return;

--- a/app/src/contexts/cartContext.tsx
+++ b/app/src/contexts/cartContext.tsx
@@ -194,7 +194,18 @@ const makeSnapshot = (state: CartState): CartSnapshot => ({
  */
 const isCartAccessError = (error: unknown): boolean => {
   const status = (error as APIError)?.status;
-  return status === 401 || status === 403;
+  return status === 401 || status === 403 || status === 404;
+};
+
+/**
+ * Returns true when an API error indicates the cached cart ID is no longer valid.
+ *
+ * This handles stale session cart IDs that can happen after cart deletion,
+ * checkout, expiry, or backend cleanup.
+ */
+const isInvalidCachedCartError = (error: unknown): boolean => {
+  const status = (error as APIError | undefined)?.status;
+  return status === 401 || status === 403 || status === 404;
 };
 
 /**
@@ -268,6 +279,9 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
   // Tracks whether we've attempted to claim the current cart.
   // Prevents duplicate claim attempts during the same session.
   const hasClaimedCurrentCart = useRef(false);
+  // When we already have cart data (e.g. createCart response),
+  // skip the immediate follow-up load to avoid a redundant getCartById call.
+  const skipNextLoadForCartId = useRef<string | null>(null);
 
   useEffect(() => {
     cartApiRef.current = api.cart;
@@ -287,6 +301,36 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
     hasClaimedCurrentCart.current = false;
   }, [state.cartId]);
 
+  /**
+   * Clears the cached cart ID from session storage and local state.
+   *
+   * This is used when a persisted cart ID no longer resolves to an accessible cart.
+   */
+  const clearCachedCartId = useCallback(() => {
+    setStoredCartId(null);
+    dispatch({ type: 'SET_CART_ID', payload: null });
+  }, [setStoredCartId]);
+
+  /**
+   * Claims the cart for authenticated users when the cart is currently unowned.
+   */
+  const claimCartIfNeeded = useCallback(
+    async (cartId: string, systemUserId: number | null): Promise<void> => {
+      if (!authStateContext.auth.isAuthenticated || systemUserId !== null || hasClaimedCurrentCart.current) {
+        return;
+      }
+
+      try {
+        hasClaimedCurrentCart.current = true;
+        await cartApiRef.current.assignCartToCurrentUser(cartId);
+      } catch (error) {
+        hasClaimedCurrentCart.current = false;
+        console.error('Failed to claim cart for authenticated user:', error);
+      }
+    },
+    [authStateContext.auth.isAuthenticated]
+  );
+
   // Effect: Load cart data when cartId changes
   // This runs whenever a cart ID is set (from session storage or after creation).
   // If no cart ID exists, it resets the cart state to empty.
@@ -296,6 +340,11 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
 
     if (!cartId) {
       dispatch({ type: 'RESET' });
+      return;
+    }
+
+    if (skipNextLoadForCartId.current === cartId) {
+      skipNextLoadForCartId.current = null;
       return;
     }
 
@@ -316,21 +365,14 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
         // Claim anonymous carts for authenticated users after a successful load.
         // Keeping this in the load-success path avoids claim/load request races.
         // Only claim carts that are currently unowned.
-        if (
-          authStateContext.auth.isAuthenticated &&
-          response.cart.system_user_id === null &&
-          !hasClaimedCurrentCart.current
-        ) {
-          try {
-            hasClaimedCurrentCart.current = true;
-            await cartApiRef.current.assignCartToCurrentUser(cartId);
-          } catch (error) {
-            hasClaimedCurrentCart.current = false;
-            console.error('Failed to claim cart for authenticated user:', error);
-          }
-        }
+        await claimCartIfNeeded(cartId, response.cart.system_user_id);
       } catch (error) {
         if (!isMounted) {
+          return;
+        }
+
+        if (isInvalidCachedCartError(error)) {
+          clearCachedCartId();
           return;
         }
 
@@ -343,7 +385,8 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
     return () => {
       isMounted = false;
     };
-  }, [authStateContext.auth.isAuthenticated, state.cartId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [claimCartIfNeeded, state.cartId]);
 
   /**
    * Updates the cart ID in both session storage and local state.
@@ -366,7 +409,7 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
    *
    * Used when:
    * 1. User adds to cart for the first time (pass features to add)
-   * 2. An addToCart request fails with 401/403 (pass features to retry with)
+   * 2. An addToCart request fails with 401/403/404 (pass features to retry with)
    *
    * Creates the cart and adds features in a single API call.
    *
@@ -382,16 +425,18 @@ export const CartContextProvider: React.FC<React.PropsWithChildren> = ({ childre
           features: features.map((feature) => feature.submission_feature_id)
         });
 
+        skipNextLoadForCartId.current = response.cart.cart_id;
         setCartId(response.cart.cart_id);
         hasClaimedCurrentCart.current = false;
 
         // Update state with the response from cart creation
         dispatch({ type: 'LOAD_SUCCESS', payload: response });
+        await claimCartIfNeeded(response.cart.cart_id, response.cart.system_user_id);
       } finally {
         operationInProgress.current = false;
       }
     },
-    [setCartId]
+    [claimCartIfNeeded, setCartId]
   );
 
   // Adds features with optimistic updates and rollback on failure.

--- a/app/src/hooks/api/useCartApi.test.ts
+++ b/app/src/hooks/api/useCartApi.test.ts
@@ -24,7 +24,8 @@ describe('useCartApi', () => {
         cart: {
           cart_id: '123',
           system_user_id: null,
-          cart_status: 'active'
+          cart_status: 'active',
+          record_end_date: null
         },
         features: [],
         pagination: {
@@ -47,7 +48,8 @@ describe('useCartApi', () => {
         cart: {
           cart_id: '123',
           system_user_id: null,
-          cart_status: 'active'
+          cart_status: 'active',
+          record_end_date: null
         },
         features: [],
         pagination: {
@@ -149,7 +151,8 @@ describe('useCartApi', () => {
         cart: {
           cart_id: '123',
           system_user_id: 1,
-          cart_status: 'active'
+          cart_status: 'active',
+          record_end_date: null
         },
         features: [],
         pagination: {

--- a/app/src/interfaces/useCartApi.interface.ts
+++ b/app/src/interfaces/useCartApi.interface.ts
@@ -19,6 +19,7 @@ export interface Cart {
   cart_id: string;
   system_user_id: number | null;
   cart_status: 'active' | 'checked_out' | 'expired' | 'abandoned';
+  record_end_date: string | null;
 }
 
 /**

--- a/app/src/test-helpers/cart-helpers.tsx
+++ b/app/src/test-helpers/cart-helpers.tsx
@@ -98,7 +98,7 @@ export const createMockCartFeaturesResponse = (
   features: CartSubmissionFeature[],
   pagination: ApiPaginationResponseParams
 ): CartWithFeaturesResponse => ({
-  cart: { cart_id, system_user_id: null, cart_status: 'active' },
+  cart: { cart_id, system_user_id: null, cart_status: 'active', record_end_date: null },
   features,
   pagination
 });


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-894

## Description of Changes

- Added stale-cart recovery: when loading a saved cart returns 401/403/404, we clear the cached cartId and reset cart state.
- Kept 5xx behavior safe: we do not clear the cart on server errors.
- Improved add-to-cart resilience: if adding features fails with 401/403/404, we create a new cart and retry once with those features.
- Removed an unnecessary extra request after cart creation: we now use the createCart response directly and skip the immediate follow-up getCartById.
- Tightened cart authorization rules on the API: only active, non-expired carts are accessible.
Added record_end_date to cart models/schemas/interfaces and updated mocks/tests accordingly.
- Cleaned up cart GET pagination: removed manual query mutation and relied on shared default pagination utility.
Expanded tests on both API and app sides to cover these stale-cart, retry, authorization, and pagination behaviors.

## Testing Notes

1) Log in
2) Add a feature to your cart to create a new cart Id
3) Log out
4) Navigate to the search result page -> should see 403 Access Denied on `GET {cartId}`
5) When you add an item to your cart, it should create a new cart
