### PR TITLE
SIMSBIOHUB-833: Bulk Download Based on Query

### DIFF
--- a/api/src/__integration__/db/download-service.integration.ts
+++ b/api/src/__integration__/db/download-service.integration.ts
@@ -60,7 +60,7 @@ describe('DownloadPipelineService (integration)', function () {
       const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset A' });
       const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset B' });
       // Step 2: Create download request through the service (no team for test)
-      const result = await service.createDownloadRequest(null, [featureId1, featureId2]);
+      const result = await service.createDownloadRequest(null, null, [featureId1, featureId2]);
 
       // Step 3: Verify download record was created with correct initial state
       const download = await crudService.findDownloadById(result.download_id);
@@ -94,7 +94,7 @@ describe('DownloadPipelineService (integration)', function () {
 
       // Step 3: Attempt to link a non-existent submission_feature_id
       try {
-        await service.createDownloadRequest(null, [999999]);
+        await service.createDownloadRequest(null, null, [999999]);
         expect.fail('Should have thrown a foreign key violation');
       } catch (error) {
         // Expected: FK constraint violation on download_feature.submission_feature_id
@@ -116,7 +116,7 @@ describe('DownloadPipelineService (integration)', function () {
       // Step 1: Create a download
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Test' });
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       // Step 2: Transition to processing
       await service.updateDownloadStatus(download_id, DownloadStatusEnum.PROCESSING);
@@ -154,7 +154,7 @@ describe('DownloadPipelineService (integration)', function () {
         count: 12,
         timestamp: '2024-01-16T14:30:00Z'
       });
-      const { download_id } = await service.createDownloadRequest(null, [featureId1, featureId2]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId1, featureId2]);
 
       // Step 2: Verify initial state
       const initial = await crudService.findDownloadById(download_id);
@@ -191,7 +191,7 @@ describe('DownloadPipelineService (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Size Test' });
 
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       const sizeData = await crudService.getDownloadFeatureSummaries(download_id, null);
 
@@ -209,7 +209,7 @@ describe('DownloadPipelineService (integration)', function () {
       const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
       await secureFeature(securedFeatureId);
 
-      const { download_id } = await service.createDownloadRequest(null, [openFeatureId, securedFeatureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [openFeatureId, securedFeatureId]);
 
       const sizeData = await crudService.getDownloadFeatureSummaries(download_id, null);
 
@@ -235,7 +235,7 @@ describe('DownloadPipelineService (integration)', function () {
       );
 
       // Step 2: Create download and plan fragments
-      const { download_id } = await service.createDownloadRequest(null, [childFeatureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [childFeatureId]);
       const sizeEstimate = await service.estimateDownloadSize(download_id, null);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -275,7 +275,7 @@ describe('DownloadPipelineService (integration)', function () {
       });
 
       // Step 2: Create download and plan fragments
-      const { download_id } = await service.createDownloadRequest(null, [rootFeatureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [rootFeatureId]);
       const sizeEstimate = await service.estimateDownloadSize(download_id, null);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -386,7 +386,7 @@ describe('DownloadPipelineService (integration)', function () {
   async function createAnonymousDownload(): Promise<string> {
     const submissionId = await createTestSubmission(connection);
     const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Anon' });
-    const { download_id } = await service.createDownloadRequest(null, [featureId]);
+    const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
     // createDownloadRequest sets system_user_id from connection.systemUserId(),
     // but the API user connection returns a real user id. Clear it for anonymous:
     await connection.sql(SQL`
@@ -438,7 +438,7 @@ describe('DownloadPipelineService (integration)', function () {
       // Create a download with team_id set
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
-      const { download_id } = await service.createDownloadRequest(teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
 
       // Clear system_user_id but keep team_id
       await connection.sql(SQL`
@@ -461,7 +461,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should authorize owner (system_user_id path)', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Owned' });
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       // API user is the owner (createDownloadRequest sets system_user_id)
       const apiUserId = connection.systemUserId();
@@ -472,7 +472,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should throw HTTP403 for wrong user (not owner, not shared, not team member)', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Owned' });
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       const otherUserId = await createOtherUser();
       try {
@@ -486,7 +486,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should authorize via download_share (shared path)', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Shared' });
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       // Share with another user
       const otherUserId = await createOtherUser();
@@ -505,7 +505,7 @@ describe('DownloadPipelineService (integration)', function () {
       // Create download linked to data request
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Request' });
-      const { download_id } = await service.createDownloadRequest(teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
 
       await service.getAuthorizedDownload(download_id, otherUserId);
       // No error thrown — authorized
@@ -520,7 +520,7 @@ describe('DownloadPipelineService (integration)', function () {
 
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Locked' });
-      const { download_id } = await service.createDownloadRequest(teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
 
       try {
         await service.getAuthorizedDownload(download_id, outsider);
@@ -537,7 +537,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should return owned downloads', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Mine' });
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       const apiUserId = connection.systemUserId();
       const downloads = await crudService.getDownloadsByTeamMembership(apiUserId);
@@ -548,7 +548,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should return shared downloads', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Shared List' });
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       const otherUserId = await createOtherUser();
       await shareDownload(download_id, otherUserId);
@@ -566,7 +566,7 @@ describe('DownloadPipelineService (integration)', function () {
 
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Team DL' });
-      const { download_id } = await service.createDownloadRequest(teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
 
       const downloads = await crudService.getDownloadsByTeamMembership(otherUserId);
       const ids = downloads.map((d) => d.download_id);
@@ -576,7 +576,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should not return downloads the user has no access to', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Private' });
-      const { download_id } = await service.createDownloadRequest(null, [featureId]);
+      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
 
       const otherUserId = await createOtherUser();
       const downloads = await crudService.getDownloadsByTeamMembership(otherUserId);

--- a/api/src/__integration__/db/download-service.integration.ts
+++ b/api/src/__integration__/db/download-service.integration.ts
@@ -60,7 +60,7 @@ describe('DownloadPipelineService (integration)', function () {
       const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset A' });
       const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset B' });
       // Step 2: Create download request through the service (no team for test)
-      const result = await service.createDownloadRequest(null, null, [featureId1, featureId2]);
+      const result = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId1, featureId2] });
 
       // Step 3: Verify download record was created with correct initial state
       const download = await crudService.findDownloadById(result.download_id);
@@ -94,7 +94,7 @@ describe('DownloadPipelineService (integration)', function () {
 
       // Step 3: Attempt to link a non-existent submission_feature_id
       try {
-        await service.createDownloadRequest(null, null, [999999]);
+        await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [999999] });
         expect.fail('Should have thrown a foreign key violation');
       } catch (error) {
         // Expected: FK constraint violation on download_feature.submission_feature_id
@@ -116,7 +116,7 @@ describe('DownloadPipelineService (integration)', function () {
       // Step 1: Create a download
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Test' });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
 
       // Step 2: Transition to processing
       await service.updateDownloadStatus(download_id, DownloadStatusEnum.PROCESSING);
@@ -143,6 +143,7 @@ describe('DownloadPipelineService (integration)', function () {
   describe('full status lifecycle', () => {
     it('should transition pending → processing → ready and track all timestamps', async () => {
       // Step 1: Create a download with features
+      const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId1 = await createTestFeature(connection, submissionId, 'species_observation', {
         taxon_id: 180703,
@@ -154,7 +155,7 @@ describe('DownloadPipelineService (integration)', function () {
         count: 12,
         timestamp: '2024-01-16T14:30:00Z'
       });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId1, featureId2]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId1, featureId2] });
 
       // Step 2: Verify initial state
       const initial = await crudService.findDownloadById(download_id);
@@ -191,7 +192,7 @@ describe('DownloadPipelineService (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Size Test' });
 
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
 
       const sizeData = await crudService.getDownloadFeatureSummaries(download_id, null);
 
@@ -209,7 +210,7 @@ describe('DownloadPipelineService (integration)', function () {
       const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
       await secureFeature(securedFeatureId);
 
-      const { download_id } = await service.createDownloadRequest(null, null, [openFeatureId, securedFeatureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [openFeatureId, securedFeatureId] });
 
       const sizeData = await crudService.getDownloadFeatureSummaries(download_id, null);
 
@@ -235,7 +236,7 @@ describe('DownloadPipelineService (integration)', function () {
       );
 
       // Step 2: Create download and plan fragments
-      const { download_id } = await service.createDownloadRequest(null, null, [childFeatureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [childFeatureId] });
       const sizeEstimate = await service.estimateDownloadSize(download_id, null);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -275,7 +276,7 @@ describe('DownloadPipelineService (integration)', function () {
       });
 
       // Step 2: Create download and plan fragments
-      const { download_id } = await service.createDownloadRequest(null, null, [rootFeatureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [rootFeatureId] });
       const sizeEstimate = await service.estimateDownloadSize(download_id, null);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -386,7 +387,7 @@ describe('DownloadPipelineService (integration)', function () {
   async function createAnonymousDownload(): Promise<string> {
     const submissionId = await createTestSubmission(connection);
     const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Anon' });
-    const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
+    const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
     // createDownloadRequest sets system_user_id from connection.systemUserId(),
     // but the API user connection returns a real user id. Clear it for anonymous:
     await connection.sql(SQL`
@@ -438,7 +439,7 @@ describe('DownloadPipelineService (integration)', function () {
       // Create a download with team_id set
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
-      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
 
       // Clear system_user_id but keep team_id
       await connection.sql(SQL`
@@ -459,20 +460,19 @@ describe('DownloadPipelineService (integration)', function () {
 
   describe('getAuthorizedDownload', () => {
     it('should authorize owner (system_user_id path)', async () => {
+      const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Owned' });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
-
-      // API user is the owner (createDownloadRequest sets system_user_id)
-      const apiUserId = connection.systemUserId();
+      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId] });
       await service.getAuthorizedDownload(download_id, apiUserId);
       // No error thrown — authorized
     });
 
     it('should throw HTTP403 for wrong user (not owner, not shared, not team member)', async () => {
+      const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Owned' });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId] });
 
       const otherUserId = await createOtherUser();
       try {
@@ -486,7 +486,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should authorize via download_share (shared path)', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Shared' });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
 
       // Share with another user
       const otherUserId = await createOtherUser();
@@ -505,7 +505,7 @@ describe('DownloadPipelineService (integration)', function () {
       // Create download linked to data request
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Request' });
-      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
 
       await service.getAuthorizedDownload(download_id, otherUserId);
       // No error thrown — authorized
@@ -520,7 +520,7 @@ describe('DownloadPipelineService (integration)', function () {
 
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Locked' });
-      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
 
       try {
         await service.getAuthorizedDownload(download_id, outsider);
@@ -535,11 +535,10 @@ describe('DownloadPipelineService (integration)', function () {
 
   describe('getDownloadsByTeamMembership', () => {
     it('should return owned downloads', async () => {
+      const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Mine' });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
-
-      const apiUserId = connection.systemUserId();
+      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId] });
       const downloads = await crudService.getDownloadsByTeamMembership(apiUserId);
       const ids = downloads.map((d) => d.download_id);
       expect(ids).to.include(download_id);
@@ -548,7 +547,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should return shared downloads', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Shared List' });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
 
       const otherUserId = await createOtherUser();
       await shareDownload(download_id, otherUserId);
@@ -566,7 +565,7 @@ describe('DownloadPipelineService (integration)', function () {
 
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Team DL' });
-      const { download_id } = await service.createDownloadRequest(null, teamId, [featureId], dataRequestId);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
 
       const downloads = await crudService.getDownloadsByTeamMembership(otherUserId);
       const ids = downloads.map((d) => d.download_id);
@@ -576,7 +575,7 @@ describe('DownloadPipelineService (integration)', function () {
     it('should not return downloads the user has no access to', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Private' });
-      const { download_id } = await service.createDownloadRequest(null, null, [featureId]);
+      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
 
       const otherUserId = await createOtherUser();
       const downloads = await crudService.getDownloadsByTeamMembership(otherUserId);

--- a/api/src/__integration__/db/download-service.integration.ts
+++ b/api/src/__integration__/db/download-service.integration.ts
@@ -60,7 +60,11 @@ describe('DownloadPipelineService (integration)', function () {
       const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset A' });
       const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset B' });
       // Step 2: Create download request through the service (no team for test)
-      const result = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId1, featureId2] });
+      const result = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [featureId1, featureId2]
+      });
 
       // Step 3: Verify download record was created with correct initial state
       const download = await crudService.findDownloadById(result.download_id);
@@ -116,7 +120,11 @@ describe('DownloadPipelineService (integration)', function () {
       // Step 1: Create a download
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Test' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
 
       // Step 2: Transition to processing
       await service.updateDownloadStatus(download_id, DownloadStatusEnum.PROCESSING);
@@ -155,7 +163,11 @@ describe('DownloadPipelineService (integration)', function () {
         count: 12,
         timestamp: '2024-01-16T14:30:00Z'
       });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId1, featureId2] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: apiUserId,
+        teamId: null,
+        submissionFeatureIds: [featureId1, featureId2]
+      });
 
       // Step 2: Verify initial state
       const initial = await crudService.findDownloadById(download_id);
@@ -192,7 +204,11 @@ describe('DownloadPipelineService (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Size Test' });
 
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
 
       const sizeData = await crudService.getDownloadFeatureSummaries(download_id, null);
 
@@ -210,7 +226,11 @@ describe('DownloadPipelineService (integration)', function () {
       const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
       await secureFeature(securedFeatureId);
 
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [openFeatureId, securedFeatureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [openFeatureId, securedFeatureId]
+      });
 
       const sizeData = await crudService.getDownloadFeatureSummaries(download_id, null);
 
@@ -236,7 +256,11 @@ describe('DownloadPipelineService (integration)', function () {
       );
 
       // Step 2: Create download and plan fragments
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [childFeatureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [childFeatureId]
+      });
       const sizeEstimate = await service.estimateDownloadSize(download_id, null);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -276,7 +300,11 @@ describe('DownloadPipelineService (integration)', function () {
       });
 
       // Step 2: Create download and plan fragments
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [rootFeatureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [rootFeatureId]
+      });
       const sizeEstimate = await service.estimateDownloadSize(download_id, null);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -387,7 +415,11 @@ describe('DownloadPipelineService (integration)', function () {
   async function createAnonymousDownload(): Promise<string> {
     const submissionId = await createTestSubmission(connection);
     const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Anon' });
-    const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
+    const { download_id } = await service.createDownloadRequest({
+      systemUserId: null,
+      teamId: null,
+      submissionFeatureIds: [featureId]
+    });
     // createDownloadRequest sets system_user_id from connection.systemUserId(),
     // but the API user connection returns a real user id. Clear it for anonymous:
     await connection.sql(SQL`
@@ -439,7 +471,12 @@ describe('DownloadPipelineService (integration)', function () {
       // Create a download with team_id set
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId,
+        submissionFeatureIds: [featureId],
+        dataRequestId
+      });
 
       // Clear system_user_id but keep team_id
       await connection.sql(SQL`
@@ -463,7 +500,11 @@ describe('DownloadPipelineService (integration)', function () {
       const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Owned' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: apiUserId,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
       await service.getAuthorizedDownload(download_id, apiUserId);
       // No error thrown — authorized
     });
@@ -472,7 +513,11 @@ describe('DownloadPipelineService (integration)', function () {
       const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Owned' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: apiUserId,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
 
       const otherUserId = await createOtherUser();
       try {
@@ -486,7 +531,11 @@ describe('DownloadPipelineService (integration)', function () {
     it('should authorize via download_share (shared path)', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Shared' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
 
       // Share with another user
       const otherUserId = await createOtherUser();
@@ -505,7 +554,12 @@ describe('DownloadPipelineService (integration)', function () {
       // Create download linked to data request
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Request' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId,
+        submissionFeatureIds: [featureId],
+        dataRequestId
+      });
 
       await service.getAuthorizedDownload(download_id, otherUserId);
       // No error thrown — authorized
@@ -520,7 +574,12 @@ describe('DownloadPipelineService (integration)', function () {
 
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Locked' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId,
+        submissionFeatureIds: [featureId],
+        dataRequestId
+      });
 
       try {
         await service.getAuthorizedDownload(download_id, outsider);
@@ -538,7 +597,11 @@ describe('DownloadPipelineService (integration)', function () {
       const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Mine' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: apiUserId, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: apiUserId,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
       const downloads = await crudService.getDownloadsByTeamMembership(apiUserId);
       const ids = downloads.map((d) => d.download_id);
       expect(ids).to.include(download_id);
@@ -547,7 +610,11 @@ describe('DownloadPipelineService (integration)', function () {
     it('should return shared downloads', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Shared List' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
 
       const otherUserId = await createOtherUser();
       await shareDownload(download_id, otherUserId);
@@ -565,7 +632,12 @@ describe('DownloadPipelineService (integration)', function () {
 
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Team DL' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId, submissionFeatureIds: [featureId], dataRequestId });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId,
+        submissionFeatureIds: [featureId],
+        dataRequestId
+      });
 
       const downloads = await crudService.getDownloadsByTeamMembership(otherUserId);
       const ids = downloads.map((d) => d.download_id);
@@ -575,7 +647,11 @@ describe('DownloadPipelineService (integration)', function () {
     it('should not return downloads the user has no access to', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Private' });
-      const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [featureId] });
+      const { download_id } = await service.createDownloadRequest({
+        systemUserId: null,
+        teamId: null,
+        submissionFeatureIds: [featureId]
+      });
 
       const otherUserId = await createOtherUser();
       const downloads = await crudService.getDownloadsByTeamMembership(otherUserId);

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -544,7 +544,7 @@ describe('DownloadPipelineService download pipeline (system)', function () {
    * Helper: run the full download pipeline and return the resulting zip.
    */
   async function executeAndGetZip(featureIds: number[]): Promise<{ zip: AdmZip; downloadId: string }> {
-    const { download_id } = await service.createDownloadRequest(null, featureIds);
+    const { download_id } = await service.createDownloadRequest(null, null, featureIds);
 
     // Run the three-phase pipeline within the test transaction
     await service.planDownloadIfNeeded(download_id);

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -544,7 +544,11 @@ describe('DownloadPipelineService download pipeline (system)', function () {
    * Helper: run the full download pipeline and return the resulting zip.
    */
   async function executeAndGetZip(featureIds: number[]): Promise<{ zip: AdmZip; downloadId: string }> {
-    const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: featureIds });
+    const { download_id } = await service.createDownloadRequest({
+      systemUserId: null,
+      teamId: null,
+      submissionFeatureIds: featureIds
+    });
 
     // Run the three-phase pipeline within the test transaction
     await service.planDownloadIfNeeded(download_id);

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -544,7 +544,7 @@ describe('DownloadPipelineService download pipeline (system)', function () {
    * Helper: run the full download pipeline and return the resulting zip.
    */
   async function executeAndGetZip(featureIds: number[]): Promise<{ zip: AdmZip; downloadId: string }> {
-    const { download_id } = await service.createDownloadRequest(null, null, featureIds);
+    const { download_id } = await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: featureIds });
 
     // Run the three-phase pipeline within the test transaction
     await service.planDownloadIfNeeded(download_id);

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -66,7 +66,7 @@ export const CreateDownload = z.object({
   dataRequestId: z.string().nullable(),
   fragmentSizeBytes: z.number().optional(),
   systemUserId: z.number().nullable().optional(),
-  searchFilters: SearchFeatureFiltersSchema.optional()
+  filters: SearchFeatureFiltersSchema.optional()
 });
 export type CreateDownload = z.infer<typeof CreateDownload>;
 
@@ -83,6 +83,6 @@ export const CreateDownloadRequest = z.object({
   submissionFeatureIds: z.array(z.number()),
   dataRequestId: z.string().optional(),
   fragmentSizeMb: z.number().optional(),
-  searchFilters: SearchFeatureFiltersSchema.optional()
+  filters: SearchFeatureFiltersSchema.optional()
 });
 export type CreateDownloadRequest = z.infer<typeof CreateDownloadRequest>;

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { DownloadStatusZod } from './download-status';
+import { SearchFeatureFiltersSchema } from '../services/search-feature-service.interface';
 
 export const DownloadRecord = z.object({
   download_id: z.string(),
@@ -53,3 +54,35 @@ export interface DownloadSizeEstimate {
   /** The features included in this download with per-feature estimated_byte_size. */
   features: DownloadFeatureSummary[];
 }
+
+/**
+ * Payload for creating a new download record.
+ *
+ * Bundles the identifiers and optional configuration that flow from the
+ * pipeline service through to the repository INSERT. 
+ */
+export const CreateDownload = z.object({
+  teamId: z.string().nullable(),
+  dataRequestId: z.string().nullable(),
+  fragmentSizeBytes: z.number().optional(),
+  systemUserId: z.number().nullable().optional(),
+  searchFilters: SearchFeatureFiltersSchema.optional()
+});
+export type CreateDownload = z.infer<typeof CreateDownload>;
+
+/**
+ * Payload for creating a download request through the pipeline.
+ *
+ * Accepted by the pipeline service's public entry point. Includes the feature
+ * selection and optional fragment sizing before the request is persisted and
+ * features are linked.
+ */
+export const CreateDownloadRequest = z.object({
+  systemUserId: z.number().nullable(),
+  teamId: z.string().nullable(),
+  submissionFeatureIds: z.array(z.number()),
+  dataRequestId: z.string().optional(),
+  fragmentSizeMb: z.number().optional(),
+  searchFilters: SearchFeatureFiltersSchema.optional()
+});
+export type CreateDownloadRequest = z.infer<typeof CreateDownloadRequest>;

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { DownloadStatusZod } from './download-status';
 import { SearchFeatureFiltersSchema } from '../services/search-feature-service.interface';
+import { DownloadStatusZod } from './download-status';
 
 export const DownloadRecord = z.object({
   download_id: z.string(),
@@ -59,7 +59,7 @@ export interface DownloadSizeEstimate {
  * Payload for creating a new download record.
  *
  * Bundles the identifiers and optional configuration that flow from the
- * pipeline service through to the repository INSERT. 
+ * pipeline service through to the repository INSERT.
  */
 export const CreateDownload = z.object({
   teamId: z.string().nullable(),

--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -22,7 +22,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([]);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(0);
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -44,6 +44,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(3);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
       sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
@@ -65,6 +66,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([10, 20]);
       const createDownloadRequestStub = sinon
         .stub(DownloadPipelineService.prototype, 'createDownloadRequest')
@@ -89,6 +91,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(3);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
       const createDownloadRequestStub = sinon
         .stub(DownloadPipelineService.prototype, 'createDownloadRequest')
@@ -113,6 +116,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
       const getSearchFeatureIdsStub = sinon
         .stub(SearchFeatureService.prototype, 'getSearchFeatureIds')
         .resolves([1, 2]);
@@ -135,6 +139,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(1);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1]);
       sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
@@ -155,6 +160,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       const getAPIUserDBConnectionStub = sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(1);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1]);
       sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
@@ -177,6 +183,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(1);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').rejects(new Error('Search failed'));
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -202,6 +209,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2]);
       sinon
         .stub(DownloadPipelineService.prototype, 'createDownloadRequest')
@@ -231,6 +239,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(3);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
       sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
       const publishStub = sinon
@@ -256,6 +265,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
       sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2]);
       sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
       sinon.stub(publisher, 'publishProcessDownloadJob').rejects(new Error('pg-boss unavailable'));

--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -1,0 +1,277 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { createDownload } from '.';
+import * as db from '../../database/db';
+import { HTTPError } from '../../errors/http-error';
+import * as publisher from '../../queue/publisher';
+import { DownloadPipelineService } from '../../services/download/download-pipeline-service';
+import { SearchFeatureService } from '../../services/search-feature-service';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../__mocks__/db';
+
+chai.use(sinonChai);
+
+describe('paths/download/index', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('createDownload', () => {
+    it('should return 400 when no features match the filter criteria', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([]);
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'nonexistent' } };
+
+      const requestHandler = createDownload();
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail();
+      } catch (error) {
+        expect((error as HTTPError).status).to.equal(400);
+        expect((error as HTTPError).message).to.equal('No features match the filter criteria');
+      }
+    });
+
+    it('should return 201 with download_id on success', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
+      sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'moose' } };
+
+      const requestHandler = createDownload();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.statusValue).to.equal(201);
+      expect(mockRes.jsonValue).to.eql({ download_id: 'uuid-1' });
+    });
+
+    it('should pass search filters to createDownloadRequest as 5th arg', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([10, 20]);
+      const createDownloadRequestStub = sinon
+        .stub(DownloadPipelineService.prototype, 'createDownloadRequest')
+        .resolves({ download_id: 'uuid-2' } as any);
+      sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { feature_types: ['dataset'] } };
+
+      const requestHandler = createDownload();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(createDownloadRequestStub.firstCall.args[4]).to.eql({ feature_types: ['dataset'] });
+    });
+
+    it('should pass teamId=null, dataRequestId=undefined to createDownloadRequest', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
+      const createDownloadRequestStub = sinon
+        .stub(DownloadPipelineService.prototype, 'createDownloadRequest')
+        .resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'elk' } };
+
+      const requestHandler = createDownload();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(createDownloadRequestStub.firstCall.args[0]).to.equal(null);
+      expect(createDownloadRequestStub.firstCall.args[2]).to.equal(undefined);
+    });
+
+    it('should pass filters to getSearchFeatureIds', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      const getSearchFeatureIdsStub = sinon
+        .stub(SearchFeatureService.prototype, 'getSearchFeatureIds')
+        .resolves([1, 2]);
+      sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'elk' } };
+
+      const requestHandler = createDownload();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(getSearchFeatureIdsStub).to.have.been.calledWith({ keyword: 'elk' });
+    });
+
+    it('should use getDBConnection when authenticated', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1]);
+      sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = 'valid-token';
+      mockReq.body = { filters: { keyword: 'moose' } };
+
+      const requestHandler = createDownload();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(getDBConnectionStub).to.have.been.calledWith('valid-token');
+    });
+
+    it('should use getAPIUserDBConnection when anonymous', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      const getAPIUserDBConnectionStub = sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1]);
+      sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'moose' } };
+
+      const requestHandler = createDownload();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(getAPIUserDBConnectionStub).to.have.been.calledOnce;
+    });
+
+    it('should rollback and release on search error', async () => {
+      const rollbackStub = sinon.stub();
+      const releaseStub = sinon.stub();
+      const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').rejects(new Error('Search failed'));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'moose' } };
+
+      const requestHandler = createDownload();
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail();
+      } catch (error) {
+        expect((error as Error).message).to.equal('Search failed');
+        expect(rollbackStub).to.have.been.calledOnce;
+        expect(releaseStub).to.have.been.calledOnce;
+      }
+    });
+
+    it('should rollback and release on download creation error', async () => {
+      const rollbackStub = sinon.stub();
+      const releaseStub = sinon.stub();
+      const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2]);
+      sinon
+        .stub(DownloadPipelineService.prototype, 'createDownloadRequest')
+        .rejects(new Error('Download creation failed'));
+
+      const publishStub = sinon.stub(publisher, 'publishProcessDownloadJob');
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'moose' } };
+
+      const requestHandler = createDownload();
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail();
+      } catch (error) {
+        expect((error as Error).message).to.equal('Download creation failed');
+        expect(rollbackStub).to.have.been.calledOnce;
+        expect(releaseStub).to.have.been.calledOnce;
+        expect(publishStub).to.not.have.been.called;
+      }
+    });
+
+    it('should publish download job with download_id before commit', async () => {
+      const dbConnectionObj = getMockDBConnection();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
+      sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      const publishStub = sinon
+        .stub(publisher, 'publishProcessDownloadJob')
+        .resolves({ status: 'published', jobId: 'job-1' });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'moose' } };
+
+      const requestHandler = createDownload();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(publishStub).to.have.been.calledOnce;
+      expect(publishStub.firstCall.args[1]).to.eql({ downloadId: 'uuid-1' });
+    });
+
+    it('should rollback and release when publishProcessDownloadJob throws', async () => {
+      const rollbackStub = sinon.stub();
+      const releaseStub = sinon.stub();
+      const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2]);
+      sinon.stub(DownloadPipelineService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(publisher, 'publishProcessDownloadJob').rejects(new Error('pg-boss unavailable'));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      mockReq.keycloak_token = undefined as any;
+      mockReq.body = { filters: { keyword: 'moose' } };
+
+      const requestHandler = createDownload();
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail();
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+        expect(rollbackStub).to.have.been.calledOnce;
+        expect(releaseStub).to.have.been.calledOnce;
+      }
+    });
+  });
+});

--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -61,7 +61,7 @@ describe('paths/download/index', () => {
       expect(mockRes.jsonValue).to.eql({ download_id: 'uuid-1' });
     });
 
-    it('should pass search filters to createDownloadRequest as 5th arg', async () => {
+    it('should pass search filters to createDownloadRequest', async () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
@@ -80,11 +80,12 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      // args[5] = searchFilters
-      expect(createDownloadRequestStub.firstCall.args[5]).to.eql({ feature_types: ['dataset'] });
+      expect(createDownloadRequestStub.firstCall.args[0]).to.have.deep.property('searchFilters', {
+        feature_types: ['dataset']
+      });
     });
 
-    it('should pass systemUserId=null, teamId=null, dataRequestId=undefined for anonymous', async () => {
+    it('should pass systemUserId=null, teamId=null for anonymous', async () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
@@ -103,10 +104,9 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      // args[0] = systemUserId (null for anonymous), args[1] = teamId (null), args[3] = dataRequestId (undefined)
-      expect(createDownloadRequestStub.firstCall.args[0]).to.equal(null);
-      expect(createDownloadRequestStub.firstCall.args[1]).to.equal(null);
-      expect(createDownloadRequestStub.firstCall.args[3]).to.equal(undefined);
+      const opts = createDownloadRequestStub.firstCall.args[0];
+      expect(opts).to.have.property('systemUserId', null);
+      expect(opts).to.have.property('teamId', null);
     });
 
     it('should pass filters to getSearchFeatureIds', async () => {

--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -80,10 +80,11 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(createDownloadRequestStub.firstCall.args[4]).to.eql({ feature_types: ['dataset'] });
+      // args[5] = searchFilters
+      expect(createDownloadRequestStub.firstCall.args[5]).to.eql({ feature_types: ['dataset'] });
     });
 
-    it('should pass teamId=null, dataRequestId=undefined to createDownloadRequest', async () => {
+    it('should pass systemUserId=null, teamId=null, dataRequestId=undefined for anonymous', async () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
@@ -102,8 +103,10 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
+      // args[0] = systemUserId (null for anonymous), args[1] = teamId (null), args[3] = dataRequestId (undefined)
       expect(createDownloadRequestStub.firstCall.args[0]).to.equal(null);
-      expect(createDownloadRequestStub.firstCall.args[2]).to.equal(undefined);
+      expect(createDownloadRequestStub.firstCall.args[1]).to.equal(null);
+      expect(createDownloadRequestStub.firstCall.args[3]).to.equal(undefined);
     });
 
     it('should pass filters to getSearchFeatureIds', async () => {

--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -80,7 +80,7 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(createDownloadRequestStub.firstCall.args[0]).to.have.deep.property('searchFilters', {
+      expect(createDownloadRequestStub.firstCall.args[0]).to.have.deep.property('filters', {
         feature_types: ['dataset']
       });
     });

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -201,14 +201,12 @@ export function createDownload(): RequestHandler {
       // Create download with search filters stored for traceability.
       // teamId is null: downloads from search are user-owned, not team-based.
       const pipelineService = new DownloadPipelineService(connection);
-      const downloadId = await pipelineService.createDownloadRequest(
+      const downloadId = await pipelineService.createDownloadRequest({
         systemUserId,
-        null,
+        teamId: null,
         submissionFeatureIds,
-        undefined,
-        undefined,
-        filters
-      );
+        searchFilters: filters
+      });
 
       // Publish async processing job within the transaction
       await publisher.publishProcessDownloadJob(connection, { downloadId: downloadId.download_id });

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -194,10 +194,15 @@ export function createDownload(): RequestHandler {
         throw new HTTP400('No features match the filter criteria');
       }
 
+      // Anonymous downloads: system_user_id is null (UUID is the credential).
+      // Matches the cart checkout pattern (cart/{cartId}/checkout/index.ts:98).
+      const systemUserId = isAuthenticated ? connection.systemUserId() : null;
+
       // Create download with search filters stored for traceability.
       // teamId is null: downloads from search are user-owned, not team-based.
       const pipelineService = new DownloadPipelineService(connection);
       const downloadId = await pipelineService.createDownloadRequest(
+        systemUserId,
         null,
         submissionFeatureIds,
         undefined,

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -1,9 +1,14 @@
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
-import { getDBConnection } from '../../database/db';
+import { getAPIUserDBConnection, getDBConnection } from '../../database/db';
+import { HTTP400 } from '../../errors/http-error';
 import { defaultErrorResponses } from '../../openapi/schemas/http-responses';
+import * as publisher from '../../queue/publisher';
 import { authorizeRequestHandler } from '../../request-handlers/security/authorization';
+import { DownloadPipelineService } from '../../services/download/download-pipeline-service';
 import { DownloadService } from '../../services/download/download-service';
+import { SearchFeatureService } from '../../services/search-feature-service';
+import { ISearchFeaturesFilters } from '../../services/search-feature-service.interface';
 import { getLogger } from '../../utils/logger';
 
 const defaultLog = getLogger('paths/download');
@@ -91,6 +96,123 @@ export function getDownloads(): RequestHandler {
       return res.status(200).json({ downloads });
     } catch (error) {
       defaultLog.error({ label: 'getDownloads', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const POST: Operation = [createDownload()];
+
+POST.apiDoc = {
+  description:
+    'Create a download from search filters. Resolves filters to feature IDs server-side and creates a download record.',
+  tags: ['download'],
+  security: [
+    {
+      OptionalBearer: []
+    }
+  ],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['filters'],
+          properties: {
+            filters: {
+              type: 'object',
+              description: 'Search filters — same schema as POST /api/search/feature',
+              properties: {
+                keyword: { type: 'string' },
+                feature_types: { type: 'array', items: { type: 'string' } },
+                species: { type: 'array', items: { type: 'string' } },
+                properties: { type: 'array', items: { type: 'object' } }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Download created',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['download_id'],
+            properties: {
+              download_id: {
+                type: 'string',
+                format: 'uuid'
+              }
+            }
+          }
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Create a download from search filters.
+ *
+ * Bulk download bypasses the shopping cart — search filters are resolved to feature IDs
+ * server-side, then a download record is created with all matching features linked.
+ * Original filters are stored in `download.search_filters` for traceability (ticket requirement).
+ * Uses a dedicated column instead of `metadata` which gets overwritten by the pipeline.
+ *
+ * OptionalBearer: anonymous users get a download with system_user_id = null
+ * (UUID is the credential). Authenticated users get it linked to their account.
+ *
+ * teamId is null: downloads from search are user-owned, not team-based.
+ * Team-based downloads originate from data requests only.
+ */
+export function createDownload(): RequestHandler {
+  return async (req, res) => {
+    const isAuthenticated = !!req.keycloak_token;
+    const connection = isAuthenticated ? getDBConnection(req.keycloak_token) : getAPIUserDBConnection();
+
+    try {
+      await connection.open();
+
+      const filters: ISearchFeaturesFilters = req.body.filters;
+
+      // Resolve filters to feature IDs via CTE intersection
+      const searchFeatureService = new SearchFeatureService(connection);
+      const submissionFeatureIds = await searchFeatureService.getSearchFeatureIds(filters);
+
+      // Empty results → 400. Prevents orphan download records with zero features.
+      // The download pipeline would fail on an empty feature set.
+      if (submissionFeatureIds.length === 0) {
+        throw new HTTP400('No features match the filter criteria');
+      }
+
+      // Create download with search filters stored for traceability.
+      // teamId is null: downloads from search are user-owned, not team-based.
+      const pipelineService = new DownloadPipelineService(connection);
+      const downloadId = await pipelineService.createDownloadRequest(
+        null,
+        submissionFeatureIds,
+        undefined,
+        undefined,
+        filters
+      );
+
+      // Publish async processing job within the transaction
+      await publisher.publishProcessDownloadJob(connection, { downloadId: downloadId.download_id });
+
+      await connection.commit();
+
+      return res.status(201).json({ download_id: downloadId.download_id });
+    } catch (error) {
+      defaultLog.error({ label: 'createDownload', message: 'error', error });
       await connection.rollback();
       throw error;
     } finally {

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -195,7 +195,6 @@ export function createDownload(): RequestHandler {
       }
 
       // Anonymous downloads: system_user_id is null (UUID is the credential).
-      // Matches the cart checkout pattern (cart/{cartId}/checkout/index.ts:98).
       const systemUserId = isAuthenticated ? connection.systemUserId() : null;
 
       // Create download with search filters stored for traceability.

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -165,7 +165,7 @@ POST.apiDoc = {
  *
  * Bulk download bypasses the shopping cart — search filters are resolved to feature IDs
  * server-side, then a download record is created with all matching features linked.
- * Original filters are stored in `download.search_filters` for traceability (ticket requirement).
+ * Original filters are stored in `download.filters` for traceability (ticket requirement).
  * Uses a dedicated column instead of `metadata` which gets overwritten by the pipeline.
  *
  * OptionalBearer: anonymous users get a download with system_user_id = null
@@ -184,15 +184,17 @@ export function createDownload(): RequestHandler {
 
       const filters: ISearchFeaturesFilters = req.body.filters;
 
-      // Resolve filters to feature IDs via CTE intersection
       const searchFeatureService = new SearchFeatureService(connection);
-      const submissionFeatureIds = await searchFeatureService.getSearchFeatureIds(filters);
 
-      // Empty results → 400. Prevents orphan download records with zero features.
-      // The download pipeline would fail on an empty feature set.
-      if (submissionFeatureIds.length === 0) {
+      // Quick count check before fetching all IDs
+      const featureCount = await searchFeatureService.getSearchFeaturesCount(filters);
+
+      if (featureCount === 0) {
         throw new HTTP400('No features match the filter criteria');
       }
+
+      // Resolve filters to feature IDs via CTE intersection
+      const submissionFeatureIds = await searchFeatureService.getSearchFeatureIds(filters);
 
       // Anonymous downloads: system_user_id is null (UUID is the credential).
       const systemUserId = isAuthenticated ? connection.systemUserId() : null;
@@ -204,7 +206,7 @@ export function createDownload(): RequestHandler {
         systemUserId,
         teamId: null,
         submissionFeatureIds,
-        searchFilters: filters
+        filters
       });
 
       // Publish async processing job within the transaction

--- a/api/src/paths/download/{downloadId}/index.ts
+++ b/api/src/paths/download/{downloadId}/index.ts
@@ -89,7 +89,8 @@ GET.apiDoc = {
                 type: 'integer'
               },
               estimated_total_size_bytes: {
-                type: 'integer',
+                type: 'string',
+                format: 'int64',
                 nullable: true
               },
               started_at: {
@@ -122,11 +123,13 @@ GET.apiDoc = {
                       nullable: true
                     },
                     file_size_bytes: {
-                      type: 'integer',
+                      type: 'string',
+                      format: 'int64',
                       nullable: true
                     },
                     estimated_size_bytes: {
-                      type: 'integer',
+                      type: 'string',
+                      format: 'int64',
                       nullable: true
                     },
                     feature_count: {

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -108,7 +108,7 @@ describe('DownloadRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
 
       const repo = new DownloadRepository(mockDBConnection);
-      await repo.createDownload(null, null, undefined, 42);
+      await repo.createDownload({ teamId: null, dataRequestId: null, systemUserId: 42 });
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlText = sqlStub.firstCall.args[0].text;
@@ -124,7 +124,7 @@ describe('DownloadRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
 
       const repo = new DownloadRepository(mockDBConnection);
-      await repo.createDownload(null, null, undefined, null);
+      await repo.createDownload({ teamId: null, dataRequestId: null, systemUserId: null });
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlValues = sqlStub.firstCall.args[0].values;
@@ -139,7 +139,7 @@ describe('DownloadRepository', () => {
 
       const repo = new DownloadRepository(mockDBConnection);
       const filters = { keyword: 'moose' };
-      await repo.createDownload(null, null, undefined, null, filters);
+      await repo.createDownload({ teamId: null, dataRequestId: null, systemUserId: null, searchFilters: filters });
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlText = sqlStub.firstCall.args[0].text;
@@ -155,7 +155,7 @@ describe('DownloadRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
 
       const repo = new DownloadRepository(mockDBConnection);
-      await repo.createDownload(null, null, undefined, null);
+      await repo.createDownload({ teamId: null, dataRequestId: null, systemUserId: null });
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlText = sqlStub.firstCall.args[0].text;

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -130,6 +130,42 @@ describe('DownloadRepository', () => {
       const sqlValues = sqlStub.firstCall.args[0].values;
       expect(sqlValues).to.include(null);
     });
+
+    it('serializes searchFilters as JSONB in SQL', async () => {
+      const sqlStub = sinon
+        .stub()
+        .resolves(mockQueryResult([{ download_id: 'aaaa0000-0000-0000-0000-000000000001' }], 1));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const filters = { keyword: 'moose' };
+      await repo.createDownload(null, null, undefined, null, filters);
+
+      expect(sqlStub).to.have.been.calledOnce;
+      const sqlText = sqlStub.firstCall.args[0].text;
+      expect(sqlText).to.include('search_filters');
+      const sqlValues = sqlStub.firstCall.args[0].values;
+      expect(sqlValues).to.include(JSON.stringify(filters));
+    });
+
+    it('passes null search_filters when searchFilters is omitted', async () => {
+      const sqlStub = sinon
+        .stub()
+        .resolves(mockQueryResult([{ download_id: 'aaaa0000-0000-0000-0000-000000000001' }], 1));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+      await repo.createDownload(null, null, undefined, null);
+
+      expect(sqlStub).to.have.been.calledOnce;
+      const sqlText = sqlStub.firstCall.args[0].text;
+      expect(sqlText).to.include('search_filters');
+      // Last value before the ::jsonb cast should be null (no searchFilters provided)
+      const sqlValues = sqlStub.firstCall.args[0].values;
+      // Values: teamId, dataRequestId, sizeBytes, systemUserId, searchFilters
+      const searchFiltersValue = sqlValues[sqlValues.length - 1];
+      expect(searchFiltersValue).to.be.null;
+    });
   });
 
   describe('getDownloadsByTeamMembership', () => {

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -131,7 +131,7 @@ describe('DownloadRepository', () => {
       expect(sqlValues).to.include(null);
     });
 
-    it('serializes searchFilters as JSONB in SQL', async () => {
+    it('serializes filters as JSONB in SQL', async () => {
       const sqlStub = sinon
         .stub()
         .resolves(mockQueryResult([{ download_id: 'aaaa0000-0000-0000-0000-000000000001' }], 1));
@@ -139,16 +139,16 @@ describe('DownloadRepository', () => {
 
       const repo = new DownloadRepository(mockDBConnection);
       const filters = { keyword: 'moose' };
-      await repo.createDownload({ teamId: null, dataRequestId: null, systemUserId: null, searchFilters: filters });
+      await repo.createDownload({ teamId: null, dataRequestId: null, systemUserId: null, filters });
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlText = sqlStub.firstCall.args[0].text;
-      expect(sqlText).to.include('search_filters');
+      expect(sqlText).to.include('filters');
       const sqlValues = sqlStub.firstCall.args[0].values;
       expect(sqlValues).to.include(JSON.stringify(filters));
     });
 
-    it('passes null search_filters when searchFilters is omitted', async () => {
+    it('passes null filters when filters is omitted', async () => {
       const sqlStub = sinon
         .stub()
         .resolves(mockQueryResult([{ download_id: 'aaaa0000-0000-0000-0000-000000000001' }], 1));
@@ -159,12 +159,12 @@ describe('DownloadRepository', () => {
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlText = sqlStub.firstCall.args[0].text;
-      expect(sqlText).to.include('search_filters');
-      // Last value before the ::jsonb cast should be null (no searchFilters provided)
+      expect(sqlText).to.include('filters');
+      // Last value before the ::jsonb cast should be null (no filters provided)
       const sqlValues = sqlStub.firstCall.args[0].values;
-      // Values: teamId, dataRequestId, sizeBytes, systemUserId, searchFilters
-      const searchFiltersValue = sqlValues[sqlValues.length - 1];
-      expect(searchFiltersValue).to.be.null;
+      // Values: teamId, dataRequestId, sizeBytes, systemUserId, filters
+      const filtersValue = sqlValues[sqlValues.length - 1];
+      expect(filtersValue).to.be.null;
     });
   });
 

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -25,13 +25,13 @@ export class DownloadRepository extends BaseRepository {
    * @memberof DownloadRepository
    */
   async createDownload(payload: CreateDownload): Promise<DownloadId> {
-    const { teamId, dataRequestId, fragmentSizeBytes, systemUserId, searchFilters } = payload;
+    const { teamId, dataRequestId, fragmentSizeBytes, systemUserId, filters } = payload;
     const sizeBytes = fragmentSizeBytes ?? FRAGMENT_SIZE_THRESHOLD;
 
     const sql = SQL`
-      INSERT INTO download (team_id, data_request_id, download_status, fragment_size_bytes, system_user_id, search_filters)
+      INSERT INTO download (team_id, data_request_id, download_status, fragment_size_bytes, system_user_id, filters)
       VALUES (${teamId}, ${dataRequestId}, 'pending', ${sizeBytes}, ${systemUserId ?? null}, ${
-      searchFilters ? JSON.stringify(searchFilters) : null
+      filters ? JSON.stringify(filters) : null
     }::jsonb)
       RETURNING download_id;
     `;

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -2,9 +2,8 @@ import SQL from 'sql-template-strings';
 import { z } from 'zod';
 import { FRAGMENT_SIZE_THRESHOLD } from '../../constants/download';
 import { ApiExecuteSQLError } from '../../errors/api-error';
-import { DownloadFeatureSummary, DownloadId, DownloadRecord } from '../../models/download';
+import { CreateDownload, DownloadFeatureSummary, DownloadId, DownloadRecord } from '../../models/download';
 import { DownloadStatusEnum } from '../../models/download-status';
-import { ISearchFeaturesFilters } from '../../services/search-feature-service.interface';
 import { BaseRepository } from '../base-repository';
 
 const IsAuthorized = z.object({ authorized: z.boolean() });
@@ -21,21 +20,12 @@ export class DownloadRepository extends BaseRepository {
   /**
    * Create a new download record.
    *
-   * @param {string | null} teamId - The team that owns this download. Null for anonymous downloads.
-   * @param {string | null} dataRequestId - The data request that originated this download. Null for non-request downloads.
-   * @param {number} [fragmentSizeBytes] - Target fragment size in bytes. Defaults to FRAGMENT_SIZE_THRESHOLD (200 MB).
-   * @param {number | null} [systemUserId] - The user who created this download. Null for anonymous downloads.
-   * @param {ISearchFeaturesFilters} [searchFilters] - Original search filters for traceability. Null for cart-based downloads.
+   * @param {CreateDownload} payload
    * @return {Promise<DownloadId>} The created record ID.
    * @memberof DownloadRepository
    */
-  async createDownload(
-    teamId: string | null,
-    dataRequestId: string | null,
-    fragmentSizeBytes?: number,
-    systemUserId?: number | null,
-    searchFilters?: ISearchFeaturesFilters
-  ): Promise<DownloadId> {
+  async createDownload(payload: CreateDownload): Promise<DownloadId> {
+    const { teamId, dataRequestId, fragmentSizeBytes, systemUserId, searchFilters } = payload;
     const sizeBytes = fragmentSizeBytes ?? FRAGMENT_SIZE_THRESHOLD;
 
     const sql = SQL`

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -4,6 +4,7 @@ import { FRAGMENT_SIZE_THRESHOLD } from '../../constants/download';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { DownloadFeatureSummary, DownloadId, DownloadRecord } from '../../models/download';
 import { DownloadStatusEnum } from '../../models/download-status';
+import { ISearchFeaturesFilters } from '../../services/search-feature-service.interface';
 import { BaseRepository } from '../base-repository';
 
 const IsAuthorized = z.object({ authorized: z.boolean() });
@@ -24,6 +25,7 @@ export class DownloadRepository extends BaseRepository {
    * @param {string | null} dataRequestId - The data request that originated this download. Null for non-request downloads.
    * @param {number} [fragmentSizeBytes] - Target fragment size in bytes. Defaults to FRAGMENT_SIZE_THRESHOLD (200 MB).
    * @param {number | null} [systemUserId] - The user who created this download. Null for anonymous downloads.
+   * @param {ISearchFeaturesFilters} [searchFilters] - Original search filters for traceability. Null for cart-based downloads.
    * @return {Promise<DownloadId>} The created record ID.
    * @memberof DownloadRepository
    */
@@ -31,13 +33,16 @@ export class DownloadRepository extends BaseRepository {
     teamId: string | null,
     dataRequestId: string | null,
     fragmentSizeBytes?: number,
-    systemUserId?: number | null
+    systemUserId?: number | null,
+    searchFilters?: ISearchFeaturesFilters
   ): Promise<DownloadId> {
     const sizeBytes = fragmentSizeBytes ?? FRAGMENT_SIZE_THRESHOLD;
 
     const sql = SQL`
-      INSERT INTO download (team_id, data_request_id, download_status, fragment_size_bytes, system_user_id)
-      VALUES (${teamId}, ${dataRequestId}, 'pending', ${sizeBytes}, ${systemUserId ?? null})
+      INSERT INTO download (team_id, data_request_id, download_status, fragment_size_bytes, system_user_id, search_filters)
+      VALUES (${teamId}, ${dataRequestId}, 'pending', ${sizeBytes}, ${systemUserId ?? null}, ${
+      searchFilters ? JSON.stringify(searchFilters) : null
+    }::jsonb)
       RETURNING download_id;
     `;
 

--- a/api/src/repositories/search-feature-repository.test.ts
+++ b/api/src/repositories/search-feature-repository.test.ts
@@ -10,7 +10,7 @@ import {
   SpatialSearchableRecord,
   StringSearchableRecord
 } from '../services/search-feature-service.interface';
-import { getMockDBConnection } from '../__mocks__/db';
+import { getMockDBConnection, mockQueryResult } from '../__mocks__/db';
 import { SearchFeatureRepository } from './search-feature-repository';
 
 describe('SearchFeatureRepository', () => {
@@ -701,10 +701,7 @@ describe('SearchFeatureRepository', () => {
     });
 
     it('should return flat number array of submission_feature_ids for matching filters', async () => {
-      const mockQueryResponse = {
-        rowCount: 2,
-        rows: [{ submission_feature_id: 1 }, { submission_feature_id: 2 }]
-      } as unknown as Promise<QueryResult<any>>;
+      const mockQueryResponse = mockQueryResult([{ submission_feature_id: 1 }, { submission_feature_id: 2 }], 2);
 
       const mockDBConnection = getMockDBConnection({
         knex: async () => mockQueryResponse
@@ -718,10 +715,7 @@ describe('SearchFeatureRepository', () => {
     });
 
     it('should return empty array when DB returns no rows', async () => {
-      const mockQueryResponse = {
-        rowCount: 0,
-        rows: []
-      } as unknown as Promise<QueryResult<any>>;
+      const mockQueryResponse = mockQueryResult([], 0);
 
       const mockDBConnection = getMockDBConnection({
         knex: async () => mockQueryResponse

--- a/api/src/repositories/search-feature-repository.test.ts
+++ b/api/src/repositories/search-feature-repository.test.ts
@@ -668,4 +668,84 @@ describe('SearchFeatureRepository', () => {
       expect(response).to.equal(0);
     });
   });
+
+  describe('searchFeatureIdsByFilters', () => {
+    it('should return empty array for empty filters', async () => {
+      const knexSpy = Sinon.stub().resolves({ rowCount: 0, rows: [] });
+
+      const mockDBConnection = getMockDBConnection({
+        knex: knexSpy
+      });
+
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      const response = await repository.searchFeatureIdsByFilters({} as any);
+
+      expect(response).to.deep.equal([]);
+      expect(knexSpy.callCount).to.equal(0);
+    });
+
+    it('should return empty array for undefined filters', async () => {
+      const knexSpy = Sinon.stub().resolves({ rowCount: 0, rows: [] });
+
+      const mockDBConnection = getMockDBConnection({
+        knex: knexSpy
+      });
+
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      const response = await repository.searchFeatureIdsByFilters(undefined as any);
+
+      expect(response).to.deep.equal([]);
+      expect(knexSpy.callCount).to.equal(0);
+    });
+
+    it('should return flat number array of submission_feature_ids for matching filters', async () => {
+      const mockQueryResponse = {
+        rowCount: 2,
+        rows: [{ submission_feature_id: 1 }, { submission_feature_id: 2 }]
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        knex: async () => mockQueryResponse
+      });
+
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      const response = await repository.searchFeatureIdsByFilters({ keyword: 'moose' });
+
+      expect(response).to.deep.equal([1, 2]);
+    });
+
+    it('should return empty array when DB returns no rows', async () => {
+      const mockQueryResponse = {
+        rowCount: 0,
+        rows: []
+      } as unknown as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        knex: async () => mockQueryResponse
+      });
+
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      const response = await repository.searchFeatureIdsByFilters({ keyword: 'nonexistent' });
+
+      expect(response).to.deep.equal([]);
+    });
+
+    it('should call connection.knex exactly once', async () => {
+      const knexSpy = Sinon.stub().resolves({ rowCount: 1, rows: [{ submission_feature_id: 10 }] });
+
+      const mockDBConnection = getMockDBConnection({
+        knex: knexSpy
+      });
+
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      await repository.searchFeatureIdsByFilters({ feature_types: ['dataset'] });
+
+      expect(knexSpy.callCount).to.equal(1);
+    });
+  });
 });

--- a/api/src/repositories/search-feature-repository.test.ts
+++ b/api/src/repositories/search-feature-repository.test.ts
@@ -700,7 +700,7 @@ describe('SearchFeatureRepository', () => {
       expect(knexSpy.callCount).to.equal(0);
     });
 
-    it('should return flat number array of submission_feature_ids for matching filters', async () => {
+    it('should return rows with submission_feature_id for matching filters', async () => {
       const mockQueryResponse = mockQueryResult([{ submission_feature_id: 1 }, { submission_feature_id: 2 }], 2);
 
       const mockDBConnection = getMockDBConnection({
@@ -711,7 +711,7 @@ describe('SearchFeatureRepository', () => {
 
       const response = await repository.searchFeatureIdsByFilters({ keyword: 'moose' });
 
-      expect(response).to.deep.equal([1, 2]);
+      expect(response).to.deep.equal([{ submission_feature_id: 1 }, { submission_feature_id: 2 }]);
     });
 
     it('should return empty array when DB returns no rows', async () => {

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -196,9 +196,9 @@ export class SearchFeatureRepository extends BaseRepository {
    * feature IDs for the download pipeline. No pagination — returns ALL matching IDs.
    *
    * @param {ISearchFeaturesFilters} filters - Search filters (keyword, feature_types, species, properties)
-   * @returns {Promise<number[]>} Array of matching submission_feature_id values
+   * @returns {Promise<{ submission_feature_id: number }[]>} Raw rows with submission_feature_id
    */
-  async searchFeatureIdsByFilters(filters: ISearchFeaturesFilters): Promise<number[]> {
+  async searchFeatureIdsByFilters(filters: ISearchFeaturesFilters): Promise<{ submission_feature_id: number }[]> {
     defaultLog.debug({ label: 'searchFeatureIdsByFilters', filters });
 
     if (!filters || Object.keys(filters).length === 0) {
@@ -210,7 +210,7 @@ export class SearchFeatureRepository extends BaseRepository {
     const idsQuery = knex.from(query.as('sf_filtered')).select('submission_feature_id');
     const response = await this.connection.knex(idsQuery);
 
-    return response.rows.map((row: { submission_feature_id: number }) => row.submission_feature_id);
+    return response.rows;
   }
 
   /**

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -190,6 +190,30 @@ export class SearchFeatureRepository extends BaseRepository {
   }
 
   /**
+   * Returns submission feature IDs matching the provided search filters.
+   *
+   * Used by POST /api/download to resolve filter criteria into the canonical set of
+   * feature IDs for the download pipeline. No pagination — returns ALL matching IDs.
+   *
+   * @param {ISearchFeaturesFilters} filters - Search filters (keyword, feature_types, species, properties)
+   * @returns {Promise<number[]>} Array of matching submission_feature_id values
+   */
+  async searchFeatureIdsByFilters(filters: ISearchFeaturesFilters): Promise<number[]> {
+    defaultLog.debug({ label: 'searchFeatureIdsByFilters', filters });
+
+    if (!filters || Object.keys(filters).length === 0) {
+      return [];
+    }
+
+    const knex = getKnex();
+    const query = this.buildSearchQuery(knex, filters);
+    const idsQuery = knex.from(query.as('sf_filtered')).select('submission_feature_id');
+    const response = await this.connection.knex(idsQuery);
+
+    return response.rows.map((row: { submission_feature_id: number }) => row.submission_feature_id);
+  }
+
+  /**
    * Builds the search query combining all filter types and CTEs.
    * @param {Knex} knex - Knex instance
    * @param {ISearchFeaturesFilters} filters - Search filters to apply

--- a/api/src/services/cart-service.test.ts
+++ b/api/src/services/cart-service.test.ts
@@ -266,7 +266,12 @@ describe('CartService', () => {
 
       expect(result).to.deep.equal({ download_id: 'dl-uuid' });
       expect(getIdsStub).to.have.been.calledOnceWith('cart-1');
-      expect(createDownloadStub).to.have.been.calledOnceWith('team-1', null, undefined, 42);
+      expect(createDownloadStub).to.have.been.calledOnceWith({
+        teamId: 'team-1',
+        dataRequestId: null,
+        fragmentSizeBytes: undefined,
+        systemUserId: 42
+      });
       expect(createFeaturesStub).to.have.been.calledOnceWith('dl-uuid', [1, 2, 3]);
       expect(updateCartStub).to.have.been.calledOnceWith('cart-1', {
         cart_status: CartStatus.CHECKED_OUT,
@@ -301,7 +306,12 @@ describe('CartService', () => {
 
       await service.checkoutCart('cart-1', null);
 
-      expect(createDownloadStub).to.have.been.calledOnceWith(null, null, undefined, null);
+      expect(createDownloadStub).to.have.been.calledOnceWith({
+        teamId: null,
+        dataRequestId: null,
+        fragmentSizeBytes: undefined,
+        systemUserId: null
+      });
       expect(updateCartStub).to.have.been.calledOnceWith('cart-1', {
         cart_status: CartStatus.CHECKED_OUT,
         checkout_date: sinon.match.string,
@@ -362,7 +372,12 @@ describe('CartService', () => {
 
       await service.checkoutCart('cart-1', 7);
 
-      expect(createDownloadStub).to.have.been.calledOnceWith('team-1', null, undefined, 7);
+      expect(createDownloadStub).to.have.been.calledOnceWith({
+        teamId: 'team-1',
+        dataRequestId: null,
+        fragmentSizeBytes: undefined,
+        systemUserId: 7
+      });
       expect(updateCartStub).to.have.been.calledOnceWith('cart-1', {
         cart_status: CartStatus.CHECKED_OUT,
         checkout_date: sinon.match.string,
@@ -385,7 +400,12 @@ describe('CartService', () => {
 
       await service.checkoutCart('cart-1', null);
 
-      expect(createDownloadStub).to.have.been.calledOnceWith(null, null, undefined, null);
+      expect(createDownloadStub).to.have.been.calledOnceWith({
+        teamId: null,
+        dataRequestId: null,
+        fragmentSizeBytes: undefined,
+        systemUserId: null
+      });
       expect(updateCartStub).to.have.been.calledOnceWith('cart-1', {
         cart_status: CartStatus.CHECKED_OUT,
         checkout_date: sinon.match.string,

--- a/api/src/services/cart-service.ts
+++ b/api/src/services/cart-service.ts
@@ -156,7 +156,12 @@ export class CartService extends DBService {
     }
 
     // Create download record (no data request for cart checkouts)
-    const downloadId = await this.downloadService.createDownload(teamId, null, fragmentSizeBytes, systemUserId);
+    const downloadId = await this.downloadService.createDownload({
+      teamId,
+      dataRequestId: null,
+      fragmentSizeBytes,
+      systemUserId
+    });
 
     // Link features to download
     await this.downloadService.createDownloadFeatures(downloadId.download_id, featureIds);

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -79,10 +79,10 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(42, null, [10, 20]);
+      await service.createDownloadRequest({ systemUserId: 42, teamId: null, submissionFeatureIds: [10, 20] });
 
       expect(createDownloadStub).to.have.been.calledOnce;
-      expect(createDownloadStub.firstCall.args[3]).to.equal(42);
+      expect(createDownloadStub.firstCall.args[0]).to.have.property('systemUserId', 42);
     });
 
     it('passes null systemUserId for anonymous downloads', async () => {
@@ -94,13 +94,13 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(null, null, [10, 20]);
+      await service.createDownloadRequest({ systemUserId: null, teamId: null, submissionFeatureIds: [10, 20] });
 
       expect(createDownloadStub).to.have.been.calledOnce;
-      expect(createDownloadStub.firstCall.args[3]).to.be.null;
+      expect(createDownloadStub.firstCall.args[0]).to.have.property('systemUserId', null);
     });
 
-    it('passes searchFilters to createDownload as 5th arg', async () => {
+    it('passes searchFilters to createDownload', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
@@ -110,14 +110,20 @@ describe('DownloadPipelineService', () => {
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
       const filters = { keyword: 'elk' };
-      await service.createDownloadRequest(42, null, [10, 20], undefined, undefined, filters);
+      await service.createDownloadRequest({
+        systemUserId: 42,
+        teamId: null,
+        submissionFeatureIds: [10, 20],
+        searchFilters: filters
+      });
 
       expect(createDownloadStub).to.have.been.calledOnce;
-      expect(createDownloadStub.firstCall.args[3]).to.equal(42);
-      expect(createDownloadStub.firstCall.args[4]).to.deep.equal({ keyword: 'elk' });
+      const opts = createDownloadStub.firstCall.args[0];
+      expect(opts).to.have.property('systemUserId', 42);
+      expect(opts).to.have.deep.property('searchFilters', { keyword: 'elk' });
     });
 
-    it('omitting searchFilters passes undefined as 5th arg', async () => {
+    it('omitting searchFilters passes undefined', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
@@ -126,13 +132,13 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(42, null, [10, 20]);
+      await service.createDownloadRequest({ systemUserId: 42, teamId: null, submissionFeatureIds: [10, 20] });
 
       expect(createDownloadStub).to.have.been.calledOnce;
-      expect(createDownloadStub.firstCall.args[4]).to.be.undefined;
+      expect(createDownloadStub.firstCall.args[0].searchFilters).to.be.undefined;
     });
 
-    it('still creates download features after searchFilters signature change', async () => {
+    it('still creates download features after options refactor', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
@@ -141,7 +147,12 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       const createFeaturesStub = sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(42, null, [10, 20], undefined, undefined, { keyword: 'elk' });
+      await service.createDownloadRequest({
+        systemUserId: 42,
+        teamId: null,
+        submissionFeatureIds: [10, 20],
+        searchFilters: { keyword: 'elk' }
+      });
 
       expect(createFeaturesStub).to.have.been.calledOnce;
       expect(createFeaturesStub.firstCall.args[0]).to.equal('aaaa0000-0000-0000-0000-000000000001');

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -104,6 +104,62 @@ describe('DownloadPipelineService', () => {
       expect(createDownloadStub).to.have.been.calledOnce;
       expect(createDownloadStub.firstCall.args[3]).to.be.null;
     });
+
+    it('passes searchFilters to createDownload as 5th arg', async () => {
+      const mockDBConnection = getMockDBConnection({
+        systemUserId: () => 42
+      });
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      const createDownloadStub = sinon
+        .stub(DownloadRepository.prototype, 'createDownload')
+        .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
+      sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
+
+      const filters = { keyword: 'elk' };
+      await service.createDownloadRequest(null, [10, 20], undefined, undefined, filters);
+
+      expect(createDownloadStub).to.have.been.calledOnce;
+      // systemUserId still in correct position (4th arg)
+      expect(createDownloadStub.firstCall.args[3]).to.equal(42);
+      // searchFilters forwarded as 5th arg
+      expect(createDownloadStub.firstCall.args[4]).to.deep.equal({ keyword: 'elk' });
+    });
+
+    it('omitting searchFilters passes undefined as 5th arg', async () => {
+      const mockDBConnection = getMockDBConnection({
+        systemUserId: () => 42
+      });
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      const createDownloadStub = sinon
+        .stub(DownloadRepository.prototype, 'createDownload')
+        .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
+      sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
+
+      await service.createDownloadRequest(null, [10, 20]);
+
+      expect(createDownloadStub).to.have.been.calledOnce;
+      expect(createDownloadStub.firstCall.args[4]).to.be.undefined;
+    });
+
+    it('still creates download features after searchFilters signature change', async () => {
+      const mockDBConnection = getMockDBConnection({
+        systemUserId: () => 42
+      });
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      sinon
+        .stub(DownloadRepository.prototype, 'createDownload')
+        .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
+      const createFeaturesStub = sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
+
+      await service.createDownloadRequest(null, [10, 20], undefined, undefined, { keyword: 'elk' });
+
+      expect(createFeaturesStub).to.have.been.calledOnce;
+      expect(createFeaturesStub.firstCall.args[0]).to.equal('aaaa0000-0000-0000-0000-000000000001');
+      expect(createFeaturesStub.firstCall.args[1]).to.deep.equal([10, 20]);
+    });
   });
 
   describe('claimDownload', () => {

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -100,7 +100,7 @@ describe('DownloadPipelineService', () => {
       expect(createDownloadStub.firstCall.args[0]).to.have.property('systemUserId', null);
     });
 
-    it('passes searchFilters to createDownload', async () => {
+    it('passes filters to createDownload', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
@@ -114,16 +114,16 @@ describe('DownloadPipelineService', () => {
         systemUserId: 42,
         teamId: null,
         submissionFeatureIds: [10, 20],
-        searchFilters: filters
+        filters
       });
 
       expect(createDownloadStub).to.have.been.calledOnce;
       const opts = createDownloadStub.firstCall.args[0];
       expect(opts).to.have.property('systemUserId', 42);
-      expect(opts).to.have.deep.property('searchFilters', { keyword: 'elk' });
+      expect(opts).to.have.deep.property('filters', { keyword: 'elk' });
     });
 
-    it('omitting searchFilters passes undefined', async () => {
+    it('omitting filters passes undefined', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
@@ -135,7 +135,7 @@ describe('DownloadPipelineService', () => {
       await service.createDownloadRequest({ systemUserId: 42, teamId: null, submissionFeatureIds: [10, 20] });
 
       expect(createDownloadStub).to.have.been.calledOnce;
-      expect(createDownloadStub.firstCall.args[0].searchFilters).to.be.undefined;
+      expect(createDownloadStub.firstCall.args[0].filters).to.be.undefined;
     });
 
     it('still creates download features after options refactor', async () => {
@@ -151,7 +151,7 @@ describe('DownloadPipelineService', () => {
         systemUserId: 42,
         teamId: null,
         submissionFeatureIds: [10, 20],
-        searchFilters: { keyword: 'elk' }
+        filters: { keyword: 'elk' }
       });
 
       expect(createFeaturesStub).to.have.been.calledOnce;

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -71,9 +71,7 @@ describe('DownloadPipelineService', () => {
 
   describe('createDownloadRequest', () => {
     it('passes systemUserId to createDownload for authenticated users', async () => {
-      const mockDBConnection = getMockDBConnection({
-        systemUserId: () => 42
-      });
+      const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
       const createDownloadStub = sinon
@@ -81,17 +79,14 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(null, [10, 20]);
+      await service.createDownloadRequest(42, null, [10, 20]);
 
       expect(createDownloadStub).to.have.been.calledOnce;
-      // systemUserId (42) should be passed as the 4th argument
       expect(createDownloadStub.firstCall.args[3]).to.equal(42);
     });
 
     it('passes null systemUserId for anonymous downloads', async () => {
-      const mockDBConnection = getMockDBConnection({
-        systemUserId: () => null as unknown as number
-      });
+      const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
       const createDownloadStub = sinon
@@ -99,16 +94,14 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(null, [10, 20]);
+      await service.createDownloadRequest(null, null, [10, 20]);
 
       expect(createDownloadStub).to.have.been.calledOnce;
       expect(createDownloadStub.firstCall.args[3]).to.be.null;
     });
 
     it('passes searchFilters to createDownload as 5th arg', async () => {
-      const mockDBConnection = getMockDBConnection({
-        systemUserId: () => 42
-      });
+      const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
       const createDownloadStub = sinon
@@ -117,19 +110,15 @@ describe('DownloadPipelineService', () => {
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
       const filters = { keyword: 'elk' };
-      await service.createDownloadRequest(null, [10, 20], undefined, undefined, filters);
+      await service.createDownloadRequest(42, null, [10, 20], undefined, undefined, filters);
 
       expect(createDownloadStub).to.have.been.calledOnce;
-      // systemUserId still in correct position (4th arg)
       expect(createDownloadStub.firstCall.args[3]).to.equal(42);
-      // searchFilters forwarded as 5th arg
       expect(createDownloadStub.firstCall.args[4]).to.deep.equal({ keyword: 'elk' });
     });
 
     it('omitting searchFilters passes undefined as 5th arg', async () => {
-      const mockDBConnection = getMockDBConnection({
-        systemUserId: () => 42
-      });
+      const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
       const createDownloadStub = sinon
@@ -137,16 +126,14 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(null, [10, 20]);
+      await service.createDownloadRequest(42, null, [10, 20]);
 
       expect(createDownloadStub).to.have.been.calledOnce;
       expect(createDownloadStub.firstCall.args[4]).to.be.undefined;
     });
 
     it('still creates download features after searchFilters signature change', async () => {
-      const mockDBConnection = getMockDBConnection({
-        systemUserId: () => 42
-      });
+      const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
       sinon
@@ -154,7 +141,7 @@ describe('DownloadPipelineService', () => {
         .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
       const createFeaturesStub = sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
 
-      await service.createDownloadRequest(null, [10, 20], undefined, undefined, { keyword: 'elk' });
+      await service.createDownloadRequest(42, null, [10, 20], undefined, undefined, { keyword: 'elk' });
 
       expect(createFeaturesStub).to.have.been.calledOnce;
       expect(createFeaturesStub.firstCall.args[0]).to.equal('aaaa0000-0000-0000-0000-000000000001');

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -66,6 +66,7 @@ export class DownloadPipelineService extends DBService {
    * For authenticated users, `system_user_id` is set on the download record directly.
    * For anonymous users, `system_user_id` is null (UUID is the credential).
    *
+   * @param {number | null} systemUserId - The user that owns this download. Null for anonymous downloads (UUID is the credential).
    * @param {string | null} teamId - The team that owns this download. Null for anonymous downloads.
    * @param {number[]} submissionFeatureIds - The submission feature IDs to include.
    * @param {string} [dataRequestId] - The data request that originated this download.
@@ -75,6 +76,7 @@ export class DownloadPipelineService extends DBService {
    * @memberof DownloadPipelineService
    */
   async createDownloadRequest(
+    systemUserId: number | null,
     teamId: string | null,
     submissionFeatureIds: number[],
     dataRequestId?: string,
@@ -82,7 +84,6 @@ export class DownloadPipelineService extends DBService {
     searchFilters?: ISearchFeaturesFilters
   ): Promise<DownloadId> {
     const fragmentSizeBytes = fragmentSizeMb ? fragmentSizeMb * 1024 * 1024 : undefined;
-    const systemUserId = this.connection.systemUserId() || null;
 
     const downloadId = await this.downloadRepository.createDownload(
       teamId,

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -4,7 +4,7 @@ import { FRAGMENT_SIZE_THRESHOLD, SIGNED_URL_EXPIRY_FRAGMENT } from '../../const
 import { IDBConnection } from '../../database/db';
 import { ApiConflictError } from '../../errors/api-error';
 import { HTTP403, HTTP404, HTTP409, HTTP500 } from '../../errors/http-error';
-import { DownloadId, DownloadRecord, DownloadSizeEstimate } from '../../models/download';
+import { CreateDownloadRequest, DownloadId, DownloadRecord, DownloadSizeEstimate } from '../../models/download';
 import { DownloadFragmentRecord } from '../../models/download-fragment';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { DownloadFragmentRepository } from '../../repositories/download/download-fragment-repository';
@@ -20,7 +20,6 @@ import { getLogger } from '../../utils/logger';
 import { CodeService } from '../code-service';
 import { DBService } from '../db-service';
 import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
-import { ISearchFeaturesFilters } from '../search-feature-service.interface';
 
 const defaultLog = getLogger('services/download-pipeline-service');
 
@@ -66,32 +65,21 @@ export class DownloadPipelineService extends DBService {
    * For authenticated users, `system_user_id` is set on the download record directly.
    * For anonymous users, `system_user_id` is null (UUID is the credential).
    *
-   * @param {number | null} systemUserId - The user that owns this download. Null for anonymous downloads (UUID is the credential).
-   * @param {string | null} teamId - The team that owns this download. Null for anonymous downloads.
-   * @param {number[]} submissionFeatureIds - The submission feature IDs to include.
-   * @param {string} [dataRequestId] - The data request that originated this download.
-   * @param {number} [fragmentSizeMb] - Target fragment size in MB (500, 1000, or 5000). Defaults to 500.
-   * @param {ISearchFeaturesFilters} [searchFilters] - Original search filters for traceability. Null for cart-based downloads.
+   * @param {CreateDownloadRequest} payload
    * @return {Promise<DownloadId>} The created download record ID.
    * @memberof DownloadPipelineService
    */
-  async createDownloadRequest(
-    systemUserId: number | null,
-    teamId: string | null,
-    submissionFeatureIds: number[],
-    dataRequestId?: string,
-    fragmentSizeMb?: number,
-    searchFilters?: ISearchFeaturesFilters
-  ): Promise<DownloadId> {
+  async createDownloadRequest(payload: CreateDownloadRequest): Promise<DownloadId> {
+    const { systemUserId, teamId, submissionFeatureIds, dataRequestId, fragmentSizeMb, searchFilters } = payload;
     const fragmentSizeBytes = fragmentSizeMb ? fragmentSizeMb * 1024 * 1024 : undefined;
 
-    const downloadId = await this.downloadRepository.createDownload(
+    const downloadId = await this.downloadRepository.createDownload({
       teamId,
-      dataRequestId ?? null,
+      dataRequestId: dataRequestId ?? null,
       fragmentSizeBytes,
       systemUserId,
       searchFilters
-    );
+    });
 
     await this.downloadRepository.createDownloadFeatures(downloadId.download_id, submissionFeatureIds);
 

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -20,6 +20,7 @@ import { getLogger } from '../../utils/logger';
 import { CodeService } from '../code-service';
 import { DBService } from '../db-service';
 import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
+import { ISearchFeaturesFilters } from '../search-feature-service.interface';
 
 const defaultLog = getLogger('services/download-pipeline-service');
 
@@ -69,6 +70,7 @@ export class DownloadPipelineService extends DBService {
    * @param {number[]} submissionFeatureIds - The submission feature IDs to include.
    * @param {string} [dataRequestId] - The data request that originated this download.
    * @param {number} [fragmentSizeMb] - Target fragment size in MB (500, 1000, or 5000). Defaults to 500.
+   * @param {ISearchFeaturesFilters} [searchFilters] - Original search filters for traceability. Null for cart-based downloads.
    * @return {Promise<DownloadId>} The created download record ID.
    * @memberof DownloadPipelineService
    */
@@ -76,7 +78,8 @@ export class DownloadPipelineService extends DBService {
     teamId: string | null,
     submissionFeatureIds: number[],
     dataRequestId?: string,
-    fragmentSizeMb?: number
+    fragmentSizeMb?: number,
+    searchFilters?: ISearchFeaturesFilters
   ): Promise<DownloadId> {
     const fragmentSizeBytes = fragmentSizeMb ? fragmentSizeMb * 1024 * 1024 : undefined;
     const systemUserId = this.connection.systemUserId() || null;
@@ -85,7 +88,8 @@ export class DownloadPipelineService extends DBService {
       teamId,
       dataRequestId ?? null,
       fragmentSizeBytes,
-      systemUserId
+      systemUserId,
+      searchFilters
     );
 
     await this.downloadRepository.createDownloadFeatures(downloadId.download_id, submissionFeatureIds);

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -70,7 +70,7 @@ export class DownloadPipelineService extends DBService {
    * @memberof DownloadPipelineService
    */
   async createDownloadRequest(payload: CreateDownloadRequest): Promise<DownloadId> {
-    const { systemUserId, teamId, submissionFeatureIds, dataRequestId, fragmentSizeMb, searchFilters } = payload;
+    const { systemUserId, teamId, submissionFeatureIds, dataRequestId, fragmentSizeMb, filters } = payload;
     const fragmentSizeBytes = fragmentSizeMb ? fragmentSizeMb * 1024 * 1024 : undefined;
 
     const downloadId = await this.downloadRepository.createDownload({
@@ -78,7 +78,7 @@ export class DownloadPipelineService extends DBService {
       dataRequestId: dataRequestId ?? null,
       fragmentSizeBytes,
       systemUserId,
-      searchFilters
+      filters
     });
 
     await this.downloadRepository.createDownloadFeatures(downloadId.download_id, submissionFeatureIds);

--- a/api/src/services/download/download-service.ts
+++ b/api/src/services/download/download-service.ts
@@ -1,5 +1,5 @@
 import { IDBConnection } from '../../database/db';
-import { DownloadFeatureSummary, DownloadId, DownloadRecord } from '../../models/download';
+import { CreateDownload, DownloadFeatureSummary, DownloadId, DownloadRecord } from '../../models/download';
 import { DownloadRepository } from '../../repositories/download/download-repository';
 import { DBService } from '../db-service';
 
@@ -24,20 +24,12 @@ export class DownloadService extends DBService {
   /**
    * Create a new download record.
    *
-   * @param {string | null} teamId - The team that owns this download. Null for anonymous downloads.
-   * @param {string | null} dataRequestId - The data request that originated this download. Null for non-request downloads.
-   * @param {number} [fragmentSizeBytes] - Target fragment size in bytes.
-   * @param {number | null} [systemUserId] - The user who created this download. Null for anonymous downloads.
+   * @param {CreateDownload} payload - The download record to create.
    * @return {Promise<DownloadId>} The created record ID.
    * @memberof DownloadService
    */
-  async createDownload(
-    teamId: string | null,
-    dataRequestId: string | null,
-    fragmentSizeBytes?: number,
-    systemUserId?: number | null
-  ): Promise<DownloadId> {
-    return this.downloadRepository.createDownload(teamId, dataRequestId, fragmentSizeBytes, systemUserId);
+  async createDownload(payload: CreateDownload): Promise<DownloadId> {
+    return this.downloadRepository.createDownload(payload);
   }
 
   /**

--- a/api/src/services/search-feature-service.ts
+++ b/api/src/services/search-feature-service.ts
@@ -65,6 +65,18 @@ export class SearchFeatureService extends DBService {
   }
 
   /**
+   * Returns submission feature IDs matching the provided search filters.
+   * Delegates to repository for the CTE-based query.
+   *
+   * @param {ISearchFeaturesFilters} filters - Search filters (keyword, feature_types, species, properties)
+   * @returns {Promise<number[]>} Array of matching submission_feature_id values
+   */
+  async getSearchFeatureIds(filters: ISearchFeaturesFilters): Promise<number[]> {
+    defaultLog.debug({ label: 'getSearchFeatureIds', filters });
+    return this.searchFeatureRepository.searchFeatureIdsByFilters(filters);
+  }
+
+  /**
    * Creates search indexes for datetime, number, spatial and string properties belonging to
    * all features found for the given submission.
    *

--- a/api/src/services/search-feature-service.ts
+++ b/api/src/services/search-feature-service.ts
@@ -73,7 +73,8 @@ export class SearchFeatureService extends DBService {
    */
   async getSearchFeatureIds(filters: ISearchFeaturesFilters): Promise<number[]> {
     defaultLog.debug({ label: 'getSearchFeatureIds', filters });
-    return this.searchFeatureRepository.searchFeatureIdsByFilters(filters);
+    const rows = await this.searchFeatureRepository.searchFeatureIdsByFilters(filters);
+    return rows.map((row) => row.submission_feature_id);
   }
 
   /**

--- a/app/src/features/search/result/SearchResultPage.tsx
+++ b/app/src/features/search/result/SearchResultPage.tsx
@@ -2,6 +2,7 @@ import { Box, Divider, Paper } from '@mui/material';
 import { PageHeader } from 'components/header/PageHeader';
 import { URL_PARAMS, UrlParamKey } from 'constants/query-params';
 import { APIError } from 'hooks/api/useAxios';
+import { useApi } from 'hooks/useApi';
 import { useCartContext, useCodesContext, useDialogContext } from 'hooks/useContext';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -26,12 +27,14 @@ export enum SEARCH_RESULT_OPTION_VIEW {
 
 export const SearchResultPage = () => {
   const navigate = useNavigate();
-  const { rows, isLoading, searchParams, setSearchParams, removeSearchParam, pagination } = useSearchResults();
+  const { rows, isLoading, searchParams, setSearchParams, removeSearchParam, pagination, filters } = useSearchResults();
+  const api = useApi();
   const { codesDataLoader } = useCodesContext();
   const { features, pagination: cartPagination, addToCart, checkout } = useCartContext();
   const dialogContext = useDialogContext();
 
   const [view, setView] = useState<SEARCH_RESULT_OPTION_VIEW>(SEARCH_RESULT_OPTION_VIEW.LIST);
+  const [isDownloading, setIsDownloading] = useState(false);
   const { recommended, handleRefresh: refreshRecommended } = useRecommendedFilters();
 
   /**
@@ -197,6 +200,26 @@ export const SearchResultPage = () => {
     }
   }, [rows, addToCart, dialogContext]);
 
+  /**
+   * Download all features matching the current search filters in one click.
+   * Bypasses the shopping cart — sends filters to POST /api/download which resolves
+   * them to feature IDs server-side and creates a download record.
+   */
+  const handleDownloadAll = useCallback(async () => {
+    try {
+      setIsDownloading(true);
+      await api.search.createDownload(filters);
+      dialogContext.setSnackbar({
+        snackbarMessage: 'Download started. You can track its progress in your downloads.',
+        open: true
+      });
+    } catch (error) {
+      dialogContext.setSnackbar({ snackbarMessage: (error as APIError).message, open: true });
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [filters, api.search, dialogContext]);
+
   const handleCheckout = useCallback(async () => {
     try {
       const download = await checkout();
@@ -244,6 +267,8 @@ export const SearchResultPage = () => {
               activeSort={activeSort}
               onSortChange={handleSortChange}
               handleAddAllToCart={handleAddAllToCart}
+              handleDownloadAll={handleDownloadAll}
+              isDownloading={isDownloading}
             />
           </Box>
 

--- a/app/src/features/search/result/content/toolbar/SearchResultToolbar.test.tsx
+++ b/app/src/features/search/result/content/toolbar/SearchResultToolbar.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent } from '@testing-library/react';
+import { render } from 'test-helpers/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SEARCH_RESULT_OPTION_VIEW } from '../../SearchResultPage';
+import { SearchResultToolbar } from './SearchResultToolbar';
+
+vi.mock('components/button/SortButton', () => ({
+  SortButton: ({ children, ...props }: any) => (
+    <button data-testid="sort-button" {...props}>
+      {children}
+    </button>
+  )
+}));
+
+vi.mock('components/toggle-button/ToggleButtons', () => ({
+  ToggleButtons: () => <div data-testid="toggle-buttons" />
+}));
+
+const defaultProps = {
+  view: SEARCH_RESULT_OPTION_VIEW.LIST,
+  onViewChange: vi.fn(),
+  sortOptions: [{ label: 'Relevance', value: 'relevancy_score', direction: 'desc' as const }],
+  activeSort: 'relevancy_score',
+  onSortChange: vi.fn(),
+  handleAddAllToCart: vi.fn(),
+  handleDownloadAll: vi.fn()
+};
+
+describe('SearchResultToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders Download All button alongside Add All to Cart', () => {
+    const { getByRole } = render(<SearchResultToolbar {...defaultProps} />);
+
+    expect(getByRole('button', { name: /download all/i })).toBeInTheDocument();
+    expect(getByRole('button', { name: /add all to cart/i })).toBeInTheDocument();
+  });
+
+  it('disables Download All button when isDownloading is true', () => {
+    const { getByRole } = render(<SearchResultToolbar {...defaultProps} isDownloading={true} />);
+
+    expect(getByRole('button', { name: /download all/i })).toBeDisabled();
+  });
+
+  it('enables Download All button when isDownloading is not provided', () => {
+    const { getByRole } = render(<SearchResultToolbar {...defaultProps} />);
+
+    expect(getByRole('button', { name: /download all/i })).not.toBeDisabled();
+  });
+
+  it('calls handleDownloadAll on click', () => {
+    const handleDownloadAll = vi.fn();
+    const { getByRole } = render(<SearchResultToolbar {...defaultProps} handleDownloadAll={handleDownloadAll} />);
+
+    fireEvent.click(getByRole('button', { name: /download all/i }));
+
+    expect(handleDownloadAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call handleDownloadAll when disabled', () => {
+    const handleDownloadAll = vi.fn();
+    const { getByRole } = render(
+      <SearchResultToolbar {...defaultProps} handleDownloadAll={handleDownloadAll} isDownloading={true} />
+    );
+
+    fireEvent.click(getByRole('button', { name: /download all/i }));
+
+    expect(handleDownloadAll).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/features/search/result/content/toolbar/SearchResultToolbar.tsx
+++ b/app/src/features/search/result/content/toolbar/SearchResultToolbar.tsx
@@ -1,4 +1,4 @@
-import { mdiPlus } from '@mdi/js';
+import { mdiDownload, mdiPlus } from '@mdi/js';
 import Icon from '@mdi/react';
 import { Button, Stack } from '@mui/material';
 import { SortButton } from 'components/button/SortButton';
@@ -19,6 +19,8 @@ interface SearchResultToolbarProps {
   onSortChange: (sort: string, direction: 'asc' | 'desc') => void;
   viewOptions?: ToggleButtonView<SEARCH_RESULT_OPTION_VIEW>[];
   handleAddAllToCart: () => void;
+  handleDownloadAll: () => void;
+  isDownloading?: boolean;
 }
 
 export const SearchResultToolbar = ({
@@ -28,7 +30,9 @@ export const SearchResultToolbar = ({
   activeSort,
   onSortChange,
   viewOptions,
-  handleAddAllToCart
+  handleAddAllToCart,
+  handleDownloadAll,
+  isDownloading
 }: SearchResultToolbarProps) => {
   const defaultViews: ToggleButtonView<SEARCH_RESULT_OPTION_VIEW>[] = [
     { value: SEARCH_RESULT_OPTION_VIEW.TABLE, label: 'Table' },
@@ -63,6 +67,15 @@ export const SearchResultToolbar = ({
 
       {/* Right: Actions + View */}
       <Stack direction="row" alignItems="center" spacing={1}>
+        <Button
+          size="small"
+          color="primary"
+          onClick={handleDownloadAll}
+          disabled={isDownloading}
+          startIcon={<Icon path={mdiDownload} size={0.8} />}
+          sx={{ flexWrap: 'nowrap', fontWeight: 700 }}>
+          Download All
+        </Button>
         <Button
           size="small"
           color="primary"

--- a/app/src/features/search/result/hooks/useSearchResults.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.tsx
@@ -172,6 +172,7 @@ export const useSearchResults = () => {
     setSearchParams,
     getParam,
     removeSearchParam,
-    pagination: searchDataLoader.data?.pagination
+    pagination: searchDataLoader.data?.pagination,
+    filters: buildRequest(searchParams).filters
   };
 };

--- a/app/src/hooks/api/useSearchApi.test.ts
+++ b/app/src/hooks/api/useSearchApi.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { PRIORITY_FEATURE_TYPE } from 'constants/feature-type';
 import {
+  CreateDownloadResponse,
   GroupedPropertyResults,
   SearchFeatureResponse,
   SearchFeatureResultWithRelevancy,
@@ -244,6 +245,35 @@ describe('useSearchApi', () => {
         page: 1,
         limit: 10
       });
+    });
+  });
+
+  describe('createDownload', () => {
+    it('should POST filters to /api/download and return download_id', async () => {
+      const mockResponse: CreateDownloadResponse = { download_id: '550e8400-e29b-41d4-a716-446655440099' };
+
+      mock.onPost('/api/download').reply(201, mockResponse);
+
+      const result = await useSearchApi(axios).createDownload({ keyword: 'moose' });
+
+      expect(result).toEqual(mockResponse);
+      expect(mock.history.post[0].data).toEqual(JSON.stringify({ filters: { keyword: 'moose' } }));
+    });
+
+    it('should resolve with download_id from response', async () => {
+      const mockResponse: CreateDownloadResponse = { download_id: 'uuid-abc-123' };
+
+      mock.onPost('/api/download').reply(201, mockResponse);
+
+      const result = await useSearchApi(axios).createDownload({ feature_types: ['dataset'], species: [42] });
+
+      expect(result.download_id).toBe('uuid-abc-123');
+    });
+
+    it('should propagate rejection on server error', async () => {
+      mock.onPost('/api/download').reply(400);
+
+      await expect(useSearchApi(axios).createDownload({ keyword: 'moose' })).rejects.toThrow();
     });
   });
 

--- a/app/src/hooks/api/useSearchApi.ts
+++ b/app/src/hooks/api/useSearchApi.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance } from 'axios';
 import {
+  CreateDownloadResponse,
   ISearchAllFilters,
   ISearchFeaturesFilters,
   ISearchPropertyFilters,
@@ -88,10 +89,22 @@ export const useSearchApi = (axios: AxiosInstance) => {
     return data;
   };
 
+  /**
+   * Create a download from search filters.
+   * Bypasses the shopping cart — sends current search filters to the server which resolves
+   * them to feature IDs and creates a download record. The download UUID is the access
+   * credential for anonymous users; authenticated users get it linked to their account.
+   */
+  const createDownload = async (filters: ISearchFeaturesFilters): Promise<CreateDownloadResponse> => {
+    const { data } = await axios.post<CreateDownloadResponse>('/api/download', { filters });
+    return data;
+  };
+
   return {
     searchFeatures,
     searchAll,
     searchProperties,
-    searchSummary
+    searchSummary,
+    createDownload
   };
 };

--- a/app/src/interfaces/useSearchApi.interface.ts
+++ b/app/src/interfaces/useSearchApi.interface.ts
@@ -52,6 +52,14 @@ export interface ISearchFeaturePropertyGroup {
   conditions: ISearchFeaturePropertyCondition[];
 }
 
+/**
+ * Response from POST /api/download — a download created directly from search filters.
+ * Bypasses the shopping cart; the download UUID is the access credential for anonymous users.
+ */
+export interface CreateDownloadResponse {
+  download_id: string;
+}
+
 /** Request parameters for advanced feature search */
 export interface ISearchFeaturesFilters {
   /** Free-text keyword search across all searchable properties */

--- a/database/src/migrations/20260303155539_add_download_search_filters.ts
+++ b/database/src/migrations/20260303155539_add_download_search_filters.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 
 /**
- * Add search_filters JSONB column to the download table.
+ * Add filters JSONB column to the download table.
  * Null for cart-based downloads (no search filter context exists).
  */
 
@@ -9,9 +9,9 @@ export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
-    ALTER TABLE download ADD COLUMN search_filters JSONB;
+    ALTER TABLE download ADD COLUMN filters JSONB;
 
-    COMMENT ON COLUMN download.search_filters IS 'Original search filters used to create this download. Null for cart-based downloads.';
+    COMMENT ON COLUMN download.filters IS 'Original search filters used to create this download. Null for cart-based downloads.';
   `);
 }
 
@@ -19,6 +19,6 @@ export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
-    ALTER TABLE download DROP COLUMN IF EXISTS search_filters;
+    ALTER TABLE download DROP COLUMN IF EXISTS filters;
   `);
 }

--- a/database/src/migrations/20260303155539_add_download_search_filters.ts
+++ b/database/src/migrations/20260303155539_add_download_search_filters.ts
@@ -1,0 +1,24 @@
+import { Knex } from 'knex';
+
+/**
+ * Add search_filters JSONB column to the download table.
+ * Null for cart-based downloads (no search filter context exists).
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE download ADD COLUMN search_filters JSONB;
+
+    COMMENT ON COLUMN download.search_filters IS 'Original search filters used to create this download. Null for cart-based downloads.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE download DROP COLUMN IF EXISTS search_filters;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-833](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-833)

## Description of Changes

As a BioHub client, I want to download all features that match a search query, so that I can efficiently retrieve large sets of data without manually adding each feature to a shopping cart.

Acceptance Criteria
1. Performing a Search for Bulk Download  
WHEN a client enters search criteria (keywords, filters, etc.) and executes a search,  
  THEN the system should return all matching features and display the results.
2. Initiating Bulk Download  
WHEN the client clicks the "Download All" button,  
  THEN the current search query parameters should be sent to the server for processing.
3. Creating a Bulk Download Record  
WHEN the bulk download request is received by the server,  
  THEN a new record should be inserted into the `download` table,  
  AND all features matching the search query should be linked to this download record in the `download_feature` table.
4. Notes  
This bulk download bypasses the shopping cart and uses the search query directly to generate the download.  
The `download_feature` table should track the `feature_id` for each feature included in the bulk download.  
Search query parameters (filters, keywords) should be stored with the download record for traceability.

## Testing Notes

Navigate to the search page and click the "Download All" button, a download record should be created.

Note: the notification message is not precise for anonymous users, this we be improved in ticket 824.
