### PR TITLE
SIMSBIOHUB-899: Fix error when publishing from SIMS

### DIFF
--- a/api/src/repositories/upload/artifact-repository.ts
+++ b/api/src/repositories/upload/artifact-repository.ts
@@ -94,10 +94,11 @@ export class ArtifactRepository extends BaseRepository {
         ${artifact.checksum_sha256 ?? null},
         ${artifact.uploaded_at ?? null}
       )
-      ON CONFLICT (bucket, object_key) DO NOTHING;
+      ON CONFLICT (bucket, object_key) DO NOTHING
+      RETURNING artifact_id;
     `;
 
-    const response = await this.connection.sql(sqlStatement);
+    const response = await this.connection.sql(sqlStatement, z.object({ artifact_id: z.string().uuid() }));
 
     if (response.rowCount === 1) {
       return response.rows[0];


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-899](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-899)

## Description of Changes

In ArtifactRepository.insertArtifact, the INSERT had no RETURNING clause. On a successful insert, response.rows was empty, so response.rows[0] was undefined. The caller then did artifact.artifact_id, which became “read property 'artifact_id' of undefined” and triggered the TypeError.

RETURNING artifact_id was added to the INSERT so PostgreSQL returns the new row’s artifact_id when a row is inserted.
A response schema was added to the connection.sql() call for the INSERT: z.object({ artifact_id: z.string().uuid() }), so the returned row is validated and typed.
With this, a successful insert returns the new artifact_id, and the existing “conflict” path (SELECT by bucket + object_key) still handles the case where the row already exists. Archive upload should no longer hit that error.

## Testing Notes

- Test publishing from SIMS to BioHub
