### PR TITLE
SIMSBIOHUB-875: Add CRUD endpoints for submissions

### DIFF
--- a/api/src/models/submission-upload-review-status.ts
+++ b/api/src/models/submission-upload-review-status.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+export const SubmissionUploadStatusTypeEnum = z.enum(['submitted', 'approved', 'denied', 'deleted']);
+export type SubmissionUploadStatusTypeEnum = z.infer<typeof SubmissionUploadStatusTypeEnum>;
+
+/**
+ * SubmissionUploadReviewStatus table schema
+ */
+export const SubmissionUploadReviewStatus = z.object({
+  submission_upload_status_id: z.number(),
+  submission_upload_id: z.string().uuid(),
+  status: SubmissionUploadStatusTypeEnum
+});
+export type SubmissionUploadReviewStatus = z.infer<typeof SubmissionUploadReviewStatus>;
+
+/**
+ * Payload for creating a new SubmissionUploadReviewStatus
+ */
+export const CreateSubmissionUploadReviewStatus = z.object({
+  submission_upload_id: z.string().uuid(),
+  status: SubmissionUploadStatusTypeEnum.default('submitted')
+});
+export type CreateSubmissionUploadReviewStatus = z.infer<typeof CreateSubmissionUploadReviewStatus>;
+
+/**
+ * Payload for updating a SubmissionUploadReviewStatus.
+ * Admin PATCH uses only approved/denied; delete handler sets status to 'deleted'.
+ */
+export const UpdateSubmissionUploadReviewStatus = z.object({
+  status: z.enum(['approved', 'denied', 'deleted'])
+});
+export type UpdateSubmissionUploadReviewStatus = z.infer<typeof UpdateSubmissionUploadReviewStatus>;
+
+/**
+ * Row shape for submission_upload_status history (includes create_date and submission_id for ordering/display).
+ */
+export const SubmissionUploadReviewStatusHistoryRow = z.object({
+  submission_id: z.number(),
+  submission_upload_id: z.string().uuid(),
+  status: SubmissionUploadStatusTypeEnum,
+  create_date: z.coerce.date()
+});
+export type SubmissionUploadReviewStatusHistoryRow = z.infer<typeof SubmissionUploadReviewStatusHistoryRow>;

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -8,7 +8,7 @@ export const SubmissionUpload = z.object({
   submission_upload_id: z.string().uuid(),
   submission_id: z.number(),
   upload_id: z.string().uuid(),
-  record_end_date: z.string().nullable().optional()
+  record_end_date: z.coerce.date().nullable().optional()
 });
 export type SubmissionUpload = z.infer<typeof SubmissionUpload>;
 

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -7,7 +7,8 @@ import { UploadArtifactRoleEnum } from './upload-artifact';
 export const SubmissionUpload = z.object({
   submission_upload_id: z.string().uuid(),
   submission_id: z.number(),
-  upload_id: z.string().uuid()
+  upload_id: z.string().uuid(),
+  record_end_date: z.string().nullable().optional()
 });
 export type SubmissionUpload = z.infer<typeof SubmissionUpload>;
 

--- a/api/src/openapi/schemas/upload.ts
+++ b/api/src/openapi/schemas/upload.ts
@@ -31,6 +31,7 @@ export const CreateSubmissionUploadResponseSchema: OpenAPIV3.SchemaObject = {
   additionalProperties: false,
   required: [
     'submissionId',
+    'submissionUploadId',
     'uploadId',
     's3UploadId',
     'uploadArchiveId',
@@ -41,8 +42,14 @@ export const CreateSubmissionUploadResponseSchema: OpenAPIV3.SchemaObject = {
   ],
   properties: {
     submissionId: {
-      type: 'number',
-      description: 'Primary key of the submission'
+      type: 'string',
+      format: 'uuid',
+      description: 'UUID of the submission (globally unique identifier).'
+    },
+    submissionUploadId: {
+      type: 'string',
+      format: 'uuid',
+      description: 'Primary key of the submission_upload record.'
     },
     uploadId: {
       type: 'string',
@@ -89,6 +96,120 @@ export const CreateSubmissionUploadResponseSchema: OpenAPIV3.SchemaObject = {
           }
         }
       }
+    }
+  }
+};
+
+/**
+ * Request body for creating a submission upload (POST /submission/:submissionId/upload)
+ */
+export const SubmissionUploadRequestSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['bytes'],
+  properties: {
+    bytes: {
+      type: 'integer',
+      minimum: 1,
+      maximum: 1073741824,
+      description: 'The expected size of the file to be uploaded in bytes (max 1 GB).'
+    },
+    name: {
+      type: 'string',
+      description: 'Name of the submission.'
+    },
+    description: {
+      type: 'string',
+      description: 'Description of the submission.'
+    },
+    comment: {
+      type: 'string',
+      description: 'Comments for system administrators about the submission.'
+    }
+  }
+};
+
+/**
+ * Response for updating a submission upload review status (PATCH /administrative/...)
+ */
+export const SubmissionUploadReviewStatusResponseSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['submission_upload_status_id', 'submission_upload_id', 'status'],
+  properties: {
+    submission_upload_status_id: {
+      type: 'integer',
+      description: 'Primary key of the submission_upload_status record.'
+    },
+    submission_upload_id: {
+      type: 'string',
+      format: 'uuid',
+      description: 'Foreign key to the submission_upload record.'
+    },
+    status: {
+      type: 'string',
+      enum: ['submitted', 'approved', 'denied', 'deleted'],
+      description: 'The review status of the submission upload.'
+    }
+  }
+};
+
+/**
+ * Response for GET /submission/{submissionId}/history (publish history from submission_upload_status).
+ */
+export const SubmissionUploadStatusHistoryItemSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['submissionUploadId', 'status'],
+  properties: {
+    submissionUploadId: {
+      type: 'string',
+      format: 'uuid',
+      description: 'UUID of the submission_upload record.'
+    },
+    status: {
+      type: 'string',
+      enum: ['submitted', 'approved', 'denied', 'deleted'],
+      description: 'Review status of the submission upload at this point in history.'
+    },
+    createDate: {
+      type: 'string',
+      format: 'date-time',
+      description: 'When this status record was created.'
+    }
+  }
+};
+
+export const SubmissionUploadStatusHistoryResponseSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  description: 'Publish history for the submission, newest first.',
+  required: ['submissionId', 'history'],
+  properties: {
+    submissionId: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Primary key of the submission record (submission_id).'
+    },
+    history: {
+      type: 'array',
+      items: SubmissionUploadStatusHistoryItemSchema
+    }
+  },
+  additionalProperties: false
+};
+
+/**
+ * Request body for updating a submission upload review status
+ */
+export const UpdateSubmissionUploadReviewStatusRequestSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['status'],
+  properties: {
+    status: {
+      type: 'string',
+      enum: ['approved', 'denied'],
+      description: 'The new review status for the submission upload.'
     }
   }
 };

--- a/api/src/paths/administrative/submission/{submissionId}/status/index.ts
+++ b/api/src/paths/administrative/submission/{submissionId}/status/index.ts
@@ -77,7 +77,7 @@ export function getSubmissionUploadStatus(): RequestHandler {
 
       await connection.commit();
 
-      res.status(200).json(result);
+      return res.status(200).json(result);
     } catch (error) {
       defaultLog.error({ label: 'getSubmissionUploadStatus', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
+++ b/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
@@ -95,7 +95,7 @@ export function updateSubmissionUploadReviewStatus(): RequestHandler {
       const { status } = req.body;
 
       const submissionUploadService = new SubmissionUploadService(connection);
-      await submissionUploadService.getSubmissionUploadForSubmissionOrThrow(submissionIdParam, submissionUploadId);
+      await submissionUploadService.getSubmissionUploadBySubmissionUuid(submissionIdParam, submissionUploadId);
 
       const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
       const result = await reviewStatusService.updateSubmissionUploadReviewStatus(submissionUploadId, { status });

--- a/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
+++ b/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
@@ -102,7 +102,7 @@ export function updateSubmissionUploadReviewStatus(): RequestHandler {
 
       await connection.commit();
 
-      res.status(200).json(result);
+      return res.status(200).json(result);
     } catch (error) {
       defaultLog.error({
         label: 'updateSubmissionUploadReviewStatus',

--- a/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
+++ b/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
@@ -2,14 +2,12 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../../database/db';
-import { HTTP404 } from '../../../../../../../errors/http-error';
 import { defaultErrorResponses } from '../../../../../../../openapi/schemas/http-responses';
 import {
   SubmissionUploadReviewStatusResponseSchema,
   UpdateSubmissionUploadReviewStatusRequestSchema
 } from '../../../../../../../openapi/schemas/upload';
 import { authorizeRequestHandler } from '../../../../../../../request-handlers/security/authorization';
-import { SubmissionService } from '../../../../../../../services/submission-service';
 import { SubmissionUploadReviewStatusService } from '../../../../../../../services/upload/submission-upload-review-status-service';
 import { SubmissionUploadService } from '../../../../../../../services/upload/submission-upload-service';
 import { getLogger } from '../../../../../../../utils/logger';
@@ -96,22 +94,8 @@ export function updateSubmissionUploadReviewStatus(): RequestHandler {
       const { submissionId: submissionIdParam, submissionUploadId } = req.params;
       const { status } = req.body;
 
-      const submissionService = new SubmissionService(connection);
-      const byUuid = await submissionService.getSubmissionIdByUUID(submissionIdParam);
-      if (!byUuid) {
-        return res.status(404).json({ message: 'Submission not found.' });
-      }
-
       const submissionUploadService = new SubmissionUploadService(connection);
-      let submissionUpload;
-      try {
-        submissionUpload = await submissionUploadService.getSubmissionUpload(submissionUploadId);
-      } catch {
-        throw new HTTP404('Submission upload not found');
-      }
-      if (submissionUpload.submission_id !== byUuid.submission_id) {
-        throw new HTTP404('Submission upload not found');
-      }
+      await submissionUploadService.getSubmissionUploadForSubmissionOrThrow(submissionIdParam, submissionUploadId);
 
       const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
       const result = await reviewStatusService.updateSubmissionUploadReviewStatus(submissionUploadId, { status });

--- a/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
+++ b/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
@@ -1,0 +1,110 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../../../../constants/roles';
+import { getDBConnection } from '../../../../../../../database/db';
+import { defaultErrorResponses } from '../../../../../../../openapi/schemas/http-responses';
+import {
+  SubmissionUploadReviewStatusResponseSchema,
+  UpdateSubmissionUploadReviewStatusRequestSchema
+} from '../../../../../../../openapi/schemas/upload';
+import { authorizeRequestHandler } from '../../../../../../../request-handlers/security/authorization';
+import { SubmissionUploadReviewStatusService } from '../../../../../../../services/upload/submission-upload-review-status-service';
+import { getLogger } from '../../../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status');
+
+export const PATCH: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  updateSubmissionUploadReviewStatus()
+];
+
+PATCH.apiDoc = {
+  description:
+    'Update the review status of a submission upload to approved or denied. Only system administrators may perform this action.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      description: 'Submission ID (UUID).',
+      in: 'path',
+      name: 'submissionId',
+      schema: {
+        type: 'string',
+        format: 'uuid'
+      },
+      required: true
+    },
+    {
+      description: 'Submission Upload ID (UUID).',
+      in: 'path',
+      name: 'submissionUploadId',
+      schema: {
+        type: 'string',
+        format: 'uuid'
+      },
+      required: true
+    }
+  ],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: UpdateSubmissionUploadReviewStatusRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Submission upload review status updated successfully.',
+      content: {
+        'application/json': {
+          schema: SubmissionUploadReviewStatusResponseSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Updates the review status (approved or denied) for a submission upload.
+ * Only system administrators are authorized to call this endpoint.
+ *
+ * @returns {RequestHandler}
+ */
+export function updateSubmissionUploadReviewStatus(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const { submissionUploadId } = req.params;
+      const { status } = req.body;
+
+      const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
+      const result = await reviewStatusService.updateSubmissionUploadReviewStatus(submissionUploadId, { status });
+
+      await connection.commit();
+
+      res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({
+        label: 'updateSubmissionUploadReviewStatus',
+        message: 'error updating submission upload review status',
+        error
+      });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
+++ b/api/src/paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status/index.ts
@@ -2,13 +2,16 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../../../../constants/roles';
 import { getDBConnection } from '../../../../../../../database/db';
+import { HTTP404 } from '../../../../../../../errors/http-error';
 import { defaultErrorResponses } from '../../../../../../../openapi/schemas/http-responses';
 import {
   SubmissionUploadReviewStatusResponseSchema,
   UpdateSubmissionUploadReviewStatusRequestSchema
 } from '../../../../../../../openapi/schemas/upload';
 import { authorizeRequestHandler } from '../../../../../../../request-handlers/security/authorization';
+import { SubmissionService } from '../../../../../../../services/submission-service';
 import { SubmissionUploadReviewStatusService } from '../../../../../../../services/upload/submission-upload-review-status-service';
+import { SubmissionUploadService } from '../../../../../../../services/upload/submission-upload-service';
 import { getLogger } from '../../../../../../../utils/logger';
 
 const defaultLog = getLogger('paths/administrative/submission/{submissionId}/upload/{submissionUploadId}/status');
@@ -69,7 +72,11 @@ PATCH.apiDoc = {
         }
       }
     },
-    ...defaultErrorResponses
+    ...defaultErrorResponses,
+    404: {
+      description:
+        'Submission not found (invalid submissionId) or submission upload not found (submissionUploadId does not belong to this submission).'
+    }
   }
 };
 
@@ -86,8 +93,25 @@ export function updateSubmissionUploadReviewStatus(): RequestHandler {
     try {
       await connection.open();
 
-      const { submissionUploadId } = req.params;
+      const { submissionId: submissionIdParam, submissionUploadId } = req.params;
       const { status } = req.body;
+
+      const submissionService = new SubmissionService(connection);
+      const byUuid = await submissionService.getSubmissionIdByUUID(submissionIdParam);
+      if (!byUuid) {
+        return res.status(404).json({ message: 'Submission not found.' });
+      }
+
+      const submissionUploadService = new SubmissionUploadService(connection);
+      let submissionUpload;
+      try {
+        submissionUpload = await submissionUploadService.getSubmissionUpload(submissionUploadId);
+      } catch {
+        throw new HTTP404('Submission upload not found');
+      }
+      if (submissionUpload.submission_id !== byUuid.submission_id) {
+        throw new HTTP404('Submission upload not found');
+      }
 
       const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
       const result = await reviewStatusService.updateSubmissionUploadReviewStatus(submissionUploadId, { status });

--- a/api/src/paths/search/index.ts
+++ b/api/src/paths/search/index.ts
@@ -69,7 +69,7 @@ export function searchAll(): RequestHandler {
 
       res.setHeader('Cache-Control', 'public, max-age=90');
 
-      res.status(200).json(result);
+      return res.status(200).json(result);
     } catch (error) {
       defaultLog.error({ label: 'searchAll', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/submission/upload/archive/index.test.ts
+++ b/api/src/paths/submission/upload/archive/index.test.ts
@@ -24,7 +24,8 @@ describe('archive upload handler', () => {
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
     const mockUploadResponse: PresignedUploadUrlResponse = {
-      submissionId: 1,
+      submissionId: 'mock-submission-uuid',
+      submissionUploadId: 'mock-submission-upload-id',
       uploadId: 'mock-upload-id',
       s3UploadId: 'mock-s3-upload-id',
       uploadArchiveId: 'mock-archive-id',
@@ -146,7 +147,8 @@ describe('archive upload handler', () => {
     sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
 
     const startArchiveUploadStub = sinon.stub(UploadIngestionService.prototype, 'startArchiveUpload').resolves({
-      submissionId: 1,
+      submissionId: 'mock-submission-uuid',
+      submissionUploadId: 'mock-submission-upload-id',
       uploadId: 'mock-upload-id',
       s3UploadId: 'mock-s3-upload-id',
       uploadArchiveId: 'mock-archive-id',

--- a/api/src/paths/submission/{submissionId}/download/index.ts
+++ b/api/src/paths/submission/{submissionId}/download/index.ts
@@ -89,7 +89,7 @@ export function downloadSubmission(): RequestHandler {
 
       await connection.commit();
 
-      res.status(200).json(result);
+      return res.status(200).json(result);
     } catch (error) {
       defaultLog.error({ label: 'downloadSubmission', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/submission/{submissionId}/history/index.ts
+++ b/api/src/paths/submission/{submissionId}/history/index.ts
@@ -4,7 +4,6 @@ import { getDBConnection } from '../../../../database/db';
 import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
 import { SubmissionUploadStatusHistoryResponseSchema } from '../../../../openapi/schemas/upload';
 import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
-import { SubmissionService } from '../../../../services/submission-service';
 import { SubmissionUploadReviewStatusService } from '../../../../services/upload/submission-upload-review-status-service';
 import { getLogger } from '../../../../utils/logger';
 
@@ -64,32 +63,11 @@ export function getSubmissionHistory(): RequestHandler {
 
       const submissionUuid = req.params.submissionId as string;
       const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
-      const rows = await reviewStatusService.getSubmissionUploadStatusHistory(submissionUuid);
-
-      const history = rows.map((row) => ({
-        submissionUploadId: row.submission_upload_id,
-        status: row.status,
-        ...(row.create_date && {
-          createDate: row.create_date instanceof Date ? row.create_date.toISOString() : String(row.create_date)
-        })
-      }));
-
-      let submissionId: number;
-      if (rows.length > 0) {
-        submissionId = rows[0].submission_id;
-      } else {
-        const submissionService = new SubmissionService(connection);
-        const byUuid = await submissionService.getSubmissionIdByUUID(submissionUuid);
-        if (!byUuid) {
-          await connection.rollback();
-          return res.status(404).json({ message: 'Submission not found.' });
-        }
-        submissionId = byUuid.submission_id;
-      }
+      const result = await reviewStatusService.getSubmissionHistoryByUuid(submissionUuid);
 
       await connection.commit();
 
-      res.status(200).json({ submissionId, history });
+      return res.status(200).json(result);
     } catch (error) {
       defaultLog.error({ label: 'getSubmissionHistory', message: 'error fetching submission history', error });
       await connection.rollback();

--- a/api/src/paths/submission/{submissionId}/history/index.ts
+++ b/api/src/paths/submission/{submissionId}/history/index.ts
@@ -1,0 +1,101 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { getDBConnection } from '../../../../database/db';
+import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
+import { SubmissionUploadStatusHistoryResponseSchema } from '../../../../openapi/schemas/upload';
+import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
+import { SubmissionService } from '../../../../services/submission-service';
+import { SubmissionUploadReviewStatusService } from '../../../../services/upload/submission-upload-review-status-service';
+import { getLogger } from '../../../../utils/logger';
+
+const defaultLog = getLogger('paths/submission/{submissionId}/history');
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [{ discriminator: 'ServiceClient' }]
+  })),
+  getSubmissionHistory()
+];
+
+GET.apiDoc = {
+  description:
+    'Return publish history for the submission from submission_upload_status (all status records, newest first).',
+  tags: ['submission'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      description: 'Submission UUID.',
+      in: 'path',
+      name: 'submissionId',
+      schema: {
+        type: 'string',
+        format: 'uuid'
+      },
+      required: true
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Publish history for the submission.',
+      content: {
+        'application/json': {
+          schema: SubmissionUploadStatusHistoryResponseSchema
+        }
+      }
+    },
+    404: {
+      description: 'Submission not found (invalid submission UUID).'
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Returns publish history (submission_upload_status records) for the submission, newest first.
+ *
+ * @returns {RequestHandler}
+ */
+export function getSubmissionHistory(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const submissionUuid = req.params.submissionId as string;
+      const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
+      const rows = await reviewStatusService.getSubmissionUploadStatusHistory(submissionUuid);
+
+      const history = rows.map((row) => ({
+        submissionUploadId: row.submission_upload_id,
+        status: row.status,
+        ...(row.create_date && {
+          createDate: row.create_date instanceof Date ? row.create_date.toISOString() : String(row.create_date)
+        })
+      }));
+
+      let submissionId: number;
+      if (rows.length > 0) {
+        submissionId = rows[0].submission_id;
+      } else {
+        const submissionService = new SubmissionService(connection);
+        const byUuid = await submissionService.getSubmissionIdByUUID(submissionUuid);
+        if (!byUuid) {
+          await connection.rollback();
+          return res.status(404).json({ message: 'Submission not found.' });
+        }
+        submissionId = byUuid.submission_id;
+      }
+
+      await connection.commit();
+
+      res.status(200).json({ submissionId, history });
+    } catch (error) {
+      defaultLog.error({ label: 'getSubmissionHistory', message: 'error fetching submission history', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/submission/{submissionId}/history/index.ts
+++ b/api/src/paths/submission/{submissionId}/history/index.ts
@@ -43,10 +43,10 @@ GET.apiDoc = {
         }
       }
     },
+    ...defaultErrorResponses,
     404: {
       description: 'Submission not found (invalid submission UUID).'
-    },
-    ...defaultErrorResponses
+    }
   }
 };
 

--- a/api/src/paths/submission/{submissionId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/index.ts
@@ -157,7 +157,7 @@ export function getSubmissionRecordWithSecurity(): RequestHandler {
 
       await connection.commit();
 
-      res.status(200).json(result);
+      return res.status(200).json(result);
     } catch (error) {
       defaultLog.error({ label: 'getSubmissionRecordWithSecurity', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/submission/{submissionId}/published/download/index.ts
+++ b/api/src/paths/submission/{submissionId}/published/download/index.ts
@@ -90,7 +90,7 @@ export function downloadPublishedSubmission(): RequestHandler {
 
       await connection.commit();
 
-      res.status(200).json(result);
+      return res.status(200).json(result);
     } catch (error) {
       defaultLog.error({ label: 'downloadPublishedSubmission', message: 'error', error });
       await connection.rollback();

--- a/api/src/paths/submission/{submissionId}/upload/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/index.ts
@@ -1,0 +1,94 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { getDBConnection } from '../../../../database/db';
+import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
+import {
+  CreateSubmissionUploadResponseSchema,
+  SubmissionUploadRequestSchema
+} from '../../../../openapi/schemas/upload';
+import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
+import { UploadIngestionService } from '../../../../services/upload/upload-ingestion-service';
+import { getLogger } from '../../../../utils/logger';
+
+const defaultLog = getLogger('paths/submission/{submissionId}/upload');
+
+export const POST: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [{ discriminator: 'ServiceClient' }]
+  })),
+  createSubmissionUpload()
+];
+
+POST.apiDoc = {
+  description: 'Initialize a new archive upload for an existing submission and get presigned URLs.',
+  tags: ['submission'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      description: 'Submission UUID.',
+      in: 'path',
+      name: 'submissionId',
+      schema: {
+        type: 'string',
+        format: 'uuid'
+      },
+      required: true
+    }
+  ],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: SubmissionUploadRequestSchema
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Multipart upload initialized successfully with presigned URLs.',
+      content: {
+        'application/json': {
+          schema: CreateSubmissionUploadResponseSchema
+        }
+      }
+    },
+    ...defaultErrorResponses,
+    404: {
+      description: 'Submission not found (invalid submission UUID).'
+    }
+  }
+};
+
+/**
+ * Appends a new upload to an existing submission.
+ *
+ * @returns {RequestHandler}
+ */
+export function createSubmissionUpload(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const submissionUuid = req.params.submissionId as string;
+      const { bytes } = req.body;
+
+      const uploadIngestionService = new UploadIngestionService(connection);
+      const result = await uploadIngestionService.startArchiveUploadForExistingSubmissionByUuid(
+        bytes,
+        submissionUuid
+      );
+
+      await connection.commit();
+
+      res.status(201).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'createSubmissionUpload', message: 'error initializing submission upload', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/submission/{submissionId}/upload/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/index.ts
@@ -79,7 +79,7 @@ export function createSubmissionUpload(): RequestHandler {
 
       await connection.commit();
 
-      res.status(201).json(result);
+      return res.status(201).json(result);
     } catch (error) {
       defaultLog.error({ label: 'createSubmissionUpload', message: 'error initializing submission upload', error });
       await connection.rollback();

--- a/api/src/paths/submission/{submissionId}/upload/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/index.ts
@@ -75,10 +75,7 @@ export function createSubmissionUpload(): RequestHandler {
       const { bytes } = req.body;
 
       const uploadIngestionService = new UploadIngestionService(connection);
-      const result = await uploadIngestionService.startArchiveUploadForExistingSubmissionByUuid(
-        bytes,
-        submissionUuid
-      );
+      const result = await uploadIngestionService.startArchiveUploadForExistingSubmissionByUuid(bytes, submissionUuid);
 
       await connection.commit();
 

--- a/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
@@ -6,7 +6,6 @@ import { ApiExecuteSQLError } from '../../../../../errors/api-error';
 import { HTTP404, HTTP409 } from '../../../../../errors/http-error';
 import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
 import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
-import { SubmissionService } from '../../../../../services/submission-service';
 import { SubmissionUploadReviewStatusService } from '../../../../../services/upload/submission-upload-review-status-service';
 import { SubmissionUploadService } from '../../../../../services/upload/submission-upload-service';
 import { getLogger } from '../../../../../utils/logger';
@@ -79,22 +78,8 @@ export function deleteSubmissionUpload(): RequestHandler {
 
       const { submissionId: submissionIdParam, submissionUploadId } = req.params;
 
-      const submissionService = new SubmissionService(connection);
-      const byUuid = await submissionService.getSubmissionIdByUUID(submissionIdParam);
-      if (!byUuid) {
-        return res.status(404).json({ message: 'Submission not found.' });
-      }
-
       const submissionUploadService = new SubmissionUploadService(connection);
-      let submissionUpload;
-      try {
-        submissionUpload = await submissionUploadService.getSubmissionUpload(submissionUploadId);
-      } catch {
-        throw new HTTP404('Submission upload not found');
-      }
-      if (submissionUpload.submission_id !== byUuid.submission_id) {
-        throw new HTTP404('Submission upload not found');
-      }
+      await submissionUploadService.getSubmissionUploadForSubmissionOrThrow(submissionIdParam, submissionUploadId);
 
       const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
       let reviewStatus;

--- a/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
@@ -1,0 +1,113 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../../constants/roles';
+import { getDBConnection } from '../../../../../database/db';
+import { ApiExecuteSQLError } from '../../../../../errors/api-error';
+import { HTTP404, HTTP409 } from '../../../../../errors/http-error';
+import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
+import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
+import { SubmissionUploadReviewStatusService } from '../../../../../services/upload/submission-upload-review-status-service';
+import { SubmissionUploadService } from '../../../../../services/upload/submission-upload-service';
+import { getLogger } from '../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/submission/{submissionId}/upload/{submissionUploadId}');
+
+export const DELETE: Operation = [
+  authorizeRequestHandler(() => ({
+    or: [
+      { discriminator: 'ServiceClient' },
+      { validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN], discriminator: 'SystemRole' }
+    ]
+  })),
+  deleteSubmissionUpload()
+];
+
+DELETE.apiDoc = {
+  description:
+    'Soft-delete a submission upload. Only allowed when the upload has a status of "submitted" (unreviewed). Deletion is blocked if the upload has already been approved or denied.',
+  tags: ['submission'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    {
+      description: 'Submission ID (UUID).',
+      in: 'path',
+      name: 'submissionId',
+      schema: {
+        type: 'string',
+        format: 'uuid'
+      },
+      required: true
+    },
+    {
+      description: 'Submission Upload ID (UUID).',
+      in: 'path',
+      name: 'submissionUploadId',
+      schema: {
+        type: 'string',
+        format: 'uuid'
+      },
+      required: true
+    }
+  ],
+  responses: {
+    204: {
+      description: 'Submission upload successfully soft-deleted.'
+    },
+    ...defaultErrorResponses,
+    404: {
+      description: 'Submission upload not found (invalid submissionUploadId or no status record).'
+    },
+    409: {
+      description: 'Cannot delete a submission upload that has already been reviewed (approved or denied).'
+    }
+  }
+};
+
+/**
+ * Soft-deletes a submission upload, provided it has not yet been reviewed.
+ *
+ * @returns {RequestHandler}
+ */
+export function deleteSubmissionUpload(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const { submissionUploadId } = req.params;
+
+      const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
+      let reviewStatus;
+      try {
+        reviewStatus = await reviewStatusService.getSubmissionUploadReviewStatus(submissionUploadId);
+      } catch (err) {
+        if (err instanceof ApiExecuteSQLError && err.message === 'Failed to get submission_upload_status record') {
+          throw new HTTP404('Submission upload not found');
+        }
+        throw err;
+      }
+
+      if (reviewStatus.status !== 'submitted') {
+        throw new HTTP409(
+          `Cannot delete a submission upload with status "${reviewStatus.status}". Only uploads with status "submitted" may be deleted.`
+        );
+      }
+
+      const submissionUploadService = new SubmissionUploadService(connection);
+      await submissionUploadService.softDeleteSubmissionUpload(submissionUploadId);
+
+      await reviewStatusService.updateSubmissionUploadReviewStatus(submissionUploadId, { status: 'deleted' });
+
+      await connection.commit();
+
+      res.status(204).send();
+    } catch (error) {
+      defaultLog.error({ label: 'deleteSubmissionUpload', message: 'error deleting submission upload', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
@@ -2,8 +2,7 @@ import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SYSTEM_ROLE } from '../../../../../constants/roles';
 import { getDBConnection } from '../../../../../database/db';
-import { ApiExecuteSQLError } from '../../../../../errors/api-error';
-import { HTTP404, HTTP409 } from '../../../../../errors/http-error';
+import { HTTP409 } from '../../../../../errors/http-error';
 import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
 import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
 import { SubmissionUploadReviewStatusService } from '../../../../../services/upload/submission-upload-review-status-service';
@@ -79,18 +78,10 @@ export function deleteSubmissionUpload(): RequestHandler {
       const { submissionId: submissionIdParam, submissionUploadId } = req.params;
 
       const submissionUploadService = new SubmissionUploadService(connection);
-      await submissionUploadService.getSubmissionUploadForSubmissionOrThrow(submissionIdParam, submissionUploadId);
+      await submissionUploadService.getSubmissionUploadBySubmissionUuid(submissionIdParam, submissionUploadId);
 
       const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
-      let reviewStatus;
-      try {
-        reviewStatus = await reviewStatusService.getSubmissionUploadReviewStatus(submissionUploadId);
-      } catch (err) {
-        if (err instanceof ApiExecuteSQLError && err.message === 'Failed to get submission_upload_status record') {
-          throw new HTTP404('Submission upload not found');
-        }
-        throw err;
-      }
+      const reviewStatus = await reviewStatusService.getSubmissionUploadReviewStatus(submissionUploadId);
 
       if (reviewStatus.status !== 'submitted') {
         throw new HTTP409(

--- a/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
@@ -95,7 +95,7 @@ export function deleteSubmissionUpload(): RequestHandler {
 
       await connection.commit();
 
-      res.status(204).send();
+      return res.status(204).send();
     } catch (error) {
       defaultLog.error({ label: 'deleteSubmissionUpload', message: 'error deleting submission upload', error });
       await connection.rollback();

--- a/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/{submissionUploadId}/index.ts
@@ -6,6 +6,7 @@ import { ApiExecuteSQLError } from '../../../../../errors/api-error';
 import { HTTP404, HTTP409 } from '../../../../../errors/http-error';
 import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
 import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
+import { SubmissionService } from '../../../../../services/submission-service';
 import { SubmissionUploadReviewStatusService } from '../../../../../services/upload/submission-upload-review-status-service';
 import { SubmissionUploadService } from '../../../../../services/upload/submission-upload-service';
 import { getLogger } from '../../../../../utils/logger';
@@ -55,7 +56,8 @@ DELETE.apiDoc = {
     },
     ...defaultErrorResponses,
     404: {
-      description: 'Submission upload not found (invalid submissionUploadId or no status record).'
+      description:
+        'Submission not found (invalid submissionId) or submission upload not found (invalid submissionUploadId, no status record, or upload does not belong to this submission).'
     },
     409: {
       description: 'Cannot delete a submission upload that has already been reviewed (approved or denied).'
@@ -75,7 +77,24 @@ export function deleteSubmissionUpload(): RequestHandler {
     try {
       await connection.open();
 
-      const { submissionUploadId } = req.params;
+      const { submissionId: submissionIdParam, submissionUploadId } = req.params;
+
+      const submissionService = new SubmissionService(connection);
+      const byUuid = await submissionService.getSubmissionIdByUUID(submissionIdParam);
+      if (!byUuid) {
+        return res.status(404).json({ message: 'Submission not found.' });
+      }
+
+      const submissionUploadService = new SubmissionUploadService(connection);
+      let submissionUpload;
+      try {
+        submissionUpload = await submissionUploadService.getSubmissionUpload(submissionUploadId);
+      } catch {
+        throw new HTTP404('Submission upload not found');
+      }
+      if (submissionUpload.submission_id !== byUuid.submission_id) {
+        throw new HTTP404('Submission upload not found');
+      }
 
       const reviewStatusService = new SubmissionUploadReviewStatusService(connection);
       let reviewStatus;
@@ -94,7 +113,6 @@ export function deleteSubmissionUpload(): RequestHandler {
         );
       }
 
-      const submissionUploadService = new SubmissionUploadService(connection);
       await submissionUploadService.softDeleteSubmissionUpload(submissionUploadId);
 
       await reviewStatusService.updateSubmissionUploadReviewStatus(submissionUploadId, { status: 'deleted' });

--- a/api/src/repositories/submission-repository.test.ts
+++ b/api/src/repositories/submission-repository.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { ApiExecuteSQLError, ApiGeneralError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiGeneralError, ApiNotFoundError } from '../errors/api-error';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SECURITY_APPLIED_STATUS } from './security-repository';
 import {
@@ -194,10 +194,10 @@ describe('SubmissionRepository', () => {
 
       const response = await submissionRepository.getSubmissionIdByUUID('test_uuid');
 
-      expect(response?.submission_id).to.equal(1);
+      expect(response.submission_id).to.equal(1);
     });
 
-    it('should return null', async () => {
+    it('should throw ApiNotFoundError when submission not found', async () => {
       const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
 
       const mockDBConnection = getMockDBConnection({
@@ -206,9 +206,13 @@ describe('SubmissionRepository', () => {
 
       const submissionRepository = new SubmissionRepository(mockDBConnection);
 
-      const response = await submissionRepository.getSubmissionIdByUUID('test_uuid');
-
-      expect(response).to.be.null;
+      try {
+        await submissionRepository.getSubmissionIdByUUID('test_uuid');
+        expect.fail('Expected ApiNotFoundError');
+      } catch (err) {
+        expect(err).to.be.instanceOf(ApiNotFoundError);
+        expect((err as ApiNotFoundError).message).to.equal('Submission not found');
+      }
     });
   });
 

--- a/api/src/repositories/submission-repository.ts
+++ b/api/src/repositories/submission-repository.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import SQL from 'sql-template-strings';
 import { z } from 'zod';
 import { getKnex, getKnexQueryBuilder } from '../database/db';
-import { ApiExecuteSQLError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { SubmissionFeatureForReview } from '../models/submission';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
@@ -674,11 +674,12 @@ export class SubmissionRepository extends BaseRepository {
   /**
    * Fetch a submission_id from uuid.
    *
-   * @param {number} uuid
-   * @return {*}  {Promise<{ submission_id: number }>}
+   * @param {string} uuid - The submission UUID.
+   * @return {Promise<{ submission_id: number }>} The submission_id for the given UUID.
+   * @throws {ApiNotFoundError} If no submission exists for the given UUID.
    * @memberof SubmissionRepository
    */
-  async getSubmissionIdByUUID(uuid: string): Promise<{ submission_id: number } | null> {
+  async getSubmissionIdByUUID(uuid: string): Promise<{ submission_id: number }> {
     const sqlStatement = SQL`
       SELECT
         submission_id
@@ -689,11 +690,10 @@ export class SubmissionRepository extends BaseRepository {
     `;
 
     const response = await this.connection.sql<{ submission_id: number }>(sqlStatement);
-    if (response.rowCount !== 0) {
-      return response.rows[0];
-    } else {
-      return null;
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Submission not found', ['SubmissionRepository->getSubmissionIdByUUID', { uuid }]);
     }
+    return response.rows[0];
   }
 
   /**

--- a/api/src/repositories/submission-upload-status-repository.ts
+++ b/api/src/repositories/submission-upload-status-repository.ts
@@ -58,7 +58,8 @@ export class SubmissionUploadStatusRepository extends BaseRepository {
         qb.select('submission_upload.submission_id', 'upload.upload_id', 'upload.upload_status')
           .from('submission_upload')
           .join('upload', 'submission_upload.upload_id', 'upload.upload_id')
-          .where('submission_upload.submission_id', submissionId);
+          .where('submission_upload.submission_id', submissionId)
+          .whereNull('submission_upload.record_end_date');
       })
       .with('upload_artifacts', (qb) => {
         qb.select('upload_artifact.upload_id', 'upload_artifact.artifact_id', 'upload_artifact.role')

--- a/api/src/repositories/upload/submission-upload-repository.test.ts
+++ b/api/src/repositories/upload/submission-upload-repository.test.ts
@@ -46,6 +46,36 @@ describe('SubmissionUploadRepository', () => {
     });
   });
 
+  describe('getSubmissionUploadBySubmissionUuid', () => {
+    it('throws ApiNotFoundError when no matching record found', async () => {
+      const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new SubmissionUploadRepository(mockDBConnection);
+
+      try {
+        await repo.getSubmissionUploadBySubmissionUuid('submission-uuid', 'upload-id');
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Submission upload not found');
+      }
+    });
+
+    it('returns the submission upload when it belongs to the submission', async () => {
+      const mockRow = {
+        submission_upload_id: 'upload-id',
+        submission_id: 123,
+        upload_id: 'upload-uuid'
+      };
+      const mockQueryResponse = { rowCount: 1, rows: [mockRow] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new SubmissionUploadRepository(mockDBConnection);
+
+      const result = await repo.getSubmissionUploadBySubmissionUuid('submission-uuid', 'upload-id');
+      expect(result).to.eql(mockRow);
+    });
+  });
+
   describe('getSubmissionUploadsBySubmissionId', () => {
     it('returns an array of records without filters', async () => {
       const mockQueryResponse = {

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -52,6 +52,53 @@ export class SubmissionUploadRepository extends BaseRepository {
   }
 
   /**
+   * Get a single active submission_upload record by submission UUID and submission_upload_id.
+   * Use to validate that an upload belongs to the given submission (e.g. path parameter validation).
+   *
+   * @param {string} submissionUuid - The submission UUID (submission.uuid).
+   * @param {string} submissionUploadId - The submission_upload_id.
+   * @returns {Promise<SubmissionUpload>} - The requested submission_upload record.
+   * @throws {ApiNotFoundError} - If the record is not found or does not belong to the submission.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
+   */
+  async getSubmissionUploadBySubmissionUuid(
+    submissionUuid: string,
+    submissionUploadId: string
+  ): Promise<SubmissionUpload> {
+    const sqlStatement = SQL`
+      SELECT
+        su.submission_upload_id,
+        su.submission_id,
+        su.upload_id,
+        su.record_end_date
+      FROM
+        submission_upload su
+      INNER JOIN submission s ON s.submission_id = su.submission_id
+      WHERE
+        s.uuid = ${submissionUuid}
+        AND su.submission_upload_id = ${submissionUploadId}
+        AND su.record_end_date IS NULL;
+    `;
+
+    const response = await this.connection.sql(sqlStatement, SubmissionUpload);
+
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Submission upload not found', [
+        'SubmissionUploadRepository->getSubmissionUploadBySubmissionUuid',
+        { submissionUuid, submissionUploadId }
+      ]);
+    }
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'SubmissionUploadRepository->getSubmissionUploadBySubmissionUuid',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
    * Retrieves submission_upload records with optional filters and pagination.
    *
    * @param {number} submissionId - The ID of the submission.

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -12,7 +12,7 @@ import { BaseRepository } from '../base-repository';
 
 export class SubmissionUploadRepository extends BaseRepository {
   /**
-   * Get a single submission_upload record by ID.
+   * Get a single active submission_upload record by ID.
    *
    * @param {string} submissionUploadId - The ID of the submission_upload record.
    * @returns {Promise<SubmissionUpload>} - The requested submission_upload record.
@@ -28,7 +28,8 @@ export class SubmissionUploadRepository extends BaseRepository {
       FROM
         submission_upload
       WHERE
-        submission_upload_id = ${submissionUploadId};
+        submission_upload_id = ${submissionUploadId}
+        AND record_end_date IS NULL;
     `;
 
     const response = await this.connection.sql(sqlStatement, SubmissionUpload);
@@ -73,7 +74,8 @@ export class SubmissionUploadRepository extends BaseRepository {
       )
       .from('submission_upload')
       .join('upload_artifact as ua', 'ua.upload_id', 'submission_upload.upload_id')
-      .where('submission_upload.submission_id', submissionId);
+      .where('submission_upload.submission_id', submissionId)
+      .whereNull('submission_upload.record_end_date');
 
     if (filters?.role) {
       query = query.andWhere('role', filters.role);
@@ -192,7 +194,7 @@ export class SubmissionUploadRepository extends BaseRepository {
   }
 
   /**
-   * Get a submission_upload record by upload_id (reverse lookup).
+   * Get an active submission_upload record by upload_id (reverse lookup).
    *
    * @param {string} uploadId - The upload_id to look up.
    * @returns {Promise<SubmissionUpload>} - The submission_upload record.
@@ -208,7 +210,8 @@ export class SubmissionUploadRepository extends BaseRepository {
       FROM
         submission_upload
       WHERE
-        upload_id = ${uploadId};
+        upload_id = ${uploadId}
+        AND record_end_date IS NULL;
     `;
 
     const response = await this.connection.sql(sqlStatement, SubmissionUpload);
@@ -231,7 +234,50 @@ export class SubmissionUploadRepository extends BaseRepository {
   }
 
   /**
-   * Delete a submission_upload record by ID.
+   * Soft-delete a single active submission_upload record by setting record_end_date to now.
+   *
+   * @param {string} submissionUploadId - The ID of the submission_upload record to soft-delete.
+   * @throws {ApiExecuteSQLError} - If no active record is found.
+   */
+  async softDeleteSubmissionUpload(submissionUploadId: string): Promise<void> {
+    const sqlStatement = SQL`
+      UPDATE submission_upload
+      SET record_end_date = NOW()
+      WHERE submission_upload_id = ${submissionUploadId}
+        AND record_end_date IS NULL;
+    `;
+
+    const response = await this.connection.sql(sqlStatement);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to soft-delete submission_upload record', [
+        'SubmissionUploadRepository->softDeleteSubmissionUpload',
+        `rowCount was ${response.rowCount}, expected 1`
+      ]);
+    }
+  }
+
+  /**
+   * Soft-delete all active submission_upload records for a given submission.
+   *
+   * @param {number} submissionId - The submission ID whose uploads should be soft-deleted.
+   * @returns {Promise<number>} - The number of records soft-deleted.
+   */
+  async softDeleteSubmissionUploadsBySubmissionId(submissionId: number): Promise<number> {
+    const sqlStatement = SQL`
+      UPDATE submission_upload
+      SET record_end_date = NOW()
+      WHERE submission_id = ${submissionId}
+        AND record_end_date IS NULL;
+    `;
+
+    const response = await this.connection.sql(sqlStatement);
+
+    return response.rowCount ?? 0;
+  }
+
+  /**
+   * Hard-delete a submission_upload record by ID.
    *
    * @param {string} submissionUploadId - The ID of the submission_upload record to delete.
    * @throws {ApiExecuteSQLError} - If the deletion fails.

--- a/api/src/repositories/upload/submission-upload-review-status-repository.ts
+++ b/api/src/repositories/upload/submission-upload-review-status-repository.ts
@@ -1,0 +1,142 @@
+import { SQL } from 'sql-template-strings';
+import { ApiExecuteSQLError } from '../../errors/api-error';
+import {
+  CreateSubmissionUploadReviewStatus,
+  SubmissionUploadReviewStatus,
+  SubmissionUploadReviewStatusHistoryRow,
+  UpdateSubmissionUploadReviewStatus
+} from '../../models/submission-upload-review-status';
+import { BaseRepository } from '../base-repository';
+
+/**
+ * Repository for managing submission_upload_status records.
+ * Tracks the admin review status (submitted, approved, denied) for each submission upload.
+ */
+export class SubmissionUploadReviewStatusRepository extends BaseRepository {
+  /**
+   * Insert a new submission_upload_status record.
+   *
+   * @param {CreateSubmissionUploadReviewStatus} data - The status data to insert.
+   * @returns {Promise<SubmissionUploadReviewStatus>} - The newly created status record.
+   * @throws {ApiExecuteSQLError} - If the insert fails.
+   */
+  async insertSubmissionUploadReviewStatus(
+    data: CreateSubmissionUploadReviewStatus
+  ): Promise<SubmissionUploadReviewStatus> {
+    const sqlStatement = SQL`
+      INSERT INTO submission_upload_status (
+        submission_upload_id,
+        status
+      ) VALUES (
+        ${data.submission_upload_id},
+        ${data.status}
+      )
+      RETURNING submission_upload_status_id, submission_upload_id, status;
+    `;
+
+    const response = await this.connection.sql(sqlStatement, SubmissionUploadReviewStatus);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to insert submission_upload_status record', [
+        'SubmissionUploadReviewStatusRepository->insertSubmissionUploadReviewStatus',
+        `rowCount was ${response.rowCount}, expected 1`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Get the review status for a submission upload.
+   *
+   * @param {string} submissionUploadId - The submission_upload_id to look up.
+   * @returns {Promise<SubmissionUploadReviewStatus>} - The status record.
+   * @throws {ApiExecuteSQLError} - If the record is not found.
+   */
+  async getSubmissionUploadReviewStatus(submissionUploadId: string): Promise<SubmissionUploadReviewStatus> {
+    const sqlStatement = SQL`
+      SELECT
+        submission_upload_status_id,
+        submission_upload_id,
+        status
+      FROM
+        submission_upload_status
+      WHERE
+        submission_upload_id = ${submissionUploadId};
+    `;
+
+    const response = await this.connection.sql(sqlStatement, SubmissionUploadReviewStatus);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to get submission_upload_status record', [
+        'SubmissionUploadReviewStatusRepository->getSubmissionUploadReviewStatus',
+        `rowCount was ${response.rowCount}, expected 1`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Update the review status for a submission upload.
+   *
+   * @param {string} submissionUploadId - The submission_upload_id whose status should be updated.
+   * @param {UpdateSubmissionUploadReviewStatus} data - The new status value.
+   * @returns {Promise<SubmissionUploadReviewStatus>} - The updated status record.
+   * @throws {ApiExecuteSQLError} - If the update fails.
+   */
+  async updateSubmissionUploadReviewStatus(
+    submissionUploadId: string,
+    data: UpdateSubmissionUploadReviewStatus
+  ): Promise<SubmissionUploadReviewStatus> {
+    const sqlStatement = SQL`
+      UPDATE submission_upload_status
+      SET
+        status = ${data.status}
+      WHERE
+        submission_upload_id = ${submissionUploadId}
+      RETURNING submission_upload_status_id, submission_upload_id, status;
+    `;
+
+    const response = await this.connection.sql(sqlStatement, SubmissionUploadReviewStatus);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to update submission_upload_status record', [
+        'SubmissionUploadReviewStatusRepository->updateSubmissionUploadReviewStatus',
+        `rowCount was ${response.rowCount}, expected 1`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Get all submission_upload_status records for a submission (publish history), newest first.
+   *
+   * @param {string} submissionUuid - The submission UUID to look up.
+   * @returns {Promise<SubmissionUploadReviewStatusHistoryRow[]>} - All status records for the submission.
+   */
+  async getStatusHistoryBySubmissionUuid(
+    submissionUuid: string
+  ): Promise<SubmissionUploadReviewStatusHistoryRow[]> {
+    const sqlStatement = SQL`
+      SELECT
+        s.submission_id,
+        sus.submission_upload_id,
+        sus.status,
+        sus.create_date
+      FROM
+        submission_upload_status sus
+      INNER JOIN submission_upload su ON su.submission_upload_id = sus.submission_upload_id
+      INNER JOIN submission s ON s.submission_id = su.submission_id
+      WHERE
+        s.uuid = ${submissionUuid}
+      ORDER BY
+        sus.create_date DESC;
+    `;
+
+    const response = await this.connection.sql(sqlStatement, SubmissionUploadReviewStatusHistoryRow);
+
+    return response.rows ?? [];
+  }
+}

--- a/api/src/repositories/upload/submission-upload-review-status-repository.ts
+++ b/api/src/repositories/upload/submission-upload-review-status-repository.ts
@@ -1,5 +1,5 @@
 import { SQL } from 'sql-template-strings';
-import { ApiExecuteSQLError } from '../../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
 import {
   CreateSubmissionUploadReviewStatus,
   SubmissionUploadReviewStatus,
@@ -51,7 +51,8 @@ export class SubmissionUploadReviewStatusRepository extends BaseRepository {
    *
    * @param {string} submissionUploadId - The submission_upload_id to look up.
    * @returns {Promise<SubmissionUploadReviewStatus>} - The status record.
-   * @throws {ApiExecuteSQLError} - If the record is not found.
+   * @throws {ApiNotFoundError} - If the record is not found.
+   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
    */
   async getSubmissionUploadReviewStatus(submissionUploadId: string): Promise<SubmissionUploadReviewStatus> {
     const sqlStatement = SQL`
@@ -67,10 +68,16 @@ export class SubmissionUploadReviewStatusRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, SubmissionUploadReviewStatus);
 
-    if (response.rowCount !== 1) {
-      throw new ApiExecuteSQLError('Failed to get submission_upload_status record', [
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Submission upload status not found', [
         'SubmissionUploadReviewStatusRepository->getSubmissionUploadReviewStatus',
-        `rowCount was ${response.rowCount}, expected 1`
+        { submissionUploadId }
+      ]);
+    }
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'SubmissionUploadReviewStatusRepository->getSubmissionUploadReviewStatus',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
       ]);
     }
 
@@ -135,6 +142,6 @@ export class SubmissionUploadReviewStatusRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, SubmissionUploadReviewStatusHistoryRow);
 
-    return response.rows ?? [];
+    return response.rows;
   }
 }

--- a/api/src/repositories/upload/submission-upload-review-status-repository.ts
+++ b/api/src/repositories/upload/submission-upload-review-status-repository.ts
@@ -116,9 +116,7 @@ export class SubmissionUploadReviewStatusRepository extends BaseRepository {
    * @param {string} submissionUuid - The submission UUID to look up.
    * @returns {Promise<SubmissionUploadReviewStatusHistoryRow[]>} - All status records for the submission.
    */
-  async getStatusHistoryBySubmissionUuid(
-    submissionUuid: string
-  ): Promise<SubmissionUploadReviewStatusHistoryRow[]> {
+  async getStatusHistoryBySubmissionUuid(submissionUuid: string): Promise<SubmissionUploadReviewStatusHistoryRow[]> {
     const sqlStatement = SQL`
       SELECT
         s.submission_id,

--- a/api/src/services/submission-service.ts
+++ b/api/src/services/submission-service.ts
@@ -170,7 +170,7 @@ export class SubmissionService extends DBService {
    * @return {*}  {Promise<{ submission_id: number }>}
    * @memberof SubmissionService
    */
-  async getSubmissionIdByUUID(uuid: string): Promise<{ submission_id: number } | null> {
+  async getSubmissionIdByUUID(uuid: string): Promise<{ submission_id: number }> {
     return this.submissionRepository.getSubmissionIdByUUID(uuid);
   }
 

--- a/api/src/services/upload/submission-upload-review-status-service.ts
+++ b/api/src/services/upload/submission-upload-review-status-service.ts
@@ -2,11 +2,20 @@ import { IDBConnection } from '../../database/db';
 import {
   CreateSubmissionUploadReviewStatus,
   SubmissionUploadReviewStatus,
-  SubmissionUploadReviewStatusHistoryRow,
   UpdateSubmissionUploadReviewStatus
 } from '../../models/submission-upload-review-status';
 import { SubmissionUploadReviewStatusRepository } from '../../repositories/upload/submission-upload-review-status-repository';
 import { DBService } from '../db-service';
+import { SubmissionService } from '../submission-service';
+
+export interface SubmissionHistoryResponse {
+  submissionId: number;
+  history: Array<{
+    submissionUploadId: string;
+    status: string;
+    createDate: string;
+  }>;
+}
 
 export class SubmissionUploadReviewStatusService extends DBService {
   submissionUploadReviewStatusRepository: SubmissionUploadReviewStatusRepository;
@@ -55,12 +64,31 @@ export class SubmissionUploadReviewStatusService extends DBService {
   }
 
   /**
-   * Get publish history for a submission (all submission_upload_status records, newest first).
+   * Get submission history by UUID, returning the API response shape (submissionId + history array).
+   * When there are no status rows, resolves submissionId via getSubmissionIdByUUID (throws if submission not found).
    *
    * @param {string} submissionUuid
-   * @returns {Promise<SubmissionUploadReviewStatusHistoryRow[]>}
+   * @returns {Promise<SubmissionHistoryResponse>}
+   * @throws {ApiNotFoundError} If submission does not exist (when rows.length === 0).
    */
-  async getSubmissionUploadStatusHistory(submissionUuid: string): Promise<SubmissionUploadReviewStatusHistoryRow[]> {
-    return this.submissionUploadReviewStatusRepository.getStatusHistoryBySubmissionUuid(submissionUuid);
+  async getSubmissionHistoryByUuid(submissionUuid: string): Promise<SubmissionHistoryResponse> {
+    const rows = await this.submissionUploadReviewStatusRepository.getStatusHistoryBySubmissionUuid(submissionUuid);
+
+    let submissionId: number;
+    if (rows.length > 0) {
+      submissionId = rows[0].submission_id;
+    } else {
+      const submissionService = new SubmissionService(this.connection);
+      const byUuid = await submissionService.getSubmissionIdByUUID(submissionUuid);
+      submissionId = byUuid.submission_id;
+    }
+
+    const history = rows.map((row) => ({
+      submissionUploadId: row.submission_upload_id,
+      status: row.status,
+      createDate: row.create_date instanceof Date ? row.create_date.toISOString() : String(row.create_date)
+    }));
+
+    return { submissionId, history };
   }
 }

--- a/api/src/services/upload/submission-upload-review-status-service.ts
+++ b/api/src/services/upload/submission-upload-review-status-service.ts
@@ -1,0 +1,68 @@
+import { IDBConnection } from '../../database/db';
+import {
+  CreateSubmissionUploadReviewStatus,
+  SubmissionUploadReviewStatus,
+  SubmissionUploadReviewStatusHistoryRow,
+  UpdateSubmissionUploadReviewStatus
+} from '../../models/submission-upload-review-status';
+import { SubmissionUploadReviewStatusRepository } from '../../repositories/upload/submission-upload-review-status-repository';
+import { DBService } from '../db-service';
+
+export class SubmissionUploadReviewStatusService extends DBService {
+  submissionUploadReviewStatusRepository: SubmissionUploadReviewStatusRepository;
+
+  constructor(connection: IDBConnection) {
+    super(connection);
+    this.submissionUploadReviewStatusRepository = new SubmissionUploadReviewStatusRepository(connection);
+  }
+
+  /**
+   * Insert a new review status record for a submission upload.
+   * Typically called with status 'submitted' when a new submission upload is created.
+   *
+   * @param {CreateSubmissionUploadReviewStatus} data
+   * @returns {Promise<SubmissionUploadReviewStatus>}
+   */
+  async insertSubmissionUploadReviewStatus(
+    data: CreateSubmissionUploadReviewStatus
+  ): Promise<SubmissionUploadReviewStatus> {
+    return this.submissionUploadReviewStatusRepository.insertSubmissionUploadReviewStatus(data);
+  }
+
+  /**
+   * Get the current review status for a submission upload.
+   *
+   * @param {string} submissionUploadId
+   * @returns {Promise<SubmissionUploadReviewStatus>}
+   */
+  async getSubmissionUploadReviewStatus(submissionUploadId: string): Promise<SubmissionUploadReviewStatus> {
+    return this.submissionUploadReviewStatusRepository.getSubmissionUploadReviewStatus(submissionUploadId);
+  }
+
+  /**
+   * Update the review status of a submission upload (approved or denied).
+   * Only callable by system administrators.
+   *
+   * @param {string} submissionUploadId
+   * @param {UpdateSubmissionUploadReviewStatus} data
+   * @returns {Promise<SubmissionUploadReviewStatus>}
+   */
+  async updateSubmissionUploadReviewStatus(
+    submissionUploadId: string,
+    data: UpdateSubmissionUploadReviewStatus
+  ): Promise<SubmissionUploadReviewStatus> {
+    return this.submissionUploadReviewStatusRepository.updateSubmissionUploadReviewStatus(submissionUploadId, data);
+  }
+
+  /**
+   * Get publish history for a submission (all submission_upload_status records, newest first).
+   *
+   * @param {string} submissionUuid
+   * @returns {Promise<SubmissionUploadReviewStatusHistoryRow[]>}
+   */
+  async getSubmissionUploadStatusHistory(
+    submissionUuid: string
+  ): Promise<SubmissionUploadReviewStatusHistoryRow[]> {
+    return this.submissionUploadReviewStatusRepository.getStatusHistoryBySubmissionUuid(submissionUuid);
+  }
+}

--- a/api/src/services/upload/submission-upload-review-status-service.ts
+++ b/api/src/services/upload/submission-upload-review-status-service.ts
@@ -60,9 +60,7 @@ export class SubmissionUploadReviewStatusService extends DBService {
    * @param {string} submissionUuid
    * @returns {Promise<SubmissionUploadReviewStatusHistoryRow[]>}
    */
-  async getSubmissionUploadStatusHistory(
-    submissionUuid: string
-  ): Promise<SubmissionUploadReviewStatusHistoryRow[]> {
+  async getSubmissionUploadStatusHistory(submissionUuid: string): Promise<SubmissionUploadReviewStatusHistoryRow[]> {
     return this.submissionUploadReviewStatusRepository.getStatusHistoryBySubmissionUuid(submissionUuid);
   }
 }

--- a/api/src/services/upload/submission-upload-service.ts
+++ b/api/src/services/upload/submission-upload-service.ts
@@ -89,7 +89,29 @@ export class SubmissionUploadService extends DBService {
   }
 
   /**
-   * Deletes a submission_upload record by ID.
+   * Soft-deletes a single active submission_upload record by ID.
+   *
+   * @param {string} submissionUploadId The ID of the record to soft-delete
+   * @return {Promise<void>}
+   * @memberof SubmissionUploadService
+   */
+  async softDeleteSubmissionUpload(submissionUploadId: string): Promise<void> {
+    return this.submissionUploadRepository.softDeleteSubmissionUpload(submissionUploadId);
+  }
+
+  /**
+   * Soft-deletes all active submission_upload records for a given submission.
+   *
+   * @param {number} submissionId The submission whose uploads should be soft-deleted
+   * @return {Promise<number>} The number of records soft-deleted
+   * @memberof SubmissionUploadService
+   */
+  async softDeleteSubmissionUploadsBySubmissionId(submissionId: number): Promise<number> {
+    return this.submissionUploadRepository.softDeleteSubmissionUploadsBySubmissionId(submissionId);
+  }
+
+  /**
+   * Hard-deletes a submission_upload record by ID.
    *
    * @param {string} submissionUploadId The ID of the artifact to delete
    * @return {Promise<void>}

--- a/api/src/services/upload/submission-upload-service.ts
+++ b/api/src/services/upload/submission-upload-service.ts
@@ -1,4 +1,5 @@
 import { IDBConnection } from '../../database/db';
+import { HTTP404 } from '../../errors/http-error';
 import {
   CreateSubmissionUpload,
   SubmissionUpload,
@@ -8,6 +9,7 @@ import {
 import { SubmissionUploadRepository } from '../../repositories/upload/submission-upload-repository';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
+import { SubmissionService } from '../submission-service';
 
 export class SubmissionUploadService extends DBService {
   submissionUploadRepository: SubmissionUploadRepository;
@@ -32,6 +34,37 @@ export class SubmissionUploadService extends DBService {
    */
   async getSubmissionUpload(submissionUploadId: string): Promise<SubmissionUpload> {
     return this.submissionUploadRepository.getSubmissionUpload(submissionUploadId);
+  }
+
+  /**
+   * Retrieves a submission_upload record only if it belongs to the submission identified by the given UUID.
+   * Use this to validate path parameters (submissionId + submissionUploadId) before acting on an upload.
+   *
+   * @param {string} submissionUuid Submission UUID from path (submission.uuid)
+   * @param {string} submissionUploadId Submission upload ID from path
+   * @return {Promise<SubmissionUpload>} The submission upload record
+   * @throws {HTTP404} If the submission does not exist, or the upload does not exist, or the upload does not belong to the submission
+   * @memberof SubmissionUploadService
+   */
+  async getSubmissionUploadForSubmissionOrThrow(
+    submissionUuid: string,
+    submissionUploadId: string
+  ): Promise<SubmissionUpload> {
+    const submissionService = new SubmissionService(this.connection);
+    const byUuid = await submissionService.getSubmissionIdByUUID(submissionUuid);
+    if (!byUuid) {
+      throw new HTTP404('Submission not found.');
+    }
+    let submissionUpload: SubmissionUpload;
+    try {
+      submissionUpload = await this.submissionUploadRepository.getSubmissionUpload(submissionUploadId);
+    } catch {
+      throw new HTTP404('Submission upload not found');
+    }
+    if (submissionUpload.submission_id !== byUuid.submission_id) {
+      throw new HTTP404('Submission upload not found');
+    }
+    return submissionUpload;
   }
 
   /**

--- a/api/src/services/upload/submission-upload-service.ts
+++ b/api/src/services/upload/submission-upload-service.ts
@@ -1,5 +1,4 @@
 import { IDBConnection } from '../../database/db';
-import { HTTP404 } from '../../errors/http-error';
 import {
   CreateSubmissionUpload,
   SubmissionUpload,
@@ -9,7 +8,6 @@ import {
 import { SubmissionUploadRepository } from '../../repositories/upload/submission-upload-repository';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
-import { SubmissionService } from '../submission-service';
 
 export class SubmissionUploadService extends DBService {
   submissionUploadRepository: SubmissionUploadRepository;
@@ -43,28 +41,14 @@ export class SubmissionUploadService extends DBService {
    * @param {string} submissionUuid Submission UUID from path (submission.uuid)
    * @param {string} submissionUploadId Submission upload ID from path
    * @return {Promise<SubmissionUpload>} The submission upload record
-   * @throws {HTTP404} If the submission does not exist, or the upload does not exist, or the upload does not belong to the submission
+   * @throws {ApiNotFoundError} If the submission or upload does not exist, or the upload does not belong to the submission (mapped to 404 by error handler)
    * @memberof SubmissionUploadService
    */
-  async getSubmissionUploadForSubmissionOrThrow(
+  async getSubmissionUploadBySubmissionUuid(
     submissionUuid: string,
     submissionUploadId: string
   ): Promise<SubmissionUpload> {
-    const submissionService = new SubmissionService(this.connection);
-    const byUuid = await submissionService.getSubmissionIdByUUID(submissionUuid);
-    if (!byUuid) {
-      throw new HTTP404('Submission not found.');
-    }
-    let submissionUpload: SubmissionUpload;
-    try {
-      submissionUpload = await this.submissionUploadRepository.getSubmissionUpload(submissionUploadId);
-    } catch {
-      throw new HTTP404('Submission upload not found');
-    }
-    if (submissionUpload.submission_id !== byUuid.submission_id) {
-      throw new HTTP404('Submission upload not found');
-    }
-    return submissionUpload;
+    return this.submissionUploadRepository.getSubmissionUploadBySubmissionUuid(submissionUuid, submissionUploadId);
   }
 
   /**

--- a/api/src/services/upload/upload-ingestion-service.interface.ts
+++ b/api/src/services/upload/upload-ingestion-service.interface.ts
@@ -9,7 +9,8 @@ interface PresignedUrl {
 }
 
 export interface PresignedUploadUrlResponse {
-  submissionId: number;
+  submissionId: string;
+  submissionUploadId: string;
   uploadId: string;
   s3UploadId: string;
   uploadArchiveId: string;

--- a/api/src/services/upload/upload-ingestion-service.test.ts
+++ b/api/src/services/upload/upload-ingestion-service.test.ts
@@ -58,6 +58,9 @@ describe('UploadIngestionService', () => {
       const mockBytes = 5_000_000;
 
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: mockSubmissionId });
+      sinon
+        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
+        .resolves({ uuid: mockSubmission.uuid } as any);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: mockUploadId });
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
@@ -111,6 +114,9 @@ describe('UploadIngestionService', () => {
 
     it('should throw if upload creation fails', async () => {
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: 123 });
+      sinon
+        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
+        .resolves({ uuid: mockSubmission.uuid } as any);
       sinon.stub(UploadService.prototype, 'insertUpload').rejects(new Error('Database error: upload insert failed'));
 
       try {
@@ -123,6 +129,9 @@ describe('UploadIngestionService', () => {
 
     it('should throw if artifact creation fails', async () => {
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: 123 });
+      sinon
+        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
+        .resolves({ uuid: mockSubmission.uuid } as any);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'upload-456' });
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
@@ -146,6 +155,9 @@ describe('UploadIngestionService', () => {
 
     it('should throw if presigned URL generation fails', async () => {
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: 123 });
+      sinon
+        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
+        .resolves({ uuid: mockSubmission.uuid } as any);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'upload-456' });
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')

--- a/api/src/services/upload/upload-ingestion-service.test.ts
+++ b/api/src/services/upload/upload-ingestion-service.test.ts
@@ -1,3 +1,4 @@
+import { S3Client } from '@aws-sdk/client-s3';
 import chai, { expect } from 'chai';
 import dayjs from 'dayjs';
 import sinon from 'sinon';
@@ -8,10 +9,11 @@ import { HTTP401 } from '../../errors/http-error';
 import { ArtifactSecurity } from '../../models/artifact-security';
 import { ProcessStatusStatusEnum } from '../../models/process-status';
 import { SecurityStatusEnum } from '../../models/security-status';
+import { SubmissionUploadReviewStatus } from '../../models/submission-upload-review-status';
 import { Upload, UploadStatusEnum } from '../../models/upload';
 import { UploadArchive } from '../../models/upload-archive';
 import * as publisher from '../../queue/publisher';
-import { ICreateSubmission } from '../../repositories/submission-repository';
+import { ICreateSubmission, ISubmissionModel } from '../../repositories/submission-repository';
 import * as fileUtils from '../../utils/file-utils';
 import * as submissionUploadUtils from '../../utils/submission-upload-utils';
 import { getMockDBConnection } from '../../__mocks__/db';
@@ -58,9 +60,9 @@ describe('UploadIngestionService', () => {
       const mockBytes = 5_000_000;
 
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: mockSubmissionId });
-      sinon
-        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
-        .resolves({ uuid: mockSubmission.uuid } as any);
+      sinon.stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId').resolves({
+        uuid: mockSubmission.uuid
+      } as ISubmissionModel);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: mockUploadId });
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
@@ -69,7 +71,7 @@ describe('UploadIngestionService', () => {
         submission_upload_status_id: 1,
         submission_upload_id: 'submission-upload-id-1',
         status: 'submitted'
-      } as any);
+      } as SubmissionUploadReviewStatus);
       sinon.stub(ArtifactService.prototype, 'insertArtifact').resolves({ artifact_id: mockArtifactId });
       sinon
         .stub(UploadArchiveService.prototype, 'insertUploadArchive')
@@ -114,9 +116,9 @@ describe('UploadIngestionService', () => {
 
     it('should throw if upload creation fails', async () => {
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: 123 });
-      sinon
-        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
-        .resolves({ uuid: mockSubmission.uuid } as any);
+      sinon.stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId').resolves({
+        uuid: mockSubmission.uuid
+      } as ISubmissionModel);
       sinon.stub(UploadService.prototype, 'insertUpload').rejects(new Error('Database error: upload insert failed'));
 
       try {
@@ -129,9 +131,9 @@ describe('UploadIngestionService', () => {
 
     it('should throw if artifact creation fails', async () => {
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: 123 });
-      sinon
-        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
-        .resolves({ uuid: mockSubmission.uuid } as any);
+      sinon.stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId').resolves({
+        uuid: mockSubmission.uuid
+      } as ISubmissionModel);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'upload-456' });
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
@@ -140,7 +142,7 @@ describe('UploadIngestionService', () => {
         submission_upload_status_id: 1,
         submission_upload_id: 'submission-upload-id-1',
         status: 'submitted'
-      } as any);
+      } as SubmissionUploadReviewStatus);
       sinon
         .stub(ArtifactService.prototype, 'insertArtifact')
         .rejects(new Error('Database error: artifact insert failed'));
@@ -155,9 +157,9 @@ describe('UploadIngestionService', () => {
 
     it('should throw if presigned URL generation fails', async () => {
       sinon.stub(SubmissionService.prototype, 'insertSubmissionRecord').resolves({ submission_id: 123 });
-      sinon
-        .stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId')
-        .resolves({ uuid: mockSubmission.uuid } as any);
+      sinon.stub(SubmissionService.prototype, 'getSubmissionRecordBySubmissionId').resolves({
+        uuid: mockSubmission.uuid
+      } as ISubmissionModel);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'upload-456' });
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
@@ -166,7 +168,7 @@ describe('UploadIngestionService', () => {
         submission_upload_status_id: 1,
         submission_upload_id: 'submission-upload-id-1',
         status: 'submitted'
-      } as any);
+      } as SubmissionUploadReviewStatus);
       sinon.stub(ArtifactService.prototype, 'insertArtifact').resolves({ artifact_id: 'artifact-789' });
       sinon
         .stub(UploadArchiveService.prototype, 'insertUploadArchive')
@@ -232,7 +234,7 @@ describe('UploadIngestionService', () => {
     ];
 
     beforeEach(() => {
-      sinon.stub(publisher, 'publishMalwareScanJob').resolves({ status: 'published', jobId: 'job-1' } as any);
+      sinon.stub(publisher, 'publishMalwareScanJob').resolves({ status: 'published', jobId: 'job-1' });
     });
 
     it('should complete upload successfully and enqueue security artifacts', async () => {
@@ -247,7 +249,7 @@ describe('UploadIngestionService', () => {
       sinon.stub(UploadArchiveService.prototype, 'updateUploadArchivesByUploadId').resolves(mockUploadArchiveRecords);
 
       const s3ClientStub = { send: sinon.stub().resolves({ ETag: 'etag' }) };
-      sinon.stub(fileUtils, 'getSecurityS3Client').returns(s3ClientStub as any);
+      sinon.stub(fileUtils, 'getSecurityS3Client').returns(s3ClientStub as unknown as S3Client);
       sinon.stub(fileUtils, 'getSecurityObjectStoreBucketName').returns('security-bucket');
 
       await service.completeArchiveUpload(mockParams);
@@ -404,11 +406,11 @@ describe('UploadIngestionService', () => {
 
       sinon.stub(UploadArchiveService.prototype, 'updateUploadArchivesByUploadId').resolves(mockUploadArchiveRecords);
 
-      const fakeS3Client = {
+      const fakeS3Client: Pick<S3Client, 'send'> = {
         send: sinon.stub().rejects(new Error('S3 API error: Access Denied'))
       };
 
-      sinon.stub(fileUtils, 'getSecurityS3Client').returns(fakeS3Client as any);
+      sinon.stub(fileUtils, 'getSecurityS3Client').returns(fakeS3Client as S3Client);
       sinon.stub(fileUtils, 'getSecurityObjectStoreBucketName').returns('security-bucket');
 
       try {

--- a/api/src/services/upload/upload-ingestion-service.test.ts
+++ b/api/src/services/upload/upload-ingestion-service.test.ts
@@ -18,6 +18,7 @@ import { getMockDBConnection } from '../../__mocks__/db';
 import { SubmissionService } from '../submission-service';
 import { ArtifactSecurityService } from './artifact-security-service';
 import { ArtifactService } from './artifact-service';
+import { SubmissionUploadReviewStatusService } from './submission-upload-review-status-service';
 import { SubmissionUploadService } from './submission-upload-service';
 import { UploadArchiveService } from './upload-archive-service';
 import { UploadIngestionService } from './upload-ingestion-service';
@@ -61,6 +62,11 @@ describe('UploadIngestionService', () => {
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
         .resolves({ submission_upload_id: 'submission-upload-id-1' });
+      sinon.stub(SubmissionUploadReviewStatusService.prototype, 'insertSubmissionUploadReviewStatus').resolves({
+        submission_upload_status_id: 1,
+        submission_upload_id: 'submission-upload-id-1',
+        status: 'submitted'
+      } as any);
       sinon.stub(ArtifactService.prototype, 'insertArtifact').resolves({ artifact_id: mockArtifactId });
       sinon
         .stub(UploadArchiveService.prototype, 'insertUploadArchive')
@@ -81,7 +87,7 @@ describe('UploadIngestionService', () => {
 
       const result = await service.startArchiveUpload(mockBytes, mockSubmission);
 
-      expect(result.submissionId).to.equal(mockSubmissionId);
+      expect(result.submissionId).to.equal(mockSubmission.uuid);
       expect(result.uploadId).to.equal(mockUploadId);
       expect(result.uploadArchiveId).to.equal(mockUploadArchiveId);
       expect(result.s3UploadId).to.equal(mockS3UploadId);
@@ -121,6 +127,11 @@ describe('UploadIngestionService', () => {
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
         .resolves({ submission_upload_id: 'submission-upload-id-1' });
+      sinon.stub(SubmissionUploadReviewStatusService.prototype, 'insertSubmissionUploadReviewStatus').resolves({
+        submission_upload_status_id: 1,
+        submission_upload_id: 'submission-upload-id-1',
+        status: 'submitted'
+      } as any);
       sinon
         .stub(ArtifactService.prototype, 'insertArtifact')
         .rejects(new Error('Database error: artifact insert failed'));
@@ -139,6 +150,11 @@ describe('UploadIngestionService', () => {
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
         .resolves({ submission_upload_id: 'submission-upload-id-1' });
+      sinon.stub(SubmissionUploadReviewStatusService.prototype, 'insertSubmissionUploadReviewStatus').resolves({
+        submission_upload_status_id: 1,
+        submission_upload_id: 'submission-upload-id-1',
+        status: 'submitted'
+      } as any);
       sinon.stub(ArtifactService.prototype, 'insertArtifact').resolves({ artifact_id: 'artifact-789' });
       sinon
         .stub(UploadArchiveService.prototype, 'insertUploadArchive')

--- a/api/src/services/upload/upload-ingestion-service.ts
+++ b/api/src/services/upload/upload-ingestion-service.ts
@@ -1,6 +1,6 @@
 import { CompleteMultipartUploadCommand } from '@aws-sdk/client-s3';
 import dayjs from 'dayjs';
-import { HTTP401 } from '../../errors/http-error';
+import { HTTP401, HTTP404 } from '../../errors/http-error';
 import { ArtifactStatusEnum } from '../../models/artifact';
 import { ProcessStatusStatusEnum } from '../../models/process-status';
 import { SecurityStatusEnum } from '../../models/security-status';
@@ -13,6 +13,7 @@ import { DBService } from '../db-service';
 import { SubmissionService } from '../submission-service';
 import { ArtifactSecurityService } from './artifact-security-service';
 import { ArtifactService } from './artifact-service';
+import { SubmissionUploadReviewStatusService } from './submission-upload-review-status-service';
 import { SubmissionUploadService } from './submission-upload-service';
 import { UploadArchiveService } from './upload-archive-service';
 import { UploadArtifactService } from './upload-artifact-service';
@@ -34,10 +35,11 @@ export class UploadIngestionService extends DBService {
   artifactService = new ArtifactService(this.connection);
   uploadArchiveService = new UploadArchiveService(this.connection);
   submissionUploadService = new SubmissionUploadService(this.connection);
+  submissionUploadReviewStatusService = new SubmissionUploadReviewStatusService(this.connection);
   artifactSecurityService = new ArtifactSecurityService(this.connection);
 
   /**
-   * Create a new archive upload
+   * Create a new archive upload along with a new submission record.
    *
    * @param {number} bytes
    * @param {ICreateSubmission} submission
@@ -47,21 +49,69 @@ export class UploadIngestionService extends DBService {
     // 1. Create submission (intent)
     const { submission_id } = await this.submissionService.insertSubmissionRecord(submission);
 
-    // 2. Create upload session
+    // 2. Use UUID from submission table only (not submission_upload or submission_upload_status)
+    const submissionRecord = await this.submissionService.getSubmissionRecordBySubmissionId(submission_id);
+    const submissionUuidFromTable = submissionRecord.uuid;
+
+    return this._startArchiveUploadForSubmission(bytes, submission_id, submissionUuidFromTable);
+  }
+
+  /**
+   * Create a new archive upload for an existing submission (append mode).
+   * Does not create a new submission record. Identifies submission by UUID.
+   *
+   * @param {number} bytes
+   * @param {string} submissionUuid - Submission UUID (submission.uuid).
+   * @returns {Promise<PresignedUploadUrlResponse>}
+   * @throws {HTTP404} If no submission exists for the given UUID.
+   */
+  async startArchiveUploadForExistingSubmissionByUuid(
+    bytes: number,
+    submissionUuid: string
+  ): Promise<PresignedUploadUrlResponse> {
+    const byUuid = await this.submissionService.getSubmissionIdByUUID(submissionUuid);
+    if (!byUuid) {
+      throw new HTTP404('Submission not found');
+    }
+    const submissionRecord = await this.submissionService.getSubmissionRecordBySubmissionId(byUuid.submission_id);
+    return this._startArchiveUploadForSubmission(bytes, byUuid.submission_id, submissionRecord.uuid);
+  }
+
+  /**
+   * Internal helper: creates a new upload session, submission_upload record, review status,
+   * artifact, upload_archive, and presigned URLs for the given submissionId.
+   *
+   * @param {number} bytes
+   * @param {number} submissionId - Integer PK for DB operations
+   * @param {string} submissionUuid - UUID returned to client as submissionId
+   * @returns {Promise<PresignedUploadUrlResponse>}
+   */
+  async _startArchiveUploadForSubmission(
+    bytes: number,
+    submissionId: number,
+    _submissionUuid: string
+  ): Promise<PresignedUploadUrlResponse> {
+    // 1. Create upload session
     const { upload_id } = await this.uploadService.insertUpload({
       upload_status: UploadStatusEnum.PENDING,
       record_end_date: dayjs().add(30, 'minute').toISOString(),
       s3_upload_id: null
     });
 
-    // 3. Bind submission → upload
-    await this.submissionUploadService.insertSubmissionUpload({
-      submission_id,
+    // 2. Bind submission → upload
+    const { submission_upload_id } = await this.submissionUploadService.insertSubmissionUpload({
+      submission_id: submissionId,
       upload_id
     });
 
+    // 3. Create initial review status (submitted = unreviewed)
+    await this.submissionUploadReviewStatusService.insertSubmissionUploadReviewStatus({
+      submission_upload_id,
+      status: 'submitted'
+    });
+
     // 4. Create placeholder artifact for archive
-    const key = `submissions/${submission_id}/uploads/${upload_id}.tar`;
+    const key = `submissions/${submissionId}/uploads/${upload_id}.tar`;
     const artifact = await this.artifactService.insertArtifact({
       bucket: getSecurityObjectStoreBucketName(),
       artifact_status: ArtifactStatusEnum.PENDING,
@@ -75,7 +125,7 @@ export class UploadIngestionService extends DBService {
     const { upload_archive_id } = await this.uploadArchiveService.insertUploadArchive({
       upload_id,
       artifact_id: artifact.artifact_id,
-      archive_status: ProcessStatusStatusEnum.DRAFT // Draft indicates that the archive record is not ready for processing
+      archive_status: ProcessStatusStatusEnum.DRAFT
     });
 
     // 6. Initialize multipart upload
@@ -93,8 +143,13 @@ export class UploadIngestionService extends DBService {
     // 7. Persist S3 upload ID
     await this.uploadService.updateUpload(upload_id, { s3_upload_id: s3UploadId });
 
+    // 8. Submission UUID must come from submission table only (never upload_id or submission_upload_id)
+    const submissionRow = await this.submissionService.getSubmissionRecordBySubmissionId(submissionId);
+    const submissionIdForResponse = submissionRow.uuid;
+
     return {
-      submissionId: submission_id,
+      submissionId: submissionIdForResponse,
+      submissionUploadId: submission_upload_id,
       uploadId: upload_id,
       uploadArchiveId: upload_archive_id,
       s3UploadId,

--- a/api/src/services/upload/upload-ingestion-service.ts
+++ b/api/src/services/upload/upload-ingestion-service.ts
@@ -1,6 +1,6 @@
 import { CompleteMultipartUploadCommand } from '@aws-sdk/client-s3';
 import dayjs from 'dayjs';
-import { HTTP401, HTTP404 } from '../../errors/http-error';
+import { HTTP401 } from '../../errors/http-error';
 import { ArtifactStatusEnum } from '../../models/artifact';
 import { ProcessStatusStatusEnum } from '../../models/process-status';
 import { SecurityStatusEnum } from '../../models/security-status';
@@ -63,16 +63,13 @@ export class UploadIngestionService extends DBService {
    * @param {number} bytes
    * @param {string} submissionUuid - Submission UUID (submission.uuid).
    * @returns {Promise<PresignedUploadUrlResponse>}
-   * @throws {HTTP404} If no submission exists for the given UUID.
+   * @throws {ApiNotFoundError} If no submission exists for the given UUID (mapped to 404 by error handler).
    */
   async startArchiveUploadForExistingSubmissionByUuid(
     bytes: number,
     submissionUuid: string
   ): Promise<PresignedUploadUrlResponse> {
     const byUuid = await this.submissionService.getSubmissionIdByUUID(submissionUuid);
-    if (!byUuid) {
-      throw new HTTP404('Submission not found');
-    }
     const submissionRecord = await this.submissionService.getSubmissionRecordBySubmissionId(byUuid.submission_id);
     return this._startArchiveUploadForSubmission(bytes, byUuid.submission_id, submissionRecord.uuid);
   }
@@ -83,13 +80,13 @@ export class UploadIngestionService extends DBService {
    *
    * @param {number} bytes
    * @param {number} submissionId - Integer PK for DB operations
-   * @param {string} submissionUuid - UUID returned to client as submissionId
+   * @param {string} submissionUuid - Submission UUID; used when building response (API returns this as submissionId for client use).
    * @returns {Promise<PresignedUploadUrlResponse>}
    */
   async _startArchiveUploadForSubmission(
     bytes: number,
     submissionId: number,
-    _submissionUuid: string
+    submissionUuid: string
   ): Promise<PresignedUploadUrlResponse> {
     // 1. Create upload session
     const { upload_id } = await this.uploadService.insertUpload({
@@ -143,12 +140,9 @@ export class UploadIngestionService extends DBService {
     // 7. Persist S3 upload ID
     await this.uploadService.updateUpload(upload_id, { s3_upload_id: s3UploadId });
 
-    // 8. Submission UUID must come from submission table only (never upload_id or submission_upload_id)
-    const submissionRow = await this.submissionService.getSubmissionRecordBySubmissionId(submissionId);
-    const submissionIdForResponse = submissionRow.uuid;
-
+    // 8. Response submissionId is the submission UUID (callers pass it for clarity; API returns it for client use).
     return {
-      submissionId: submissionIdForResponse,
+      submissionId: submissionUuid,
       submissionUploadId: submission_upload_id,
       uploadId: upload_id,
       uploadArchiveId: upload_archive_id,

--- a/database/src/migrations/20260302000000_submission_upload_soft_delete.ts
+++ b/database/src/migrations/20260302000000_submission_upload_soft_delete.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+/**
+ * Add record_end_date column to submission_upload to support soft-delete.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE submission_upload ADD COLUMN record_end_date timestamptz(6);
+
+    COMMENT ON COLUMN submission_upload.record_end_date IS 'The datetime the record was soft-deleted. NULL indicates the record is active.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE submission_upload DROP COLUMN IF EXISTS record_end_date;
+  `);
+}

--- a/database/src/migrations/20260302000001_submission_upload_status.ts
+++ b/database/src/migrations/20260302000001_submission_upload_status.ts
@@ -15,7 +15,7 @@ export async function up(knex: Knex): Promise<void> {
     CREATE TYPE submission_upload_status_type AS ENUM (
       'submitted',  -- Upload has been submitted and is awaiting admin review
       'approved',   -- Admin has approved the upload
-      'denied'      -- Admin has denied the upload
+      'denied',     -- Admin has denied the upload
       'deleted'     -- Upload has been deleted
     );
 

--- a/database/src/migrations/20260302000001_submission_upload_status.ts
+++ b/database/src/migrations/20260302000001_submission_upload_status.ts
@@ -1,0 +1,77 @@
+import { Knex } from 'knex';
+
+/**
+ * Create submission_upload_status table to track the review status of each submission upload.
+ * Supports statuses: submitted (unreviewed), approved, and denied.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- ENUM TYPE
+    --------------------------------------------------------------------------------
+
+    CREATE TYPE submission_upload_status_type AS ENUM (
+      'submitted',  -- Upload has been submitted and is awaiting admin review
+      'approved',   -- Admin has approved the upload
+      'denied'      -- Admin has denied the upload
+      'deleted'     -- Upload has been deleted
+    );
+
+    --------------------------------------------------------------------------------
+    -- SUBMISSION_UPLOAD_STATUS
+    --------------------------------------------------------------------------------
+
+    CREATE TABLE submission_upload_status (
+      submission_upload_status_id  integer GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+      submission_upload_id         uuid NOT NULL,
+      status                       submission_upload_status_type NOT NULL DEFAULT 'submitted',
+      create_date                  timestamptz(6) DEFAULT now() NOT NULL,
+      create_user                  integer NOT NULL,
+      update_date                  timestamptz(6),
+      update_user                  integer,
+      revision_count               integer DEFAULT 0 NOT NULL,
+      CONSTRAINT submission_upload_status_pk PRIMARY KEY (submission_upload_status_id),
+      CONSTRAINT submission_upload_status_fk FOREIGN KEY (submission_upload_id) REFERENCES submission_upload(submission_upload_id)
+    );
+
+    CREATE INDEX submission_upload_status_upload_idx ON submission_upload_status(submission_upload_id);
+    CREATE INDEX submission_upload_status_status_idx ON submission_upload_status(status);
+
+    COMMENT ON TABLE submission_upload_status IS 'Tracks the review status of a submission upload. Each row represents the current review state (submitted, approved, or denied) for a given submission_upload_id.';
+    COMMENT ON COLUMN submission_upload_status.submission_upload_status_id IS 'System generated surrogate primary key identifier.';
+    COMMENT ON COLUMN submission_upload_status.submission_upload_id IS 'Foreign key to the submission_upload record.';
+    COMMENT ON COLUMN submission_upload_status.status IS 'Review status of the submission upload. submitted = unreviewed, approved = accepted by admin, denied = rejected by admin, deleted = upload has been deleted.';
+    COMMENT ON COLUMN submission_upload_status.create_date IS 'The datetime the record was created.';
+    COMMENT ON COLUMN submission_upload_status.create_user IS 'The id of the user who created the record.';
+    COMMENT ON COLUMN submission_upload_status.update_date IS 'The datetime the record was last updated.';
+    COMMENT ON COLUMN submission_upload_status.update_user IS 'The id of the user who last updated the record.';
+    COMMENT ON COLUMN submission_upload_status.revision_count IS 'Revision count used for concurrency control.';
+
+    --------------------------------------------------------------------------------
+    -- AUDIT / JOURNAL TRIGGERS
+    --------------------------------------------------------------------------------
+
+    CREATE TRIGGER audit_submission_upload_status
+      BEFORE INSERT OR UPDATE OR DELETE ON submission_upload_status
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_audit_trigger();
+
+    CREATE TRIGGER journal_submission_upload_status
+      AFTER INSERT OR UPDATE OR DELETE ON submission_upload_status
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_journal_trigger();
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    DROP TRIGGER IF EXISTS journal_submission_upload_status ON submission_upload_status;
+    DROP TRIGGER IF EXISTS audit_submission_upload_status ON submission_upload_status;
+
+    DROP TABLE IF EXISTS submission_upload_status;
+
+    DROP TYPE IF EXISTS submission_upload_status_type;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-875: CRUD Operations on Submissions](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-875)
- [SIMSBIOHUB-876: Show Publish History in SIMS](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-876)

## Description of Changes

- Added `record_end_date` to `submission_upload` and introduced a `submission_upload_status` table (`submitted`, `approved`, `denied`, `deleted`) to support review workflows and soft-deletes.
- Added submission upload CRUD endpoints:
  - `POST /submission/:submissionId/upload` to create (append) a new upload.
  - `DELETE /submission/:submissionId/upload/:submissionUploadId` to soft-delete uploads only when status is `submitted`.
  - `PATCH /administrative/submission/:submissionId/upload/:submissionUploadId/status` for admins to set status to `approved` or `denied`.
  - `GET /submission/{submissionId}/history` returns publish history from `submission_upload_status` (newest first), with status, submissionUploadId, and createDate.  

## Testing Notes
- Requires [SIMS PR-1613](https://github.com/bcgov/biohubbc/pull/1613)
- Automated: `cd api && npm test` (all tests passing).
- Manual smoke tests against `http://localhost:6100/api`:
  - Verified POST create uploads and `submission_upload_status` rows with `submitted`.
  - Verified DELETE succeeds only for `submitted` uploads and soft-deletes the `submission_upload` row.
  - Verified PATCH as a system admin updates status to `approved`/`denied` and blocks DELETE once reviewed.