### PR TITLE
SIMSBIOHUB 881: Adding Ticket ID to Data Request

### DIFF
--- a/api/src/models/data-request.ts
+++ b/api/src/models/data-request.ts
@@ -5,7 +5,8 @@ export const DataRequest = z.object({
   data_request_id: z.string().uuid(),
   reason: z.string(),
   team_id: z.string().uuid(),
-  requested_by: z.number()
+  requested_by: z.number(),
+  ticket_id: z.string().uuid()
 });
 export type DataRequest = z.infer<typeof DataRequest>;
 
@@ -24,6 +25,11 @@ export const CreateDataRequest = z.object({
   team_id: z.string().uuid().optional()
 });
 export type CreateDataRequest = z.infer<typeof CreateDataRequest>;
+
+export type CreateDataRequestPayload = CreateDataRequest & {
+  team_id: string;
+  ticket_id: string;
+};
 
 export const UpdateDataRequest = z.object({
   reason: z.string().optional()

--- a/api/src/openapi/schemas/data-request.ts
+++ b/api/src/openapi/schemas/data-request.ts
@@ -3,7 +3,7 @@ import { DataRequestStatusResponseSchema } from './data-request-status';
 
 export const DataRequestResponseSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
-  required: ['requested_by', 'team_id', 'data_request_id', 'reason', 'data_request_status'],
+  required: ['requested_by', 'team_id', 'data_request_id', 'reason', 'ticket_id', 'data_request_status'],
   additionalProperties: false,
   properties: {
     data_request_id: {
@@ -23,6 +23,11 @@ export const DataRequestResponseSchema: OpenAPIV3.SchemaObject = {
     requested_by: {
       type: 'integer',
       description: 'System user ID of the requester'
+    },
+    ticket_id: {
+      type: 'string',
+      format: 'uuid',
+      description: 'ID of the ticket associated with this data request'
     },
     data_request_status: {
       ...DataRequestStatusResponseSchema,

--- a/api/src/paths/data-request/index.test.ts
+++ b/api/src/paths/data-request/index.test.ts
@@ -24,6 +24,7 @@ describe('data-request', () => {
     reason: 'Research purposes',
     team_id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
     requested_by: 1,
+    ticket_id: 'd4e5f6a7-b8c9-0123-def0-234567890123',
     data_request_status: {
       data_request_status_id: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
       data_request_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',

--- a/api/src/paths/data-request/{dataRequestId}/index.test.ts
+++ b/api/src/paths/data-request/{dataRequestId}/index.test.ts
@@ -21,6 +21,7 @@ describe('data-request/{dataRequestId}', () => {
     reason: 'Research purposes',
     team_id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
     requested_by: 1,
+    ticket_id: 'd4e5f6a7-b8c9-0123-def0-234567890123',
     data_request_status: {
       data_request_status_id: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
       data_request_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
@@ -33,7 +34,8 @@ describe('data-request/{dataRequestId}', () => {
     data_request_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
     reason: 'Research purposes',
     team_id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
-    requested_by: 1
+    requested_by: 1,
+    ticket_id: 'd4e5f6a7-b8c9-0123-def0-234567890123'
   };
 
   describe('getDataRequestById', () => {

--- a/api/src/repositories/data-request-repository.test.ts
+++ b/api/src/repositories/data-request-repository.test.ts
@@ -4,7 +4,7 @@ import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { ApiNotFoundError } from '../errors/api-error';
-import { CreateDataRequest, DataRequest, UpdateDataRequest } from '../models/data-request';
+import { CreateDataRequestPayload, DataRequest, UpdateDataRequest } from '../models/data-request';
 import { getMockDBConnection } from '../__mocks__/db';
 import { DataRequestRepository } from './data-request-repository';
 
@@ -19,7 +19,8 @@ describe('DataRequestRepository', () => {
     data_request_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
     reason: 'Research purposes',
     team_id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
-    requested_by: 1
+    requested_by: 1,
+    ticket_id: 'd4e5f6a7-b8c9-0123-def0-234567890123'
   };
 
   describe('findDataRequests', () => {
@@ -239,9 +240,11 @@ describe('DataRequestRepository', () => {
 
       const repo = new DataRequestRepository(mockDBConnection);
 
-      const payload: CreateDataRequest = {
+      const payload: CreateDataRequestPayload = {
         requested_by: mockDataRequest.requested_by,
-        reason: 'New research project'
+        reason: 'New research project',
+        team_id: mockDataRequest.team_id,
+        ticket_id: mockDataRequest.ticket_id
       };
 
       const result = await repo.createDataRequest(mockDataRequest.requested_by, payload);
@@ -261,9 +264,11 @@ describe('DataRequestRepository', () => {
 
       const repo = new DataRequestRepository(mockDBConnection);
 
-      const payload: CreateDataRequest = {
+      const payload: CreateDataRequestPayload = {
         requested_by: mockDataRequest.requested_by,
-        reason: 'Test'
+        reason: 'Test',
+        team_id: mockDataRequest.team_id,
+        ticket_id: mockDataRequest.ticket_id
       };
 
       try {

--- a/api/src/repositories/data-request-repository.ts
+++ b/api/src/repositories/data-request-repository.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { getKnex } from '../database/db';
 import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import {
-  CreateDataRequest,
+  CreateDataRequestPayload,
   DataRequest,
   DataRequestFilters,
   FlatDataRequestWithStatus,
@@ -33,6 +33,7 @@ export class DataRequestRepository extends BaseRepository {
         'dr.team_id',
         'dr.reason',
         'dr.requested_by',
+        'dr.ticket_id',
         'drs.data_request_status_id',
         'drs.comment_id',
         'drs.request_status'
@@ -65,6 +66,7 @@ export class DataRequestRepository extends BaseRepository {
         'dr.team_id',
         'dr.reason',
         'dr.requested_by',
+        'dr.ticket_id',
         'drs.data_request_status_id',
         'drs.comment_id',
         'drs.request_status'
@@ -127,6 +129,7 @@ export class DataRequestRepository extends BaseRepository {
         'dr.team_id',
         'dr.reason',
         'dr.requested_by',
+        'dr.ticket_id',
         'drs.data_request_status_id',
         'drs.comment_id',
         'drs.request_status'
@@ -170,6 +173,7 @@ export class DataRequestRepository extends BaseRepository {
         'dr.team_id',
         'dr.reason',
         'dr.requested_by',
+        'dr.ticket_id',
         'drs.data_request_status_id',
         'drs.comment_id',
         'drs.request_status'
@@ -187,19 +191,20 @@ export class DataRequestRepository extends BaseRepository {
    * Create a new data request.
    *
    * @param {number} requestedBy
-   * @param {CreateDataRequest} payload
+   * @param {CreateDataRequestPayload} payload
    * @return {Promise<DataRequest>}
    * @memberof DataRequestRepository
    */
-  async createDataRequest(requestedBy: number, payload: CreateDataRequest): Promise<DataRequest> {
+  async createDataRequest(requestedBy: number, payload: CreateDataRequestPayload): Promise<DataRequest> {
     const knex = getKnex();
     const query = knex('data_request')
       .insert({
         requested_by: requestedBy,
         team_id: payload.team_id,
-        reason: payload.reason
+        reason: payload.reason,
+        ticket_id: payload.ticket_id
       })
-      .returning(['requested_by', 'team_id', 'data_request_id', 'reason']);
+      .returning(['requested_by', 'team_id', 'data_request_id', 'reason', 'ticket_id']);
 
     const response = await this.connection.knex(query, DataRequest);
 
@@ -227,7 +232,7 @@ export class DataRequestRepository extends BaseRepository {
       .where('data_request_id', dataRequestId)
       .whereNull('record_end_date')
       .update(payload)
-      .returning(['data_request_id', 'reason', 'requested_by', 'team_id']);
+      .returning(['data_request_id', 'reason', 'requested_by', 'team_id', 'ticket_id']);
 
     const response = await this.connection.knex(query, DataRequest);
 

--- a/api/src/services/data-request-service.test.ts
+++ b/api/src/services/data-request-service.test.ts
@@ -309,6 +309,7 @@ describe('DataRequestService', () => {
         reason: 'New research project',
         team_id: mockDataRequest.team_id
       };
+      const expectedTicketSubject = `Data Request - ${payload.reason.split(' ').slice(0, 10).join(' ')}`;
 
       stubCreateDataRequestDependencies();
 
@@ -324,8 +325,8 @@ describe('DataRequestService', () => {
       });
 
       expect(ticketStub).to.have.been.calledOnceWith({
-        subject: 'Data Request',
-        description: payload.reason,
+        subject: expectedTicketSubject,
+        description: null,
         priority: 'medium'
       });
     });

--- a/api/src/services/data-request-service.test.ts
+++ b/api/src/services/data-request-service.test.ts
@@ -14,6 +14,7 @@ import { TeamPolicyService } from './access-policy/team-policy-service';
 import { TeamService } from './access-policy/team-service';
 import { DataRequestService } from './data-request-service';
 import { DataRequestStatusService } from './data-request-status-service';
+import { TicketService } from './ticket-service';
 
 chai.use(sinonChai);
 
@@ -28,6 +29,7 @@ describe('DataRequestService', () => {
     reason: 'Research purposes',
     team_id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
     requested_by: 1,
+    ticket_id: 'd4e5f6a7-b8c9-0123-def0-234567890123',
     comment_id: null,
     request_status: 'REQUESTED'
   };
@@ -36,7 +38,8 @@ describe('DataRequestService', () => {
     data_request_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
     reason: 'Research purposes',
     team_id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
-    requested_by: 1
+    requested_by: 1,
+    ticket_id: 'd4e5f6a7-b8c9-0123-def0-234567890123'
   };
 
   const mockDataRequestStatus: DataRequestStatus = {
@@ -233,6 +236,17 @@ describe('DataRequestService', () => {
         sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(mockTeamMember);
       }
 
+      sinon.stub(TicketService.prototype, 'createTicket').resolves({
+        ticket_id: mockDataRequest.ticket_id,
+        ticket_slug: '06600000',
+        subject: 'Data Request',
+        description: null,
+        team_id: teamId,
+        create_date: '2026-03-06',
+        priority: 'medium',
+        status: 'open'
+      });
+
       sinon
         .stub(DataRequestRepository.prototype, 'createDataRequest')
         .resolves({ ...mockDataRequest, team_id: teamId });
@@ -262,7 +276,8 @@ describe('DataRequestService', () => {
 
       expect(createStub).to.have.been.calledOnceWith(mockDataRequest.requested_by, {
         ...payload,
-        team_id: mockDataRequest.team_id
+        team_id: mockDataRequest.team_id,
+        ticket_id: mockDataRequest.ticket_id
       });
 
       expect(policyStub).to.have.been.calledOnce;
@@ -283,6 +298,36 @@ describe('DataRequestService', () => {
 
       expect(result.data_request_id).to.equal(mockDataRequest.data_request_id);
       expect(result.data_request_status.request_status).to.equal('APPROVED');
+    });
+
+    it('should create a ticket when creating a data request', async () => {
+      const mockDB = getMockDBConnection();
+      const service = new DataRequestService(mockDB);
+
+      const payload: CreateDataRequest = {
+        requested_by: mockDataRequest.requested_by,
+        reason: 'New research project',
+        team_id: mockDataRequest.team_id
+      };
+
+      stubCreateDataRequestDependencies();
+
+      const createStub = DataRequestRepository.prototype.createDataRequest as sinon.SinonStub;
+      const ticketStub = TicketService.prototype.createTicket as sinon.SinonStub;
+
+      await service.createDataRequest(payload);
+
+      expect(createStub).to.have.been.calledOnceWith(mockDataRequest.requested_by, {
+        ...payload,
+        team_id: mockDataRequest.team_id,
+        ticket_id: mockDataRequest.ticket_id
+      });
+
+      expect(ticketStub).to.have.been.calledOnceWith({
+        subject: 'Data Request',
+        description: payload.reason,
+        priority: 'medium'
+      });
     });
 
     it('should create a new team when payload.team_id is undefined', async () => {
@@ -322,6 +367,16 @@ describe('DataRequestService', () => {
         reason: 'Test',
         team_id: mockDataRequest.team_id
       };
+      sinon.stub(TicketService.prototype, 'createTicket').resolves({
+        ticket_id: mockDataRequest.ticket_id,
+        ticket_slug: '06600000',
+        subject: 'Data Request',
+        description: null,
+        team_id: mockDataRequest.team_id,
+        create_date: '2026-03-06',
+        priority: 'medium',
+        status: 'open'
+      });
       sinon.stub(DataRequestRepository.prototype, 'createDataRequest').rejects(new Error('DB error'));
 
       try {

--- a/api/src/services/data-request-service.ts
+++ b/api/src/services/data-request-service.ts
@@ -11,6 +11,7 @@ import {
 import { DataRequestStatusEnum } from '../models/data-request-status';
 import { PolicyEffect } from '../models/policy-statement';
 import { Team } from '../models/team';
+import { CreateTicketRequest, Ticket } from '../models/ticket';
 import { DataRequestRepository } from '../repositories/data-request-repository';
 import {
   _generateDataRequestPolicyName,
@@ -24,6 +25,7 @@ import { TeamPolicyService } from './access-policy/team-policy-service';
 import { TeamService } from './access-policy/team-service';
 import { DataRequestStatusService } from './data-request-status-service';
 import { DBService } from './db-service';
+import { TicketService } from './ticket-service';
 
 /**
  * Service for managing data requests.
@@ -98,7 +100,7 @@ export class DataRequestService extends DBService {
   /**
    * Create a new data request.
    *
-   * Creates a team for the requester, a wildcard access policy expiring in 30 days
+   * Creates a team for the requester, at ticket, a wildcard access policy expiring in 30 days
    * linked to the team, and auto-approves the request.
    *
    * @param {CreateDataRequest} payload
@@ -111,9 +113,15 @@ export class DataRequestService extends DBService {
       const team = await this.createTeam(payload.requested_by);
       teamId = team.team_id;
     }
-    const payloadWithTeamId = { ...payload, team_id: teamId };
+    const ticket = await this.createTicket({
+      subject: 'Data Request',
+      description: payload.reason,
+      priority: 'medium'
+    });
 
-    const dataRequest = await this.dataRequestRepository.createDataRequest(payload.requested_by, payloadWithTeamId);
+    const payloadWithIds = { ...payload, team_id: teamId, ticket_id: ticket.ticket_id };
+
+    const dataRequest = await this.dataRequestRepository.createDataRequest(payload.requested_by, payloadWithIds);
 
     const policy = await this.createPolicy(dataRequest.data_request_id);
     await this.createTeamPolicy({ teamId, policyId: policy.policy_id });
@@ -165,6 +173,22 @@ export class DataRequestService extends DBService {
     }
 
     return this.dataRequestRepository.deleteDataRequest(dataRequestId);
+  }
+
+  /**
+   * Create a new ticket.
+   *
+   * @param {CreateTicketRequest} params
+   * @return {Promise<Ticket>}
+   * @memberof DataRequestService
+   */
+  private async createTicket(params: CreateTicketRequest): Promise<Ticket> {
+    const { subject, description, priority } = params;
+
+    const ticketService = new TicketService(this.connection);
+    const ticket = await ticketService.createTicket({ subject, description, priority });
+
+    return ticket;
   }
 
   /**

--- a/api/src/services/data-request-service.ts
+++ b/api/src/services/data-request-service.ts
@@ -100,7 +100,7 @@ export class DataRequestService extends DBService {
   /**
    * Create a new data request.
    *
-   * Creates a team for the requester, at ticket, a wildcard access policy expiring in 30 days
+   * Creates a team for the requester, a ticket, a wildcard access policy expiring in 30 days
    * linked to the team, and auto-approves the request.
    *
    * @param {CreateDataRequest} payload

--- a/api/src/services/data-request-service.ts
+++ b/api/src/services/data-request-service.ts
@@ -11,7 +11,6 @@ import {
 import { DataRequestStatusEnum } from '../models/data-request-status';
 import { PolicyEffect } from '../models/policy-statement';
 import { Team } from '../models/team';
-import { CreateTicketRequest, Ticket } from '../models/ticket';
 import { DataRequestRepository } from '../repositories/data-request-repository';
 import {
   _generateDataRequestPolicyName,
@@ -113,9 +112,12 @@ export class DataRequestService extends DBService {
       const team = await this.createTeam(payload.requested_by);
       teamId = team.team_id;
     }
-    const ticket = await this.createTicket({
-      subject: 'Data Request',
-      description: payload.reason,
+
+    const ticketSubject = `Data Request - ${payload.reason.split(' ').slice(0, 10).join(' ')}`;
+    const ticketService = new TicketService(this.connection);
+    const ticket = await ticketService.createTicket({
+      subject: ticketSubject,
+      description: null,
       priority: 'medium'
     });
 
@@ -173,22 +175,6 @@ export class DataRequestService extends DBService {
     }
 
     return this.dataRequestRepository.deleteDataRequest(dataRequestId);
-  }
-
-  /**
-   * Create a new ticket.
-   *
-   * @param {CreateTicketRequest} params
-   * @return {Promise<Ticket>}
-   * @memberof DataRequestService
-   */
-  private async createTicket(params: CreateTicketRequest): Promise<Ticket> {
-    const { subject, description, priority } = params;
-
-    const ticketService = new TicketService(this.connection);
-    const ticket = await ticketService.createTicket({ subject, description, priority });
-
-    return ticket;
   }
 
   /**

--- a/api/src/utils/data-request.ts
+++ b/api/src/utils/data-request.ts
@@ -43,6 +43,7 @@ export function _transformFlatDataRequestToNested(flatDataRequest: FlatDataReque
     reason: flatDataRequest.reason,
     team_id: flatDataRequest.team_id,
     requested_by: flatDataRequest.requested_by,
+    ticket_id: flatDataRequest.ticket_id,
     data_request_status: {
       data_request_status_id: flatDataRequest.data_request_status_id,
       data_request_id: flatDataRequest.data_request_id,

--- a/database/src/migrations/20260306173934_adds_ticket_id_to_data_requests.ts
+++ b/database/src/migrations/20260306173934_adds_ticket_id_to_data_requests.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE "data_request" ADD COLUMN ticket_id uuid NOT NULL;
+
+    COMMENT ON COLUMN data_request.ticket_id IS 'Foreign key to the ticket associated with this data request.';
+
+    ALTER TABLE data_request ADD CONSTRAINT data_request_ticket_fk
+      FOREIGN KEY (ticket_id) REFERENCES ticket(ticket_id);
+
+    CREATE INDEX data_request_ticket_idx ON data_request(ticket_id);
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    DROP INDEX IF EXISTS data_request_ticket_idx;
+
+    ALTER TABLE data_request DROP CONSTRAINT IF EXISTS data_request_ticket_fk;
+
+    ALTER TABLE data_request DROP COLUMN IF EXISTS ticket_id;
+  `);
+}

--- a/database/src/seeds/08_ticket_data.ts
+++ b/database/src/seeds/08_ticket_data.ts
@@ -129,6 +129,28 @@ export async function seed(knex: Knex): Promise<void> {
     }
   }
 
+  // Seed data_request records linked to tickets
+  const opsCheckTicket = seededTicketsByKey['ops-check'];
+  const dataFixTicket = seededTicketsByKey['data-fix'];
+
+  if (opsCheckTicket) {
+    await ensureDataRequest(knex, {
+      reason: 'Ops health check data request',
+      teamId,
+      requestedBy: createUser,
+      ticketId: opsCheckTicket.ticket_id
+    });
+  }
+
+  if (dataFixTicket) {
+    await ensureDataRequest(knex, {
+      reason: 'Data correction data request',
+      teamId,
+      requestedBy: createUser,
+      ticketId: dataFixTicket.ticket_id
+    });
+  }
+
   for (const referenceScenario of TICKET_REFERENCE_SCENARIOS) {
     const sourceTicket = seededTicketsByKey[referenceScenario.sourceKey];
     const targetTicket = seededTicketsByKey[referenceScenario.targetKey];
@@ -325,5 +347,43 @@ const ensureTicketReference = async (
     target_ticket_id: targetTicketId,
     relationship,
     create_user: createUser
+  });
+};
+
+const ensureDataRequest = async (
+  knex: Knex,
+  input: { reason: string; teamId: string; requestedBy: number; ticketId: string }
+): Promise<void> => {
+  const existing = await knex('data_request').where({ ticket_id: input.ticketId }).whereNull('record_end_date').first();
+
+  let dataRequestId: string;
+
+  if (existing) {
+    dataRequestId = existing.data_request_id;
+    const hasStatus = await knex('data_request_status')
+      .where({ data_request_id: dataRequestId })
+      .whereNull('record_end_date')
+      .first();
+    if (hasStatus) {
+      return;
+    }
+  } else {
+    const [inserted] = await knex('data_request')
+      .insert({
+        reason: input.reason,
+        team_id: input.teamId,
+        requested_by: input.requestedBy,
+        ticket_id: input.ticketId,
+        create_user: input.requestedBy
+      })
+      .returning(['data_request_id']);
+    dataRequestId = inserted.data_request_id;
+  }
+
+  await knex('data_request_status').insert({
+    data_request_id: dataRequestId,
+    request_status: 'APPROVED',
+    comment_id: null,
+    create_user: input.requestedBy
   });
 };


### PR DESCRIPTION
## Links to Jira Tickets

https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-881

## Description of Changes

**Database** – Adds `ticket_id` to `data_request`: migration adds `ticket_id` (UUID, NOT NULL), FK to `ticket(ticket_id)`, and index `data_request_ticket_idx`.

**API – Models** – Data request models now include `ticket_id`: added to `DataRequest` (Zod), `FlatDataRequestWithStatus`, `DataRequestWithStatus`, and `CreateDataRequestPayload`.

**API – OpenAPI & schema** – `ticket_id` added to the data request response schema and OpenAPI spec (required, UUID, description: “ID of the ticket associated with this data request”).

**API – Data request creation** – When a data request is created, a ticket is created first via a new private `DataRequestService.createTicket()` (subject “Data Request”, description = request reason, priority “medium”). The new ticket’s `ticket_id` is passed into the repository so each data request is stored with a non-null `ticket_id`.

**API – Repository** – `DataRequestRepository` selects and returns `ticket_id` in all relevant queries; `createDataRequest` accepts and persists `ticket_id` in the payload.

**API – Utils** – `_transformFlatDataRequestToNested` in `data-request.ts` includes `ticket_id` in the nested response so all service responses expose it.

**API – Tests** – Data request service, repository, and route tests updated to use and assert `ticket_id`; seeds updated so data requests are created with linked tickets.

## Testing Instructions

- **Create data request**: Create a data request via the API; response and DB row should include a valid `ticket_id` pointing to a new ticket with subject “Data Request” and the request reason as description.
- **Get/list data requests**: GET by ID and list endpoints should return `ticket_id` for each data request.
- **API tests**: Run data request service, repository, and path tests; all should pass with the new `ticket_id` expectations.
- **Seeds**: Run seeds; data requests should be created with valid `ticket_id` values.

