### PR TITLE
SIMSBIOHUB-882: Refactor Ingestion Job to support multiple uploads

### DIFF
--- a/api/src/__integration__/db/cart-checkout.integration.ts
+++ b/api/src/__integration__/db/cart-checkout.integration.ts
@@ -66,11 +66,18 @@ describe('Cart checkout (integration)', function () {
     `);
     const uploadId = uploadResult.rows[0].upload_id;
 
+    const bridgeResult = await connection.sql(SQL`
+      INSERT INTO submission_upload (submission_id, upload_id, create_user)
+      VALUES (${submissionId}, ${uploadId}, ${systemUserId})
+      RETURNING submission_upload_id;
+    `);
+    const submissionUploadId = bridgeResult.rows[0].submission_upload_id;
+
     const result = await connection.sql(SQL`
-      INSERT INTO submission_feature (submission_id, upload_id, feature_type_id, data, data_byte_size, create_user)
+      INSERT INTO submission_feature (submission_id, submission_upload_id, feature_type_id, data, data_byte_size, create_user)
       VALUES (
         ${submissionId},
-        ${uploadId},
+        ${submissionUploadId},
         (SELECT feature_type_id FROM feature_type WHERE name = 'dataset' LIMIT 1),
         ${dataJson}::jsonb,
         octet_length(${dataJson}::jsonb::text),

--- a/api/src/__integration__/db/search-feature-repository.integration.ts
+++ b/api/src/__integration__/db/search-feature-repository.integration.ts
@@ -61,11 +61,18 @@ describe('SearchFeatureRepository (integration)', function () {
     `);
     const uploadId = uploadResult.rows[0].upload_id;
 
+    const bridgeResult = await connection.sql(SQL`
+      INSERT INTO submission_upload (submission_id, upload_id, create_user)
+      VALUES (${submissionId}, ${uploadId}, ${systemUserId})
+      RETURNING submission_upload_id;
+    `);
+    const submissionUploadId = bridgeResult.rows[0].submission_upload_id;
+
     const result = await connection.sql(SQL`
-      INSERT INTO submission_feature (submission_id, upload_id, feature_type_id, data, data_byte_size, create_user)
+      INSERT INTO submission_feature (submission_id, submission_upload_id, feature_type_id, data, data_byte_size, create_user)
       VALUES (
         ${submissionId},
-        ${uploadId},
+        ${submissionUploadId},
         (SELECT feature_type_id FROM feature_type WHERE name = 'dataset' LIMIT 1),
         '{"name": "test"}'::jsonb,
         100,

--- a/api/src/__integration__/helpers/test-submission-helpers.ts
+++ b/api/src/__integration__/helpers/test-submission-helpers.ts
@@ -39,11 +39,18 @@ export async function createTestFeature(
   `);
   const uploadId = uploadResult.rows[0].upload_id;
 
+  const bridgeResult = await connection.sql(SQL`
+    INSERT INTO submission_upload (submission_id, upload_id, create_user)
+    VALUES (${submissionId}, ${uploadId}, ${systemUserId})
+    RETURNING submission_upload_id;
+  `);
+  const submissionUploadId = bridgeResult.rows[0].submission_upload_id;
+
   const result = await connection.sql(SQL`
-    INSERT INTO submission_feature (submission_id, upload_id, feature_type_id, parent_submission_feature_id, data, data_byte_size, create_user)
+    INSERT INTO submission_feature (submission_id, submission_upload_id, feature_type_id, parent_submission_feature_id, data, data_byte_size, create_user)
     VALUES (
       ${submissionId},
-      ${uploadId},
+      ${submissionUploadId},
       (SELECT feature_type_id FROM feature_type WHERE name = ${featureTypeName} LIMIT 1),
       ${parentFeatureId ?? null},
       ${dataJson}::jsonb,

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -181,6 +181,14 @@ describe('Download Worker', function () {
       })
       .returning('upload_id');
 
+    const [bridge] = await db('biohub.submission_upload')
+      .insert({
+        submission_id: submissionId,
+        upload_id: upload.upload_id,
+        create_user: SYSTEM_USER_ID
+      })
+      .returning('submission_upload_id');
+
     const [row] = await db('biohub.submission_feature')
       .insert({
         submission_id: submissionId,
@@ -188,7 +196,7 @@ describe('Download Worker', function () {
         parent_submission_feature_id: parentFeatureId ?? null,
         data: dataJson,
         data_byte_size: db.raw(`octet_length(?::jsonb::text) + 500`, [dataJson]),
-        upload_id: upload.upload_id,
+        submission_upload_id: bridge.submission_upload_id,
         create_user: SYSTEM_USER_ID
       })
       .returning('submission_feature_id');

--- a/api/src/__integration__/system/process-submission-features-worker.integration.ts
+++ b/api/src/__integration__/system/process-submission-features-worker.integration.ts
@@ -8,9 +8,9 @@ import { randomUUID } from 'node:crypto';
 import SQL from 'sql-template-strings';
 import * as tar from 'tar-stream';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
-import { initPgBoss, stopPgBoss } from '../../queue/pg-boss-service';
+import { JobQueues } from '../../queue/jobs';
+import { getPgBoss, initPgBoss, stopPgBoss } from '../../queue/pg-boss-service';
 import { publishProcessSubmissionFeaturesJob } from '../../queue/publisher';
-
 import { ValidationErrorType } from '../../services/ingestion/feature-validation-service.interface';
 import { SubmissionIngestionService } from '../../services/ingestion/submission-ingestion-service';
 import { BucketType, ObjectStorageService } from '../../services/object-storage/object-storage-service';
@@ -83,6 +83,16 @@ describe('Process Submission Features Worker', function () {
     initDBPool(defaultPoolConfig);
 
     await initPgBoss();
+
+    // Ensure queue exists with 'short' policy (enforces singletonKey uniqueness).
+    // createQueue is ON CONFLICT DO NOTHING, so if the queue already exists with 'standard'
+    // policy from a previous startup, we must update it directly.
+    const boss = getPgBoss();
+    await boss.createQueue(JobQueues.PROCESS_SUBMISSION_FEATURES);
+    await db.raw(
+      `UPDATE pgboss.queue SET policy = 'short' WHERE name = ? AND policy != 'short'`,
+      [JobQueues.PROCESS_SUBMISSION_FEATURES]
+    );
   });
 
   after(async () => {
@@ -266,6 +276,40 @@ describe('Process Submission Features Worker', function () {
     expect(features.some((f: { feature_type_name: string }) => f.feature_type_name === 'dataset')).to.be.true;
   });
 
+  it('should prevent concurrent jobs for same submission via singleton key', async () => {
+    // Singleton key is `submission-${submissionId}` (not per-upload). Prod runs 2 worker replicas —
+    // per-upload keys would allow two uploads for the same submission to process simultaneously,
+    // causing conflicting feature writes.
+    //
+    // Tests pg-boss singleton enforcement directly: two sends with the same key back-to-back,
+    // the second should return null (ON CONFLICT DO NOTHING). Requires queue policy = 'short'.
+
+    const boss = getPgBoss();
+    const testSubmissionId = Date.now(); // unique per run, avoids collisions
+    const singletonKey = `submission-${testSubmissionId}`;
+
+    // Send first job — should succeed
+    const jobId1 = await boss.send(
+      JobQueues.PROCESS_SUBMISSION_FEATURES,
+      { uploadId: randomUUID(), submissionId: testSubmissionId },
+      { singletonKey, expireInSeconds: 5 }
+    );
+    expect(jobId1).to.not.be.null;
+
+    // Send second job with same singleton key — should be rejected
+    const jobId2 = await boss.send(
+      JobQueues.PROCESS_SUBMISSION_FEATURES,
+      { uploadId: randomUUID(), submissionId: testSubmissionId },
+      { singletonKey, expireInSeconds: 5 }
+    );
+    expect(jobId2).to.be.null;
+
+    // Clean up: cancel the test job so it doesn't interfere with other tests
+    if (jobId1) {
+      await boss.cancel(JobQueues.PROCESS_SUBMISSION_FEATURES, jobId1);
+    }
+  });
+
   it('should mark submission as invalid for unknown feature type', async () => {
     const datasetId = randomUUID();
     const featureId = randomUUID();
@@ -346,7 +390,7 @@ describe('SubmissionIngestionService pipeline (system)', function () {
    * Insert the full FK chain and upload a TAR to S3.
    * Same chain as the worker test's setupSubmissionWithTar, using connection.sql() for rollback cleanup.
    */
-  async function setupSubmissionWithTar(tarBuffer: Buffer): Promise<{ submissionId: number }> {
+  async function setupSubmissionWithTar(tarBuffer: Buffer): Promise<{ submissionId: number; uploadId: string }> {
     const objectKey = `${TEST_PREFIX}/${Date.now()}/archive.tar`;
 
     await storageService.uploadBuffer(BucketType.MAIN, tarBuffer, 'application/x-tar', objectKey);
@@ -396,7 +440,7 @@ describe('SubmissionIngestionService pipeline (system)', function () {
           VALUES (${uploadId}, ${artifactId}, 'feature')`
     );
 
-    return { submissionId };
+    return { submissionId, uploadId };
   }
 
   it('should process a valid submission and create features', async () => {
@@ -436,8 +480,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission(submissionId);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({ submissionId, uploadId });
 
     expect(result.valid).to.be.true;
     expect(result.errors).to.have.lengthOf(0);
@@ -481,8 +525,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission(submissionId);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({ submissionId, uploadId });
 
     expect(result.valid).to.be.false;
     expect(result.errors.some((e) => e.type === ValidationErrorType.INVALID_FEATURE_TYPE)).to.be.true;
@@ -532,8 +576,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       { name: 'files/photo.jpg', content: 'fake-image-bytes' }
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission(submissionId);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({ submissionId, uploadId });
 
     // Track S3 media upload for cleanup
     s3KeysToCleanup.push(`submissions/${submissionId}/media/photo.jpg`);
@@ -606,8 +650,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       // No files/missing.pdf in archive
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission(submissionId);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({ submissionId, uploadId });
 
     expect(result.valid).to.be.false;
     expect(result.errors.some((e) => e.type === ValidationErrorType.MISSING_MEDIA_FILE)).to.be.true;
@@ -645,8 +689,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission(submissionId);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({ submissionId, uploadId });
 
     expect(result.valid).to.be.true;
 
@@ -695,8 +739,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission(submissionId);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({ submissionId, uploadId });
 
     expect(result.valid).to.be.false;
     expect(result.errors.length).to.be.greaterThan(1);

--- a/api/src/__integration__/system/process-submission-features-worker.integration.ts
+++ b/api/src/__integration__/system/process-submission-features-worker.integration.ts
@@ -153,6 +153,7 @@ describe('Process Submission Features Worker', function () {
   async function setupSubmissionWithTar(tarBuffer: Buffer): Promise<{
     submissionId: number;
     uploadId: string;
+    submissionUploadId: string;
     artifactId: string;
     objectKey: string;
   }> {
@@ -204,10 +205,12 @@ describe('Process Submission Features Worker', function () {
     });
 
     // 5. submission_upload (links submission to upload)
-    await db('biohub.submission_upload').insert({
-      submission_id: submission.submission_id,
-      upload_id: upload.upload_id
-    });
+    const [submissionUpload] = await db('biohub.submission_upload')
+      .insert({
+        submission_id: submission.submission_id,
+        upload_id: upload.upload_id
+      })
+      .returning('submission_upload_id');
 
     // 6. upload_artifact (required for JOIN in getSubmissionUploadsBySubmissionId)
     await db('biohub.upload_artifact').insert({
@@ -219,6 +222,7 @@ describe('Process Submission Features Worker', function () {
     return {
       submissionId: submission.submission_id,
       uploadId: upload.upload_id,
+      submissionUploadId: submissionUpload.submission_upload_id,
       artifactId: artifact.artifact_id,
       objectKey
     };
@@ -248,13 +252,17 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
 
     // Publish job (needs IDBConnection for submission_validation tracking)
     const connection = getAPIUserDBConnection();
     try {
       await connection.open();
-      const result = await publishProcessSubmissionFeaturesJob(connection, { uploadId, submissionId });
+      const result = await publishProcessSubmissionFeaturesJob(connection, {
+        submission_upload_id: submissionUploadId,
+        submission_id: submissionId,
+        upload_id: uploadId
+      });
       await connection.commit();
       expect(result.status).to.equal('published');
     } finally {
@@ -329,12 +337,16 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
 
     const connection = getAPIUserDBConnection();
     try {
       await connection.open();
-      const result = await publishProcessSubmissionFeaturesJob(connection, { uploadId, submissionId });
+      const result = await publishProcessSubmissionFeaturesJob(connection, {
+        submission_upload_id: submissionUploadId,
+        submission_id: submissionId,
+        upload_id: uploadId
+      });
       await connection.commit();
       expect(result.status).to.equal('published');
     } finally {
@@ -389,7 +401,9 @@ describe('SubmissionIngestionService pipeline (system)', function () {
    * Insert the full FK chain and upload a TAR to S3.
    * Same chain as the worker test's setupSubmissionWithTar, using connection.sql() for rollback cleanup.
    */
-  async function setupSubmissionWithTar(tarBuffer: Buffer): Promise<{ submissionId: number; uploadId: string }> {
+  async function setupSubmissionWithTar(
+    tarBuffer: Buffer
+  ): Promise<{ submissionId: number; uploadId: string; submissionUploadId: string }> {
     const objectKey = `${TEST_PREFIX}/${Date.now()}/archive.tar`;
 
     await storageService.uploadBuffer(BucketType.MAIN, tarBuffer, 'application/x-tar', objectKey);
@@ -428,10 +442,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
     );
 
     // 5. submission_upload
-    await connection.sql(
+    const submissionUploadResult = await connection.sql<{ submission_upload_id: string }>(
       SQL`INSERT INTO biohub.submission_upload (submission_id, upload_id)
-          VALUES (${submissionId}, ${uploadId})`
+          VALUES (${submissionId}, ${uploadId})
+          RETURNING submission_upload_id`
     );
+    const submissionUploadId = submissionUploadResult.rows[0].submission_upload_id;
 
     // 6. upload_artifact
     await connection.sql(
@@ -439,7 +455,7 @@ describe('SubmissionIngestionService pipeline (system)', function () {
           VALUES (${uploadId}, ${artifactId}, 'feature')`
     );
 
-    return { submissionId, uploadId };
+    return { submissionId, uploadId, submissionUploadId };
   }
 
   it('should process a valid submission and create features', async () => {
@@ -479,8 +495,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission({ submissionId, uploadId });
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({
+      submission_upload_id: submissionUploadId,
+      submission_id: submissionId,
+      upload_id: uploadId
+    });
 
     expect(result.valid).to.be.true;
     expect(result.errors).to.have.lengthOf(0);
@@ -524,8 +544,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission({ submissionId, uploadId });
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({
+      submission_upload_id: submissionUploadId,
+      submission_id: submissionId,
+      upload_id: uploadId
+    });
 
     expect(result.valid).to.be.false;
     expect(result.errors.some((e) => e.type === ValidationErrorType.INVALID_FEATURE_TYPE)).to.be.true;
@@ -575,8 +599,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       { name: 'files/photo.jpg', content: 'fake-image-bytes' }
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission({ submissionId, uploadId });
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({
+      submission_upload_id: submissionUploadId,
+      submission_id: submissionId,
+      upload_id: uploadId
+    });
 
     // Track S3 media upload for cleanup
     s3KeysToCleanup.push(`submissions/${submissionId}/media/photo.jpg`);
@@ -649,8 +677,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       // No files/missing.pdf in archive
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission({ submissionId, uploadId });
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({
+      submission_upload_id: submissionUploadId,
+      submission_id: submissionId,
+      upload_id: uploadId
+    });
 
     expect(result.valid).to.be.false;
     expect(result.errors.some((e) => e.type === ValidationErrorType.MISSING_MEDIA_FILE)).to.be.true;
@@ -688,8 +720,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission({ submissionId, uploadId });
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({
+      submission_upload_id: submissionUploadId,
+      submission_id: submissionId,
+      upload_id: uploadId
+    });
 
     expect(result.valid).to.be.true;
 
@@ -738,8 +774,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
-    const result = await service.processSubmission({ submissionId, uploadId });
+    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const result = await service.processSubmission({
+      submission_upload_id: submissionUploadId,
+      submission_id: submissionId,
+      upload_id: uploadId
+    });
 
     expect(result.valid).to.be.false;
     expect(result.errors.length).to.be.greaterThan(1);

--- a/api/src/__integration__/system/process-submission-features-worker.integration.ts
+++ b/api/src/__integration__/system/process-submission-features-worker.integration.ts
@@ -89,10 +89,9 @@ describe('Process Submission Features Worker', function () {
     // policy from a previous startup, we must update it directly.
     const boss = getPgBoss();
     await boss.createQueue(JobQueues.PROCESS_SUBMISSION_FEATURES);
-    await db.raw(
-      `UPDATE pgboss.queue SET policy = 'short' WHERE name = ? AND policy != 'short'`,
-      [JobQueues.PROCESS_SUBMISSION_FEATURES]
-    );
+    await db.raw(`UPDATE pgboss.queue SET policy = 'short' WHERE name = ? AND policy != 'short'`, [
+      JobQueues.PROCESS_SUBMISSION_FEATURES
+    ]);
   });
 
   after(async () => {

--- a/api/src/__integration__/system/process-submission-features-worker.integration.ts
+++ b/api/src/__integration__/system/process-submission-features-worker.integration.ts
@@ -239,13 +239,13 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
 
     // Publish job (needs IDBConnection for submission_validation tracking)
     const connection = getAPIUserDBConnection();
     try {
       await connection.open();
-      const result = await publishProcessSubmissionFeaturesJob(connection, { submissionId });
+      const result = await publishProcessSubmissionFeaturesJob(connection, { uploadId, submissionId });
       await connection.commit();
       expect(result.status).to.equal('published');
     } finally {
@@ -286,12 +286,12 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId } = await setupSubmissionWithTar(tarBuffer);
 
     const connection = getAPIUserDBConnection();
     try {
       await connection.open();
-      const result = await publishProcessSubmissionFeaturesJob(connection, { submissionId });
+      const result = await publishProcessSubmissionFeaturesJob(connection, { uploadId, submissionId });
       await connection.commit();
       expect(result.status).to.equal('published');
     } finally {

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -34,11 +34,11 @@ export interface SubmissionUploadFilters {
 }
 
 /**
- * The upload + submission identifier pair used across the ingestion pipeline.
- * Both IDs travel together through publisher, job handler, validation tracking,
- * and feature insertion. The trigger resolves both before publishing.
+ * Job payload for the ingestion pipeline. Single identifier eliminates the risk
+ * of submissionId/uploadId getting out of sync — each consumer resolves what
+ * it needs from the submission_upload bridge table.
  */
 export interface IngestionJobData {
-  uploadId: string;
-  submissionId: number;
+  /** The submission_upload_id that triggered this ingestion job */
+  submissionUploadId: string;
 }

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -38,7 +38,7 @@ export interface SubmissionUploadFilters {
  * Both IDs travel together through publisher, job handler, validation tracking,
  * and feature insertion. The trigger resolves both before publishing.
  */
-export interface SubmissionUploadRef {
+export interface IngestionJobData {
   uploadId: string;
   submissionId: number;
 }

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -32,3 +32,13 @@ export type UpdateSubmissionUpload = z.infer<typeof UpdateSubmissionUpload>;
 export interface SubmissionUploadFilters {
   role?: UploadArtifactRoleEnum;
 }
+
+/**
+ * The upload + submission identifier pair used across the ingestion pipeline.
+ * Both IDs travel together through publisher, job handler, validation tracking,
+ * and feature insertion. The trigger resolves both before publishing.
+ */
+export interface SubmissionUploadRef {
+  uploadId: string;
+  submissionId: number;
+}

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -32,13 +32,3 @@ export type UpdateSubmissionUpload = z.infer<typeof UpdateSubmissionUpload>;
 export interface SubmissionUploadFilters {
   role?: UploadArtifactRoleEnum;
 }
-
-/**
- * Job payload for the ingestion pipeline. Single identifier eliminates the risk
- * of submissionId/uploadId getting out of sync — each consumer resolves what
- * it needs from the submission_upload bridge table.
- */
-export interface IngestionJobData {
-  /** The submission_upload_id that triggered this ingestion job */
-  submissionUploadId: string;
-}

--- a/api/src/paths/submission/intake.test.ts
+++ b/api/src/paths/submission/intake.test.ts
@@ -8,6 +8,7 @@ import { SystemUser } from '../../repositories/user-repository';
 import { RegionService } from '../../services/region-service';
 import { SearchFeatureService } from '../../services/search-feature-service';
 import { SubmissionService } from '../../services/submission-service';
+import { SubmissionUploadService } from '../../services/upload/submission-upload-service';
 import { UploadService } from '../../services/upload/upload-service';
 import { ValidationService } from '../../services/validation-service';
 import * as keycloakUtils from '../../utils/keycloak-utils';
@@ -147,6 +148,10 @@ describe('intake', () => {
 
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'some-uuid' });
 
+      sinon
+        .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
+        .resolves({ submission_upload_id: 'sub-upload-uuid' });
+
       const insertSubmissionFeatureRecordsStub = sinon
         .stub(SubmissionService.prototype, 'insertSubmissionFeatureRecords')
         .resolves();
@@ -213,7 +218,7 @@ describe('intake', () => {
         serviceClientSystemUser.system_user_id,
         serviceClientSystemUser.user_identifier
       );
-      expect(insertSubmissionFeatureRecordsStub).to.have.been.calledOnceWith(submissionId, 'some-uuid', [feature1]);
+      expect(insertSubmissionFeatureRecordsStub).to.have.been.calledOnceWith(submissionId, 'sub-upload-uuid', [feature1]);
       expect(indexFeaturesBySubmissionIdStub).to.have.been.calledOnceWith(submissionId);
       expect(findSubmissionFeaturesStub).to.have.been.calledOnceWith({
         submissionId: submissionId,

--- a/api/src/paths/submission/intake.test.ts
+++ b/api/src/paths/submission/intake.test.ts
@@ -218,7 +218,9 @@ describe('intake', () => {
         serviceClientSystemUser.system_user_id,
         serviceClientSystemUser.user_identifier
       );
-      expect(insertSubmissionFeatureRecordsStub).to.have.been.calledOnceWith(submissionId, 'sub-upload-uuid', [feature1]);
+      expect(insertSubmissionFeatureRecordsStub).to.have.been.calledOnceWith(submissionId, 'sub-upload-uuid', [
+        feature1
+      ]);
       expect(indexFeaturesBySubmissionIdStub).to.have.been.calledOnceWith(submissionId);
       expect(findSubmissionFeaturesStub).to.have.been.calledOnceWith({
         submissionId: submissionId,

--- a/api/src/paths/submission/intake.ts
+++ b/api/src/paths/submission/intake.ts
@@ -9,6 +9,7 @@ import { authorizeRequestHandler } from '../../request-handlers/security/authori
 import { RegionService } from '../../services/region-service';
 import { SearchFeatureService } from '../../services/search-feature-service';
 import { SubmissionService } from '../../services/submission-service';
+import { SubmissionUploadService } from '../../services/upload/submission-upload-service';
 import { UploadService } from '../../services/upload/upload-service';
 import { ValidationService } from '../../services/validation-service';
 import { getServiceClientSystemUser } from '../../utils/keycloak-utils';
@@ -180,8 +181,15 @@ export function submissionIntake(): RequestHandler {
         s3_upload_id: ''
       });
 
+      // Create submission_upload bridge record (required for submission_upload_id FK on features)
+      const submissionUploadService = new SubmissionUploadService(connection);
+      const { submission_upload_id } = await submissionUploadService.insertSubmissionUpload({
+        submission_id: submissionRecord.submission_id,
+        upload_id
+      });
+
       // insert each submission feature record
-      await submissionService.insertSubmissionFeatureRecords(submissionRecord.submission_id, upload_id, [
+      await submissionService.insertSubmissionFeatureRecords(submissionRecord.submission_id, submission_upload_id, [
         submissionFeature
       ]);
 

--- a/api/src/queue/jobs/process-submission-features-job.test.ts
+++ b/api/src/queue/jobs/process-submission-features-job.test.ts
@@ -103,7 +103,6 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-
       const updateStatusStub = sinon
         .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus')
         .resolves();
@@ -149,7 +148,6 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').rejects(testError);
@@ -178,7 +176,6 @@ describe('process-submission-features-job', () => {
         mockConn.release = releaseStub;
         return mockConn;
       });
-
 
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').resolves({ valid: true, errors: [] });
@@ -246,7 +243,6 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-
       const updateStatusStub = sinon
         .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus')
         .resolves();
@@ -280,7 +276,6 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').resolves({ valid: true, errors: [] });
@@ -308,7 +303,6 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').resolves({ valid: true, errors: [] });
@@ -333,7 +327,6 @@ describe('process-submission-features-job', () => {
       mockDBConnection.release = sinon.stub();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
-
 
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 

--- a/api/src/queue/jobs/process-submission-features-job.test.ts
+++ b/api/src/queue/jobs/process-submission-features-job.test.ts
@@ -3,12 +3,12 @@ import { describe } from 'mocha';
 import PgBoss from 'pg-boss';
 import sinon from 'sinon';
 import * as db from '../../database/db';
+import { IngestionJobData } from '../../models/submission-upload';
 import { ValidationErrorType } from '../../services/ingestion/feature-validation-service.interface';
 import { SubmissionIngestionService } from '../../services/ingestion/submission-ingestion-service';
 import { SubmissionValidationService } from '../../services/submission-validation-service';
 import { getMockDBConnection } from '../../__mocks__/db';
 import * as publisher from '../publisher';
-import { SubmissionUploadRef } from '../../models/submission-upload';
 import {
   processSubmissionFeaturesFailedHandler,
   processSubmissionFeaturesJobHandler
@@ -25,7 +25,7 @@ describe('process-submission-features-job', () => {
         id: jobId,
         name: 'process-submission-features',
         data: { uploadId, submissionId }
-      } as PgBoss.Job<SubmissionUploadRef>);
+      } as PgBoss.Job<IngestionJobData>);
 
     it('processes submission successfully', async () => {
       const mockDBConnection = getMockDBConnection();
@@ -77,7 +77,7 @@ describe('process-submission-features-job', () => {
       await processSubmissionFeaturesJobHandler(mockJobs);
 
       expect(processStub.calledOnce).to.be.true;
-      expect(processStub.firstCall.args[0]).to.equal(456);
+      expect(processStub.firstCall.args[0]).to.deep.equal({ uploadId: 'test-upload-id', submissionId: 456 });
     });
 
     it('updates status to invalid on validation failure and does not throw', async () => {
@@ -187,7 +187,7 @@ describe('process-submission-features-job', () => {
         open: openStub
       } as any);
 
-      const mockJobs: PgBoss.Job<SubmissionUploadRef>[] = [];
+      const mockJobs: PgBoss.Job<IngestionJobData>[] = [];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -351,7 +351,7 @@ describe('process-submission-features-job', () => {
         name: '__state__completed__process-submission-features',
         data: { uploadId, submissionId },
         output
-      } as PgBoss.JobWithMetadata<SubmissionUploadRef>);
+      } as PgBoss.JobWithMetadata<IngestionJobData>);
 
     it('updates status to failed with error from job output', async () => {
       const mockDBConnection = getMockDBConnection();

--- a/api/src/queue/jobs/process-submission-features-job.test.ts
+++ b/api/src/queue/jobs/process-submission-features-job.test.ts
@@ -8,8 +8,8 @@ import { SubmissionIngestionService } from '../../services/ingestion/submission-
 import { SubmissionValidationService } from '../../services/submission-validation-service';
 import { getMockDBConnection } from '../../__mocks__/db';
 import * as publisher from '../publisher';
+import { SubmissionUploadRef } from '../../models/submission-upload';
 import {
-  IProcessSubmissionFeaturesJobData,
   processSubmissionFeaturesFailedHandler,
   processSubmissionFeaturesJobHandler
 } from './process-submission-features-job';
@@ -20,12 +20,12 @@ describe('process-submission-features-job', () => {
   });
 
   describe('processSubmissionFeaturesJobHandler', () => {
-    const createMockJob = (submissionId: number, jobId = 'test-job-id') =>
+    const createMockJob = (submissionId: number, jobId = 'test-job-id', uploadId = 'test-upload-id') =>
       ({
         id: jobId,
         name: 'process-submission-features',
-        data: { submissionId }
-      } as PgBoss.Job<IProcessSubmissionFeaturesJobData>);
+        data: { uploadId, submissionId }
+      } as PgBoss.Job<SubmissionUploadRef>);
 
     it('processes submission successfully', async () => {
       const mockDBConnection = getMockDBConnection();
@@ -187,7 +187,7 @@ describe('process-submission-features-job', () => {
         open: openStub
       } as any);
 
-      const mockJobs: PgBoss.Job<IProcessSubmissionFeaturesJobData>[] = [];
+      const mockJobs: PgBoss.Job<SubmissionUploadRef>[] = [];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -340,13 +340,18 @@ describe('process-submission-features-job', () => {
   });
 
   describe('processSubmissionFeaturesFailedHandler', () => {
-    const createMockFailedJob = (submissionId: number, jobId = 'dlq-job-id', output?: unknown) =>
+    const createMockFailedJob = (
+      submissionId: number,
+      jobId = 'dlq-job-id',
+      output?: unknown,
+      uploadId = 'test-upload-id'
+    ) =>
       ({
         id: jobId,
         name: '__state__completed__process-submission-features',
-        data: { submissionId },
+        data: { uploadId, submissionId },
         output
-      } as PgBoss.JobWithMetadata<IProcessSubmissionFeaturesJobData>);
+      } as PgBoss.JobWithMetadata<SubmissionUploadRef>);
 
     it('updates status to failed with error from job output', async () => {
       const mockDBConnection = getMockDBConnection();
@@ -358,7 +363,7 @@ describe('process-submission-features-job', () => {
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
       const updateStatusBySubmissionIdStub = sinon
-        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusBySubmissionId')
+        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusByUploadId')
         .resolves();
 
       const errorOutput = { message: 'Database connection failed' };
@@ -367,7 +372,7 @@ describe('process-submission-features-job', () => {
       await processSubmissionFeaturesFailedHandler(mockJobs);
 
       expect(updateStatusBySubmissionIdStub.calledOnce).to.be.true;
-      expect(updateStatusBySubmissionIdStub.firstCall.args[0]).to.equal(123);
+      expect(updateStatusBySubmissionIdStub.firstCall.args[0]).to.equal('test-upload-id');
       expect(updateStatusBySubmissionIdStub.firstCall.args[1]).to.equal('failed');
       expect(updateStatusBySubmissionIdStub.firstCall.args[2]).to.deep.equal({ error: errorOutput });
     });
@@ -382,7 +387,7 @@ describe('process-submission-features-job', () => {
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
       const updateStatusBySubmissionIdStub = sinon
-        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusBySubmissionId')
+        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusByUploadId')
         .resolves();
 
       const mockJobs = [createMockFailedJob(123, 'dlq-job-id', null)];
@@ -406,7 +411,7 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
       sinon
-        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusBySubmissionId')
+        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusByUploadId')
         .rejects(testError);
 
       const mockJobs = [createMockFailedJob(123)];

--- a/api/src/queue/jobs/process-submission-features-job.test.ts
+++ b/api/src/queue/jobs/process-submission-features-job.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import PgBoss from 'pg-boss';
 import sinon from 'sinon';
 import * as db from '../../database/db';
-import { IngestionJobData } from '../../models/submission-upload';
+import { SubmissionUpload } from '../../models/submission-upload';
 import { ValidationErrorType } from '../../services/ingestion/feature-validation-service.interface';
 import { SubmissionIngestionService } from '../../services/ingestion/submission-ingestion-service';
 import { SubmissionValidationService } from '../../services/submission-validation-service';
@@ -19,13 +19,20 @@ describe('process-submission-features-job', () => {
     sinon.restore();
   });
 
+  /** Default bridge record used across tests. */
+  const defaultSubmissionUpload: SubmissionUpload = {
+    submission_upload_id: 'test-sub-upload-id',
+    submission_id: 123,
+    upload_id: 'test-upload-id'
+  };
+
   describe('processSubmissionFeaturesJobHandler', () => {
-    const createMockJob = (submissionId: number, jobId = 'test-job-id', uploadId = 'test-upload-id') =>
+    const createMockJob = (data: Partial<SubmissionUpload> = {}, jobId = 'test-job-id') =>
       ({
         id: jobId,
         name: 'process-submission-features',
-        data: { uploadId, submissionId }
-      } as PgBoss.Job<IngestionJobData>);
+        data: { ...defaultSubmissionUpload, ...data }
+      } as PgBoss.Job<SubmissionUpload>);
 
     it('processes submission successfully', async () => {
       const mockDBConnection = getMockDBConnection();
@@ -46,7 +53,7 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'published', jobId: 'index-job-id' });
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -54,7 +61,7 @@ describe('process-submission-features-job', () => {
       expect(updateStatusStub.calledWith('test-job-id', 'completed')).to.be.true;
     });
 
-    it('calls processSubmission with correct submissionId', async () => {
+    it('calls processSubmission with the SubmissionUpload from job data', async () => {
       const mockDBConnection = getMockDBConnection();
 
       mockDBConnection.open = sinon.stub().resolves();
@@ -72,12 +79,18 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'published', jobId: 'index-job-id' });
 
-      const mockJobs = [createMockJob(456)];
+      const jobData: SubmissionUpload = {
+        submission_upload_id: 'my-sub-upload-id',
+        submission_id: 456,
+        upload_id: 'my-upload-id'
+      };
+      const mockJobs = [createMockJob(jobData)];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
       expect(processStub.calledOnce).to.be.true;
-      expect(processStub.firstCall.args[0]).to.deep.equal({ uploadId: 'test-upload-id', submissionId: 456 });
+      // Handler passes the job data directly — no DB lookup needed
+      expect(processStub.firstCall.args[0]).to.deep.equal(jobData);
     });
 
     it('updates status to invalid on validation failure and does not throw', async () => {
@@ -89,6 +102,7 @@ describe('process-submission-features-job', () => {
       mockDBConnection.release = sinon.stub();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
+
 
       const updateStatusStub = sinon
         .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus')
@@ -109,7 +123,7 @@ describe('process-submission-features-job', () => {
         .stub(SubmissionIngestionService.prototype, 'processSubmission')
         .resolves({ valid: false, errors: validationErrors });
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       // Should NOT throw
       await processSubmissionFeaturesJobHandler(mockJobs);
@@ -135,11 +149,12 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
+
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').rejects(testError);
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       try {
         await processSubmissionFeaturesJobHandler(mockJobs);
@@ -164,6 +179,7 @@ describe('process-submission-features-job', () => {
         return mockConn;
       });
 
+
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').resolves({ valid: true, errors: [] });
 
@@ -171,7 +187,10 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'published', jobId: 'index-job-id' });
 
-      const mockJobs = [createMockJob(123, 'job-1'), createMockJob(456, 'job-2')];
+      const mockJobs = [
+        createMockJob({ submission_upload_id: 'sub-upload-1' }, 'job-1'),
+        createMockJob({ submission_upload_id: 'sub-upload-2' }, 'job-2')
+      ];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -187,7 +206,7 @@ describe('process-submission-features-job', () => {
         open: openStub
       } as any);
 
-      const mockJobs: PgBoss.Job<IngestionJobData>[] = [];
+      const mockJobs: PgBoss.Job<SubmissionUpload>[] = [];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -203,6 +222,7 @@ describe('process-submission-features-job', () => {
       mockDBConnection.release = releaseStub;
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
+
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').resolves({ valid: true, errors: [] });
 
@@ -210,7 +230,7 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'published', jobId: 'index-job-id' });
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -226,6 +246,7 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
+
       const updateStatusStub = sinon
         .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus')
         .resolves();
@@ -236,7 +257,7 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'published', jobId: 'index-job-id' });
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -259,6 +280,7 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
+
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').resolves({ valid: true, errors: [] });
@@ -267,7 +289,7 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'error', message: 'pg-boss unavailable' });
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       // Should NOT throw — fire-and-forget
       await processSubmissionFeaturesJobHandler(mockJobs);
@@ -286,6 +308,7 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
+
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 
       sinon.stub(SubmissionIngestionService.prototype, 'processSubmission').resolves({ valid: true, errors: [] });
@@ -294,7 +317,7 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'duplicate', message: 'Job already exists for this submission' });
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       // Should NOT throw — duplicate is acceptable
       await processSubmissionFeaturesJobHandler(mockJobs);
@@ -310,6 +333,7 @@ describe('process-submission-features-job', () => {
       mockDBConnection.release = sinon.stub();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
+
 
       sinon.stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatus').resolves();
 
@@ -331,7 +355,7 @@ describe('process-submission-features-job', () => {
         .stub(publisher, 'publishIndexSubmissionFeaturesJob')
         .resolves({ status: 'published', jobId: 'index-job-id' });
 
-      const mockJobs = [createMockJob(123)];
+      const mockJobs = [createMockJob()];
 
       await processSubmissionFeaturesJobHandler(mockJobs);
 
@@ -340,18 +364,13 @@ describe('process-submission-features-job', () => {
   });
 
   describe('processSubmissionFeaturesFailedHandler', () => {
-    const createMockFailedJob = (
-      submissionId: number,
-      jobId = 'dlq-job-id',
-      output?: unknown,
-      uploadId = 'test-upload-id'
-    ) =>
+    const createMockFailedJob = (data: Partial<SubmissionUpload> = {}, jobId = 'dlq-job-id', output?: unknown) =>
       ({
         id: jobId,
         name: '__state__completed__process-submission-features',
-        data: { uploadId, submissionId },
+        data: { ...defaultSubmissionUpload, ...data },
         output
-      } as PgBoss.JobWithMetadata<IngestionJobData>);
+      } as PgBoss.JobWithMetadata<SubmissionUpload>);
 
     it('updates status to failed with error from job output', async () => {
       const mockDBConnection = getMockDBConnection();
@@ -362,19 +381,19 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-      const updateStatusBySubmissionIdStub = sinon
-        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusByUploadId')
+      const updateStatusBySubmissionUploadIdStub = sinon
+        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusBySubmissionUploadId')
         .resolves();
 
       const errorOutput = { message: 'Database connection failed' };
-      const mockJobs = [createMockFailedJob(123, 'dlq-job-id', errorOutput)];
+      const mockJobs = [createMockFailedJob({}, 'dlq-job-id', errorOutput)];
 
       await processSubmissionFeaturesFailedHandler(mockJobs);
 
-      expect(updateStatusBySubmissionIdStub.calledOnce).to.be.true;
-      expect(updateStatusBySubmissionIdStub.firstCall.args[0]).to.equal('test-upload-id');
-      expect(updateStatusBySubmissionIdStub.firstCall.args[1]).to.equal('failed');
-      expect(updateStatusBySubmissionIdStub.firstCall.args[2]).to.deep.equal({ error: errorOutput });
+      expect(updateStatusBySubmissionUploadIdStub.calledOnce).to.be.true;
+      expect(updateStatusBySubmissionUploadIdStub.firstCall.args[0]).to.equal('test-sub-upload-id');
+      expect(updateStatusBySubmissionUploadIdStub.firstCall.args[1]).to.equal('failed');
+      expect(updateStatusBySubmissionUploadIdStub.firstCall.args[2]).to.deep.equal({ error: errorOutput });
     });
 
     it('uses default error message when job output is null', async () => {
@@ -386,15 +405,15 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-      const updateStatusBySubmissionIdStub = sinon
-        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusByUploadId')
+      const updateStatusBySubmissionUploadIdStub = sinon
+        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusBySubmissionUploadId')
         .resolves();
 
-      const mockJobs = [createMockFailedJob(123, 'dlq-job-id', null)];
+      const mockJobs = [createMockFailedJob({}, 'dlq-job-id', null)];
 
       await processSubmissionFeaturesFailedHandler(mockJobs);
 
-      expect(updateStatusBySubmissionIdStub.firstCall.args[2]).to.deep.equal({
+      expect(updateStatusBySubmissionUploadIdStub.firstCall.args[2]).to.deep.equal({
         error: 'Job failed after all retries'
       });
     });
@@ -411,10 +430,10 @@ describe('process-submission-features-job', () => {
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
       sinon
-        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusByUploadId')
+        .stub(SubmissionValidationService.prototype, 'updateSubmissionValidationStatusBySubmissionUploadId')
         .rejects(testError);
 
-      const mockJobs = [createMockFailedJob(123)];
+      const mockJobs = [createMockFailedJob()];
 
       try {
         await processSubmissionFeaturesFailedHandler(mockJobs);

--- a/api/src/queue/jobs/process-submission-features-job.ts
+++ b/api/src/queue/jobs/process-submission-features-job.ts
@@ -9,10 +9,15 @@ const defaultLog = getLogger('queue/jobs/process-submission-features-job');
 
 /**
  * Process submission features job data interface.
- * Contains the submission ID for async processing of slow operations.
+ *
+ * The trigger (ArtifactSecurityService) naturally has upload_id from the upload_archive record
+ * and derives submissionId from submission_upload. Both are passed in the job payload so the
+ * handler needs zero additional DB lookups for keying.
  */
 export interface IProcessSubmissionFeaturesJobData {
-  /** The submission ID to process */
+  /** The upload ID (UUID) — the processing unit for ingestion */
+  uploadId: string;
+  /** The submission ID — provided by the trigger to avoid a DB lookup in the handler */
   submissionId: number;
 }
 

--- a/api/src/queue/jobs/process-submission-features-job.ts
+++ b/api/src/queue/jobs/process-submission-features-job.ts
@@ -1,5 +1,6 @@
 import PgBoss from 'pg-boss';
 import { getAPIUserDBConnection } from '../../database/db';
+import { SubmissionUploadRef } from '../../models/submission-upload';
 import { SubmissionIngestionService } from '../../services/ingestion/submission-ingestion-service';
 import { SubmissionValidationService } from '../../services/submission-validation-service';
 import { getLogger } from '../../utils/logger';
@@ -7,19 +8,6 @@ import { publishIndexSubmissionFeaturesJob } from '../publisher';
 
 const defaultLog = getLogger('queue/jobs/process-submission-features-job');
 
-/**
- * Process submission features job data interface.
- *
- * The trigger (ArtifactSecurityService) naturally has upload_id from the upload_archive record
- * and derives submissionId from submission_upload. Both are passed in the job payload so the
- * handler needs zero additional DB lookups for keying.
- */
-export interface IProcessSubmissionFeaturesJobData {
-  /** The upload ID (UUID) — the processing unit for ingestion */
-  uploadId: string;
-  /** The submission ID — provided by the trigger to avoid a DB lookup in the handler */
-  submissionId: number;
-}
 
 /**
  * Process submission features job handler.
@@ -30,10 +18,10 @@ export interface IProcessSubmissionFeaturesJobData {
  * 3. Inserts feature records
  * 4. Indexes features for search
  *
- * @param {PgBoss.Job<IProcessSubmissionFeaturesJobData>[]} jobs The jobs to process
+ * @param {PgBoss.Job<SubmissionUploadRef>[]} jobs The jobs to process
  * @return {*}  {Promise<void>}
  */
-export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<IProcessSubmissionFeaturesJobData> = async (
+export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<SubmissionUploadRef> = async (
   jobs
 ) => {
   for (const job of jobs) {
@@ -127,22 +115,23 @@ export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<IProcessSub
  * This handler is called after all retries are exhausted. It updates the
  * submission validation status to 'failed' with error details.
  *
- * @param {PgBoss.Job<IProcessSubmissionFeaturesJobData>[]} jobs The failed jobs
+ * @param {PgBoss.Job<SubmissionUploadRef>[]} jobs The failed jobs
  * @return {*}  {Promise<void>}
  */
-export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<IProcessSubmissionFeaturesJobData> = async (
+export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<SubmissionUploadRef> = async (
   jobs
 ) => {
   for (const job of jobs) {
-    const { submissionId } = job.data;
+    const { uploadId, submissionId } = job.data;
 
     // Cast to access output field available on failed jobs
-    const jobOutput = (job as PgBoss.JobWithMetadata<IProcessSubmissionFeaturesJobData>).output;
+    const jobOutput = (job as PgBoss.JobWithMetadata<SubmissionUploadRef>).output;
 
     defaultLog.warn({
       label: 'processSubmissionFeaturesFailedHandler',
       message: 'Processing failed job from dead letter queue',
       jobId: job.id,
+      uploadId,
       submissionId,
       output: jobOutput
     });
@@ -155,8 +144,8 @@ export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<IProcess
       const submissionValidationService = new SubmissionValidationService(connection);
 
       // Update validation status to failed (all retries exhausted)
-      // Use submissionId since DLQ job has a new job ID, not the original
-      await submissionValidationService.updateSubmissionValidationStatusBySubmissionId(submissionId, 'failed', {
+      // Use uploadId since DLQ job has a new job ID, not the original
+      await submissionValidationService.updateSubmissionValidationStatusByUploadId(uploadId, 'failed', {
         error: jobOutput ?? 'Job failed after all retries'
       });
 

--- a/api/src/queue/jobs/process-submission-features-job.ts
+++ b/api/src/queue/jobs/process-submission-features-job.ts
@@ -1,13 +1,12 @@
 import PgBoss from 'pg-boss';
 import { getAPIUserDBConnection } from '../../database/db';
-import { SubmissionUploadRef } from '../../models/submission-upload';
+import { IngestionJobData } from '../../models/submission-upload';
 import { SubmissionIngestionService } from '../../services/ingestion/submission-ingestion-service';
 import { SubmissionValidationService } from '../../services/submission-validation-service';
 import { getLogger } from '../../utils/logger';
 import { publishIndexSubmissionFeaturesJob } from '../publisher';
 
 const defaultLog = getLogger('queue/jobs/process-submission-features-job');
-
 
 /**
  * Process submission features job handler.
@@ -18,19 +17,18 @@ const defaultLog = getLogger('queue/jobs/process-submission-features-job');
  * 3. Inserts feature records
  * 4. Indexes features for search
  *
- * @param {PgBoss.Job<SubmissionUploadRef>[]} jobs The jobs to process
+ * @param {PgBoss.Job<IngestionJobData>[]} jobs The jobs to process
  * @return {*}  {Promise<void>}
  */
-export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<SubmissionUploadRef> = async (
-  jobs
-) => {
+export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<IngestionJobData> = async (jobs) => {
   for (const job of jobs) {
-    const { submissionId } = job.data;
+    const { uploadId, submissionId } = job.data;
 
     defaultLog.info({
       label: 'processSubmissionFeaturesJobHandler',
       message: 'Processing submission features job',
       jobId: job.id,
+      uploadId,
       submissionId
     });
 
@@ -47,7 +45,7 @@ export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<SubmissionU
 
       // Process the submission (two-pass: validate → ingest)
       const submissionIngestionService = new SubmissionIngestionService(connection);
-      const result = await submissionIngestionService.processSubmission(submissionId);
+      const result = await submissionIngestionService.processSubmission(job.data);
 
       if (!result.valid) {
         // Validation failure — permanent condition, don't retry
@@ -100,8 +98,8 @@ export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<SubmissionU
         error
       });
 
-      // Don't update status to 'failed' here - pg-boss will retry
-      // Status will be set to 'failed' by Dead Letter Queue handler after all retries exhausted
+      // Don't update status to 'failed' here — rethrow so pg-boss moves the job to DLQ.
+      // DLQ handler sets the validation status to 'failed'.
       throw error;
     } finally {
       connection.release();
@@ -115,17 +113,15 @@ export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<SubmissionU
  * This handler is called after all retries are exhausted. It updates the
  * submission validation status to 'failed' with error details.
  *
- * @param {PgBoss.Job<SubmissionUploadRef>[]} jobs The failed jobs
+ * @param {PgBoss.Job<IngestionJobData>[]} jobs The failed jobs
  * @return {*}  {Promise<void>}
  */
-export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<SubmissionUploadRef> = async (
-  jobs
-) => {
+export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<IngestionJobData> = async (jobs) => {
   for (const job of jobs) {
     const { uploadId, submissionId } = job.data;
 
     // Cast to access output field available on failed jobs
-    const jobOutput = (job as PgBoss.JobWithMetadata<SubmissionUploadRef>).output;
+    const jobOutput = (job as PgBoss.JobWithMetadata<IngestionJobData>).output;
 
     defaultLog.warn({
       label: 'processSubmissionFeaturesFailedHandler',

--- a/api/src/queue/jobs/process-submission-features-job.ts
+++ b/api/src/queue/jobs/process-submission-features-job.ts
@@ -1,6 +1,6 @@
 import PgBoss from 'pg-boss';
 import { getAPIUserDBConnection } from '../../database/db';
-import { IngestionJobData } from '../../models/submission-upload';
+import { SubmissionUpload } from '../../models/submission-upload';
 import { SubmissionIngestionService } from '../../services/ingestion/submission-ingestion-service';
 import { SubmissionValidationService } from '../../services/submission-validation-service';
 import { getLogger } from '../../utils/logger';
@@ -11,31 +11,35 @@ const defaultLog = getLogger('queue/jobs/process-submission-features-job');
 /**
  * Process submission features job handler.
  *
+ * Receives the full SubmissionUpload bridge record in the job payload,
+ * avoiding an extra DB lookup at startup.
+ *
  * Processes a submission asynchronously:
  * 1. Downloads tarball from object storage
  * 2. Extracts and validates features
  * 3. Inserts feature records
  * 4. Indexes features for search
  *
- * @param {PgBoss.Job<IngestionJobData>[]} jobs The jobs to process
+ * @param {PgBoss.Job<SubmissionUpload>[]} jobs The jobs to process
  * @return {*}  {Promise<void>}
  */
-export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<IngestionJobData> = async (jobs) => {
+export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<SubmissionUpload> = async (jobs) => {
   for (const job of jobs) {
-    const { uploadId, submissionId } = job.data;
-
-    defaultLog.info({
-      label: 'processSubmissionFeaturesJobHandler',
-      message: 'Processing submission features job',
-      jobId: job.id,
-      uploadId,
-      submissionId
-    });
+    const submissionUpload = job.data;
+    const { submission_upload_id: submissionUploadId, submission_id: submissionId } = submissionUpload;
 
     const connection = getAPIUserDBConnection();
 
     try {
       await connection.open();
+
+      defaultLog.info({
+        label: 'processSubmissionFeaturesJobHandler',
+        message: 'Processing submission features job',
+        jobId: job.id,
+        submissionUploadId,
+        submissionId
+      });
 
       const submissionValidationService = new SubmissionValidationService(connection);
 
@@ -45,7 +49,7 @@ export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<IngestionJo
 
       // Process the submission (two-pass: validate → ingest)
       const submissionIngestionService = new SubmissionIngestionService(connection);
-      const result = await submissionIngestionService.processSubmission(job.data);
+      const result = await submissionIngestionService.processSubmission(submissionUpload);
 
       if (!result.valid) {
         // Validation failure — permanent condition, don't retry
@@ -94,7 +98,7 @@ export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<IngestionJo
         label: 'processSubmissionFeaturesJobHandler',
         message: 'Process submission features job failed',
         jobId: job.id,
-        submissionId,
+        submissionUploadId,
         error
       });
 
@@ -110,25 +114,24 @@ export const processSubmissionFeaturesJobHandler: PgBoss.WorkHandler<IngestionJo
 /**
  * Dead Letter Queue handler for failed process submission features jobs.
  *
- * This handler is called after all retries are exhausted. It updates the
- * submission validation status to 'failed' with error details.
+ * DLQ creates a new job with a new job_id. The original validation record is found
+ * via submission_upload_id, not the (now-different) job_id.
  *
- * @param {PgBoss.Job<IngestionJobData>[]} jobs The failed jobs
+ * @param {PgBoss.Job<SubmissionUpload>[]} jobs The failed jobs
  * @return {*}  {Promise<void>}
  */
-export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<IngestionJobData> = async (jobs) => {
+export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<SubmissionUpload> = async (jobs) => {
   for (const job of jobs) {
-    const { uploadId, submissionId } = job.data;
+    const { submission_upload_id: submissionUploadId } = job.data;
 
     // Cast to access output field available on failed jobs
-    const jobOutput = (job as PgBoss.JobWithMetadata<IngestionJobData>).output;
+    const jobOutput = (job as PgBoss.JobWithMetadata<SubmissionUpload>).output;
 
     defaultLog.warn({
       label: 'processSubmissionFeaturesFailedHandler',
       message: 'Processing failed job from dead letter queue',
       jobId: job.id,
-      uploadId,
-      submissionId,
+      submissionUploadId,
       output: jobOutput
     });
 
@@ -140,10 +143,14 @@ export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<Ingestio
       const submissionValidationService = new SubmissionValidationService(connection);
 
       // Update validation status to failed (all retries exhausted)
-      // Use uploadId since DLQ job has a new job ID, not the original
-      await submissionValidationService.updateSubmissionValidationStatusByUploadId(uploadId, 'failed', {
-        error: jobOutput ?? 'Job failed after all retries'
-      });
+      // Use submissionUploadId since DLQ job has a new job ID, not the original
+      await submissionValidationService.updateSubmissionValidationStatusBySubmissionUploadId(
+        submissionUploadId,
+        'failed',
+        {
+          error: jobOutput ?? 'Job failed after all retries'
+        }
+      );
 
       await connection.commit();
 
@@ -151,7 +158,7 @@ export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<Ingestio
         label: 'processSubmissionFeaturesFailedHandler',
         message: 'Failed job status updated',
         jobId: job.id,
-        submissionId
+        submissionUploadId
       });
     } catch (error) {
       await connection.rollback();
@@ -160,7 +167,7 @@ export const processSubmissionFeaturesFailedHandler: PgBoss.WorkHandler<Ingestio
         label: 'processSubmissionFeaturesFailedHandler',
         message: 'Failed to update failed job status',
         jobId: job.id,
-        submissionId,
+        submissionUploadId,
         error
       });
 

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -36,7 +36,7 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      const data = { submissionId: 123 };
+      const data = { uploadId: 'upload-uuid-1', submissionId: 123 };
       const result = await publishProcessSubmissionFeaturesJob(mockConnection, data);
 
       expect(createQueueStub.calledOnce).to.be.true;
@@ -65,7 +65,7 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 });
+      await publishProcessSubmissionFeaturesJob(mockConnection, { uploadId: 'upload-uuid-1', submissionId: 123 });
 
       const options = sendStub.firstCall.args[2];
       expect(options.retryLimit).to.equal(3);
@@ -86,7 +86,11 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 }, { retryLimit: 5 });
+      await publishProcessSubmissionFeaturesJob(
+        mockConnection,
+        { uploadId: 'upload-uuid-1', submissionId: 123 },
+        { retryLimit: 5 }
+      );
 
       const options = sendStub.firstCall.args[2];
       expect(options.retryLimit).to.equal(5);
@@ -104,7 +108,10 @@ describe('publisher', () => {
 
       const createValidationStub = sinon.stub(SubmissionValidationService.prototype, 'createSubmissionValidation');
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
+        uploadId: 'upload-uuid-1',
+        submissionId: 123
+      });
 
       expect(result.status).to.equal('duplicate');
       expect((result as { status: 'duplicate'; message: string }).message).to.equal(
@@ -125,7 +132,7 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 456 });
+      await publishProcessSubmissionFeaturesJob(mockConnection, { uploadId: 'upload-uuid-2', submissionId: 456 });
 
       const options = sendStub.firstCall.args[2];
       expect(options.singletonKey).to.equal('submission-456');
@@ -137,7 +144,10 @@ describe('publisher', () => {
       sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId').resolves(null);
       sinon.stub(pgBossService, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
+        uploadId: 'upload-uuid-1',
+        submissionId: 123
+      });
 
       expect(result.status).to.equal('error');
       expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
@@ -155,7 +165,10 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId')
         .resolves(mockValidationRecord);
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
+        uploadId: 'upload-uuid-1',
+        submissionId: 123
+      });
 
       expect(result.status).to.equal('blocked');
       expect((result as { status: 'blocked'; existingStatus: string }).existingStatus).to.equal('pending');
@@ -180,7 +193,10 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 2 });
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
+        uploadId: 'upload-uuid-1',
+        submissionId: 123
+      });
 
       expect(result.status).to.equal('published');
       expect((result as { status: 'published'; jobId: string }).jobId).to.equal('new-job-id');
@@ -198,7 +214,10 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId')
         .resolves(mockCompletedRecord);
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
+        uploadId: 'upload-uuid-1',
+        submissionId: 123
+      });
 
       expect(result.status).to.equal('blocked');
       expect((result as { status: 'blocked'; existingStatus: string }).existingStatus).to.equal('completed');
@@ -223,7 +242,10 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 2 });
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, { submissionId: 123 });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
+        uploadId: 'upload-uuid-1',
+        submissionId: 123
+      });
 
       expect(result.status).to.equal('published');
       expect((result as { status: 'published'; jobId: string }).jobId).to.equal('new-job-id');

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import { DownloadRecord } from '../models/download';
-import { SubmissionUploadRef } from '../models/submission-upload';
+import { IngestionJobData } from '../models/submission-upload';
 import { SubmissionValidationRecord } from '../models/submission-validation';
 import { DownloadService } from '../services/download/download-service';
 import { SubmissionValidationService } from '../services/submission-validation-service';
@@ -37,7 +37,7 @@ describe('publisher', () => {
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      const data: SubmissionUploadRef = { uploadId: 'upload-uuid-1', submissionId: 123 };
+      const data: IngestionJobData = { uploadId: 'upload-uuid-1', submissionId: 123 };
       const result = await publishProcessSubmissionFeaturesJob(mockConnection, data);
 
       expect(createQueueStub.calledOnce).to.be.true;
@@ -48,13 +48,13 @@ describe('publisher', () => {
       expect(result.status).to.equal('published');
       expect((result as { status: 'published'; jobId: string }).jobId).to.equal('features-job-id');
 
-      // Verify submission validation was created with SubmissionUploadRef and jobId
+      // Verify submission validation was created with IngestionJobData and jobId
       expect(createValidationStub.calledOnce).to.be.true;
       expect(createValidationStub.firstCall.args[0]).to.deep.equal(data);
       expect(createValidationStub.firstCall.args[1]).to.equal('features-job-id');
     });
 
-    it('uses process submission features specific options with 10 minute timeout', async () => {
+    it('uses retryLimit: 0 — no automatic retries for ingestion jobs', async () => {
       const mockConnection = getMockDBConnection();
       const sendStub = sinon.stub().resolves('features-job-id');
       const createQueueStub = sinon.stub().resolves();
@@ -69,10 +69,10 @@ describe('publisher', () => {
       await publishProcessSubmissionFeaturesJob(mockConnection, { uploadId: 'upload-uuid-1', submissionId: 123 });
 
       const options = sendStub.firstCall.args[2];
-      expect(options.retryLimit).to.equal(3);
-      expect(options.retryDelay).to.equal(60);
-      expect(options.retryBackoff).to.equal(true);
-      expect(options.expireInSeconds).to.equal(60 * 10); // 10 minutes (not 1 hour)
+      expect(options.retryLimit).to.equal(0);
+      expect(options.retryDelay).to.equal(0);
+      expect(options.retryBackoff).to.equal(false);
+      expect(options.expireInSeconds).to.equal(60 * 10); // 10 minutes
     });
 
     it('merges provided options with process submission features defaults', async () => {
@@ -137,6 +137,25 @@ describe('publisher', () => {
 
       const options = sendStub.firstCall.args[2];
       expect(options.singletonKey).to.equal('submission-456');
+    });
+
+    it('passes db option to boss.send for transactional publishing', async () => {
+      const mockConnection = getMockDBConnection();
+      const sendStub = sinon.stub().resolves('features-job-id');
+      const createQueueStub = sinon.stub().resolves();
+      const mockBoss = { send: sendStub, createQueue: createQueueStub };
+
+      sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon
+        .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
+        .resolves({ submission_validation_id: 1 });
+
+      await publishProcessSubmissionFeaturesJob(mockConnection, { uploadId: 'upload-uuid-1', submissionId: 123 });
+
+      const options = sendStub.firstCall.args[2];
+      expect(options.db).to.exist;
+      expect(options.db.executeSql).to.be.a('function');
     });
 
     it('returns error status when pg-boss throws', async () => {

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import { DownloadRecord } from '../models/download';
-import { IngestionJobData } from '../models/submission-upload';
+import { SubmissionUpload } from '../models/submission-upload';
 import { SubmissionValidationRecord } from '../models/submission-validation';
 import { DownloadService } from '../services/download/download-service';
 import { SubmissionValidationService } from '../services/submission-validation-service';
@@ -21,6 +21,13 @@ describe('publisher', () => {
     sinon.restore();
   });
 
+  /** Default bridge record used across tests. */
+  const defaultSubmissionUpload: SubmissionUpload = {
+    submission_upload_id: 'sub-upload-uuid-1',
+    submission_id: 123,
+    upload_id: 'upload-uuid-1'
+  };
+
   describe('publishProcessSubmissionFeaturesJob', () => {
     it('publishes a job and creates submission validation record', async () => {
       const mockConnection = getMockDBConnection();
@@ -31,47 +38,48 @@ describe('publisher', () => {
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
 
       // No existing validation record
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
 
       const createValidationStub = sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      const data: IngestionJobData = { uploadId: 'upload-uuid-1', submissionId: 123 };
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, data);
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       expect(createQueueStub.calledOnce).to.be.true;
       expect(createQueueStub.firstCall.args[0]).to.equal(JobQueues.PROCESS_SUBMISSION_FEATURES);
       expect(sendStub.calledOnce).to.be.true;
       expect(sendStub.firstCall.args[0]).to.equal(JobQueues.PROCESS_SUBMISSION_FEATURES);
-      expect(sendStub.firstCall.args[1]).to.deep.equal(data);
+      // Full SubmissionUpload record travels through the queue
+      expect(sendStub.firstCall.args[1]).to.deep.equal(defaultSubmissionUpload);
       expect(result.status).to.equal('published');
       expect((result as { status: 'published'; jobId: string }).jobId).to.equal('features-job-id');
 
-      // Verify submission validation was created with IngestionJobData and jobId
+      // Verify submission validation was created with individual params
       expect(createValidationStub.calledOnce).to.be.true;
-      expect(createValidationStub.firstCall.args[0]).to.deep.equal(data);
-      expect(createValidationStub.firstCall.args[1]).to.equal('features-job-id');
+      expect(createValidationStub.firstCall.args[0]).to.equal('sub-upload-uuid-1');
+      expect(createValidationStub.firstCall.args[1]).to.equal(123);
+      expect(createValidationStub.firstCall.args[2]).to.equal('features-job-id');
     });
 
-    it('uses retryLimit: 0 — no automatic retries for ingestion jobs', async () => {
+    it('uses retryLimit: 2 with exponential backoff for ingestion jobs', async () => {
       const mockConnection = getMockDBConnection();
       const sendStub = sinon.stub().resolves('features-job-id');
       const createQueueStub = sinon.stub().resolves();
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      await publishProcessSubmissionFeaturesJob(mockConnection, { uploadId: 'upload-uuid-1', submissionId: 123 });
+      await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       const options = sendStub.firstCall.args[2];
-      expect(options.retryLimit).to.equal(0);
-      expect(options.retryDelay).to.equal(0);
-      expect(options.retryBackoff).to.equal(false);
+      expect(options.retryLimit).to.equal(2);
+      expect(options.retryDelay).to.equal(60);
+      expect(options.retryBackoff).to.equal(true);
       expect(options.expireInSeconds).to.equal(60 * 10); // 10 minutes
     });
 
@@ -82,16 +90,12 @@ describe('publisher', () => {
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      await publishProcessSubmissionFeaturesJob(
-        mockConnection,
-        { uploadId: 'upload-uuid-1', submissionId: 123 },
-        { retryLimit: 5 }
-      );
+      await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload, { retryLimit: 5 });
 
       const options = sendStub.firstCall.args[2];
       expect(options.retryLimit).to.equal(5);
@@ -105,14 +109,11 @@ describe('publisher', () => {
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
 
       const createValidationStub = sinon.stub(SubmissionValidationService.prototype, 'createSubmissionValidation');
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
-        uploadId: 'upload-uuid-1',
-        submissionId: 123
-      });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       expect(result.status).to.equal('duplicate');
       expect((result as { status: 'duplicate'; message: string }).message).to.equal(
@@ -121,19 +122,23 @@ describe('publisher', () => {
       expect(createValidationStub.called).to.be.false;
     });
 
-    it('uses singletonKey based on submissionId to prevent duplicates', async () => {
+    it('uses singletonKey based on submissionId resolved from bridge to prevent duplicates', async () => {
       const mockConnection = getMockDBConnection();
       const sendStub = sinon.stub().resolves('features-job-id');
       const createQueueStub = sinon.stub().resolves();
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      await publishProcessSubmissionFeaturesJob(mockConnection, { uploadId: 'upload-uuid-2', submissionId: 456 });
+      await publishProcessSubmissionFeaturesJob(mockConnection, {
+        ...defaultSubmissionUpload,
+        submission_id: 456,
+        submission_upload_id: 'sub-upload-uuid-2'
+      });
 
       const options = sendStub.firstCall.args[2];
       expect(options.singletonKey).to.equal('submission-456');
@@ -146,12 +151,12 @@ describe('publisher', () => {
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      await publishProcessSubmissionFeaturesJob(mockConnection, { uploadId: 'upload-uuid-1', submissionId: 123 });
+      await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       const options = sendStub.firstCall.args[2];
       expect(options.db).to.exist;
@@ -161,13 +166,10 @@ describe('publisher', () => {
     it('returns error status when pg-boss throws', async () => {
       const mockConnection = getMockDBConnection();
 
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
       sinon.stub(pgBossService, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
-        uploadId: 'upload-uuid-1',
-        submissionId: 123
-      });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       expect(result.status).to.equal('error');
       expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
@@ -182,13 +184,10 @@ describe('publisher', () => {
         status: 'pending'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId')
         .resolves(mockValidationRecord);
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
-        uploadId: 'upload-uuid-1',
-        submissionId: 123
-      });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       expect(result.status).to.equal('blocked');
       expect((result as { status: 'blocked'; existingStatus: string }).existingStatus).to.equal('pending');
@@ -207,16 +206,13 @@ describe('publisher', () => {
         status: 'invalid'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId')
         .resolves(mockInvalidValidationRecord);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 2 });
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
-        uploadId: 'upload-uuid-1',
-        submissionId: 123
-      });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       expect(result.status).to.equal('published');
       expect((result as { status: 'published'; jobId: string }).jobId).to.equal('new-job-id');
@@ -231,13 +227,10 @@ describe('publisher', () => {
         status: 'completed'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId')
         .resolves(mockCompletedRecord);
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
-        uploadId: 'upload-uuid-1',
-        submissionId: 123
-      });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       expect(result.status).to.equal('blocked');
       expect((result as { status: 'blocked'; existingStatus: string }).existingStatus).to.equal('completed');
@@ -256,16 +249,13 @@ describe('publisher', () => {
         status: 'failed'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId')
         .resolves(mockFailedValidationRecord);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 2 });
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
-        uploadId: 'upload-uuid-1',
-        submissionId: 123
-      });
+      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
 
       expect(result.status).to.equal('published');
       expect((result as { status: 'published'; jobId: string }).jobId).to.equal('new-job-id');
@@ -478,9 +468,6 @@ describe('publisher', () => {
     });
 
     it('publishes job to pg-boss with correct queue and data', async () => {
-      // Verifies: Job is published to pg-boss with correct queue name and data payload
-
-      // Step 1: Setup mock pg-boss
       const mockConnection = getMockDBConnection();
       const sendStub = sinon.stub().resolves('download-job-id');
       const createQueueStub = sinon.stub().resolves();
@@ -489,11 +476,9 @@ describe('publisher', () => {
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
       sinon.stub(DownloadService.prototype, 'findDownloadById').resolves(createMockDownload());
 
-      // Step 2: Call publisher
       const data = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
       const result = await publishProcessDownloadJob(mockConnection, data);
 
-      // Step 3: Verify job was sent to correct queue with correct data
       expect(createQueueStub.calledOnce).to.be.true;
       expect(createQueueStub.firstCall.args[0]).to.equal(JobQueues.PROCESS_DOWNLOAD);
       expect(sendStub.calledOnce).to.be.true;
@@ -504,9 +489,6 @@ describe('publisher', () => {
     });
 
     it('passes db adapter for transactional job insert', async () => {
-      // Verifies: The db option wraps connection.query so the job row is inserted
-      // in the same transaction as the business data (atomic commit/rollback)
-
       const queryStub = sinon.stub().resolves({ rows: [], rowCount: 0 });
       const mockConnection = getMockDBConnection({ query: queryStub });
       const sendStub = sinon.stub().resolves('download-job-id');
@@ -520,30 +502,23 @@ describe('publisher', () => {
         downloadId: 'aaaa0000-0000-0000-0000-000000000001'
       });
 
-      // Verify db adapter is passed to boss.send
       const options = sendStub.firstCall.args[2];
       expect(options.db).to.exist;
       expect(options.db.executeSql).to.be.a('function');
 
-      // Verify the adapter delegates to connection.query
       await options.db.executeSql('SELECT 1', [42]);
       expect(queryStub).to.have.been.calledOnceWith('SELECT 1', [42]);
     });
 
     it('returns duplicate when download is not in pending status', async () => {
-      // Verifies: Publisher returns duplicate status when download is already processing
-
-      // Step 1: Setup mock with download that is already processing
       const mockConnection = getMockDBConnection();
       sinon
         .stub(DownloadService.prototype, 'findDownloadById')
         .resolves(createMockDownload({ download_status: 'processing' }));
 
-      // Step 2: Call publisher
       const data = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
       const result = await publishProcessDownloadJob(mockConnection, data);
 
-      // Step 3: Verify duplicate status returned
       expect(result.status).to.equal('duplicate');
       expect((result as { status: 'duplicate'; message: string }).message).to.equal(
         'Job already exists for this download'
@@ -551,25 +526,17 @@ describe('publisher', () => {
     });
 
     it('returns error when download not found', async () => {
-      // Verifies: Publisher returns error status when download doesn't exist
-
-      // Step 1: Setup mock to return null (not found)
       const mockConnection = getMockDBConnection();
       sinon.stub(DownloadService.prototype, 'findDownloadById').resolves(null);
 
-      // Step 2: Call publisher
       const data = { downloadId: 'aaaa0000-0000-0000-0000-000000000999' };
       const result = await publishProcessDownloadJob(mockConnection, data);
 
-      // Step 3: Verify error status returned
       expect(result.status).to.equal('error');
       expect((result as { status: 'error'; message: string }).message).to.equal('Download not found');
     });
 
     it('uses singletonKey based on downloadId to prevent duplicates', async () => {
-      // Verifies: singletonKey is constructed from downloadId to prevent duplicate concurrent jobs
-
-      // Step 1: Setup mock pg-boss
       const mockConnection = getMockDBConnection();
       const sendStub = sinon.stub().resolves('download-job-id');
       const createQueueStub = sinon.stub().resolves();
@@ -580,20 +547,15 @@ describe('publisher', () => {
         .stub(DownloadService.prototype, 'findDownloadById')
         .resolves(createMockDownload({ download_id: 'aaaa0000-0000-0000-0000-000000000456' }));
 
-      // Step 2: Call publisher
       await publishProcessDownloadJob(mockConnection, {
         downloadId: 'aaaa0000-0000-0000-0000-000000000456'
       });
 
-      // Step 3: Verify singletonKey passed to pg-boss
       const options = sendStub.firstCall.args[2];
       expect(options.singletonKey).to.equal('download-aaaa0000-0000-0000-0000-000000000456');
     });
 
     it('returns duplicate status when send returns null (singleton conflict)', async () => {
-      // Verifies: When pg-boss rejects due to singleton conflict, returns duplicate status
-
-      // Step 1: Setup mock pg-boss to return null (singleton conflict)
       const mockConnection = getMockDBConnection();
       const sendStub = sinon.stub().resolves(null);
       const createQueueStub = sinon.stub().resolves();
@@ -602,12 +564,10 @@ describe('publisher', () => {
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
       sinon.stub(DownloadService.prototype, 'findDownloadById').resolves(createMockDownload());
 
-      // Step 2: Call publisher
       const result = await publishProcessDownloadJob(mockConnection, {
         downloadId: 'aaaa0000-0000-0000-0000-000000000001'
       });
 
-      // Step 3: Verify duplicate status
       expect(result.status).to.equal('duplicate');
       expect((result as { status: 'duplicate'; message: string }).message).to.equal(
         'Job already exists for this download'
@@ -615,20 +575,15 @@ describe('publisher', () => {
     });
 
     it('returns error status when pg-boss throws', async () => {
-      // Verifies: Exceptions from pg-boss are caught and returned as error status
-
-      // Step 1: Setup mock that throws
       const mockConnection = getMockDBConnection();
 
       sinon.stub(DownloadService.prototype, 'findDownloadById').resolves(createMockDownload());
       sinon.stub(pgBossService, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      // Step 2: Call publisher
       const result = await publishProcessDownloadJob(mockConnection, {
         downloadId: 'aaaa0000-0000-0000-0000-000000000001'
       });
 
-      // Step 3: Verify error status
       expect(result.status).to.equal('error');
       expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
     });

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import { DownloadRecord } from '../models/download';
+import { SubmissionUploadRef } from '../models/submission-upload';
 import { SubmissionValidationRecord } from '../models/submission-validation';
 import { DownloadService } from '../services/download/download-service';
 import { SubmissionValidationService } from '../services/submission-validation-service';
@@ -30,13 +31,13 @@ describe('publisher', () => {
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
 
       // No existing validation record
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
 
       const createValidationStub = sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      const data = { uploadId: 'upload-uuid-1', submissionId: 123 };
+      const data: SubmissionUploadRef = { uploadId: 'upload-uuid-1', submissionId: 123 };
       const result = await publishProcessSubmissionFeaturesJob(mockConnection, data);
 
       expect(createQueueStub.calledOnce).to.be.true;
@@ -47,9 +48,9 @@ describe('publisher', () => {
       expect(result.status).to.equal('published');
       expect((result as { status: 'published'; jobId: string }).jobId).to.equal('features-job-id');
 
-      // Verify submission validation was created
+      // Verify submission validation was created with SubmissionUploadRef and jobId
       expect(createValidationStub.calledOnce).to.be.true;
-      expect(createValidationStub.firstCall.args[0]).to.equal(123);
+      expect(createValidationStub.firstCall.args[0]).to.deep.equal(data);
       expect(createValidationStub.firstCall.args[1]).to.equal('features-job-id');
     });
 
@@ -60,7 +61,7 @@ describe('publisher', () => {
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
@@ -81,7 +82,7 @@ describe('publisher', () => {
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
@@ -104,7 +105,7 @@ describe('publisher', () => {
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
 
       const createValidationStub = sinon.stub(SubmissionValidationService.prototype, 'createSubmissionValidation');
 
@@ -127,7 +128,7 @@ describe('publisher', () => {
       const mockBoss = { send: sendStub, createQueue: createQueueStub };
 
       sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
@@ -141,7 +142,7 @@ describe('publisher', () => {
     it('returns error status when pg-boss throws', async () => {
       const mockConnection = getMockDBConnection();
 
-      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId').resolves(null);
+      sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId').resolves(null);
       sinon.stub(pgBossService, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
       const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
@@ -162,7 +163,7 @@ describe('publisher', () => {
         status: 'pending'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
         .resolves(mockValidationRecord);
 
       const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
@@ -187,7 +188,7 @@ describe('publisher', () => {
         status: 'invalid'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
         .resolves(mockInvalidValidationRecord);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')
@@ -211,7 +212,7 @@ describe('publisher', () => {
         status: 'completed'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
         .resolves(mockCompletedRecord);
 
       const result = await publishProcessSubmissionFeaturesJob(mockConnection, {
@@ -236,7 +237,7 @@ describe('publisher', () => {
         status: 'failed'
       };
       sinon
-        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionId')
+        .stub(SubmissionValidationService.prototype, 'getSubmissionValidationByUploadId')
         .resolves(mockFailedValidationRecord);
       sinon
         .stub(SubmissionValidationService.prototype, 'createSubmissionValidation')

--- a/api/src/queue/publisher.ts
+++ b/api/src/queue/publisher.ts
@@ -1,5 +1,6 @@
 import { IDBConnection } from '../database/db';
 import { DownloadStatusEnum } from '../models/download-status';
+import { IngestionJobData } from '../models/submission-upload';
 import { DownloadService } from '../services/download/download-service';
 import { SubmissionValidationService } from '../services/submission-validation-service';
 import { getLogger } from '../utils/logger';
@@ -7,7 +8,6 @@ import { JobQueues } from './jobs';
 import { IIndexSubmissionFeaturesJobData } from './jobs/index-submission-features-job';
 import { IMalwareScanJobData } from './jobs/malware-scan-job';
 import { IProcessDownloadJobData } from './jobs/process-download-job';
-import { SubmissionUploadRef } from '../models/submission-upload';
 import { getPgBoss } from './pg-boss-service';
 
 const defaultLog = getLogger('queue/publisher');
@@ -44,12 +44,16 @@ export type PublishJobResult =
 
 /**
  * Options for process submission features jobs.
- * Shorter timeout since indexing/regions should complete in minutes.
+ *
+ * retryLimit: 0 — no automatic retries. Retries risk processing uploads out of sequence:
+ * a failed job for upload A could retry after upload B has been processed, silently
+ * overwriting newer features with stale data. Users retry explicitly by creating a new
+ * upload (POST).
  */
 const PROCESS_SUBMISSION_FEATURES_OPTIONS: IPublishOptions = {
-  retryLimit: 3,
-  retryDelay: 60,
-  retryBackoff: true,
+  retryLimit: 0,
+  retryDelay: 0,
+  retryBackoff: false,
   expireInSeconds: 60 * 10 // 10 minutes
 };
 
@@ -86,13 +90,13 @@ const PROCESS_DOWNLOAD_OPTIONS: IPublishOptions = {
  * which allows retrying failed jobs.
  *
  * @param {IDBConnection} connection Database connection for submission validation tracking
- * @param {SubmissionUploadRef} data Job data containing submissionId
+ * @param {IngestionJobData} data Job data containing submissionId
  * @param {IPublishOptions} [options={}] Job options
  * @return {*}  {Promise<PublishJobResult>} Result indicating success, blocked, duplicate, or error
  */
 export const publishProcessSubmissionFeaturesJob = async (
   connection: IDBConnection,
-  data: SubmissionUploadRef,
+  data: IngestionJobData,
   options: IPublishOptions = {}
 ): Promise<PublishJobResult> => {
   try {
@@ -133,10 +137,18 @@ export const publishProcessSubmissionFeaturesJob = async (
     // Ensure queue exists before sending jobs
     await boss.createQueue(JobQueues.PROCESS_SUBMISSION_FEATURES);
 
+    const db = {
+      executeSql: async (text: string, values: any[]) => {
+        const result = await connection.query(text, values);
+        return { rows: result.rows, rowCount: result.rowCount };
+      }
+    };
+
     // Use singletonKey to prevent duplicate concurrent jobs for the same submission
     const jobId = await boss.send(JobQueues.PROCESS_SUBMISSION_FEATURES, data, {
       ...mergedOptions,
-      singletonKey: `submission-${data.submissionId}`
+      singletonKey: `submission-${data.submissionId}`,
+      db
     });
 
     // jobId is null when pg-boss rejects the job (e.g., duplicate singletonKey still active)

--- a/api/src/queue/publisher.ts
+++ b/api/src/queue/publisher.ts
@@ -7,7 +7,7 @@ import { JobQueues } from './jobs';
 import { IIndexSubmissionFeaturesJobData } from './jobs/index-submission-features-job';
 import { IMalwareScanJobData } from './jobs/malware-scan-job';
 import { IProcessDownloadJobData } from './jobs/process-download-job';
-import { IProcessSubmissionFeaturesJobData } from './jobs/process-submission-features-job';
+import { SubmissionUploadRef } from '../models/submission-upload';
 import { getPgBoss } from './pg-boss-service';
 
 const defaultLog = getLogger('queue/publisher');
@@ -86,22 +86,20 @@ const PROCESS_DOWNLOAD_OPTIONS: IPublishOptions = {
  * which allows retrying failed jobs.
  *
  * @param {IDBConnection} connection Database connection for submission validation tracking
- * @param {IProcessSubmissionFeaturesJobData} data Job data containing submissionId
+ * @param {SubmissionUploadRef} data Job data containing submissionId
  * @param {IPublishOptions} [options={}] Job options
  * @return {*}  {Promise<PublishJobResult>} Result indicating success, blocked, duplicate, or error
  */
 export const publishProcessSubmissionFeaturesJob = async (
   connection: IDBConnection,
-  data: IProcessSubmissionFeaturesJobData,
+  data: SubmissionUploadRef,
   options: IPublishOptions = {}
 ): Promise<PublishJobResult> => {
   try {
     const submissionValidationService = new SubmissionValidationService(connection);
 
-    // Check for existing validation record
-    const existingValidation = await submissionValidationService.getSubmissionValidationBySubmissionId(
-      data.submissionId
-    );
+    // Check for existing validation record by upload ID
+    const existingValidation = await submissionValidationService.getSubmissionValidationByUploadId(data.uploadId);
 
     if (existingValidation) {
       // Only allow retry if status is 'failed' or 'invalid'
@@ -144,7 +142,7 @@ export const publishProcessSubmissionFeaturesJob = async (
     // jobId is null when pg-boss rejects the job (e.g., duplicate singletonKey still active)
     if (jobId) {
       // Create submission validation record for tracking
-      await submissionValidationService.createSubmissionValidation(data.submissionId, jobId);
+      await submissionValidationService.createSubmissionValidation(data, jobId);
 
       defaultLog.info({
         label: 'publishProcessSubmissionFeaturesJob',

--- a/api/src/queue/publisher.ts
+++ b/api/src/queue/publisher.ts
@@ -1,6 +1,6 @@
 import { IDBConnection } from '../database/db';
 import { DownloadStatusEnum } from '../models/download-status';
-import { IngestionJobData } from '../models/submission-upload';
+import { SubmissionUpload } from '../models/submission-upload';
 import { DownloadService } from '../services/download/download-service';
 import { SubmissionValidationService } from '../services/submission-validation-service';
 import { getLogger } from '../utils/logger';
@@ -45,15 +45,13 @@ export type PublishJobResult =
 /**
  * Options for process submission features jobs.
  *
- * retryLimit: 0 — no automatic retries. Retries risk processing uploads out of sequence:
- * a failed job for upload A could retry after upload B has been processed, silently
- * overwriting newer features with stale data. Users retry explicitly by creating a new
- * upload (POST).
+ * Singleton key is per-submission, so retries cannot interleave with a newer upload's job —
+ * pg-boss won't dequeue a new job for the same singleton key while the current one is active.
  */
 const PROCESS_SUBMISSION_FEATURES_OPTIONS: IPublishOptions = {
-  retryLimit: 0,
-  retryDelay: 0,
-  retryBackoff: false,
+  retryLimit: 2,
+  retryDelay: 60,
+  retryBackoff: true,
   expireInSeconds: 60 * 10 // 10 minutes
 };
 
@@ -89,21 +87,30 @@ const PROCESS_DOWNLOAD_OPTIONS: IPublishOptions = {
  * Blocks if an existing validation record exists unless status is 'failed',
  * which allows retrying failed jobs.
  *
+ * Caller provides the pre-resolved submission_upload bridge record — avoids
+ * redundant lookups since the caller (ArtifactSecurityService) already has it.
+ * Singleton key is per-submission (not per-upload) to prevent concurrent jobs for the
+ * same submission — two uploads must serialize to avoid conflicting feature writes.
+ *
  * @param {IDBConnection} connection Database connection for submission validation tracking
- * @param {IngestionJobData} data Job data containing submissionId
+ * @param {SubmissionUpload} submissionUpload Pre-resolved bridge record
  * @param {IPublishOptions} [options={}] Job options
  * @return {*}  {Promise<PublishJobResult>} Result indicating success, blocked, duplicate, or error
  */
 export const publishProcessSubmissionFeaturesJob = async (
   connection: IDBConnection,
-  data: IngestionJobData,
+  submissionUpload: SubmissionUpload,
   options: IPublishOptions = {}
 ): Promise<PublishJobResult> => {
+  const { submission_upload_id: submissionUploadId, submission_id: submissionId } = submissionUpload;
+
   try {
     const submissionValidationService = new SubmissionValidationService(connection);
 
-    // Check for existing validation record by upload ID
-    const existingValidation = await submissionValidationService.getSubmissionValidationByUploadId(data.uploadId);
+    // Check for existing validation record by submission_upload_id
+    const existingValidation = await submissionValidationService.getSubmissionValidationBySubmissionUploadId(
+      submissionUploadId
+    );
 
     if (existingValidation) {
       // Only allow retry if status is 'failed' or 'invalid'
@@ -111,7 +118,7 @@ export const publishProcessSubmissionFeaturesJob = async (
         defaultLog.warn({
           label: 'publishProcessSubmissionFeaturesJob',
           message: 'Blocked: validation record already exists',
-          submissionId: data.submissionId,
+          submissionUploadId,
           existingStatus: existingValidation.status,
           existingJobId: existingValidation.job_id
         });
@@ -126,7 +133,7 @@ export const publishProcessSubmissionFeaturesJob = async (
       defaultLog.info({
         label: 'publishProcessSubmissionFeaturesJob',
         message: 'Retrying failed validation',
-        submissionId: data.submissionId,
+        submissionUploadId,
         previousJobId: existingValidation.job_id
       });
     }
@@ -144,23 +151,26 @@ export const publishProcessSubmissionFeaturesJob = async (
       }
     };
 
+    // Full bridge record travels through the queue — handler uses it directly
+    const jobData: SubmissionUpload = submissionUpload;
+
     // Use singletonKey to prevent duplicate concurrent jobs for the same submission
-    const jobId = await boss.send(JobQueues.PROCESS_SUBMISSION_FEATURES, data, {
+    const jobId = await boss.send(JobQueues.PROCESS_SUBMISSION_FEATURES, jobData, {
       ...mergedOptions,
-      singletonKey: `submission-${data.submissionId}`,
+      singletonKey: `submission-${submissionId}`,
       db
     });
 
     // jobId is null when pg-boss rejects the job (e.g., duplicate singletonKey still active)
     if (jobId) {
       // Create submission validation record for tracking
-      await submissionValidationService.createSubmissionValidation(data, jobId);
+      await submissionValidationService.createSubmissionValidation(submissionUploadId, submissionId, jobId);
 
       defaultLog.info({
         label: 'publishProcessSubmissionFeaturesJob',
         message: 'Process submission features job published',
         jobId,
-        submissionId: data.submissionId
+        submissionUploadId
       });
 
       return { status: 'published', jobId };
@@ -168,7 +178,7 @@ export const publishProcessSubmissionFeaturesJob = async (
       defaultLog.warn({
         label: 'publishProcessSubmissionFeaturesJob',
         message: 'Job not published (duplicate or throttled)',
-        submissionId: data.submissionId
+        submissionUploadId
       });
 
       return { status: 'duplicate', message: 'Job already exists for this submission' };
@@ -179,7 +189,7 @@ export const publishProcessSubmissionFeaturesJob = async (
     defaultLog.error({
       label: 'publishProcessSubmissionFeaturesJob',
       message: 'Failed to publish job',
-      submissionId: data.submissionId,
+      submissionUploadId,
       error
     });
 

--- a/api/src/queue/publisher.ts
+++ b/api/src/queue/publisher.ts
@@ -45,7 +45,7 @@ export type PublishJobResult =
 /**
  * Options for process submission features jobs.
  *
- * Singleton key is per-submission, so retries cannot interleave with a newer upload's job —
+ * Singleton key is per-submission
  * pg-boss won't dequeue a new job for the same singleton key while the current one is active.
  */
 const PROCESS_SUBMISSION_FEATURES_OPTIONS: IPublishOptions = {

--- a/api/src/queue/worker.test.ts
+++ b/api/src/queue/worker.test.ts
@@ -74,12 +74,11 @@ describe('worker', () => {
       await registerWorkers();
 
       // Second createQueue call (PROCESS_SUBMISSION_FEATURES) should have DLQ config
-      // retryLimit: 0 — no automatic retries for ingestion jobs (AC #7)
       // policy: 'short' — enforces singletonKey uniqueness for queued jobs
       const queueConfig = createQueueStub.secondCall.args[1];
       expect(queueConfig.deadLetter).to.equal(JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED);
-      expect(queueConfig.retryLimit).to.equal(0);
-      expect(queueConfig.retryBackoff).to.equal(false);
+      expect(queueConfig.retryLimit).to.equal(2);
+      expect(queueConfig.retryBackoff).to.equal(true);
       expect(queueConfig.policy).to.equal('short');
     });
 

--- a/api/src/queue/worker.test.ts
+++ b/api/src/queue/worker.test.ts
@@ -74,10 +74,13 @@ describe('worker', () => {
       await registerWorkers();
 
       // Second createQueue call (PROCESS_SUBMISSION_FEATURES) should have DLQ config
+      // retryLimit: 0 — no automatic retries for ingestion jobs (AC #7)
+      // policy: 'short' — enforces singletonKey uniqueness for queued jobs
       const queueConfig = createQueueStub.secondCall.args[1];
       expect(queueConfig.deadLetter).to.equal(JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED);
-      expect(queueConfig.retryLimit).to.equal(2);
-      expect(queueConfig.retryBackoff).to.equal(true);
+      expect(queueConfig.retryLimit).to.equal(0);
+      expect(queueConfig.retryBackoff).to.equal(false);
+      expect(queueConfig.policy).to.equal('short');
     });
 
     it('registers dead letter queue handler for failed jobs', async () => {

--- a/api/src/queue/worker.ts
+++ b/api/src/queue/worker.ts
@@ -1,3 +1,4 @@
+import { IngestionJobData } from '../models/submission-upload';
 import { getLogger } from '../utils/logger';
 import { JobQueues } from './jobs';
 import {
@@ -15,7 +16,6 @@ import {
   processSubmissionFeaturesFailedHandler,
   processSubmissionFeaturesJobHandler
 } from './jobs/process-submission-features-job';
-import { SubmissionUploadRef } from '../models/submission-upload';
 import { getPgBoss } from './pg-boss-service';
 
 const defaultLog = getLogger('queue/worker');
@@ -33,12 +33,15 @@ export const registerWorkers = async (): Promise<void> => {
   // Create dead letter queue first (must exist before main queue references it)
   await boss.createQueue(JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED);
 
-  // Create main queue with dead letter queue and retry configuration
+  // Create main queue with dead letter queue and retry configuration.
+  // policy: 'short' — enforces singleton_key uniqueness for queued (created) jobs.
+  // Without this, the default 'standard' policy ignores singletonKey entirely.
   await boss.createQueue(JobQueues.PROCESS_SUBMISSION_FEATURES, {
     deadLetter: JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED,
-    retryLimit: 2,
-    retryDelay: 60,
-    retryBackoff: true
+    retryLimit: 0,
+    retryDelay: 0,
+    retryBackoff: false,
+    policy: 'short'
   });
 
   // Create dead letter queue first (must exist before main queue references it)
@@ -52,13 +55,10 @@ export const registerWorkers = async (): Promise<void> => {
   });
 
   // Register process submission features job handler
-  await boss.work<SubmissionUploadRef>(
-    JobQueues.PROCESS_SUBMISSION_FEATURES,
-    processSubmissionFeaturesJobHandler
-  );
+  await boss.work<IngestionJobData>(JobQueues.PROCESS_SUBMISSION_FEATURES, processSubmissionFeaturesJobHandler);
 
   // Register dead letter queue handler for failed jobs
-  await boss.work<SubmissionUploadRef>(
+  await boss.work<IngestionJobData>(
     JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED,
     processSubmissionFeaturesFailedHandler
   );

--- a/api/src/queue/worker.ts
+++ b/api/src/queue/worker.ts
@@ -1,4 +1,4 @@
-import { IngestionJobData } from '../models/submission-upload';
+import { SubmissionUpload } from '../models/submission-upload';
 import { getLogger } from '../utils/logger';
 import { JobQueues } from './jobs';
 import {
@@ -38,9 +38,9 @@ export const registerWorkers = async (): Promise<void> => {
   // Without this, the default 'standard' policy ignores singletonKey entirely.
   await boss.createQueue(JobQueues.PROCESS_SUBMISSION_FEATURES, {
     deadLetter: JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED,
-    retryLimit: 0,
-    retryDelay: 0,
-    retryBackoff: false,
+    retryLimit: 2,
+    retryDelay: 60,
+    retryBackoff: true,
     policy: 'short'
   });
 
@@ -55,10 +55,10 @@ export const registerWorkers = async (): Promise<void> => {
   });
 
   // Register process submission features job handler
-  await boss.work<IngestionJobData>(JobQueues.PROCESS_SUBMISSION_FEATURES, processSubmissionFeaturesJobHandler);
+  await boss.work<SubmissionUpload>(JobQueues.PROCESS_SUBMISSION_FEATURES, processSubmissionFeaturesJobHandler);
 
   // Register dead letter queue handler for failed jobs
-  await boss.work<IngestionJobData>(
+  await boss.work<SubmissionUpload>(
     JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED,
     processSubmissionFeaturesFailedHandler
   );

--- a/api/src/queue/worker.ts
+++ b/api/src/queue/worker.ts
@@ -12,10 +12,10 @@ import {
   processDownloadJobHandler
 } from './jobs/process-download-job';
 import {
-  IProcessSubmissionFeaturesJobData,
   processSubmissionFeaturesFailedHandler,
   processSubmissionFeaturesJobHandler
 } from './jobs/process-submission-features-job';
+import { SubmissionUploadRef } from '../models/submission-upload';
 import { getPgBoss } from './pg-boss-service';
 
 const defaultLog = getLogger('queue/worker');
@@ -52,13 +52,13 @@ export const registerWorkers = async (): Promise<void> => {
   });
 
   // Register process submission features job handler
-  await boss.work<IProcessSubmissionFeaturesJobData>(
+  await boss.work<SubmissionUploadRef>(
     JobQueues.PROCESS_SUBMISSION_FEATURES,
     processSubmissionFeaturesJobHandler
   );
 
   // Register dead letter queue handler for failed jobs
-  await boss.work<IProcessSubmissionFeaturesJobData>(
+  await boss.work<SubmissionUploadRef>(
     JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED,
     processSubmissionFeaturesFailedHandler
   );

--- a/api/src/repositories/ingestion/ingestion-repository.test.ts
+++ b/api/src/repositories/ingestion/ingestion-repository.test.ts
@@ -85,10 +85,10 @@ describe('IngestionRepository', () => {
     });
   });
 
-  describe('deleteSubmissionFeaturesByUploadId', () => {
-    it('should scope WHERE by upload_id', async () => {
+  describe('deleteSubmissionFeaturesBySubmissionUploadId', () => {
+    it('should scope WHERE by submission_upload_id', async () => {
       const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
-        expect(sqlStatement.text).to.include('upload_id');
+        expect(sqlStatement.text).to.include('submission_upload_id');
         expect(sqlStatement.text).to.include('record_end_date IS NULL');
         return Promise.resolve({ rowCount: 2, rows: [], command: '', oid: 0, fields: [] });
       });
@@ -96,7 +96,7 @@ describe('IngestionRepository', () => {
 
       const ingestionRepository = new IngestionRepository(mockDBConnection);
 
-      await ingestionRepository.deleteSubmissionFeaturesByUploadId('550e8400-e29b-41d4-a716-446655440000');
+      await ingestionRepository.deleteSubmissionFeaturesBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
 
       expect(sqlStub).to.have.been.calledOnce;
     });

--- a/api/src/repositories/ingestion/ingestion-repository.test.ts
+++ b/api/src/repositories/ingestion/ingestion-repository.test.ts
@@ -85,6 +85,23 @@ describe('IngestionRepository', () => {
     });
   });
 
+  describe('deleteSubmissionFeaturesByUploadId', () => {
+    it('should scope WHERE by upload_id', async () => {
+      const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
+        expect(sqlStatement.text).to.include('upload_id');
+        expect(sqlStatement.text).to.include('record_end_date IS NULL');
+        return Promise.resolve({ rowCount: 2, rows: [], command: '', oid: 0, fields: [] });
+      });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const ingestionRepository = new IngestionRepository(mockDBConnection);
+
+      await ingestionRepository.deleteSubmissionFeaturesByUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      expect(sqlStub).to.have.been.calledOnce;
+    });
+  });
+
   describe('deleteSubmissionFeatures', () => {
     it('should soft delete all submission features for a submission', async () => {
       const mockQueryResponse: QueryResult<never> = {

--- a/api/src/repositories/ingestion/ingestion-repository.ts
+++ b/api/src/repositories/ingestion/ingestion-repository.ts
@@ -90,6 +90,8 @@ export class IngestionRepository extends BaseRepository {
   }
 
   /**
+   * Soft-deletes features for a specific upload only.
+   * Multiple uploads produce features under the same submission_id.
    * Delete all submission features for a submission (soft delete).
    * Used for idempotency - allows job retries to start fresh.
    *

--- a/api/src/repositories/ingestion/ingestion-repository.ts
+++ b/api/src/repositories/ingestion/ingestion-repository.ts
@@ -90,8 +90,26 @@ export class IngestionRepository extends BaseRepository {
   }
 
   /**
-   * Soft-deletes features for a specific upload only.
-   * Multiple uploads produce features under the same submission_id.
+   * Soft-delete features scoped to a specific upload.
+   * Multiple uploads produce features under the same submission_id;
+   * re-ingesting one upload must not affect features from other uploads.
+   *
+   * @param {string} uploadId The upload ID (UUID).
+   * @return {Promise<void>}
+   * @memberof IngestionRepository
+   */
+  async deleteSubmissionFeaturesByUploadId(uploadId: string): Promise<void> {
+    const sqlStatement = SQL`
+      UPDATE submission_feature
+      SET record_end_date = NOW()
+      WHERE upload_id = ${uploadId}
+        AND record_end_date IS NULL;
+    `;
+
+    await this.connection.sql(sqlStatement);
+  }
+
+  /**
    * Delete all submission features for a submission (soft delete).
    * Used for idempotency - allows job retries to start fresh.
    *

--- a/api/src/repositories/ingestion/ingestion-repository.ts
+++ b/api/src/repositories/ingestion/ingestion-repository.ts
@@ -15,9 +15,12 @@ import { ISubmissionFeature } from '../submission-repository';
 export class IngestionRepository extends BaseRepository {
   /**
    * Insert a new submission feature record.
+   * Features belong to a submission (submission_id) but are produced by a specific
+   * upload event (submission_upload_id). This distinction enables multi-upload-per-submission
+   * (append, replace).
    *
    * @param {number} submissionId The ID of the submission.
-   * @param {string} uploadId The ID of the upload that produced these features.
+   * @param {string} submissionUploadId The submission_upload_id that produced these features.
    * @param {(number | null)} parentSubmissionFeatureId The ID of the parent submission feature, or null.
    * @param {(string | null)} featureSourceId The source ID of the feature, or null.
    * @param {string} featureTypeName The name of the feature type.
@@ -28,7 +31,7 @@ export class IngestionRepository extends BaseRepository {
    */
   async insertSubmissionFeatureRecord(
     submissionId: number,
-    uploadId: string,
+    submissionUploadId: string,
     parentSubmissionFeatureId: number | null,
     featureSourceId: string | null,
     featureTypeName: string,
@@ -38,7 +41,7 @@ export class IngestionRepository extends BaseRepository {
     const sqlStatement = SQL`
       INSERT INTO submission_feature (
         submission_id,
-        upload_id,
+        submission_upload_id,
         parent_submission_feature_id,
         source_id,
         feature_type_id,
@@ -47,7 +50,7 @@ export class IngestionRepository extends BaseRepository {
         record_effective_date
       ) VALUES (
         ${submissionId},
-        ${uploadId},
+        ${submissionUploadId},
         ${parentSubmissionFeatureId},
         ${featureSourceId},
         (SELECT feature_type_id FROM feature_type WHERE name = ${featureTypeName}),
@@ -90,19 +93,19 @@ export class IngestionRepository extends BaseRepository {
   }
 
   /**
-   * Soft-delete features scoped to a specific upload.
+   * Soft-delete features scoped to a specific upload event.
    * Multiple uploads produce features under the same submission_id;
    * re-ingesting one upload must not affect features from other uploads.
    *
-   * @param {string} uploadId The upload ID (UUID).
+   * @param {string} submissionUploadId The submission_upload_id (UUID).
    * @return {Promise<void>}
    * @memberof IngestionRepository
    */
-  async deleteSubmissionFeaturesByUploadId(uploadId: string): Promise<void> {
+  async deleteSubmissionFeaturesBySubmissionUploadId(submissionUploadId: string): Promise<void> {
     const sqlStatement = SQL`
       UPDATE submission_feature
       SET record_end_date = NOW()
-      WHERE upload_id = ${uploadId}
+      WHERE submission_upload_id = ${submissionUploadId}
         AND record_end_date IS NULL;
     `;
 

--- a/api/src/repositories/submission-repository.ts
+++ b/api/src/repositories/submission-repository.ts
@@ -395,9 +395,12 @@ export class SubmissionRepository extends BaseRepository {
 
   /**
    * Insert a new submission feature record.
+   * Features belong to a submission (submission_id) but are produced by a specific
+   * upload event (submission_upload_id). This distinction enables multi-upload-per-submission
+   * (append, replace).
    *
    * @param {number} submissionId The ID of the submission.
-   * @param {string} uploadId The ID of the upload that produced these features.
+   * @param {string} submissionUploadId The submission_upload_id that produced these features.
    * @param {(number | null)} parentSubmissionFeatureId The ID of the parent submission feature, or null.
    * @param {(string | null)} featureSourceId The source ID of the feature, or null.
    * @param {string} featureTypeName The name of the feature type.
@@ -407,7 +410,7 @@ export class SubmissionRepository extends BaseRepository {
    */
   async insertSubmissionFeatureRecord(
     submissionId: number,
-    uploadId: string,
+    submissionUploadId: string,
     parentSubmissionFeatureId: number | null,
     featureSourceId: string | null,
     featureTypeName: string,
@@ -416,7 +419,7 @@ export class SubmissionRepository extends BaseRepository {
     const sqlStatement = SQL`
       INSERT INTO submission_feature (
         submission_id,
-        upload_id,
+        submission_upload_id,
         parent_submission_feature_id,
         source_id,
         feature_type_id,
@@ -424,7 +427,7 @@ export class SubmissionRepository extends BaseRepository {
         record_effective_date
       ) VALUES (
         ${submissionId},
-        ${uploadId},
+        ${submissionUploadId},
         ${parentSubmissionFeatureId},
         ${featureSourceId},
         (SELECT feature_type_id FROM feature_type WHERE name = ${featureTypeName}),

--- a/api/src/repositories/submission-validation-repository.test.ts
+++ b/api/src/repositories/submission-validation-repository.test.ts
@@ -3,7 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { SubmissionUploadRef } from '../models/submission-upload';
+import { IngestionJobData } from '../models/submission-upload';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SubmissionValidationRepository } from './submission-validation-repository';
 
@@ -27,7 +27,7 @@ describe('SubmissionValidationRepository', () => {
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      const upload: SubmissionUploadRef = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
+      const upload: IngestionJobData = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
       const result = await repository.createSubmissionValidation(upload, '123e4567-e89b-12d3-a456-426614174000');
 
       expect(result).to.eql({ submission_validation_id: 1 });
@@ -49,7 +49,7 @@ describe('SubmissionValidationRepository', () => {
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      const upload: SubmissionUploadRef = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
+      const upload: IngestionJobData = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
       await repository.createSubmissionValidation(upload, '123e4567-e89b-12d3-a456-426614174000');
 
       expect(sqlStub.calledOnce).to.be.true;

--- a/api/src/repositories/submission-validation-repository.test.ts
+++ b/api/src/repositories/submission-validation-repository.test.ts
@@ -3,6 +3,7 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { SubmissionUploadRef } from '../models/submission-upload';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SubmissionValidationRepository } from './submission-validation-repository';
 
@@ -26,9 +27,81 @@ describe('SubmissionValidationRepository', () => {
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      const result = await repository.createSubmissionValidation(1, '123e4567-e89b-12d3-a456-426614174000');
+      const upload: SubmissionUploadRef = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
+      const result = await repository.createSubmissionValidation(upload, '123e4567-e89b-12d3-a456-426614174000');
 
       expect(result).to.eql({ submission_validation_id: 1 });
+    });
+
+    it('should insert using both upload_id and submission_id columns', async () => {
+      const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
+        expect(sqlStatement.text).to.include('upload_id');
+        expect(sqlStatement.text).to.include('submission_id');
+        return Promise.resolve({
+          rowCount: 1,
+          rows: [{ submission_validation_id: 1 }],
+          command: '',
+          oid: 0,
+          fields: []
+        });
+      });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repository = new SubmissionValidationRepository(mockDBConnection);
+
+      const upload: SubmissionUploadRef = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
+      await repository.createSubmissionValidation(upload, '123e4567-e89b-12d3-a456-426614174000');
+
+      expect(sqlStub.calledOnce).to.be.true;
+    });
+  });
+
+  describe('getSubmissionValidationByUploadId', () => {
+    it('should return the most recent validation record for an upload', async () => {
+      const mockRecord = { submission_validation_id: 5, job_id: 'job-uuid', status: 'completed' };
+
+      const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
+        expect(sqlStatement.text).to.include('upload_id');
+        return Promise.resolve({ rowCount: 1, rows: [mockRecord], command: '', oid: 0, fields: [] });
+      });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repository = new SubmissionValidationRepository(mockDBConnection);
+
+      const result = await repository.getSubmissionValidationByUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      expect(result).to.deep.equal(mockRecord);
+      expect(sqlStub.calledOnce).to.be.true;
+    });
+
+    it('should return null when no validation record exists for the upload', async () => {
+      const mockDBConnection = getMockDBConnection({
+        sql: async () => ({ rowCount: 0, rows: [], command: '', oid: 0, fields: [] } as any)
+      });
+
+      const repository = new SubmissionValidationRepository(mockDBConnection);
+
+      const result = await repository.getSubmissionValidationByUploadId('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+
+      expect(result).to.be.null;
+    });
+  });
+
+  describe('updateSubmissionValidationStatusByUploadId', () => {
+    it('should update the most recent validation record using upload_id subquery', async () => {
+      const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
+        expect(sqlStatement.text).to.include('upload_id');
+        return Promise.resolve({ rowCount: 1, rows: [], command: '', oid: 0, fields: [] });
+      });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repository = new SubmissionValidationRepository(mockDBConnection);
+
+      await repository.updateSubmissionValidationStatusByUploadId('550e8400-e29b-41d4-a716-446655440000', 'failed', {
+        error: 'timeout'
+      });
+
+      expect(sqlStub.calledOnce).to.be.true;
     });
   });
 

--- a/api/src/repositories/submission-validation-repository.test.ts
+++ b/api/src/repositories/submission-validation-repository.test.ts
@@ -3,7 +3,6 @@ import { describe } from 'mocha';
 import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { IngestionJobData } from '../models/submission-upload';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SubmissionValidationRepository } from './submission-validation-repository';
 
@@ -27,15 +26,18 @@ describe('SubmissionValidationRepository', () => {
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      const upload: IngestionJobData = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
-      const result = await repository.createSubmissionValidation(upload, '123e4567-e89b-12d3-a456-426614174000');
+      const result = await repository.createSubmissionValidation(
+        '550e8400-e29b-41d4-a716-446655440000',
+        1,
+        '123e4567-e89b-12d3-a456-426614174000'
+      );
 
       expect(result).to.eql({ submission_validation_id: 1 });
     });
 
-    it('should insert using both upload_id and submission_id columns', async () => {
+    it('should insert using submission_upload_id and submission_id columns', async () => {
       const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
-        expect(sqlStatement.text).to.include('upload_id');
+        expect(sqlStatement.text).to.include('submission_upload_id');
         expect(sqlStatement.text).to.include('submission_id');
         return Promise.resolve({
           rowCount: 1,
@@ -49,57 +51,66 @@ describe('SubmissionValidationRepository', () => {
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      const upload: IngestionJobData = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 1 };
-      await repository.createSubmissionValidation(upload, '123e4567-e89b-12d3-a456-426614174000');
+      await repository.createSubmissionValidation(
+        '550e8400-e29b-41d4-a716-446655440000',
+        1,
+        '123e4567-e89b-12d3-a456-426614174000'
+      );
 
       expect(sqlStub.calledOnce).to.be.true;
     });
   });
 
-  describe('getSubmissionValidationByUploadId', () => {
-    it('should return the most recent validation record for an upload', async () => {
+  describe('getSubmissionValidationBySubmissionUploadId', () => {
+    it('should return the most recent validation record for a submission upload', async () => {
       const mockRecord = { submission_validation_id: 5, job_id: 'job-uuid', status: 'completed' };
 
       const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
-        expect(sqlStatement.text).to.include('upload_id');
+        expect(sqlStatement.text).to.include('submission_upload_id');
         return Promise.resolve({ rowCount: 1, rows: [mockRecord], command: '', oid: 0, fields: [] });
       });
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      const result = await repository.getSubmissionValidationByUploadId('550e8400-e29b-41d4-a716-446655440000');
+      const result = await repository.getSubmissionValidationBySubmissionUploadId(
+        '550e8400-e29b-41d4-a716-446655440000'
+      );
 
       expect(result).to.deep.equal(mockRecord);
       expect(sqlStub.calledOnce).to.be.true;
     });
 
-    it('should return null when no validation record exists for the upload', async () => {
+    it('should return null when no validation record exists', async () => {
       const mockDBConnection = getMockDBConnection({
         sql: async () => ({ rowCount: 0, rows: [], command: '', oid: 0, fields: [] } as any)
       });
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      const result = await repository.getSubmissionValidationByUploadId('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+      const result = await repository.getSubmissionValidationBySubmissionUploadId(
+        'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      );
 
       expect(result).to.be.null;
     });
   });
 
-  describe('updateSubmissionValidationStatusByUploadId', () => {
-    it('should update the most recent validation record using upload_id subquery', async () => {
+  describe('updateSubmissionValidationStatusBySubmissionUploadId', () => {
+    it('should update the most recent validation record using submission_upload_id subquery', async () => {
       const sqlStub = sinon.stub().callsFake((sqlStatement: { text: string }) => {
-        expect(sqlStatement.text).to.include('upload_id');
+        expect(sqlStatement.text).to.include('submission_upload_id');
         return Promise.resolve({ rowCount: 1, rows: [], command: '', oid: 0, fields: [] });
       });
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
 
       const repository = new SubmissionValidationRepository(mockDBConnection);
 
-      await repository.updateSubmissionValidationStatusByUploadId('550e8400-e29b-41d4-a716-446655440000', 'failed', {
-        error: 'timeout'
-      });
+      await repository.updateSubmissionValidationStatusBySubmissionUploadId(
+        '550e8400-e29b-41d4-a716-446655440000',
+        'failed',
+        { error: 'timeout' }
+      );
 
       expect(sqlStub.calledOnce).to.be.true;
     });

--- a/api/src/repositories/submission-validation-repository.ts
+++ b/api/src/repositories/submission-validation-repository.ts
@@ -1,5 +1,4 @@
 import SQL from 'sql-template-strings';
-import { IngestionJobData } from '../models/submission-upload';
 import {
   SubmissionValidationId,
   SubmissionValidationRecord,
@@ -16,21 +15,23 @@ import { BaseRepository } from './base-repository';
  */
 export class SubmissionValidationRepository extends BaseRepository {
   /**
-   * Create a new submission validation record keyed by upload_id.
-   * Each upload gets its own validation record to track ingestion status independently.
+   * Create a new submission validation record keyed by submission_upload_id.
+   * Each upload event gets its own validation record to track ingestion status independently.
    *
-   * @param {IngestionJobData} upload - The upload and submission identifiers.
+   * @param {string} submissionUploadId - The submission_upload_id (UUID).
+   * @param {number} submissionId - The submission ID.
    * @param {string} jobId - The pg-boss job UUID.
    * @return {Promise<{ submission_validation_id: number }>} The created record ID.
    * @memberof SubmissionValidationRepository
    */
   async createSubmissionValidation(
-    upload: IngestionJobData,
+    submissionUploadId: string,
+    submissionId: number,
     jobId: string
   ): Promise<{ submission_validation_id: number }> {
     const sql = SQL`
-      INSERT INTO submission_validation (upload_id, submission_id, job_id, status)
-      VALUES (${upload.uploadId}::uuid, ${upload.submissionId}, ${jobId}::uuid, 'pending')
+      INSERT INTO submission_validation (submission_upload_id, submission_id, job_id, status)
+      VALUES (${submissionUploadId}::uuid, ${submissionId}, ${jobId}::uuid, 'pending')
       RETURNING submission_validation_id;
     `;
 
@@ -70,17 +71,19 @@ export class SubmissionValidationRepository extends BaseRepository {
   }
 
   /**
-   * Get the most recent submission validation record for an upload.
+   * Get the most recent submission validation record for a submission upload.
    *
-   * @param {string} uploadId - The upload ID (UUID).
+   * @param {string} submissionUploadId - The submission_upload_id (UUID).
    * @return {Promise<SubmissionValidationRecord | null>}
    * @memberof SubmissionValidationRepository
    */
-  async getSubmissionValidationByUploadId(uploadId: string): Promise<SubmissionValidationRecord | null> {
+  async getSubmissionValidationBySubmissionUploadId(
+    submissionUploadId: string
+  ): Promise<SubmissionValidationRecord | null> {
     const sql = SQL`
       SELECT submission_validation_id, job_id, status
       FROM submission_validation
-      WHERE upload_id = ${uploadId}::uuid
+      WHERE submission_upload_id = ${submissionUploadId}::uuid
       ORDER BY create_date DESC
       LIMIT 1;
     `;
@@ -91,19 +94,19 @@ export class SubmissionValidationRepository extends BaseRepository {
   }
 
   /**
-   * Update the most recent submission validation status by upload ID.
+   * Update the most recent submission validation status by submission_upload_id.
    *
    * Used by Dead Letter Queue handler where the original job ID is not available.
    * Scoped to the latest record so manual retries don't corrupt historical records.
    *
-   * @param {string} uploadId - The upload ID (UUID).
+   * @param {string} submissionUploadId - The submission_upload_id (UUID).
    * @param {SubmissionValidationStatus} status - The new status.
    * @param {Record<string, unknown>} [metadata] - Optional metadata (e.g., error details).
    * @return {Promise<void>}
    * @memberof SubmissionValidationRepository
    */
-  async updateSubmissionValidationStatusByUploadId(
-    uploadId: string,
+  async updateSubmissionValidationStatusBySubmissionUploadId(
+    submissionUploadId: string,
     status: SubmissionValidationStatus,
     metadata?: Record<string, unknown>
   ): Promise<void> {
@@ -116,7 +119,7 @@ export class SubmissionValidationRepository extends BaseRepository {
       WHERE submission_validation_id = (
         SELECT submission_validation_id
         FROM submission_validation
-        WHERE upload_id = ${uploadId}::uuid
+        WHERE submission_upload_id = ${submissionUploadId}::uuid
         ORDER BY create_date DESC
         LIMIT 1
       );

--- a/api/src/repositories/submission-validation-repository.ts
+++ b/api/src/repositories/submission-validation-repository.ts
@@ -1,5 +1,5 @@
 import SQL from 'sql-template-strings';
-import { SubmissionUploadRef } from '../models/submission-upload';
+import { IngestionJobData } from '../models/submission-upload';
 import {
   SubmissionValidationId,
   SubmissionValidationRecord,
@@ -19,13 +19,13 @@ export class SubmissionValidationRepository extends BaseRepository {
    * Create a new submission validation record keyed by upload_id.
    * Each upload gets its own validation record to track ingestion status independently.
    *
-   * @param {SubmissionUploadRef} upload - The upload and submission identifiers.
+   * @param {IngestionJobData} upload - The upload and submission identifiers.
    * @param {string} jobId - The pg-boss job UUID.
    * @return {Promise<{ submission_validation_id: number }>} The created record ID.
    * @memberof SubmissionValidationRepository
    */
   async createSubmissionValidation(
-    upload: SubmissionUploadRef,
+    upload: IngestionJobData,
     jobId: string
   ): Promise<{ submission_validation_id: number }> {
     const sql = SQL`

--- a/api/src/repositories/submission-validation-repository.ts
+++ b/api/src/repositories/submission-validation-repository.ts
@@ -1,4 +1,5 @@
 import SQL from 'sql-template-strings';
+import { SubmissionUploadRef } from '../models/submission-upload';
 import {
   SubmissionValidationId,
   SubmissionValidationRecord,
@@ -15,17 +16,21 @@ import { BaseRepository } from './base-repository';
  */
 export class SubmissionValidationRepository extends BaseRepository {
   /**
-   * Create a new submission validation record.
+   * Create a new submission validation record keyed by upload_id.
+   * Each upload gets its own validation record to track ingestion status independently.
    *
-   * @param {number} submissionId - The submission ID.
+   * @param {SubmissionUploadRef} upload - The upload and submission identifiers.
    * @param {string} jobId - The pg-boss job UUID.
    * @return {Promise<{ submission_validation_id: number }>} The created record ID.
    * @memberof SubmissionValidationRepository
    */
-  async createSubmissionValidation(submissionId: number, jobId: string): Promise<{ submission_validation_id: number }> {
+  async createSubmissionValidation(
+    upload: SubmissionUploadRef,
+    jobId: string
+  ): Promise<{ submission_validation_id: number }> {
     const sql = SQL`
-      INSERT INTO submission_validation (submission_id, job_id, status)
-      VALUES (${submissionId}, ${jobId}::uuid, 'pending')
+      INSERT INTO submission_validation (upload_id, submission_id, job_id, status)
+      VALUES (${upload.uploadId}::uuid, ${upload.submissionId}, ${jobId}::uuid, 'pending')
       RETURNING submission_validation_id;
     `;
 
@@ -65,17 +70,17 @@ export class SubmissionValidationRepository extends BaseRepository {
   }
 
   /**
-   * Get the most recent submission validation record for a submission.
+   * Get the most recent submission validation record for an upload.
    *
-   * @param {number} submissionId - The submission ID.
+   * @param {string} uploadId - The upload ID (UUID).
    * @return {Promise<SubmissionValidationRecord | null>}
    * @memberof SubmissionValidationRepository
    */
-  async getSubmissionValidationBySubmissionId(submissionId: number): Promise<SubmissionValidationRecord | null> {
+  async getSubmissionValidationByUploadId(uploadId: string): Promise<SubmissionValidationRecord | null> {
     const sql = SQL`
       SELECT submission_validation_id, job_id, status
       FROM submission_validation
-      WHERE submission_id = ${submissionId}
+      WHERE upload_id = ${uploadId}::uuid
       ORDER BY create_date DESC
       LIMIT 1;
     `;
@@ -86,19 +91,19 @@ export class SubmissionValidationRepository extends BaseRepository {
   }
 
   /**
-   * Update the most recent submission validation status by submission ID.
+   * Update the most recent submission validation status by upload ID.
    *
    * Used by Dead Letter Queue handler where the original job ID is not available.
    * Scoped to the latest record so manual retries don't corrupt historical records.
    *
-   * @param {number} submissionId - The submission ID.
+   * @param {string} uploadId - The upload ID (UUID).
    * @param {SubmissionValidationStatus} status - The new status.
    * @param {Record<string, unknown>} [metadata] - Optional metadata (e.g., error details).
    * @return {Promise<void>}
    * @memberof SubmissionValidationRepository
    */
-  async updateSubmissionValidationStatusBySubmissionId(
-    submissionId: number,
+  async updateSubmissionValidationStatusByUploadId(
+    uploadId: string,
     status: SubmissionValidationStatus,
     metadata?: Record<string, unknown>
   ): Promise<void> {
@@ -111,7 +116,7 @@ export class SubmissionValidationRepository extends BaseRepository {
       WHERE submission_validation_id = (
         SELECT submission_validation_id
         FROM submission_validation
-        WHERE submission_id = ${submissionId}
+        WHERE upload_id = ${uploadId}::uuid
         ORDER BY create_date DESC
         LIMIT 1
       );

--- a/api/src/services/ingestion/feature-ingestion-service.ts
+++ b/api/src/services/ingestion/feature-ingestion-service.ts
@@ -30,14 +30,14 @@ export class FeatureIngestionService extends DBService {
    * Idempotent: soft-deletes existing features before inserting, safe for job retries.
    *
    * @param {number} submissionId - The submission to add features to
-   * @param {string} uploadId - The upload that produced these features
+   * @param {string} submissionUploadId - The submission_upload_id that produced these features
    * @param {IFlattenedBlock[]} features - Flat array of features with UUID references
    * @returns {Promise<IValidationResult>} Validation result with valid flag and any errors
    * @memberof FeatureIngestionService
    */
   async ingestFeatures(
     submissionId: number,
-    uploadId: string,
+    submissionUploadId: string,
     features: IFlattenedBlock[]
   ): Promise<IValidationResult> {
     // 1. Validate all features
@@ -53,7 +53,7 @@ export class FeatureIngestionService extends DBService {
     await submissionRepository.deleteSubmissionFeatureRelationships(submissionId);
 
     // 3. Insert features (two-pass for parent references, Pass 3 for content relationships)
-    await this.insertFlatFeatures(submissionId, uploadId, features);
+    await this.insertFlatFeatures(submissionId, submissionUploadId, features);
 
     return { valid: true, errors: [] };
   }
@@ -66,11 +66,15 @@ export class FeatureIngestionService extends DBService {
    *
    * @private
    * @param {number} submissionId - The submission ID
-   * @param {string} uploadId - The upload ID
+   * @param {string} submissionUploadId - The submission_upload_id that produced these features
    * @param {IFlattenedBlock[]} features - Features to insert
    * @memberof FeatureIngestionService
    */
-  private async insertFlatFeatures(submissionId: number, uploadId: string, features: IFlattenedBlock[]): Promise<void> {
+  private async insertFlatFeatures(
+    submissionId: number,
+    submissionUploadId: string,
+    features: IFlattenedBlock[]
+  ): Promise<void> {
     const submissionRepository = new SubmissionRepository(this.connection);
     const uuidToDbId = new Map<string, number>();
 
@@ -78,7 +82,7 @@ export class FeatureIngestionService extends DBService {
     for (const feature of features) {
       const result = await submissionRepository.insertSubmissionFeatureRecord(
         submissionId,
-        uploadId,
+        submissionUploadId,
         null, // parent set in pass 2
         feature.id,
         feature.type,

--- a/api/src/services/ingestion/submission-ingestion-service.test.ts
+++ b/api/src/services/ingestion/submission-ingestion-service.test.ts
@@ -4,7 +4,7 @@ import { Readable } from 'node:stream';
 import sinon from 'sinon';
 import { Artifact, ArtifactStatusEnum } from '../../models/artifact';
 import { IFlattenedBlock } from '../../models/submission-feature';
-import { SubmissionUpload } from '../../models/submission-upload';
+import { SubmissionUploadRef } from '../../models/submission-upload';
 import { UploadArchive } from '../../models/upload-archive';
 import { IngestionRepository } from '../../repositories/ingestion/ingestion-repository';
 import * as biohubTarParser from '../../utils/biohub-tar-parser';
@@ -13,7 +13,6 @@ import * as fileUtils from '../../utils/file-utils';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
 import { ArtifactService } from '../upload/artifact-service';
-import { SubmissionUploadService } from '../upload/submission-upload-service';
 import { UploadArchiveService } from '../upload/upload-archive-service';
 import { FeatureValidationService } from './feature-validation-service';
 import { IValidationError, ValidationErrorType } from './feature-validation-service.interface';
@@ -98,6 +97,7 @@ describe('SubmissionIngestionService', () => {
 
   describe('processSubmission', () => {
     const submissionId = 123;
+    const upload: SubmissionUploadRef = { submissionId, uploadId: 'upload-1' };
     const mockObjectKey = 'submissions/123/uploads/upload-1.tar';
 
     // Shared mock data
@@ -118,12 +118,6 @@ describe('SubmissionIngestionService', () => {
       const blocks = blocksOverride ?? mockBlocks;
       const mockReadable = Readable.from(Buffer.alloc(0));
 
-      const mockSubmissionUpload: SubmissionUpload = {
-        submission_upload_id: 'su-1',
-        submission_id: submissionId,
-        upload_id: 'upload-1'
-      };
-
       const mockUploadArchive: UploadArchive = {
         upload_archive_id: 'archive-1',
         upload_id: 'upload-1',
@@ -140,10 +134,6 @@ describe('SubmissionIngestionService', () => {
         checksum_sha256: null,
         uploaded_at: '2025-01-01T00:00:00Z'
       };
-
-      const getSubmissionUploadsStub = sinon
-        .stub(SubmissionUploadService.prototype, 'getSubmissionUploadsBySubmissionId')
-        .resolves([mockSubmissionUpload]);
 
       const getUploadArchivesStub = sinon
         .stub(UploadArchiveService.prototype, 'getUploadArchivesByUploadId')
@@ -168,8 +158,8 @@ describe('SubmissionIngestionService', () => {
         .stub(FeatureValidationService.prototype, 'validateFlatSubmissionFeatures')
         .resolves({ valid: true, errors: [] });
 
-      const deleteSubmissionFeaturesStub = sinon
-        .stub(IngestionRepository.prototype, 'deleteSubmissionFeatures')
+      const deleteSubmissionFeaturesByUploadIdStub = sinon
+        .stub(IngestionRepository.prototype, 'deleteSubmissionFeaturesByUploadId')
         .resolves();
 
       const insertSubmissionFeatureRecordStub = sinon
@@ -187,14 +177,13 @@ describe('SubmissionIngestionService', () => {
       const getBucketNameStub = sinon.stub(fileUtils, 'getObjectStoreBucketName').returns('test-bucket');
 
       return {
-        getSubmissionUploadsStub,
         getUploadArchivesStub,
         getArtifactStub,
         getFileStreamStub,
         extractBlocksStub,
         extractAndUploadMediaStub,
         validateStub,
-        deleteSubmissionFeaturesStub,
+        deleteSubmissionFeaturesByUploadIdStub,
         insertSubmissionFeatureRecordStub,
         updateSubmissionFeatureParentStub,
         insertArtifactStub,
@@ -207,7 +196,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      const result = await service.processSubmission(submissionId);
+      const result = await service.processSubmission(upload);
 
       expect(result).to.eql({ valid: true, errors: [] });
 
@@ -230,8 +219,8 @@ describe('SubmissionIngestionService', () => {
       expect(stubs.insertArtifactStub.calledOnce).to.be.true;
 
       // Features deleted and inserted
-      expect(stubs.deleteSubmissionFeaturesStub.calledOnce).to.be.true;
-      expect(stubs.deleteSubmissionFeaturesStub.getCall(0).args[0]).to.equal(submissionId);
+      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.calledOnce).to.be.true;
+      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.getCall(0).args[0]).to.equal('upload-1');
       expect(stubs.insertSubmissionFeatureRecordStub.callCount).to.equal(2);
     });
 
@@ -250,14 +239,14 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      const result = await service.processSubmission(submissionId);
+      const result = await service.processSubmission(upload);
 
       expect(result).to.eql({ valid: false, errors: [mockError] });
 
       // Pass 2 methods should NOT be called
       expect(stubs.extractAndUploadMediaStub.called).to.be.false;
       expect(stubs.insertArtifactStub.called).to.be.false;
-      expect(stubs.deleteSubmissionFeaturesStub.called).to.be.false;
+      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.called).to.be.false;
       expect(stubs.insertSubmissionFeatureRecordStub.called).to.be.false;
     });
 
@@ -280,7 +269,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      const result = await service.processSubmission(submissionId);
+      const result = await service.processSubmission(upload);
 
       expect(result.valid).to.be.false;
       expect(result.errors.length).to.be.greaterThan(0);
@@ -302,7 +291,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(submissionId);
+      await service.processSubmission(upload);
 
       // insertArtifact called twice — once per media file
       expect(stubs.insertArtifactStub.callCount).to.equal(2);
@@ -337,7 +326,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(submissionId);
+      await service.processSubmission(upload);
 
       expect(stubs.getFileStreamStub.callCount).to.equal(2);
       expect(stubs.getFileStreamStub.getCall(0).args[0]).to.equal(BucketType.MAIN);
@@ -364,7 +353,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(submissionId);
+      await service.processSubmission(upload);
 
       // Find the insertSubmissionFeatureRecord call for file-1
       const fileInsertCall = Array.from({ length: stubs.insertSubmissionFeatureRecordStub.callCount }, (_, i) =>
@@ -388,7 +377,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(submissionId);
+      await service.processSubmission(upload);
 
       // Find insert calls by feature UUID (3rd arg)
       const obsInsertCall = Array.from({ length: stubs.insertSubmissionFeatureRecordStub.callCount }, (_, i) =>
@@ -411,59 +400,14 @@ describe('SubmissionIngestionService', () => {
       expect(fileInsertCall!.args[6]).to.equal(expectedFileSize);
     });
 
-    it('getTarballObjectKey failure throws', async () => {
-      const dbError = new Error('Database connection failed');
-
-      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadsBySubmissionId').rejects(dbError);
-
-      // Stub methods that should NOT be called
-      const extractBlocksStub = sinon.stub(biohubTarParser, 'extractBlocksFromArchive');
-      const extractAndUploadMediaStub = sinon.stub(biohubTarParser, 'extractAndUploadMedia');
-      const validateStub = sinon.stub(FeatureValidationService.prototype, 'validateFlatSubmissionFeatures');
-      const deleteStub = sinon.stub(IngestionRepository.prototype, 'deleteSubmissionFeatures');
-
-      const dbConnection = getMockDBConnection();
-      const service = new SubmissionIngestionService(dbConnection);
-
-      try {
-        await service.processSubmission(submissionId);
-        expect.fail('Expected processSubmission to throw');
-      } catch (error) {
-        expect((error as Error).message).to.equal('Database connection failed');
-      }
-
-      // No downstream methods should have been called
-      expect(extractBlocksStub.called).to.be.false;
-      expect(extractAndUploadMediaStub.called).to.be.false;
-      expect(validateStub.called).to.be.false;
-      expect(deleteStub.called).to.be.false;
-    });
-
-    it('throws when submission has no uploads', async () => {
-      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadsBySubmissionId').resolves([]);
-
-      const dbConnection = getMockDBConnection();
-      const service = new SubmissionIngestionService(dbConnection);
-
-      try {
-        await service.processSubmission(submissionId);
-        expect.fail('Expected processSubmission to throw');
-      } catch (error) {
-        expect((error as Error).message).to.equal(`No uploads found for submission ${submissionId}`);
-      }
-    });
-
     it('throws when upload has no archives', async () => {
-      sinon
-        .stub(SubmissionUploadService.prototype, 'getSubmissionUploadsBySubmissionId')
-        .resolves([{ submission_upload_id: 'su-1', submission_id: submissionId, upload_id: 'upload-1' }]);
       sinon.stub(UploadArchiveService.prototype, 'getUploadArchivesByUploadId').resolves([]);
 
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
       try {
-        await service.processSubmission(submissionId);
+        await service.processSubmission(upload);
         expect.fail('Expected processSubmission to throw');
       } catch (error) {
         expect((error as Error).message).to.equal('No archives found for upload upload-1');
@@ -476,7 +420,7 @@ describe('SubmissionIngestionService', () => {
       const service = new SubmissionIngestionService(dbConnection);
 
       // Run processSubmission (simulating a re-run, same as happy path — no cleanup needed)
-      const result = await service.processSubmission(submissionId);
+      const result = await service.processSubmission(upload);
 
       expect(result).to.eql({ valid: true, errors: [] });
 
@@ -485,7 +429,7 @@ describe('SubmissionIngestionService', () => {
       expect(stubs.validateStub.calledOnce).to.be.true;
       expect(stubs.extractAndUploadMediaStub.calledOnce).to.be.true;
       expect(stubs.insertArtifactStub.calledOnce).to.be.true;
-      expect(stubs.deleteSubmissionFeaturesStub.calledOnce).to.be.true;
+      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.calledOnce).to.be.true;
       expect(stubs.insertSubmissionFeatureRecordStub.callCount).to.equal(2);
 
       // getFileStream called twice (pass 1 and pass 2)

--- a/api/src/services/ingestion/submission-ingestion-service.test.ts
+++ b/api/src/services/ingestion/submission-ingestion-service.test.ts
@@ -4,7 +4,6 @@ import { Readable } from 'node:stream';
 import sinon from 'sinon';
 import { Artifact, ArtifactStatusEnum } from '../../models/artifact';
 import { IFlattenedBlock } from '../../models/submission-feature';
-import { IngestionJobData } from '../../models/submission-upload';
 import { UploadArchive } from '../../models/upload-archive';
 import { IngestionRepository } from '../../repositories/ingestion/ingestion-repository';
 import * as biohubTarParser from '../../utils/biohub-tar-parser';
@@ -96,8 +95,11 @@ describe('SubmissionIngestionService', () => {
   });
 
   describe('processSubmission', () => {
-    const submissionId = 123;
-    const upload: IngestionJobData = { submissionId, uploadId: 'upload-1' };
+    const mockSubmissionUpload = {
+      submission_upload_id: 'sub-upload-uuid-1',
+      submission_id: 123,
+      upload_id: 'upload-1'
+    };
     const mockObjectKey = 'submissions/123/uploads/upload-1.tar';
 
     // Shared mock data
@@ -112,7 +114,7 @@ describe('SubmissionIngestionService', () => {
 
     /**
      * Sets up the common happy-path stubs for processSubmission tests.
-     * Returns the stubs so individual tests can override or assert on them.
+     * processSubmission now accepts a pre-resolved SubmissionUpload record — no bridge stub needed.
      */
     function setupHappyPathStubs(blocksOverride?: IFlattenedBlock[]) {
       const blocks = blocksOverride ?? mockBlocks;
@@ -158,8 +160,8 @@ describe('SubmissionIngestionService', () => {
         .stub(FeatureValidationService.prototype, 'validateFlatSubmissionFeatures')
         .resolves({ valid: true, errors: [] });
 
-      const deleteSubmissionFeaturesByUploadIdStub = sinon
-        .stub(IngestionRepository.prototype, 'deleteSubmissionFeaturesByUploadId')
+      const deleteSubmissionFeaturesBySubmissionUploadIdStub = sinon
+        .stub(IngestionRepository.prototype, 'deleteSubmissionFeaturesBySubmissionUploadId')
         .resolves();
 
       const insertSubmissionFeatureRecordStub = sinon
@@ -183,7 +185,7 @@ describe('SubmissionIngestionService', () => {
         extractBlocksStub,
         extractAndUploadMediaStub,
         validateStub,
-        deleteSubmissionFeaturesByUploadIdStub,
+        deleteSubmissionFeaturesBySubmissionUploadIdStub,
         insertSubmissionFeatureRecordStub,
         updateSubmissionFeatureParentStub,
         insertArtifactStub,
@@ -196,7 +198,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      const result = await service.processSubmission(upload);
+      const result = await service.processSubmission(mockSubmissionUpload);
 
       expect(result).to.eql({ valid: true, errors: [] });
 
@@ -218,9 +220,11 @@ describe('SubmissionIngestionService', () => {
       // insertArtifact called once (one media file)
       expect(stubs.insertArtifactStub.calledOnce).to.be.true;
 
-      // Features deleted and inserted
-      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.calledOnce).to.be.true;
-      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.getCall(0).args[0]).to.equal('upload-1');
+      // Features deleted by submissionUploadId and inserted
+      expect(stubs.deleteSubmissionFeaturesBySubmissionUploadIdStub.calledOnce).to.be.true;
+      expect(stubs.deleteSubmissionFeaturesBySubmissionUploadIdStub.getCall(0).args[0]).to.equal(
+        mockSubmissionUpload.submission_upload_id
+      );
       expect(stubs.insertSubmissionFeatureRecordStub.callCount).to.equal(2);
     });
 
@@ -239,14 +243,14 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      const result = await service.processSubmission(upload);
+      const result = await service.processSubmission(mockSubmissionUpload);
 
       expect(result).to.eql({ valid: false, errors: [mockError] });
 
       // Pass 2 methods should NOT be called
       expect(stubs.extractAndUploadMediaStub.called).to.be.false;
       expect(stubs.insertArtifactStub.called).to.be.false;
-      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.called).to.be.false;
+      expect(stubs.deleteSubmissionFeaturesBySubmissionUploadIdStub.called).to.be.false;
       expect(stubs.insertSubmissionFeatureRecordStub.called).to.be.false;
     });
 
@@ -269,7 +273,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      const result = await service.processSubmission(upload);
+      const result = await service.processSubmission(mockSubmissionUpload);
 
       expect(result.valid).to.be.false;
       expect(result.errors.length).to.be.greaterThan(0);
@@ -291,7 +295,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(upload);
+      await service.processSubmission(mockSubmissionUpload);
 
       // insertArtifact called twice — once per media file
       expect(stubs.insertArtifactStub.callCount).to.equal(2);
@@ -326,7 +330,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(upload);
+      await service.processSubmission(mockSubmissionUpload);
 
       expect(stubs.getFileStreamStub.callCount).to.equal(2);
       expect(stubs.getFileStreamStub.getCall(0).args[0]).to.equal(BucketType.MAIN);
@@ -353,7 +357,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(upload);
+      await service.processSubmission(mockSubmissionUpload);
 
       // Find the insertSubmissionFeatureRecord call for file-1
       const fileInsertCall = Array.from({ length: stubs.insertSubmissionFeatureRecordStub.callCount }, (_, i) =>
@@ -377,7 +381,7 @@ describe('SubmissionIngestionService', () => {
       const dbConnection = getMockDBConnection();
       const service = new SubmissionIngestionService(dbConnection);
 
-      await service.processSubmission(upload);
+      await service.processSubmission(mockSubmissionUpload);
 
       // Find insert calls by feature UUID (3rd arg)
       const obsInsertCall = Array.from({ length: stubs.insertSubmissionFeatureRecordStub.callCount }, (_, i) =>
@@ -407,7 +411,7 @@ describe('SubmissionIngestionService', () => {
       const service = new SubmissionIngestionService(dbConnection);
 
       try {
-        await service.processSubmission(upload);
+        await service.processSubmission(mockSubmissionUpload);
         expect.fail('Expected processSubmission to throw');
       } catch (error) {
         expect((error as Error).message).to.equal('No archives found for upload upload-1');
@@ -420,7 +424,7 @@ describe('SubmissionIngestionService', () => {
       const service = new SubmissionIngestionService(dbConnection);
 
       // Run processSubmission (simulating a re-run, same as happy path — no cleanup needed)
-      const result = await service.processSubmission(upload);
+      const result = await service.processSubmission(mockSubmissionUpload);
 
       expect(result).to.eql({ valid: true, errors: [] });
 
@@ -429,7 +433,7 @@ describe('SubmissionIngestionService', () => {
       expect(stubs.validateStub.calledOnce).to.be.true;
       expect(stubs.extractAndUploadMediaStub.calledOnce).to.be.true;
       expect(stubs.insertArtifactStub.calledOnce).to.be.true;
-      expect(stubs.deleteSubmissionFeaturesByUploadIdStub.calledOnce).to.be.true;
+      expect(stubs.deleteSubmissionFeaturesBySubmissionUploadIdStub.calledOnce).to.be.true;
       expect(stubs.insertSubmissionFeatureRecordStub.callCount).to.equal(2);
 
       // getFileStream called twice (pass 1 and pass 2)

--- a/api/src/services/ingestion/submission-ingestion-service.test.ts
+++ b/api/src/services/ingestion/submission-ingestion-service.test.ts
@@ -4,7 +4,7 @@ import { Readable } from 'node:stream';
 import sinon from 'sinon';
 import { Artifact, ArtifactStatusEnum } from '../../models/artifact';
 import { IFlattenedBlock } from '../../models/submission-feature';
-import { SubmissionUploadRef } from '../../models/submission-upload';
+import { IngestionJobData } from '../../models/submission-upload';
 import { UploadArchive } from '../../models/upload-archive';
 import { IngestionRepository } from '../../repositories/ingestion/ingestion-repository';
 import * as biohubTarParser from '../../utils/biohub-tar-parser';
@@ -97,7 +97,7 @@ describe('SubmissionIngestionService', () => {
 
   describe('processSubmission', () => {
     const submissionId = 123;
-    const upload: SubmissionUploadRef = { submissionId, uploadId: 'upload-1' };
+    const upload: IngestionJobData = { submissionId, uploadId: 'upload-1' };
     const mockObjectKey = 'submissions/123/uploads/upload-1.tar';
 
     // Shared mock data

--- a/api/src/services/ingestion/submission-ingestion-service.ts
+++ b/api/src/services/ingestion/submission-ingestion-service.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { ArtifactStatusEnum } from '../../models/artifact';
 import { IFlattenedBlock } from '../../models/submission-feature';
-import { SubmissionUploadRef } from '../../models/submission-upload';
+import { IngestionJobData } from '../../models/submission-upload';
 import { IngestionRepository } from '../../repositories/ingestion/ingestion-repository';
 import { extractAndUploadMedia, extractBlocksFromArchive, IUploadedMediaFile } from '../../utils/biohub-tar-parser';
 import { getObjectStoreBucketName } from '../../utils/file-utils';
@@ -42,26 +42,33 @@ export class SubmissionIngestionService extends DBService {
    * Idempotent: safe for pg-boss retries. Existing features are soft-deleted before
    * re-insertion, artifact inserts use ON CONFLICT DO NOTHING, and S3 PUTs overwrite.
    *
-   * @param {SubmissionUploadRef} upload - The upload and submission identifiers.
+   * @param {IngestionJobData} upload - The upload and submission identifiers.
    * @returns {Promise<IValidationResult>} Validation result
    * @memberof SubmissionIngestionService
    */
-  async processSubmission(upload: SubmissionUploadRef): Promise<IValidationResult> {
+  async processSubmission(upload: IngestionJobData): Promise<IValidationResult> {
     const { submissionId, uploadId } = upload;
+
+    // Resolve the S3 key for the uploaded tarball: submission → upload_archive → artifact → object_key
     const objectKey = await this.getTarballObjectKey(uploadId);
 
     // ================================================================
     // PASS 1: VALIDATE (zero side effects)
+    // Two-pass architecture: validate everything before writing anything,
+    // so a validation failure never leaves partial data behind.
     // ================================================================
 
+    // Stream 1: parse the tarball into flat feature blocks and a set of media filenames
     const tarStream1 = await this.objectStorageService.getFileStream(BucketType.MAIN, objectKey);
     const { allBlocks, mediaFileNames } = await extractBlocksFromArchive(tarStream1);
 
+    // Validate feature structure: types exist in feature_type, required properties present, types correct
     const featureValidation = await this.featureValidationService.validateFlatSubmissionFeatures(allBlocks);
     if (!featureValidation.valid) {
       return featureValidation;
     }
 
+    // Validate media integrity: every file/report block's filename must have a matching file in the archive
     const mediaErrors = validateMediaReferences(allBlocks, mediaFileNames);
     if (mediaErrors.length > 0) {
       return { valid: false, errors: mediaErrors };
@@ -69,15 +76,26 @@ export class SubmissionIngestionService extends DBService {
 
     // ================================================================
     // PASS 2: INGEST (DB writes + S3 uploads)
+    // All validation passed — safe to write. From here, operations are
+    // idempotent: S3 PUTs overwrite, artifact inserts use ON CONFLICT DO
+    // NOTHING, and features are soft-deleted before re-insertion.
     // ================================================================
 
+    // Stream 2: re-stream the tarball to extract and upload media files to S3
+    // (tar streams are single-pass, so we need a fresh stream)
     const tarStream2 = await this.objectStorageService.getFileStream(BucketType.MAIN, objectKey);
     const s3KeyPrefix = `submissions/${submissionId}/media`;
     const uploadedMediaFiles = await extractAndUploadMedia(tarStream2, this.objectStorageService, s3KeyPrefix);
 
+    // Stamp each file/report block with its S3 artifact_key so downstream
+    // consumers (download pipeline, UI) can locate the file without a join
     this.setArtifactKeys(allBlocks, uploadedMediaFiles);
+
+    // Pre-compute data_byte_size per feature for download size estimation
+    // (avoids fetching full JSONB at query time — see data_byte_size column docs)
     const dataByteSizeMap = this.computeDataByteSizeMap(allBlocks, uploadedMediaFiles);
 
+    // Create artifact records for each uploaded media file
     for (const [, mediaFile] of uploadedMediaFiles) {
       await this.artifactService.insertArtifact({
         bucket: getObjectStoreBucketName(),
@@ -89,7 +107,9 @@ export class SubmissionIngestionService extends DBService {
       });
     }
 
-    // Clear previous features for this upload before re-inserting (admin re-trigger or re-upload)
+    // Soft-delete previous features for this upload, then insert fresh ones.
+    // Scoped by uploadId (not submissionId) so re-triggering one upload
+    // doesn't wipe features from a different upload in the same submission.
     await this.ingestionRepository.deleteSubmissionFeaturesByUploadId(uploadId);
     await this.insertFlatFeatures(submissionId, uploadId, allBlocks, dataByteSizeMap);
 

--- a/api/src/services/ingestion/submission-ingestion-service.ts
+++ b/api/src/services/ingestion/submission-ingestion-service.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { ArtifactStatusEnum } from '../../models/artifact';
 import { IFlattenedBlock } from '../../models/submission-feature';
+import { SubmissionUploadRef } from '../../models/submission-upload';
 import { IngestionRepository } from '../../repositories/ingestion/ingestion-repository';
 import { extractAndUploadMedia, extractBlocksFromArchive, IUploadedMediaFile } from '../../utils/biohub-tar-parser';
 import { getObjectStoreBucketName } from '../../utils/file-utils';
@@ -8,7 +9,6 @@ import { getLogger } from '../../utils/logger';
 import { DBService } from '../db-service';
 import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
 import { ArtifactService } from '../upload/artifact-service';
-import { SubmissionUploadService } from '../upload/submission-upload-service';
 import { UploadArchiveService } from '../upload/upload-archive-service';
 import { FeatureValidationService } from './feature-validation-service';
 import { IValidationError, IValidationResult, ValidationErrorType } from './feature-validation-service.interface';
@@ -30,7 +30,6 @@ const CSV_ROW_OVERHEAD_BYTES = 500;
 export class SubmissionIngestionService extends DBService {
   featureValidationService = new FeatureValidationService(this.connection);
   ingestionRepository = new IngestionRepository(this.connection);
-  submissionUploadService = new SubmissionUploadService(this.connection);
   uploadArchiveService = new UploadArchiveService(this.connection);
   artifactService = new ArtifactService(this.connection);
   objectStorageService = new ObjectStorageService();
@@ -43,16 +42,12 @@ export class SubmissionIngestionService extends DBService {
    * Idempotent: safe for pg-boss retries. Existing features are soft-deleted before
    * re-insertion, artifact inserts use ON CONFLICT DO NOTHING, and S3 PUTs overwrite.
    *
-   * @param {number} submissionId - The submission to process
+   * @param {SubmissionUploadRef} upload - The upload and submission identifiers.
    * @returns {Promise<IValidationResult>} Validation result
    * @memberof SubmissionIngestionService
    */
-  async processSubmission(submissionId: number): Promise<IValidationResult> {
-    const submissionUploads = await this.submissionUploadService.getSubmissionUploadsBySubmissionId(submissionId);
-    if (submissionUploads.length === 0) {
-      throw new Error(`No uploads found for submission ${submissionId}`);
-    }
-    const uploadId = submissionUploads[0].upload_id;
+  async processSubmission(upload: SubmissionUploadRef): Promise<IValidationResult> {
+    const { submissionId, uploadId } = upload;
     const objectKey = await this.getTarballObjectKey(uploadId);
 
     // ================================================================
@@ -94,8 +89,8 @@ export class SubmissionIngestionService extends DBService {
       });
     }
 
-    // Delete existing features (idempotency for job retries), then insert
-    await this.ingestionRepository.deleteSubmissionFeatures(submissionId);
+    // Clear previous features for this upload before re-inserting (admin re-trigger or re-upload)
+    await this.ingestionRepository.deleteSubmissionFeaturesByUploadId(uploadId);
     await this.insertFlatFeatures(submissionId, uploadId, allBlocks, dataByteSizeMap);
 
     return { valid: true, errors: [] };

--- a/api/src/services/ingestion/submission-ingestion-service.ts
+++ b/api/src/services/ingestion/submission-ingestion-service.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { ArtifactStatusEnum } from '../../models/artifact';
 import { IFlattenedBlock } from '../../models/submission-feature';
-import { IngestionJobData } from '../../models/submission-upload';
+import { SubmissionUpload } from '../../models/submission-upload';
 import { IngestionRepository } from '../../repositories/ingestion/ingestion-repository';
 import { extractAndUploadMedia, extractBlocksFromArchive, IUploadedMediaFile } from '../../utils/biohub-tar-parser';
 import { getObjectStoreBucketName } from '../../utils/file-utils';
@@ -42,14 +42,23 @@ export class SubmissionIngestionService extends DBService {
    * Idempotent: safe for pg-boss retries. Existing features are soft-deleted before
    * re-insertion, artifact inserts use ON CONFLICT DO NOTHING, and S3 PUTs overwrite.
    *
-   * @param {IngestionJobData} upload - The upload and submission identifiers.
+   * Caller provides the pre-resolved submission_upload bridge record to avoid redundant
+   * lookups — the job handler already resolves it for logging/indexing.
+   * Tarball resolution requires upload_id (upload → upload_archive → artifact → S3 key),
+   * while feature inserts use submission_upload_id (the processing identifier).
+   *
+   * @param {SubmissionUpload} submissionUpload - The pre-resolved bridge record.
    * @returns {Promise<IValidationResult>} Validation result
    * @memberof SubmissionIngestionService
    */
-  async processSubmission(upload: IngestionJobData): Promise<IValidationResult> {
-    const { submissionId, uploadId } = upload;
+  async processSubmission(submissionUpload: SubmissionUpload): Promise<IValidationResult> {
+    const {
+      submission_upload_id: submissionUploadId,
+      submission_id: submissionId,
+      upload_id: uploadId
+    } = submissionUpload;
 
-    // Resolve the S3 key for the uploaded tarball: submission → upload_archive → artifact → object_key
+    // Resolve the S3 key for the uploaded tarball: upload_id → upload_archive → artifact → object_key
     const objectKey = await this.getTarballObjectKey(uploadId);
 
     // ================================================================
@@ -108,10 +117,10 @@ export class SubmissionIngestionService extends DBService {
     }
 
     // Soft-delete previous features for this upload, then insert fresh ones.
-    // Scoped by uploadId (not submissionId) so re-triggering one upload
+    // Scoped by submissionUploadId (not submissionId) so re-triggering one upload
     // doesn't wipe features from a different upload in the same submission.
-    await this.ingestionRepository.deleteSubmissionFeaturesByUploadId(uploadId);
-    await this.insertFlatFeatures(submissionId, uploadId, allBlocks, dataByteSizeMap);
+    await this.ingestionRepository.deleteSubmissionFeaturesBySubmissionUploadId(submissionUploadId);
+    await this.insertFlatFeatures(submissionId, submissionUploadId, allBlocks, dataByteSizeMap);
 
     return { valid: true, errors: [] };
   }
@@ -123,14 +132,14 @@ export class SubmissionIngestionService extends DBService {
    *
    * @private
    * @param {number} submissionId - The submission ID
-   * @param {string} uploadId - The upload ID
+   * @param {string} submissionUploadId - The submission_upload_id that produced these features
    * @param {IFlattenedBlock[]} features - Features to insert
    * @param {Map<string, number>} dataByteSizeMap - Pre-computed byte sizes per feature UUID
    * @memberof SubmissionIngestionService
    */
   private async insertFlatFeatures(
     submissionId: number,
-    uploadId: string,
+    submissionUploadId: string,
     features: IFlattenedBlock[],
     dataByteSizeMap: Map<string, number>
   ): Promise<void> {
@@ -140,7 +149,7 @@ export class SubmissionIngestionService extends DBService {
     for (const feature of features) {
       const result = await this.ingestionRepository.insertSubmissionFeatureRecord(
         submissionId,
-        uploadId,
+        submissionUploadId,
         null, // parent set in pass 2
         feature.id,
         feature.type,

--- a/api/src/services/submission-service.ts
+++ b/api/src/services/submission-service.ts
@@ -87,14 +87,14 @@ export class SubmissionService extends DBService {
    * Insert submission features.
    *
    * @param {number} submissionId
-   * @param {string} uploadId - The upload that produced these features.
+   * @param {string} submissionUploadId - The submission_upload_id that produced these features.
    * @param {ISubmissionFeature[]} submissionFeatures
    * @return {*}  {Promise<void>}
    * @memberof SubmissionService
    */
   async insertSubmissionFeatureRecords(
     submissionId: number,
-    uploadId: string,
+    submissionUploadId: string,
     submissionFeatures: ISubmissionFeature[]
   ): Promise<void> {
     try {
@@ -132,7 +132,7 @@ export class SubmissionService extends DBService {
         // Validate the submissionFeature object
         const response = await this.ingestionRepository.insertSubmissionFeatureRecord(
           submissionId,
-          uploadId,
+          submissionUploadId,
           parentSubmissionFeatureId,
           featureNode.id,
           featureNode.type,

--- a/api/src/services/submission-validation-service.test.ts
+++ b/api/src/services/submission-validation-service.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
-import { IngestionJobData } from '../models/submission-upload';
 import { SubmissionValidationRepository } from '../repositories/submission-validation-repository';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SubmissionValidationService } from './submission-validation-service';
@@ -20,27 +19,31 @@ describe('SubmissionValidationService', () => {
         .stub(SubmissionValidationRepository.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      const ids: IngestionJobData = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 123 };
-      const result = await service.createSubmissionValidation(ids, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+      const result = await service.createSubmissionValidation(
+        '550e8400-e29b-41d4-a716-446655440000',
+        123,
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+      );
 
       expect(createStub.calledOnce).to.be.true;
-      expect(createStub.firstCall.args[0]).to.deep.equal(ids);
-      expect(createStub.firstCall.args[1]).to.equal('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+      expect(createStub.firstCall.args[0]).to.equal('550e8400-e29b-41d4-a716-446655440000');
+      expect(createStub.firstCall.args[1]).to.equal(123);
+      expect(createStub.firstCall.args[2]).to.equal('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
       expect(result).to.deep.equal({ submission_validation_id: 1 });
     });
   });
 
-  describe('getSubmissionValidationByUploadId', () => {
-    it('delegates to renamed repository method', async () => {
+  describe('getSubmissionValidationBySubmissionUploadId', () => {
+    it('delegates to repository method', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new SubmissionValidationService(mockDBConnection);
 
       const mockRecord = { submission_validation_id: 3, job_id: 'job-uuid', status: 'completed' as const };
       const getStub = sinon
-        .stub(SubmissionValidationRepository.prototype, 'getSubmissionValidationByUploadId')
+        .stub(SubmissionValidationRepository.prototype, 'getSubmissionValidationBySubmissionUploadId')
         .resolves(mockRecord);
 
-      const result = await service.getSubmissionValidationByUploadId('550e8400-e29b-41d4-a716-446655440000');
+      const result = await service.getSubmissionValidationBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
 
       expect(getStub.calledOnce).to.be.true;
       expect(getStub.firstCall.args[0]).to.equal('550e8400-e29b-41d4-a716-446655440000');
@@ -48,18 +51,20 @@ describe('SubmissionValidationService', () => {
     });
   });
 
-  describe('updateSubmissionValidationStatusByUploadId', () => {
-    it('delegates to renamed repository method', async () => {
+  describe('updateSubmissionValidationStatusBySubmissionUploadId', () => {
+    it('delegates to repository method', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new SubmissionValidationService(mockDBConnection);
 
       const updateStub = sinon
-        .stub(SubmissionValidationRepository.prototype, 'updateSubmissionValidationStatusByUploadId')
+        .stub(SubmissionValidationRepository.prototype, 'updateSubmissionValidationStatusBySubmissionUploadId')
         .resolves();
 
-      await service.updateSubmissionValidationStatusByUploadId('550e8400-e29b-41d4-a716-446655440000', 'failed', {
-        error: 'timeout'
-      });
+      await service.updateSubmissionValidationStatusBySubmissionUploadId(
+        '550e8400-e29b-41d4-a716-446655440000',
+        'failed',
+        { error: 'timeout' }
+      );
 
       expect(updateStub.calledOnce).to.be.true;
       expect(updateStub.firstCall.args[0]).to.equal('550e8400-e29b-41d4-a716-446655440000');

--- a/api/src/services/submission-validation-service.test.ts
+++ b/api/src/services/submission-validation-service.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
-import { SubmissionUploadRef } from '../models/submission-upload';
+import { IngestionJobData } from '../models/submission-upload';
 import { SubmissionValidationRepository } from '../repositories/submission-validation-repository';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SubmissionValidationService } from './submission-validation-service';
@@ -20,11 +20,8 @@ describe('SubmissionValidationService', () => {
         .stub(SubmissionValidationRepository.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      const ids: SubmissionUploadRef = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 123 };
-      const result = await service.createSubmissionValidation(
-        ids,
-        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
-      );
+      const ids: IngestionJobData = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 123 };
+      const result = await service.createSubmissionValidation(ids, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
 
       expect(createStub.calledOnce).to.be.true;
       expect(createStub.firstCall.args[0]).to.deep.equal(ids);

--- a/api/src/services/submission-validation-service.test.ts
+++ b/api/src/services/submission-validation-service.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
+import { SubmissionUploadRef } from '../models/submission-upload';
 import { SubmissionValidationRepository } from '../repositories/submission-validation-repository';
 import { getMockDBConnection } from '../__mocks__/db';
 import { SubmissionValidationService } from './submission-validation-service';
@@ -19,12 +20,54 @@ describe('SubmissionValidationService', () => {
         .stub(SubmissionValidationRepository.prototype, 'createSubmissionValidation')
         .resolves({ submission_validation_id: 1 });
 
-      const result = await service.createSubmissionValidation(123, '550e8400-e29b-41d4-a716-446655440000');
+      const ids: SubmissionUploadRef = { uploadId: '550e8400-e29b-41d4-a716-446655440000', submissionId: 123 };
+      const result = await service.createSubmissionValidation(
+        ids,
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+      );
 
       expect(createStub.calledOnce).to.be.true;
-      expect(createStub.firstCall.args[0]).to.equal(123);
-      expect(createStub.firstCall.args[1]).to.equal('550e8400-e29b-41d4-a716-446655440000');
+      expect(createStub.firstCall.args[0]).to.deep.equal(ids);
+      expect(createStub.firstCall.args[1]).to.equal('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
       expect(result).to.deep.equal({ submission_validation_id: 1 });
+    });
+  });
+
+  describe('getSubmissionValidationByUploadId', () => {
+    it('delegates to renamed repository method', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new SubmissionValidationService(mockDBConnection);
+
+      const mockRecord = { submission_validation_id: 3, job_id: 'job-uuid', status: 'completed' as const };
+      const getStub = sinon
+        .stub(SubmissionValidationRepository.prototype, 'getSubmissionValidationByUploadId')
+        .resolves(mockRecord);
+
+      const result = await service.getSubmissionValidationByUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      expect(getStub.calledOnce).to.be.true;
+      expect(getStub.firstCall.args[0]).to.equal('550e8400-e29b-41d4-a716-446655440000');
+      expect(result).to.deep.equal(mockRecord);
+    });
+  });
+
+  describe('updateSubmissionValidationStatusByUploadId', () => {
+    it('delegates to renamed repository method', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new SubmissionValidationService(mockDBConnection);
+
+      const updateStub = sinon
+        .stub(SubmissionValidationRepository.prototype, 'updateSubmissionValidationStatusByUploadId')
+        .resolves();
+
+      await service.updateSubmissionValidationStatusByUploadId('550e8400-e29b-41d4-a716-446655440000', 'failed', {
+        error: 'timeout'
+      });
+
+      expect(updateStub.calledOnce).to.be.true;
+      expect(updateStub.firstCall.args[0]).to.equal('550e8400-e29b-41d4-a716-446655440000');
+      expect(updateStub.firstCall.args[1]).to.equal('failed');
+      expect(updateStub.firstCall.args[2]).to.deep.equal({ error: 'timeout' });
     });
   });
 

--- a/api/src/services/submission-validation-service.ts
+++ b/api/src/services/submission-validation-service.ts
@@ -1,4 +1,5 @@
 import { IDBConnection } from '../database/db';
+import { SubmissionUploadRef } from '../models/submission-upload';
 import { SubmissionValidationRecord, SubmissionValidationStatus } from '../models/submission-validation';
 import { SubmissionValidationRepository } from '../repositories/submission-validation-repository';
 import { DBService } from './db-service';
@@ -19,15 +20,18 @@ export class SubmissionValidationService extends DBService {
   }
 
   /**
-   * Create a new submission validation record.
+   * Create a new submission validation record keyed by upload_id.
    *
-   * @param {number} submissionId - The submission ID.
+   * @param {SubmissionUploadRef} upload - The upload and submission identifiers.
    * @param {string} jobId - The pg-boss job UUID.
    * @return {Promise<{ submission_validation_id: number }>} The created record ID.
    * @memberof SubmissionValidationService
    */
-  async createSubmissionValidation(submissionId: number, jobId: string): Promise<{ submission_validation_id: number }> {
-    return this.submissionValidationRepository.createSubmissionValidation(submissionId, jobId);
+  async createSubmissionValidation(
+    upload: SubmissionUploadRef,
+    jobId: string
+  ): Promise<{ submission_validation_id: number }> {
+    return this.submissionValidationRepository.createSubmissionValidation(upload, jobId);
   }
 
   /**
@@ -51,36 +55,32 @@ export class SubmissionValidationService extends DBService {
   }
 
   /**
-   * Get the most recent submission validation record for a submission.
+   * Get the most recent submission validation record for an upload.
    *
-   * @param {number} submissionId - The submission ID.
+   * @param {string} uploadId - The upload ID (UUID).
    * @return {Promise<SubmissionValidationRecord | null>}
    * @memberof SubmissionValidationService
    */
-  async getSubmissionValidationBySubmissionId(submissionId: number): Promise<SubmissionValidationRecord | null> {
-    return this.submissionValidationRepository.getSubmissionValidationBySubmissionId(submissionId);
+  async getSubmissionValidationByUploadId(uploadId: string): Promise<SubmissionValidationRecord | null> {
+    return this.submissionValidationRepository.getSubmissionValidationByUploadId(uploadId);
   }
 
   /**
-   * Update submission validation status by submission ID.
+   * Update submission validation status by upload ID.
    *
    * Used by Dead Letter Queue handler where the original job ID is not available.
    *
-   * @param {number} submissionId - The submission ID.
+   * @param {string} uploadId - The upload ID (UUID).
    * @param {SubmissionValidationStatus} status - The new status.
    * @param {Record<string, unknown>} [metadata] - Optional metadata (e.g., error details).
    * @return {Promise<void>}
    * @memberof SubmissionValidationService
    */
-  async updateSubmissionValidationStatusBySubmissionId(
-    submissionId: number,
+  async updateSubmissionValidationStatusByUploadId(
+    uploadId: string,
     status: SubmissionValidationStatus,
     metadata?: Record<string, unknown>
   ): Promise<void> {
-    return this.submissionValidationRepository.updateSubmissionValidationStatusBySubmissionId(
-      submissionId,
-      status,
-      metadata
-    );
+    return this.submissionValidationRepository.updateSubmissionValidationStatusByUploadId(uploadId, status, metadata);
   }
 }

--- a/api/src/services/submission-validation-service.ts
+++ b/api/src/services/submission-validation-service.ts
@@ -1,5 +1,4 @@
 import { IDBConnection } from '../database/db';
-import { IngestionJobData } from '../models/submission-upload';
 import { SubmissionValidationRecord, SubmissionValidationStatus } from '../models/submission-validation';
 import { SubmissionValidationRepository } from '../repositories/submission-validation-repository';
 import { DBService } from './db-service';
@@ -20,18 +19,21 @@ export class SubmissionValidationService extends DBService {
   }
 
   /**
-   * Create a new submission validation record keyed by upload_id.
+   * Create a new submission validation record keyed by submission_upload_id.
+   * Each upload event gets its own validation record to track ingestion status independently.
    *
-   * @param {IngestionJobData} upload - The upload and submission identifiers.
+   * @param {string} submissionUploadId - The submission_upload_id (UUID).
+   * @param {number} submissionId - The submission ID.
    * @param {string} jobId - The pg-boss job UUID.
    * @return {Promise<{ submission_validation_id: number }>} The created record ID.
    * @memberof SubmissionValidationService
    */
   async createSubmissionValidation(
-    upload: IngestionJobData,
+    submissionUploadId: string,
+    submissionId: number,
     jobId: string
   ): Promise<{ submission_validation_id: number }> {
-    return this.submissionValidationRepository.createSubmissionValidation(upload, jobId);
+    return this.submissionValidationRepository.createSubmissionValidation(submissionUploadId, submissionId, jobId);
   }
 
   /**
@@ -55,32 +57,39 @@ export class SubmissionValidationService extends DBService {
   }
 
   /**
-   * Get the most recent submission validation record for an upload.
+   * Get the most recent submission validation record for a submission upload.
    *
-   * @param {string} uploadId - The upload ID (UUID).
+   * @param {string} submissionUploadId - The submission_upload_id (UUID).
    * @return {Promise<SubmissionValidationRecord | null>}
    * @memberof SubmissionValidationService
    */
-  async getSubmissionValidationByUploadId(uploadId: string): Promise<SubmissionValidationRecord | null> {
-    return this.submissionValidationRepository.getSubmissionValidationByUploadId(uploadId);
+  async getSubmissionValidationBySubmissionUploadId(
+    submissionUploadId: string
+  ): Promise<SubmissionValidationRecord | null> {
+    return this.submissionValidationRepository.getSubmissionValidationBySubmissionUploadId(submissionUploadId);
   }
 
   /**
-   * Update submission validation status by upload ID.
+   * Update submission validation status by submission_upload_id.
    *
    * Used by Dead Letter Queue handler where the original job ID is not available.
+   * Scoped to the latest record so manual retries don't corrupt historical records.
    *
-   * @param {string} uploadId - The upload ID (UUID).
+   * @param {string} submissionUploadId - The submission_upload_id (UUID).
    * @param {SubmissionValidationStatus} status - The new status.
    * @param {Record<string, unknown>} [metadata] - Optional metadata (e.g., error details).
    * @return {Promise<void>}
    * @memberof SubmissionValidationService
    */
-  async updateSubmissionValidationStatusByUploadId(
-    uploadId: string,
+  async updateSubmissionValidationStatusBySubmissionUploadId(
+    submissionUploadId: string,
     status: SubmissionValidationStatus,
     metadata?: Record<string, unknown>
   ): Promise<void> {
-    return this.submissionValidationRepository.updateSubmissionValidationStatusByUploadId(uploadId, status, metadata);
+    return this.submissionValidationRepository.updateSubmissionValidationStatusBySubmissionUploadId(
+      submissionUploadId,
+      status,
+      metadata
+    );
   }
 }

--- a/api/src/services/submission-validation-service.ts
+++ b/api/src/services/submission-validation-service.ts
@@ -1,5 +1,5 @@
 import { IDBConnection } from '../database/db';
-import { SubmissionUploadRef } from '../models/submission-upload';
+import { IngestionJobData } from '../models/submission-upload';
 import { SubmissionValidationRecord, SubmissionValidationStatus } from '../models/submission-validation';
 import { SubmissionValidationRepository } from '../repositories/submission-validation-repository';
 import { DBService } from './db-service';
@@ -22,13 +22,13 @@ export class SubmissionValidationService extends DBService {
   /**
    * Create a new submission validation record keyed by upload_id.
    *
-   * @param {SubmissionUploadRef} upload - The upload and submission identifiers.
+   * @param {IngestionJobData} upload - The upload and submission identifiers.
    * @param {string} jobId - The pg-boss job UUID.
    * @return {Promise<{ submission_validation_id: number }>} The created record ID.
    * @memberof SubmissionValidationService
    */
   async createSubmissionValidation(
-    upload: SubmissionUploadRef,
+    upload: IngestionJobData,
     jobId: string
   ): Promise<{ submission_validation_id: number }> {
     return this.submissionValidationRepository.createSubmissionValidation(upload, jobId);

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -380,7 +380,7 @@ describe('ArtifactSecurityService', () => {
 
       expect(promoteStub.calledOnceWith('uploads/test.tar')).to.be.true;
       expect(publishStub.calledOnce).to.be.true;
-      expect(publishStub.firstCall.args[1]).to.deep.equal({ submissionId: 123 });
+      expect(publishStub.firstCall.args[1]).to.deep.equal({ uploadId: 'upload-1', submissionId: 123 });
     });
 
     it('should update scan record to FAILED on error and rethrow', async () => {
@@ -478,7 +478,7 @@ describe('ArtifactSecurityService', () => {
       await service.publishNextPipelineStep(mockUploadArchive);
 
       expect(publishStub.calledOnce).to.be.true;
-      expect(publishStub.firstCall.args[1]).to.deep.equal({ submissionId: 999 });
+      expect(publishStub.firstCall.args[1]).to.deep.equal({ uploadId: 'upload-1', submissionId: 999 });
     });
 
     it('should propagate error when submission_upload lookup throws', async () => {

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -380,7 +380,12 @@ describe('ArtifactSecurityService', () => {
 
       expect(promoteStub.calledOnceWith('uploads/test.tar')).to.be.true;
       expect(publishStub.calledOnce).to.be.true;
-      expect(publishStub.firstCall.args[1]).to.deep.equal({ uploadId: 'upload-1', submissionId: 123 });
+      // Publisher receives the full SubmissionUpload record
+      expect(publishStub.firstCall.args[1]).to.deep.equal({
+        submission_upload_id: 'su-1',
+        submission_id: 123,
+        upload_id: 'upload-1'
+      });
     });
 
     it('should update scan record to FAILED on error and rethrow', async () => {
@@ -478,7 +483,12 @@ describe('ArtifactSecurityService', () => {
       await service.publishNextPipelineStep(mockUploadArchive);
 
       expect(publishStub.calledOnce).to.be.true;
-      expect(publishStub.firstCall.args[1]).to.deep.equal({ uploadId: 'upload-1', submissionId: 999 });
+      // Publisher now receives the full SubmissionUpload record
+      expect(publishStub.firstCall.args[1]).to.deep.equal({
+        submission_upload_id: 'su-1',
+        submission_id: 999,
+        upload_id: 'upload-1'
+      });
     });
 
     it('should propagate error when submission_upload lookup throws', async () => {

--- a/api/src/services/upload/artifact-security-service.ts
+++ b/api/src/services/upload/artifact-security-service.ts
@@ -116,6 +116,7 @@ export class ArtifactSecurityService extends DBService {
     const submissionUpload = await submissionUploadService.getSubmissionUploadByUploadId(uploadArchive.upload_id);
 
     await publishProcessSubmissionFeaturesJob(this.connection, {
+      uploadId: uploadArchive.upload_id,
       submissionId: submissionUpload.submission_id
     });
   }

--- a/api/src/services/upload/artifact-security-service.ts
+++ b/api/src/services/upload/artifact-security-service.ts
@@ -115,10 +115,7 @@ export class ArtifactSecurityService extends DBService {
     const submissionUploadService = new SubmissionUploadService(this.connection);
     const submissionUpload = await submissionUploadService.getSubmissionUploadByUploadId(uploadArchive.upload_id);
 
-    await publishProcessSubmissionFeaturesJob(this.connection, {
-      uploadId: uploadArchive.upload_id,
-      submissionId: submissionUpload.submission_id
-    });
+    await publishProcessSubmissionFeaturesJob(this.connection, submissionUpload);
   }
 
   /**

--- a/database/src/migrations/20260228120000_add_upload_id_to_submission_validation.ts
+++ b/database/src/migrations/20260228120000_add_upload_id_to_submission_validation.ts
@@ -13,7 +13,7 @@ export async function up(knex: Knex): Promise<void> {
       ADD COLUMN upload_id uuid;
 
     ALTER TABLE submission_validation
-      ADD CONSTRAINT submission_validation_fk1
+      ADD CONSTRAINT submission_validation_fk2
         FOREIGN KEY (upload_id) REFERENCES upload(upload_id);
 
     CREATE INDEX submission_validation_idx4
@@ -28,7 +28,7 @@ export async function down(knex: Knex): Promise<void> {
     SET SEARCH_PATH = biohub, public;
 
     ALTER TABLE submission_validation
-      DROP CONSTRAINT IF EXISTS submission_validation_fk1;
+      DROP CONSTRAINT IF EXISTS submission_validation_fk2;
 
     ALTER TABLE submission_validation
       DROP COLUMN IF EXISTS upload_id;

--- a/database/src/migrations/20260228120000_add_upload_id_to_submission_validation.ts
+++ b/database/src/migrations/20260228120000_add_upload_id_to_submission_validation.ts
@@ -1,0 +1,36 @@
+import { Knex } from 'knex';
+
+/**
+ * Add upload_id column to submission_validation so each validation record
+ * can be traced back to the specific upload that triggered it.
+ * Enables per-upload job tracking when multiple uploads exist per submission.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE submission_validation
+      ADD COLUMN upload_id uuid;
+
+    ALTER TABLE submission_validation
+      ADD CONSTRAINT submission_validation_fk1
+        FOREIGN KEY (upload_id) REFERENCES upload(upload_id);
+
+    CREATE INDEX submission_validation_idx4
+      ON submission_validation(upload_id);
+
+    COMMENT ON COLUMN submission_validation.upload_id IS 'Foreign key to the upload table.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE submission_validation
+      DROP CONSTRAINT IF EXISTS submission_validation_fk1;
+
+    ALTER TABLE submission_validation
+      DROP COLUMN IF EXISTS upload_id;
+  `);
+}

--- a/database/src/migrations/20260228120000_add_upload_id_to_submission_validation.ts
+++ b/database/src/migrations/20260228120000_add_upload_id_to_submission_validation.ts
@@ -1,25 +1,26 @@
 import { Knex } from 'knex';
 
 /**
- * Add upload_id column to submission_validation so each validation record
- * can be traced back to the specific upload that triggered it.
- * Enables per-upload job tracking when multiple uploads exist per submission.
+ * Add submission_upload_id column to submission_validation so each validation record
+ * can be traced back to the specific upload event that triggered it.
+ * Uses submission_upload as the FK target (not upload) because submission_upload_id
+ * is the processing identifier — it tracks which upload event for a given submission.
  */
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
     ALTER TABLE submission_validation
-      ADD COLUMN upload_id uuid;
+      ADD COLUMN submission_upload_id uuid;
 
     ALTER TABLE submission_validation
       ADD CONSTRAINT submission_validation_fk2
-        FOREIGN KEY (upload_id) REFERENCES upload(upload_id);
+        FOREIGN KEY (submission_upload_id) REFERENCES submission_upload(submission_upload_id);
 
     CREATE INDEX submission_validation_idx4
-      ON submission_validation(upload_id);
+      ON submission_validation(submission_upload_id);
 
-    COMMENT ON COLUMN submission_validation.upload_id IS 'Foreign key to the upload table.';
+    COMMENT ON COLUMN submission_validation.submission_upload_id IS 'Foreign key to the submission_upload table.';
   `);
 }
 
@@ -31,6 +32,6 @@ export async function down(knex: Knex): Promise<void> {
       DROP CONSTRAINT IF EXISTS submission_validation_fk2;
 
     ALTER TABLE submission_validation
-      DROP COLUMN IF EXISTS upload_id;
+      DROP COLUMN IF EXISTS submission_upload_id;
   `);
 }

--- a/database/src/migrations/20260308120000_rename_upload_id_to_submission_upload_id.ts
+++ b/database/src/migrations/20260308120000_rename_upload_id_to_submission_upload_id.ts
@@ -1,62 +1,39 @@
 import { Knex } from 'knex';
 
 /**
- * Rename submission_feature.upload_id → submission_upload_id and retarget FK
- * from upload(upload_id) to submission_upload(submission_upload_id).
+ * Replace submission_feature.upload_id (FK → upload) with submission_upload_id (FK → submission_upload).
  *
  * submission_upload_id is the processing identifier — it tracks which upload event
  * produced these features for a submission. This distinction enables multi-upload-per-submission
  * (append, replace) and eliminates the need to carry both uploadId and submissionId
  * through the pipeline.
  *
- * Backfill resolves existing upload_id values to submission_upload_id via the
- * submission_upload bridge table. A self-check assertion ensures no orphaned rows
- * remain before applying the FK constraint.
+ * No backfill needed — no production data exists yet. Seeds provide correct values directly.
  */
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
-    -- 1. Drop existing FK and index (target: upload table)
+    -- 1. Drop old upload_id column, FK, and index
     ALTER TABLE submission_feature
       DROP CONSTRAINT IF EXISTS submission_feature_fk4;
 
     DROP INDEX IF EXISTS submission_feature_idx4;
 
-    -- 2. Backfill: resolve upload_id → submission_upload_id via bridge table
-    UPDATE submission_feature sf
-      SET upload_id = su.submission_upload_id
-      FROM submission_upload su
-      WHERE su.upload_id = sf.upload_id;
-
-    -- 3. Self-check: fail if any rows could not be resolved
-    DO $$
-    DECLARE orphan_count INTEGER;
-    BEGIN
-      SELECT COUNT(*) INTO orphan_count
-      FROM submission_feature sf
-      LEFT JOIN submission_upload su ON su.submission_upload_id = sf.upload_id
-      WHERE su.submission_upload_id IS NULL;
-
-      IF orphan_count > 0 THEN
-        RAISE EXCEPTION 'Backfill incomplete: % submission_feature rows have no matching submission_upload', orphan_count;
-      END IF;
-    END $$;
-
-    -- 4. Rename column
     ALTER TABLE submission_feature
-      RENAME COLUMN upload_id TO submission_upload_id;
+      DROP COLUMN upload_id;
 
-    -- 5. Add new FK (target: submission_upload table)
+    -- 2. Add new submission_upload_id column with FK → submission_upload
+    ALTER TABLE submission_feature
+      ADD COLUMN submission_upload_id uuid NOT NULL;
+
     ALTER TABLE submission_feature
       ADD CONSTRAINT submission_feature_fk4
         FOREIGN KEY (submission_upload_id) REFERENCES submission_upload(submission_upload_id);
 
-    -- 6. Add index
     CREATE INDEX submission_feature_idx4
       ON submission_feature(submission_upload_id);
 
-    -- 7. Update column comment
     COMMENT ON COLUMN submission_feature.submission_upload_id IS 'Foreign key to the submission_upload table.';
   `);
 }
@@ -65,28 +42,23 @@ export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
-    -- 1. Drop new FK and index
+    -- 1. Drop submission_upload_id column, FK, and index
     ALTER TABLE submission_feature
       DROP CONSTRAINT IF EXISTS submission_feature_fk4;
 
     DROP INDEX IF EXISTS submission_feature_idx4;
 
-    -- 2. Reverse backfill: resolve submission_upload_id → upload_id via bridge table
-    UPDATE submission_feature sf
-      SET submission_upload_id = su.upload_id
-      FROM submission_upload su
-      WHERE su.submission_upload_id = sf.submission_upload_id;
-
-    -- 3. Rename column back
     ALTER TABLE submission_feature
-      RENAME COLUMN submission_upload_id TO upload_id;
+      DROP COLUMN submission_upload_id;
 
-    -- 4. Restore original FK (target: upload table)
+    -- 2. Restore upload_id column with FK → upload
+    ALTER TABLE submission_feature
+      ADD COLUMN upload_id uuid NOT NULL;
+
     ALTER TABLE submission_feature
       ADD CONSTRAINT submission_feature_fk4
         FOREIGN KEY (upload_id) REFERENCES upload(upload_id);
 
-    -- 5. Restore index
     CREATE INDEX submission_feature_idx4
       ON submission_feature(upload_id);
 

--- a/database/src/migrations/20260308120000_rename_upload_id_to_submission_upload_id.ts
+++ b/database/src/migrations/20260308120000_rename_upload_id_to_submission_upload_id.ts
@@ -1,0 +1,95 @@
+import { Knex } from 'knex';
+
+/**
+ * Rename submission_feature.upload_id → submission_upload_id and retarget FK
+ * from upload(upload_id) to submission_upload(submission_upload_id).
+ *
+ * submission_upload_id is the processing identifier — it tracks which upload event
+ * produced these features for a submission. This distinction enables multi-upload-per-submission
+ * (append, replace) and eliminates the need to carry both uploadId and submissionId
+ * through the pipeline.
+ *
+ * Backfill resolves existing upload_id values to submission_upload_id via the
+ * submission_upload bridge table. A self-check assertion ensures no orphaned rows
+ * remain before applying the FK constraint.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    -- 1. Drop existing FK and index (target: upload table)
+    ALTER TABLE submission_feature
+      DROP CONSTRAINT IF EXISTS submission_feature_fk4;
+
+    DROP INDEX IF EXISTS submission_feature_idx4;
+
+    -- 2. Backfill: resolve upload_id → submission_upload_id via bridge table
+    UPDATE submission_feature sf
+      SET upload_id = su.submission_upload_id
+      FROM submission_upload su
+      WHERE su.upload_id = sf.upload_id;
+
+    -- 3. Self-check: fail if any rows could not be resolved
+    DO $$
+    DECLARE orphan_count INTEGER;
+    BEGIN
+      SELECT COUNT(*) INTO orphan_count
+      FROM submission_feature sf
+      LEFT JOIN submission_upload su ON su.submission_upload_id = sf.upload_id
+      WHERE su.submission_upload_id IS NULL;
+
+      IF orphan_count > 0 THEN
+        RAISE EXCEPTION 'Backfill incomplete: % submission_feature rows have no matching submission_upload', orphan_count;
+      END IF;
+    END $$;
+
+    -- 4. Rename column
+    ALTER TABLE submission_feature
+      RENAME COLUMN upload_id TO submission_upload_id;
+
+    -- 5. Add new FK (target: submission_upload table)
+    ALTER TABLE submission_feature
+      ADD CONSTRAINT submission_feature_fk4
+        FOREIGN KEY (submission_upload_id) REFERENCES submission_upload(submission_upload_id);
+
+    -- 6. Add index
+    CREATE INDEX submission_feature_idx4
+      ON submission_feature(submission_upload_id);
+
+    -- 7. Update column comment
+    COMMENT ON COLUMN submission_feature.submission_upload_id IS 'Foreign key to the submission_upload table.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    -- 1. Drop new FK and index
+    ALTER TABLE submission_feature
+      DROP CONSTRAINT IF EXISTS submission_feature_fk4;
+
+    DROP INDEX IF EXISTS submission_feature_idx4;
+
+    -- 2. Reverse backfill: resolve submission_upload_id → upload_id via bridge table
+    UPDATE submission_feature sf
+      SET submission_upload_id = su.upload_id
+      FROM submission_upload su
+      WHERE su.submission_upload_id = sf.submission_upload_id;
+
+    -- 3. Rename column back
+    ALTER TABLE submission_feature
+      RENAME COLUMN submission_upload_id TO upload_id;
+
+    -- 4. Restore original FK (target: upload table)
+    ALTER TABLE submission_feature
+      ADD CONSTRAINT submission_feature_fk4
+        FOREIGN KEY (upload_id) REFERENCES upload(upload_id);
+
+    -- 5. Restore index
+    CREATE INDEX submission_feature_idx4
+      ON submission_feature(upload_id);
+
+    COMMENT ON COLUMN submission_feature.upload_id IS 'Foreign key to the upload session.';
+  `);
+}

--- a/database/src/seeds/04_mock_test_data.ts
+++ b/database/src/seeds/04_mock_test_data.ts
@@ -66,15 +66,16 @@ const insertRecord = async (knex: Knex) => {
   const submission_id = await insertSubmissionRecord(knex, isReviewed, isPublished);
 
   const upload_id = await insertUploadRecord(knex);
+  const submission_upload_id = await insertSubmissionUploadRecord(knex, submission_id, upload_id);
 
   // Dataset
-  const parent_submission_feature_id1 = await insertDatasetRecord(knex, { submission_id, upload_id });
+  const parent_submission_feature_id1 = await insertDatasetRecord(knex, { submission_id, submission_upload_id });
 
   // Sample Sites and their children
   const sampleSitePromises = Array.from({ length: 10 }).map(async () => {
     const parent_submission_feature_id2 = await insertSampleSiteRecord(knex, {
       submission_id,
-      upload_id,
+      submission_upload_id,
       parent_submission_feature_id: parent_submission_feature_id1
     });
 
@@ -82,7 +83,7 @@ const insertRecord = async (knex: Knex) => {
     const animalPromises = Array.from({ length: 2 }).map(() =>
       insertAnimalRecord(knex, {
         submission_id,
-        upload_id,
+        submission_upload_id,
         parent_submission_feature_id: parent_submission_feature_id2
       })
     );
@@ -91,7 +92,7 @@ const insertRecord = async (knex: Knex) => {
     const observationPromises = Array.from({ length: 20 }).map(() =>
       insertObservationRecord(knex, {
         submission_id,
-        upload_id,
+        submission_upload_id,
         parent_submission_feature_id: parent_submission_feature_id2
       })
     );
@@ -104,7 +105,7 @@ const insertRecord = async (knex: Knex) => {
   const telemetryPromises = Array.from({ length: 100 }).map(() =>
     insertTelemetryRecord(knex, {
       submission_id,
-      upload_id,
+      submission_upload_id,
       parent_submission_feature_id: parent_submission_feature_id1
     })
   );
@@ -126,12 +127,12 @@ export const insertSubmissionRecord = async (
 
 export const insertDatasetRecord = async (
   knex: Knex,
-  options: { submission_id: number; upload_id: string }
+  options: { submission_id: number; submission_upload_id: string }
 ): Promise<number> => {
   const response = await knex.raw(
     `${insertSubmissionFeature({
       submission_id: options.submission_id,
-      upload_id: options.upload_id,
+      submission_upload_id: options.submission_upload_id,
       parent_submission_feature_id: null,
       feature_type: 'dataset',
       data: {
@@ -182,14 +183,30 @@ export const insertUploadRecord = async (knex: Knex): Promise<string> => {
   return upload_id;
 };
 
+export const insertSubmissionUploadRecord = async (
+  knex: Knex,
+  submission_id: number,
+  upload_id: string
+): Promise<string> => {
+  const [{ submission_upload_id }] = await knex('submission_upload')
+    .insert({
+      submission_id,
+      upload_id,
+      create_user: 1
+    })
+    .returning('submission_upload_id');
+
+  return submission_upload_id;
+};
+
 export const insertSampleSiteRecord = async (
   knex: Knex,
-  options: { submission_id: number; upload_id: string; parent_submission_feature_id: number }
+  options: { submission_id: number; submission_upload_id: string; parent_submission_feature_id: number }
 ): Promise<number> => {
   const response = await knex.raw(
     `${insertSubmissionFeature({
       submission_id: options.submission_id,
-      upload_id: options.upload_id,
+      submission_upload_id: options.submission_upload_id,
       parent_submission_feature_id: options.parent_submission_feature_id,
       feature_type: 'sample_site',
       data: {
@@ -214,12 +231,12 @@ export const insertSampleSiteRecord = async (
 
 export const insertObservationRecord = async (
   knex: Knex,
-  options: { submission_id: number; upload_id: string; parent_submission_feature_id: number }
+  options: { submission_id: number; submission_upload_id: string; parent_submission_feature_id: number }
 ): Promise<number> => {
   const response = await knex.raw(
     `${insertSubmissionFeature({
       submission_id: options.submission_id,
-      upload_id: options.upload_id,
+      submission_upload_id: options.submission_upload_id,
       parent_submission_feature_id: options.parent_submission_feature_id,
       feature_type: 'species_observation',
       data: {
@@ -257,12 +274,12 @@ export const insertObservationRecord = async (
 
 const insertAnimalRecord = async (
   knex: Knex,
-  options: { submission_id: number; upload_id: string; parent_submission_feature_id: number }
+  options: { submission_id: number; submission_upload_id: string; parent_submission_feature_id: number }
 ): Promise<number> => {
   const response = await knex.raw(
     `${insertSubmissionFeature({
       submission_id: options.submission_id,
-      upload_id: options.upload_id,
+      submission_upload_id: options.submission_upload_id,
       parent_submission_feature_id: options.parent_submission_feature_id,
       feature_type: 'animal',
       data: {
@@ -332,7 +349,7 @@ export const insertSubmission = (includeSecurityReviewTimestamp: boolean, includ
 
 export const insertSubmissionFeature = (options: {
   submission_id: number;
-  upload_id: string;
+  submission_upload_id: string;
   parent_submission_feature_id: number | null;
   feature_type: 'dataset' | 'sample_site' | 'species_observation' | 'animal' | 'artifact' | 'telemetry';
   data: { [key: string]: any };
@@ -340,7 +357,7 @@ export const insertSubmissionFeature = (options: {
     INSERT INTO submission_feature
     (
         submission_id,
-        upload_id,
+        submission_upload_id,
         parent_submission_feature_id,
         feature_type_id,
         source_id,
@@ -350,7 +367,7 @@ export const insertSubmissionFeature = (options: {
     values
     (
         ${options.submission_id},
-        '${options.upload_id}',
+        '${options.submission_upload_id}',
         ${options.parent_submission_feature_id},
         (select feature_type_id from feature_type where name = '${options.feature_type}'),
         public.gen_random_uuid(),
@@ -489,7 +506,7 @@ const randomIntFromInterval = (min: number, max: number) => {
 
 export const insertTelemetryRecord = async (
   knex: Knex,
-  options: { submission_id: number; upload_id: string; parent_submission_feature_id: number }
+  options: { submission_id: number; submission_upload_id: string; parent_submission_feature_id: number }
 ): Promise<number> => {
   const telemetryData = {
     device_id: faker.string.alphanumeric({ length: 8 }),
@@ -504,7 +521,7 @@ export const insertTelemetryRecord = async (
   const response = await knex.raw(
     `${insertSubmissionFeature({
       submission_id: options.submission_id,
-      upload_id: options.upload_id,
+      submission_upload_id: options.submission_upload_id,
       parent_submission_feature_id: options.parent_submission_feature_id,
       feature_type: 'telemetry',
       data: telemetryData

--- a/database/src/seeds/06_submission_data.ts
+++ b/database/src/seeds/06_submission_data.ts
@@ -4,6 +4,7 @@ import {
   insertDatasetRecord,
   insertSampleSiteRecord,
   insertSubmissionRecord,
+  insertSubmissionUploadRecord,
   insertTelemetryRecord,
   insertUploadRecord
 } from './04_mock_test_data';
@@ -17,6 +18,7 @@ type SecurityStatus = 'clean' | 'pending' | 'infected' | 'error' | 'skipped';
 interface SeedContext {
   submission_id: number;
   upload_id: string;
+  submission_upload_id: string;
   artifacts: { artifact_id: string; role: string }[];
 }
 
@@ -56,21 +58,24 @@ const createSubmissionWithUploads = async (
   // --- 1. Create upload session ---
   const upload_id = await insertUploadRecord(knex);
 
-  // --- 2. Create submission & features ---
+  // --- 2. Create submission & link upload ---
   const submission_id = await insertSubmissionRecord(knex, reviewed, reviewed);
-  const parent_feature_id = await insertDatasetRecord(knex, { submission_id, upload_id });
+  const submission_upload_id = await insertSubmissionUploadRecord(knex, submission_id, upload_id);
+
+  // --- 3. Create features (requires submission_upload_id for FK) ---
+  const parent_feature_id = await insertDatasetRecord(knex, { submission_id, submission_upload_id });
   await insertSampleSiteRecord(knex, {
     submission_id,
-    upload_id,
+    submission_upload_id,
     parent_submission_feature_id: parent_feature_id
   });
   await insertTelemetryRecord(knex, {
     submission_id,
-    upload_id,
+    submission_upload_id,
     parent_submission_feature_id: parent_feature_id
   });
 
-  // --- 3. Create artifacts and security scans ---
+  // --- 4. Create artifacts and security scans ---
   const artifacts: { artifact_id: string; role: string }[] = [];
 
   if (withArchive) {
@@ -79,14 +84,7 @@ const createSubmissionWithUploads = async (
     await createDirectUpload(knex, upload_id, submission_id, securityLevel, artifacts);
   }
 
-  // --- 4. Link submission to upload ---
-  await knex('submission_upload').insert({
-    submission_id,
-    upload_id,
-    create_user: 1
-  });
-
-  return { submission_id, upload_id, artifacts };
+  return { submission_id, upload_id, submission_upload_id, artifacts };
 };
 
 /**


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-882](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-882)

## Description of Changes

Update the ingestion jobs that currently take submission_id so they can take submission_upload_id instead.

This makes ingestion upload-scoped, so the same submission_id can be re-published by creating a new upload and running ingestion again without colliding with (or overwriting) prior runs.
Job logging and validation/processing status should be attributable to the specific upload being processed, not the parent submission.

## Testing Notes

Run `make test`
