### PR TITLE
SIMSBIOHUB-895: Return 404 for Resource Not Found

### DIFF
--- a/api/src/errors/api-error.test.ts
+++ b/api/src/errors/api-error.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
-import { ApiErrorType, ApiExecuteSQLError, ApiGeneralError } from './api-error';
+import { ApiErrorType, ApiExecuteSQLError, ApiGeneralError, ApiNotFoundError } from './api-error';
 
 describe('ApiError', () => {
   describe('No error value provided', () => {
@@ -16,6 +16,10 @@ describe('ApiError', () => {
 
     it('Creates Api execute SQL error', function () {
       expect(new ApiExecuteSQLError(message).name).to.equal(ApiErrorType.EXECUTE_SQL);
+    });
+
+    it('Creates Api not found error', function () {
+      expect(new ApiNotFoundError(message).name).to.equal(ApiErrorType.NOT_FOUND);
     });
   });
 });

--- a/api/src/errors/api-error.ts
+++ b/api/src/errors/api-error.ts
@@ -5,6 +5,7 @@ export enum ApiErrorType {
   EXECUTE_SQL = 'Error executing SQL query',
   GENERAL = 'Error',
   CONFLICT = 'Conflict',
+  NOT_FOUND = 'Not Found',
   UNKNOWN = 'Unknown Error'
 }
 
@@ -52,6 +53,19 @@ export class ApiUnknownError extends ApiError {
 export class ApiConflictError extends ApiError {
   constructor(message: string, errors?: (string | object)[]) {
     super(ApiErrorType.CONFLICT, message, errors);
+  }
+}
+
+/**
+ * Api could not find a requested resource.
+ *
+ * @export
+ * @class ApiNotFoundError
+ * @extends {ApiError}
+ */
+export class ApiNotFoundError extends ApiError {
+  constructor(message: string, errors?: (string | object)[]) {
+    super(ApiErrorType.NOT_FOUND, message, errors);
   }
 }
 

--- a/api/src/errors/http-error.test.ts
+++ b/api/src/errors/http-error.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import { DatabaseError } from 'pg';
-import { ApiError, ApiErrorType } from './api-error';
+import { ApiError, ApiErrorType, ApiNotFoundError } from './api-error';
 import { ensureHTTPError, HTTP400, HTTP401, HTTP403, HTTP409, HTTP500, HTTPError, isAjvError } from './http-error';
 
 describe('HTTPError', () => {
@@ -54,6 +54,16 @@ describe('ensureHTTPError', () => {
 
     expect(ensuredError.status).to.equal(500);
     expect(ensuredError.message).to.equal('an api error message');
+  });
+
+  it('returns HTTP404 when an ApiNotFoundError is provided', function () {
+    const apiError = new ApiNotFoundError('not found');
+
+    const ensuredError = ensureHTTPError(apiError);
+
+    expect(ensuredError).to.be.instanceof(HTTPError);
+    expect(ensuredError.status).to.equal(404);
+    expect(ensuredError.message).to.equal('not found');
   });
 
   it('returns a HTTPError when a DatabaseError provided', function () {

--- a/api/src/errors/http-error.ts
+++ b/api/src/errors/http-error.ts
@@ -1,5 +1,5 @@
 import { DatabaseError } from 'pg';
-import { ApiConflictError, ApiError } from './api-error';
+import { ApiConflictError, ApiError, ApiNotFoundError } from './api-error';
 import { BaseError } from './base-error';
 
 export enum HTTPErrorType {
@@ -151,6 +151,10 @@ export const ensureHTTPError = (error: HTTPError | ApiError | Error | any): HTTP
 
   if (error instanceof ApiConflictError) {
     return HTTP409.fromApiError(error);
+  }
+
+  if (error instanceof ApiNotFoundError) {
+    return HTTP404.fromApiError(error);
   }
 
   if (error instanceof ApiError) {

--- a/api/src/openapi/schemas/http-responses.ts
+++ b/api/src/openapi/schemas/http-responses.ts
@@ -8,6 +8,9 @@ export const defaultErrorResponses = {
   403: {
     $ref: '#/components/responses/403'
   },
+  404: {
+    $ref: '#/components/responses/404'
+  },
   409: {
     $ref: '#/components/responses/409'
   },

--- a/api/src/paths/cart/{cartId}/index.ts
+++ b/api/src/paths/cart/{cartId}/index.ts
@@ -69,9 +69,6 @@ GET.apiDoc = {
         }
       }
     },
-    404: {
-      description: 'Cart not found'
-    },
     ...defaultErrorResponses
   }
 };

--- a/api/src/paths/data-request/{dataRequestId}/index.ts
+++ b/api/src/paths/data-request/{dataRequestId}/index.ts
@@ -78,9 +78,6 @@ GET.apiDoc = {
         }
       }
     },
-    404: {
-      description: 'Data request not found'
-    },
     ...defaultErrorResponses
   }
 };
@@ -115,9 +112,6 @@ PUT.apiDoc = {
     200: {
       description: 'Data request updated successfully'
     },
-    404: {
-      description: 'Data request not found'
-    },
     ...defaultErrorResponses
   }
 };
@@ -144,9 +138,6 @@ DELETE.apiDoc = {
   responses: {
     200: {
       description: 'Data request deleted successfully'
-    },
-    404: {
-      description: 'Data request not found'
     },
     ...defaultErrorResponses
   }

--- a/api/src/repositories/authorization/policy-repository.test.ts
+++ b/api/src/repositories/authorization/policy-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { Policy } from '../../models/policy';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { PolicyRepository } from './policy-repository';
@@ -77,7 +77,8 @@ describe('PolicyRepository', () => {
         await repository.getPolicy('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Policy not found');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Policy not found');
       }
     });
   });

--- a/api/src/repositories/authorization/policy-repository.test.ts
+++ b/api/src/repositories/authorization/policy-repository.test.ts
@@ -77,7 +77,7 @@ describe('PolicyRepository', () => {
         await repository.getPolicy('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get policy');
+        expect((error as ApiExecuteSQLError).message).to.equal('Policy not found');
       }
     });
   });

--- a/api/src/repositories/authorization/policy-repository.ts
+++ b/api/src/repositories/authorization/policy-repository.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import SQL from 'sql-template-strings';
 import { getKnex } from '../../database/db';
 import { FeatureUrn } from '../../database/urn-utils.interface';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CountResult } from '../../models/count';
 import { CreatePolicy, Policy, UpdatePolicy } from '../../models/policy';
 import { PolicyEffect } from '../../models/policy-statement';
@@ -58,10 +58,14 @@ export class PolicyRepository extends BaseRepository {
   async getPolicy(policyId: string): Promise<Policy> {
     const response = await this.getPolicies({ policyId });
 
+    if (response.length === 0) {
+      throw new ApiNotFoundError('Policy not found', ['PolicyRepository->getPolicy', { policyId }]);
+    }
+
     if (response.length !== 1) {
-      throw new ApiExecuteSQLError('Failed to get policy', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'PolicyRepository->getPolicy',
-        'rowCount was null or undefined, expected rowCount = 1'
+        `expected rowCount=1, actual rowCount=${response.length}`
       ]);
     }
 

--- a/api/src/repositories/authorization/policy-statement-condition-repository.test.ts
+++ b/api/src/repositories/authorization/policy-statement-condition-repository.test.ts
@@ -105,7 +105,7 @@ describe('PolicyStatementConditionRepository', () => {
         await repository.getPolicyStatementCondition('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get policy statement condition');
+        expect((error as ApiExecuteSQLError).message).to.equal('Policy statement condition not found');
       }
     });
   });

--- a/api/src/repositories/authorization/policy-statement-condition-repository.test.ts
+++ b/api/src/repositories/authorization/policy-statement-condition-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { PolicyConditionOperator } from '../../models/policy-statement-condition';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { PolicyStatementConditionRepository } from './policy-statement-condition-repository';
@@ -105,7 +105,8 @@ describe('PolicyStatementConditionRepository', () => {
         await repository.getPolicyStatementCondition('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Policy statement condition not found');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Policy statement condition not found');
       }
     });
   });

--- a/api/src/repositories/authorization/policy-statement-condition-repository.ts
+++ b/api/src/repositories/authorization/policy-statement-condition-repository.ts
@@ -1,5 +1,5 @@
 import { getKnex } from '../../database/db';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CreatePolicyStatementCondition, PolicyStatementCondition } from '../../models/policy-statement-condition';
 import { BaseRepository } from '../base-repository';
 
@@ -60,10 +60,17 @@ export class PolicyStatementConditionRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, PolicyStatementCondition);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get policy statement condition', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Policy statement condition not found', [
         'PolicyStatementConditionRepository->getPolicyStatementCondition',
-        'rowCount was null or undefined, expected rowCount = 1'
+        { policyStatementConditionId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'PolicyStatementConditionRepository->getPolicyStatementCondition',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/authorization/policy-statement-repository.test.ts
+++ b/api/src/repositories/authorization/policy-statement-repository.test.ts
@@ -101,7 +101,7 @@ describe('PolicyStatementRepository', () => {
         await repository.getPolicyStatement('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get policy statement');
+        expect((error as ApiExecuteSQLError).message).to.equal('Policy statement not found');
       }
     });
   });

--- a/api/src/repositories/authorization/policy-statement-repository.test.ts
+++ b/api/src/repositories/authorization/policy-statement-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { PolicyEffect } from '../../models/policy-statement';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { PolicyStatementRepository } from './policy-statement-repository';
@@ -101,7 +101,8 @@ describe('PolicyStatementRepository', () => {
         await repository.getPolicyStatement('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Policy statement not found');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Policy statement not found');
       }
     });
   });

--- a/api/src/repositories/authorization/policy-statement-repository.ts
+++ b/api/src/repositories/authorization/policy-statement-repository.ts
@@ -1,5 +1,5 @@
 import { getKnex } from '../../database/db';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CreatePolicyStatement, PolicyStatement, UpdatePolicyStatement } from '../../models/policy-statement';
 import { BaseRepository } from '../base-repository';
 
@@ -57,10 +57,17 @@ export class PolicyStatementRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, PolicyStatement);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get policy statement', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Policy statement not found', [
         'PolicyStatementRepository->getPolicyStatement',
-        'rowCount was null or undefined, expected rowCount = 1'
+        { policyStatementId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'PolicyStatementRepository->getPolicyStatement',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/authorization/team-member-repository.test.ts
+++ b/api/src/repositories/authorization/team-member-repository.test.ts
@@ -73,7 +73,7 @@ describe('TeamMemberRepository', () => {
         await repository.getTeamMember('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get team member');
+        expect((error as ApiExecuteSQLError).message).to.equal('Team member not found');
       }
     });
   });

--- a/api/src/repositories/authorization/team-member-repository.test.ts
+++ b/api/src/repositories/authorization/team-member-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamMemberRepository } from './team-member-repository';
 
@@ -73,7 +73,8 @@ describe('TeamMemberRepository', () => {
         await repository.getTeamMember('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Team member not found');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Team member not found');
       }
     });
   });

--- a/api/src/repositories/authorization/team-member-repository.ts
+++ b/api/src/repositories/authorization/team-member-repository.ts
@@ -1,5 +1,5 @@
 import { getKnex } from '../../database/db';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   CreateTeamMember,
   TeamMember,
@@ -63,10 +63,14 @@ export class TeamMemberRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, TeamMember);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Team member not found', ['TeamMemberRepository->getTeamMember', { teamMemberId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get team member', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'TeamMemberRepository->getTeamMember',
-        'rowCount was null or undefined, expected rowCount = 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/authorization/team-policy-repository.test.ts
+++ b/api/src/repositories/authorization/team-policy-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamPolicyRepository } from './team-policy-repository';
 
@@ -71,7 +71,8 @@ describe('TeamPolicyRepository', () => {
         await repository.getTeamPolicy('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Team policy not found');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Team policy not found');
       }
     });
   });

--- a/api/src/repositories/authorization/team-policy-repository.test.ts
+++ b/api/src/repositories/authorization/team-policy-repository.test.ts
@@ -71,7 +71,7 @@ describe('TeamPolicyRepository', () => {
         await repository.getTeamPolicy('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get team policy');
+        expect((error as ApiExecuteSQLError).message).to.equal('Team policy not found');
       }
     });
   });

--- a/api/src/repositories/authorization/team-policy-repository.ts
+++ b/api/src/repositories/authorization/team-policy-repository.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 import { getKnex } from '../../database/db';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CountResult } from '../../models/count';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
 import { TeamPolicyFilters } from '../../services/access-policy/team-policy-service.interface';
@@ -60,10 +60,14 @@ export class TeamPolicyRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, TeamPolicy);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Team policy not found', ['TeamPolicyRepository->getTeamPolicy', { teamPolicyId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get team policy', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'TeamPolicyRepository->getTeamPolicy',
-        'rowCount was null or undefined, expected rowCount = 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/authorization/team-repository.test.ts
+++ b/api/src/repositories/authorization/team-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamRepository } from './team-repository';
 
@@ -68,7 +68,8 @@ describe('TeamRepository', () => {
         await repository.getTeam('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Team not found');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Team not found');
       }
     });
   });

--- a/api/src/repositories/authorization/team-repository.test.ts
+++ b/api/src/repositories/authorization/team-repository.test.ts
@@ -68,7 +68,7 @@ describe('TeamRepository', () => {
         await repository.getTeam('1');
         expect.fail();
       } catch (error) {
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get team');
+        expect((error as ApiExecuteSQLError).message).to.equal('Team not found');
       }
     });
   });

--- a/api/src/repositories/authorization/team-repository.ts
+++ b/api/src/repositories/authorization/team-repository.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 import { getKnex } from '../../database/db';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CountResult } from '../../models/count';
 import { CreateTeam, Team, UpdateTeam } from '../../models/team';
 import { TeamFilters } from '../../services/access-policy/team-service.interface';
@@ -65,10 +65,14 @@ export class TeamRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, Team);
 
-    if (response.rows.length !== 1) {
-      throw new ApiExecuteSQLError('Failed to get team', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Team not found', ['TeamRepository->getTeam', { teamId }]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'TeamRepository->getTeam',
-        'rowCount was null or undefined, expected rowCount = 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/cart-repository.test.ts
+++ b/api/src/repositories/cart-repository.test.ts
@@ -53,7 +53,7 @@ describe('CartRepository', () => {
         await repo.getCartById('cart-1');
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Failed to get cart');
+        expect((err as Error).message).to.equal('Cart not found');
       }
     });
   });

--- a/api/src/repositories/cart-repository.test.ts
+++ b/api/src/repositories/cart-repository.test.ts
@@ -2,6 +2,7 @@ import chai, { expect } from 'chai';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { ApiNotFoundError } from '../errors/api-error';
 import { Cart, CartStatus, UpdateCart } from '../models/cart';
 import { getMockDBConnection } from '../__mocks__/db';
 import { CartRepository } from './cart-repository';
@@ -53,7 +54,8 @@ describe('CartRepository', () => {
         await repo.getCartById('cart-1');
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Cart not found');
+        expect(err).to.be.instanceOf(ApiNotFoundError);
+        expect((err as ApiNotFoundError).message).to.equal('Cart not found');
       }
     });
   });

--- a/api/src/repositories/cart-repository.ts
+++ b/api/src/repositories/cart-repository.ts
@@ -1,5 +1,5 @@
 import { getKnex } from '../database/db';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { Cart, CartStatus, UpdateCart } from '../models/cart';
 import { BaseRepository } from './base-repository';
 
@@ -40,10 +40,14 @@ export class CartRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, Cart);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Cart not found', ['CartRepository->getCartById', { cartId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get cart', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'CartRepository->getCartById',
-        'rowCount !== 1, expected rowCount === 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 
@@ -71,7 +75,7 @@ export class CartRepository extends BaseRepository {
     if (response.rowCount !== 1) {
       throw new ApiExecuteSQLError('Failed to create cart', [
         'CartRepository->createCart',
-        'rowCount !== 1, expected rowCount === 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
     return response.rows[0];
@@ -95,7 +99,7 @@ export class CartRepository extends BaseRepository {
     if (response.rowCount !== 1) {
       throw new ApiExecuteSQLError('Failed to update cart', [
         'CartRepository->updateCart',
-        'rowCount !== 1, expected rowCount === 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
   }

--- a/api/src/repositories/code-repository.test.ts
+++ b/api/src/repositories/code-repository.test.ts
@@ -3,6 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { ApiNotFoundError } from '../errors/api-error';
 import { getMockDBConnection } from '../__mocks__/db';
 import { CodeRepository, FeaturePropertyCode, FeatureTypeCode } from './code-repository';
 
@@ -96,7 +97,8 @@ describe('CodeRepository', () => {
 
         expect.fail();
       } catch (error) {
-        expect((error as Error).message).to.equal('Feature property not found');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Feature property not found');
       }
     });
 

--- a/api/src/repositories/code-repository.test.ts
+++ b/api/src/repositories/code-repository.test.ts
@@ -96,7 +96,7 @@ describe('CodeRepository', () => {
 
         expect.fail();
       } catch (error) {
-        expect((error as Error).message).to.equal('Failed to get feature property record');
+        expect((error as Error).message).to.equal('Feature property not found');
       }
     });
 

--- a/api/src/repositories/code-repository.ts
+++ b/api/src/repositories/code-repository.ts
@@ -125,7 +125,10 @@ export class CodeRepository extends BaseRepository {
     const response = await this.connection.sql(sqlStatement, FeaturePropertyCode);
 
     if (response.rowCount === 0) {
-      throw new ApiNotFoundError('Feature property not found', ['CodeRepository->getFeaturePropertyByName', { featurePropertyName }]);
+      throw new ApiNotFoundError('Feature property not found', [
+        'CodeRepository->getFeaturePropertyByName',
+        { featurePropertyName }
+      ]);
     }
 
     if (response.rowCount !== 1) {

--- a/api/src/repositories/code-repository.ts
+++ b/api/src/repositories/code-repository.ts
@@ -1,6 +1,6 @@
 import SQL from 'sql-template-strings';
 import { z } from 'zod';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { BaseRepository } from './base-repository';
 
 const FeatureTypeCode = z.object({
@@ -124,10 +124,14 @@ export class CodeRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, FeaturePropertyCode);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Feature property not found', ['CodeRepository->getFeaturePropertyByName', { featurePropertyName }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get feature property record', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'CodeRepository->getFeaturePropertyByName',
-        'rowCount !== 1, expected rowCount === 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/contributor-repository.test.ts
+++ b/api/src/repositories/contributor-repository.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../src/errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../src/errors/api-error';
 import { ContributorRepository } from '../../src/repositories/contributor-repository';
 import { getMockDBConnection } from '../../src/__mocks__/db';
 
@@ -125,7 +125,7 @@ describe('ContributorRepository', () => {
       expect(result).to.eql({ contributor_id: 42, client_id: 'my-client-id' });
     });
 
-    it('throws ApiExecuteSQLError when contributor not found', async () => {
+    it('throws ApiNotFoundError when contributor not found', async () => {
       const mockQueryResponse = {
         rowCount: 0,
         rows: []
@@ -141,8 +141,8 @@ describe('ContributorRepository', () => {
         await repository.getContributorByClientId('non-existent-client-id');
         expect.fail('Expected error to be thrown');
       } catch (err) {
-        expect(err).to.be.instanceOf(ApiExecuteSQLError);
-        expect((err as ApiExecuteSQLError).message).to.equal('Failed to get contributor');
+        expect(err).to.be.instanceOf(ApiNotFoundError);
+        expect((err as ApiNotFoundError).message).to.equal('Contributor not found');
       }
     });
   });

--- a/api/src/repositories/contributor-repository.ts
+++ b/api/src/repositories/contributor-repository.ts
@@ -26,7 +26,10 @@ export class ContributorRepository extends BaseRepository {
     const response = await this.connection.sql(sql, GetContributor);
 
     if (response.rowCount === 0) {
-      throw new ApiNotFoundError('Contributor not found', ['ContributorRepository->getContributorByClientId', { clientId }]);
+      throw new ApiNotFoundError('Contributor not found', [
+        'ContributorRepository->getContributorByClientId',
+        { clientId }
+      ]);
     }
 
     if (response.rowCount !== 1) {

--- a/api/src/repositories/contributor-repository.ts
+++ b/api/src/repositories/contributor-repository.ts
@@ -1,5 +1,5 @@
 import SQL from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { GetContributor } from '../paths/contributor/index.interface';
 import { BaseRepository } from './base-repository';
 
@@ -25,10 +25,14 @@ export class ContributorRepository extends BaseRepository {
 
     const response = await this.connection.sql(sql, GetContributor);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Contributor not found', ['ContributorRepository->getContributorByClientId', { clientId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get contributor', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'ContributorRepository->getContributorByClientId',
-        'rowCount !== 1, expected rowCount === 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 
@@ -71,7 +75,7 @@ export class ContributorRepository extends BaseRepository {
     if (response.rowCount !== 1) {
       throw new ApiExecuteSQLError('Failed to create contributor', [
         'ContributorRepository->createContributor',
-        'rowCount !== 1, expected rowCount === 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/data-request-repository.test.ts
+++ b/api/src/repositories/data-request-repository.test.ts
@@ -3,6 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { ApiNotFoundError } from '../errors/api-error';
 import { CreateDataRequest, DataRequest, UpdateDataRequest } from '../models/data-request';
 import { getMockDBConnection } from '../__mocks__/db';
 import { DataRequestRepository } from './data-request-repository';
@@ -128,7 +129,8 @@ describe('DataRequestRepository', () => {
         await repo.getDataRequestById(mockDataRequest.data_request_id);
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Data request not found');
+        expect(err).to.be.instanceOf(ApiNotFoundError);
+        expect((err as ApiNotFoundError).message).to.equal('Data request not found');
       }
     });
   });

--- a/api/src/repositories/data-request-repository.test.ts
+++ b/api/src/repositories/data-request-repository.test.ts
@@ -128,7 +128,7 @@ describe('DataRequestRepository', () => {
         await repo.getDataRequestById(mockDataRequest.data_request_id);
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Failed to get data request');
+        expect((err as Error).message).to.equal('Data request not found');
       }
     });
   });

--- a/api/src/repositories/data-request-repository.ts
+++ b/api/src/repositories/data-request-repository.ts
@@ -1,5 +1,5 @@
 import { getKnex } from '../database/db';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import {
   CreateDataRequest,
   DataRequest,
@@ -87,10 +87,14 @@ export class DataRequestRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, FlatDataRequestWithStatus);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Data request not found', ['DataRequestRepository->getDataRequestById', { dataRequestId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get data request', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'DataRequestRepository->getDataRequestById',
-        'rowCount !== 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/data-request-repository.ts
+++ b/api/src/repositories/data-request-repository.ts
@@ -88,7 +88,10 @@ export class DataRequestRepository extends BaseRepository {
     const response = await this.connection.knex(query, FlatDataRequestWithStatus);
 
     if (response.rowCount === 0) {
-      throw new ApiNotFoundError('Data request not found', ['DataRequestRepository->getDataRequestById', { dataRequestId }]);
+      throw new ApiNotFoundError('Data request not found', [
+        'DataRequestRepository->getDataRequestById',
+        { dataRequestId }
+      ]);
     }
 
     if (response.rowCount !== 1) {

--- a/api/src/repositories/data-request-status-repository.test.ts
+++ b/api/src/repositories/data-request-status-repository.test.ts
@@ -3,6 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { ApiNotFoundError } from '../errors/api-error';
 import { DataRequestStatus, DataRequestStatusEnum, UpdateDataRequestStatus } from '../models/data-request-status';
 import { getMockDBConnection } from '../__mocks__/db';
 import { DataRequestStatusRepository } from './data-request-status-repository';
@@ -55,7 +56,8 @@ describe('DataRequestStatusRepository', () => {
         await repo.getDataRequestStatusById(mockDataRequestStatus.data_request_status_id);
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Data request status not found');
+        expect(err).to.be.instanceOf(ApiNotFoundError);
+        expect((err as ApiNotFoundError).message).to.equal('Data request status not found');
       }
     });
   });
@@ -94,7 +96,8 @@ describe('DataRequestStatusRepository', () => {
         await repo.getDataRequestStatusByDataRequestId(mockDataRequestStatus.data_request_id);
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Data request status not found');
+        expect(err).to.be.instanceOf(ApiNotFoundError);
+        expect((err as ApiNotFoundError).message).to.equal('Data request status not found');
       }
     });
   });

--- a/api/src/repositories/data-request-status-repository.test.ts
+++ b/api/src/repositories/data-request-status-repository.test.ts
@@ -55,7 +55,7 @@ describe('DataRequestStatusRepository', () => {
         await repo.getDataRequestStatusById(mockDataRequestStatus.data_request_status_id);
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Failed to get data request status');
+        expect((err as Error).message).to.equal('Data request status not found');
       }
     });
   });
@@ -94,7 +94,7 @@ describe('DataRequestStatusRepository', () => {
         await repo.getDataRequestStatusByDataRequestId(mockDataRequestStatus.data_request_id);
         throw new Error('Expected to throw');
       } catch (err) {
-        expect((err as Error).message).to.equal('Failed to get data request status');
+        expect((err as Error).message).to.equal('Data request status not found');
       }
     });
   });

--- a/api/src/repositories/data-request-status-repository.ts
+++ b/api/src/repositories/data-request-status-repository.ts
@@ -1,5 +1,5 @@
 import { getKnex } from '../database/db';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { DataRequestStatus, DataRequestStatusEnum, UpdateDataRequestStatus } from '../models/data-request-status';
 import { BaseRepository } from './base-repository';
 
@@ -27,10 +27,17 @@ export class DataRequestStatusRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, DataRequestStatus);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get data request status', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Data request status not found', [
         'DataRequestStatusRepository->getDataRequestStatusById',
-        'rowCount !== 1'
+        { dataRequestStatusId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'DataRequestStatusRepository->getDataRequestStatusById',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 
@@ -53,10 +60,17 @@ export class DataRequestStatusRepository extends BaseRepository {
 
     const response = await this.connection.knex(query, DataRequestStatus);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get data request status', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Data request status not found', [
         'DataRequestStatusRepository->getDataRequestStatusByDataRequestId',
-        'rowCount !== 1'
+        { dataRequestId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'DataRequestStatusRepository->getDataRequestStatusByDataRequestId',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/submission-upload-status-repository.test.ts
+++ b/api/src/repositories/submission-upload-status-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiGeneralError } from '../errors/api-error';
+import { ApiNotFoundError } from '../errors/api-error';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SubmissionUploadStatusRepository } from './submission-upload-status-repository';
 
@@ -74,7 +74,7 @@ describe('SubmissionUploadStatusRepository', () => {
         await repo.getSubmissionUploadStatusById(submissionId);
         expect.fail('Expected error to be thrown');
       } catch (error) {
-        expect((error as ApiGeneralError).message).to.equal(`Failed to get submission upload status`);
+        expect((error as ApiNotFoundError).message).to.equal(`Submission upload status not found`);
       }
     });
 

--- a/api/src/repositories/submission-upload-status-repository.ts
+++ b/api/src/repositories/submission-upload-status-repository.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 import { getKnex, IDBConnection } from '../database/db';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { SubmissionUploadStatus } from '../models/submission-upload-status';
 import { BaseRepository } from './base-repository';
 
@@ -26,10 +26,16 @@ export class SubmissionUploadStatusRepository extends BaseRepository {
   async getSubmissionUploadStatusById(submissionId: number): Promise<SubmissionUploadStatus> {
     const queryBuilder = this._makeGetSubmissionUploadStatusQuery(submissionId);
     const response = await this.connection.knex(queryBuilder, SubmissionUploadStatus);
-    if (!response.rowCount) {
-      throw new ApiExecuteSQLError('Failed to get submission upload status', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Submission upload status not found', [
         'SubmissionUploadStatusRepository->getSubmissionUploadStatusById',
-        'rowCount was null or undefined, expected rowCount != 0'
+        { submissionId }
+      ]);
+    }
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'SubmissionUploadStatusRepository->getSubmissionUploadStatusById',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
     return response.rows[0];

--- a/api/src/repositories/upload/artifact-repository.test.ts
+++ b/api/src/repositories/upload/artifact-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { Artifact, ArtifactStatusEnum, CreateArtifact } from '../../models/artifact';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { ArtifactRepository } from './artifact-repository';
@@ -25,8 +25,8 @@ describe('ArtifactRepository', () => {
         await repo.getArtifact('artifact-id');
         expect.fail();
       } catch (error) {
-        expect(error).to.be.instanceOf(ApiExecuteSQLError);
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get artifact record');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Artifact not found');
       }
     });
 

--- a/api/src/repositories/upload/artifact-repository.ts
+++ b/api/src/repositories/upload/artifact-repository.ts
@@ -1,6 +1,6 @@
 import { SQL } from 'sql-template-strings';
 import z from 'zod';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { Artifact, CreateArtifact, UpdateArtifact } from '../../models/artifact';
 import { BaseRepository } from '../base-repository';
 
@@ -30,10 +30,14 @@ export class ArtifactRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, Artifact);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Artifact not found', ['ArtifactRepository->getArtifact', { artifactId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get artifact record', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'ArtifactRepository->getArtifact',
-        `rowCount was ${response.rowCount}, expected 1`
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/upload/artifact-repository.ts
+++ b/api/src/repositories/upload/artifact-repository.ts
@@ -10,7 +10,8 @@ export class ArtifactRepository extends BaseRepository {
    *
    * @param {string} artifactId - The ID of the artifact to retrieve.
    * @returns {Promise<Artifact>} - The artifact record.
-   * @throws {ApiExecuteSQLError} - If the artifact is not found or query fails.
+   * @throws {ApiNotFoundError} - If the artifact is not found.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
    */
   async getArtifact(artifactId: string): Promise<Artifact> {
     const sqlStatement = SQL`

--- a/api/src/repositories/upload/artifact-security-repository.test.ts
+++ b/api/src/repositories/upload/artifact-security-repository.test.ts
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { ArtifactSecurity, CreateArtifactSecurity, UpdateArtifactSecurity } from '../../models/artifact-security';
 import { SecurityStatusEnum } from '../../models/security-status';
 import { getMockDBConnection } from '../../__mocks__/db';
@@ -32,8 +32,8 @@ describe('ArtifactSecurityRepository', () => {
         await repo.getArtifactSecurity(mockSecurityRecord.artifact_security_id);
         expect.fail('Expected error not thrown');
       } catch (err) {
-        expect(err).to.be.instanceOf(ApiExecuteSQLError);
-        expect((err as ApiExecuteSQLError).message).to.equal('Failed to get security record');
+        expect(err).to.be.instanceOf(ApiNotFoundError);
+        expect((err as ApiNotFoundError).message).to.equal('Artifact security record not found');
       }
     });
 

--- a/api/src/repositories/upload/artifact-security-repository.ts
+++ b/api/src/repositories/upload/artifact-security-repository.ts
@@ -1,5 +1,5 @@
 import { SQL } from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { ArtifactSecurity, CreateArtifactSecurity, UpdateArtifactSecurity } from '../../models/artifact-security';
 import { BaseRepository } from '../base-repository';
 
@@ -24,10 +24,17 @@ export class ArtifactSecurityRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, ArtifactSecurity);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get security record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Artifact security record not found', [
         'ArtifactSecurityRepository->getArtifactSecurity',
-        'rowCount was null or undefined, expected rowCount = 1'
+        { uploadArtifactSecurityId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'ArtifactSecurityRepository->getArtifactSecurity',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/upload/artifact-security-scan-file-repository.test.ts
+++ b/api/src/repositories/upload/artifact-security-scan-file-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   ArtifactSecurityScanFile,
   CreateArtifactSecurityScanFile,
@@ -30,10 +30,8 @@ describe('ArtifactSecurityScanFileRepository', () => {
         await repo.getArtifactSecurityScanFile('id-1');
         expect.fail();
       } catch (error) {
-        expect(error).to.be.instanceOf(ApiExecuteSQLError);
-        expect((error as ApiExecuteSQLError).message).to.equal(
-          'Failed to get upload artifact security scan file record'
-        );
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Artifact security scan file record not found');
       }
     });
 

--- a/api/src/repositories/upload/artifact-security-scan-file-repository.ts
+++ b/api/src/repositories/upload/artifact-security-scan-file-repository.ts
@@ -1,5 +1,5 @@
 import { SQL } from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   ArtifactSecurityScanFile,
   CreateArtifactSecurityScanFile,
@@ -29,10 +29,17 @@ export class ArtifactSecurityScanFileRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, ArtifactSecurityScanFile);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get upload artifact security scan file record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Artifact security scan file record not found', [
         'ArtifactSecurityScanFileRepository->getArtifactSecurityScanFile',
-        `rowCount was ${response.rowCount}, expected 1`
+        { uploadArtifactSecurityScanFileId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'ArtifactSecurityScanFileRepository->getArtifactSecurityScanFile',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/upload/artifact-security-scan-repository.test.ts
+++ b/api/src/repositories/upload/artifact-security-scan-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   ArtifactSecurityScan,
   CreateArtifactSecurityScan,
@@ -30,8 +30,8 @@ describe('ArtifactSecurityScanRepository', () => {
         await repo.getArtifactSecurityScan('scan-id-1');
         expect.fail();
       } catch (error) {
-        expect(error).to.be.instanceOf(ApiExecuteSQLError);
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get security scan record');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Artifact security scan record not found');
       }
     });
 

--- a/api/src/repositories/upload/artifact-security-scan-repository.ts
+++ b/api/src/repositories/upload/artifact-security-scan-repository.ts
@@ -1,5 +1,5 @@
 import { SQL } from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   ArtifactSecurityScan,
   CreateArtifactSecurityScan,
@@ -31,10 +31,17 @@ export class ArtifactSecurityScanRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, ArtifactSecurityScan);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get security scan record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Artifact security scan record not found', [
         'ArtifactSecurityScanRepository->getArtifactSecurityScan',
-        `rowCount was ${response.rowCount}, expected 1`
+        { uploadArtifactSecurityScanId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'ArtifactSecurityScanRepository->getArtifactSecurityScan',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/upload/submission-upload-repository.test.ts
+++ b/api/src/repositories/upload/submission-upload-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CreateSubmissionUpload, SubmissionUpload, UpdateSubmissionUpload } from '../../models/submission-upload';
 import { UploadArtifactRoleEnum } from '../../models/upload-artifact';
 import { getMockDBConnection } from '../../__mocks__/db';
@@ -26,8 +26,8 @@ describe('SubmissionUploadRepository', () => {
         await repo.getSubmissionUpload('id-1');
         expect.fail();
       } catch (error) {
-        expect(error).to.be.instanceOf(ApiExecuteSQLError);
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get submission_upload record');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Submission upload not found');
       }
     });
 

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -16,7 +16,8 @@ export class SubmissionUploadRepository extends BaseRepository {
    *
    * @param {string} submissionUploadId - The ID of the submission_upload record.
    * @returns {Promise<SubmissionUpload>} - The requested submission_upload record.
-   * @throws {ApiExecuteSQLError} - If the record is not found or an error occurs.
+   * @throws {ApiNotFoundError} - If the record is not found.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
    */
   async getSubmissionUpload(submissionUploadId: string): Promise<SubmissionUpload> {
     const sqlStatement = SQL`
@@ -194,7 +195,9 @@ export class SubmissionUploadRepository extends BaseRepository {
    * Get a submission_upload record by upload_id (reverse lookup).
    *
    * @param {string} uploadId - The upload_id to look up.
-   * @returns {Promise<SubmissionUpload | null>} - The submission_upload record, or null if not found.
+   * @returns {Promise<SubmissionUpload>} - The submission_upload record.
+   * @throws {ApiNotFoundError} - If the record is not found.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
    */
   async getSubmissionUploadByUploadId(uploadId: string): Promise<SubmissionUpload> {
     const sqlStatement = SQL`

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -1,6 +1,6 @@
 import { SQL } from 'sql-template-strings';
 import { getKnex } from '../../database/db';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   CreateSubmissionUpload,
   SubmissionUpload,
@@ -32,10 +32,17 @@ export class SubmissionUploadRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, SubmissionUpload);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get submission_upload record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Submission upload not found', [
         'SubmissionUploadRepository->getSubmissionUpload',
-        `rowCount was ${response.rowCount}, expected 1`
+        { submissionUploadId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'SubmissionUploadRepository->getSubmissionUpload',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 
@@ -203,10 +210,17 @@ export class SubmissionUploadRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, SubmissionUpload);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get submission upload record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Submission upload not found', [
         'SubmissionUploadRepository->getSubmissionUploadByUploadId',
-        `rowCount was ${response.rowCount}, expected 1`
+        { uploadId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'SubmissionUploadRepository->getSubmissionUploadByUploadId',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/upload/upload-archive-repository.test.ts
+++ b/api/src/repositories/upload/upload-archive-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { ProcessStatusStatusEnum } from '../../models/process-status';
 import { CreateUploadArchive, UpdateUploadArchive, UploadArchive } from '../../models/upload-archive';
 import { getMockDBConnection } from '../../__mocks__/db';
@@ -26,8 +26,8 @@ describe('UploadArchiveRepository', () => {
         await repo.getUploadArchive('upload-archive-id-1');
         expect.fail();
       } catch (error) {
-        expect(error).to.be.instanceOf(ApiExecuteSQLError);
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get upload archive record');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Upload archive not found');
       }
     });
 

--- a/api/src/repositories/upload/upload-archive-repository.ts
+++ b/api/src/repositories/upload/upload-archive-repository.ts
@@ -27,7 +27,10 @@ export class UploadArchiveRepository extends BaseRepository {
     const response = await this.connection.sql(sqlStatement, UploadArchive);
 
     if (response.rowCount === 0) {
-      throw new ApiNotFoundError('Upload archive not found', ['UploadArchiveRepository->getUploadArchive', { uploadArchiveId }]);
+      throw new ApiNotFoundError('Upload archive not found', [
+        'UploadArchiveRepository->getUploadArchive',
+        { uploadArchiveId }
+      ]);
     }
 
     if (response.rowCount !== 1) {

--- a/api/src/repositories/upload/upload-archive-repository.ts
+++ b/api/src/repositories/upload/upload-archive-repository.ts
@@ -9,7 +9,8 @@ export class UploadArchiveRepository extends BaseRepository {
    *
    * @param {string} uploadArchiveId - The ID of the upload archive to retrieve.
    * @returns {Promise<UploadArchive>} - The upload archive record.
-   * @throws {ApiExecuteSQLError} - Throws an error if the upload archive is not found.
+   * @throws {ApiNotFoundError} - If the upload archive is not found.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
    */
   async getUploadArchive(uploadArchiveId: string): Promise<UploadArchive> {
     const sqlStatement = SQL`
@@ -90,7 +91,9 @@ export class UploadArchiveRepository extends BaseRepository {
    * Get upload archive by artifact ID
    *
    * @param {string} artifactId - The ID of the artifact.
-   * @returns {Promise<UploadArchive | null>} - The upload archive or null if not found.
+   * @returns {Promise<UploadArchive>} - The upload archive record.
+   * @throws {ApiNotFoundError} - If the upload archive is not found.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
    */
   async getUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive> {
     const sqlStatement = SQL`

--- a/api/src/repositories/upload/upload-archive-repository.ts
+++ b/api/src/repositories/upload/upload-archive-repository.ts
@@ -1,5 +1,5 @@
 import { SQL } from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CreateUploadArchive, UpdateUploadArchive, UploadArchive } from '../../models/upload-archive';
 import { BaseRepository } from '../base-repository';
 
@@ -26,10 +26,14 @@ export class UploadArchiveRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, UploadArchive);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Upload archive not found', ['UploadArchiveRepository->getUploadArchive', { uploadArchiveId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get upload archive record', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'UploadArchiveRepository->getUploadArchive',
-        `rowCount was ${response.rowCount}, expected 1`
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 
@@ -100,10 +104,17 @@ export class UploadArchiveRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, UploadArchive);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get upload archive record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Upload archive not found', [
         'UploadArchiveRepository->getUploadArchiveByArtifactId',
-        `rowCount was ${response.rowCount}, expected 1`
+        { artifactId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'UploadArchiveRepository->getUploadArchiveByArtifactId',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/upload/upload-artifact-repository.test.ts
+++ b/api/src/repositories/upload/upload-artifact-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   CreateUploadArtifact,
   UpdateUploadArtifact,
@@ -30,8 +30,8 @@ describe('UploadArtifactRepository', () => {
         await repo.getUploadArtifact('upload-artifact-id-1');
         expect.fail();
       } catch (error) {
-        expect(error).to.be.instanceOf(ApiExecuteSQLError);
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get upload artifact record');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Upload artifact not found');
       }
     });
 

--- a/api/src/repositories/upload/upload-artifact-repository.ts
+++ b/api/src/repositories/upload/upload-artifact-repository.ts
@@ -9,7 +9,8 @@ export class UploadArtifactRepository extends BaseRepository {
    *
    * @param {string} uploadArtifactId - The ID of the upload artifact to retrieve.
    * @returns {Promise<UploadArtifact>} - The upload artifact record.
-   * @throws {ApiExecuteSQLError} - Throws an error if the upload artifact is not found.
+   * @throws {ApiNotFoundError} - If the upload artifact is not found.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
    */
   async getUploadArtifact(uploadArtifactId: string): Promise<UploadArtifact> {
     const sqlStatement = SQL`

--- a/api/src/repositories/upload/upload-artifact-repository.ts
+++ b/api/src/repositories/upload/upload-artifact-repository.ts
@@ -1,5 +1,5 @@
 import { SQL } from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CreateUploadArtifact, UpdateUploadArtifact, UploadArtifact } from '../../models/upload-artifact';
 import { BaseRepository } from '../base-repository';
 
@@ -27,10 +27,17 @@ export class UploadArtifactRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, UploadArtifact);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get upload artifact record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Upload artifact not found', [
         'UploadArtifactRepository->getUploadArtifact',
-        `rowCount was ${response.rowCount}, expected 1`
+        { uploadArtifactId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'UploadArtifactRepository->getUploadArtifact',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/upload/upload-repository.test.ts
+++ b/api/src/repositories/upload/upload-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CreateUpload, UpdateUpload, Upload, UploadStatusEnum } from '../../models/upload';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { UploadRepository } from './upload-repository';
@@ -25,8 +25,8 @@ describe('UploadRepository', () => {
         await repo.getUpload('upload-id-1');
         expect.fail();
       } catch (error) {
-        expect(error).to.be.instanceOf(ApiExecuteSQLError);
-        expect((error as ApiExecuteSQLError).message).to.equal('Failed to get upload record');
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Upload not found');
       }
     });
 

--- a/api/src/repositories/upload/upload-repository.ts
+++ b/api/src/repositories/upload/upload-repository.ts
@@ -1,5 +1,5 @@
 import { SQL } from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import { CreateUpload, UpdateUpload, Upload } from '../../models/upload';
 import { BaseRepository } from '../base-repository';
 
@@ -26,10 +26,14 @@ export class UploadRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, Upload);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Upload not found', ['UploadRepository->getUpload', { uploadId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get upload record', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'UploadRepository->getUpload',
-        `rowCount was ${response.rowCount}, expected 1`
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 

--- a/api/src/repositories/user-repository.test.ts
+++ b/api/src/repositories/user-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { getMockDBConnection } from '../__mocks__/db';
 import { UserRepository } from './user-repository';
 
@@ -52,7 +52,7 @@ describe('UserRepository', () => {
         await userRepository.getUserById(1);
         expect.fail();
       } catch (actualError) {
-        expect((actualError as ApiExecuteSQLError).message).to.equal('Failed to get user by id');
+        expect((actualError as ApiNotFoundError).message).to.equal('User not found');
       }
     });
 

--- a/api/src/repositories/user-repository.ts
+++ b/api/src/repositories/user-repository.ts
@@ -2,7 +2,7 @@ import SQL from 'sql-template-strings';
 import { z } from 'zod';
 import { SYSTEM_IDENTITY_SOURCE } from '../constants/database';
 import { getKnex } from '../database/db';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { SystemUser, SystemUserExtended } from '../models/user';
 import { BaseRepository } from './base-repository';
 
@@ -121,10 +121,14 @@ export class UserRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, SystemUserExtended);
 
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('User not found', ['UserRepository->getUserById', { systemUserId }]);
+    }
+
     if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get user by id', [
+      throw new ApiExecuteSQLError('Unexpected row count', [
         'UserRepository->getUserById',
-        'rowCount was null or undefined, expected rowCount = 1'
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-895

## Description of Changes

- When querying for a specific resource by its primary key, returns 404 instead of 500 if the resource is not found
- Updates existing repositories methods to call `throw new ApiNotFoundError` if a specific resource is not found

eg.
```sql
async getCartById(cartId: string): Promise<Cart> {
    const knex = getKnex();
    const query = knex('cart').where('cart_id', cartId).select('cart_id', 'cart_status', 'system_user_id');

    const response = await this.connection.knex(query, Cart);

    if (response.rowCount === 0) {
      throw new ApiNotFoundError('Cart not found', ['CartRepository->getCartById', { cartId }]);
    }

    if (response.rowCount !== 1) {
      throw new ApiExecuteSQLError('Unexpected row count', [
        'CartRepository->getCartById',
        `expected rowCount=1, actual rowCount=${response.rowCount}`
      ]);
    }

    return response.rows[0];
  }
```

## Testing Notes

In postman:
1) Create a cart by `POST cart`
2) Confirm that `GET cart/{cartId}` returns 200
3) Change the cartId to something that does not exist -> confirm that the response is 404
