### PR TITLE
SIMSBIOHUB-863: Caching secured records

### DIFF
--- a/api/.mocharc.integration.json
+++ b/api/.mocharc.integration.json
@@ -2,5 +2,6 @@
   "extension": ["ts"],
   "spec": "src/__integration__/db/*.integration.ts",
   "require": "ts-node/register",
+  "node-option": ["no-experimental-strip-types"],
   "exit": true
 }

--- a/api/src/__integration__/db/team-feature-search.integration.ts
+++ b/api/src/__integration__/db/team-feature-search.integration.ts
@@ -415,36 +415,36 @@ describe('Team feature cache + search (integration)', function () {
     });
   });
 
+  /**
+   * Shared setup: creates a submission with one unsecured and one secured feature,
+   * a team with a user, and a policy granting the team access to the secured feature.
+   * Returns all IDs needed for assertions.
+   */
+  async function setupSearchScenario() {
+    const submissionId = await createTestSubmission(connection);
+    const unsecuredFeatureId = await createTestFeature(connection, submissionId, 'dataset', {
+      name: 'Open Dataset'
+    });
+    const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', {
+      name: 'Secured Dataset'
+    });
+    await secureFeature(securedFeatureId);
+
+    const teamId = await createTeam('Search Test Team');
+    const userId = await createUser();
+    await addTeamMember(teamId, userId);
+
+    // Grant team access to the secured feature and populate cache
+    await grantTeamAccess(teamId, `urn:${submissionId}:dataset:${securedFeatureId}`);
+    const teamFeatureService = new TeamFeatureService(connection);
+    await teamFeatureService.refreshCacheForTeam(teamId);
+
+    return { submissionId, unsecuredFeatureId, securedFeatureId, teamId, userId };
+  }
+
   // ── Search filtering tests ─────────────────────────────────────────────
 
   describe('Search with team_feature filtering', () => {
-    /**
-     * Shared setup: creates a submission with one unsecured and one secured feature,
-     * a team with a user, and a policy granting the team access to the secured feature.
-     * Returns all IDs needed for assertions.
-     */
-    async function setupSearchScenario() {
-      const submissionId = await createTestSubmission(connection);
-      const unsecuredFeatureId = await createTestFeature(connection, submissionId, 'dataset', {
-        name: 'Open Dataset'
-      });
-      const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', {
-        name: 'Secured Dataset'
-      });
-      await secureFeature(securedFeatureId);
-
-      const teamId = await createTeam('Search Test Team');
-      const userId = await createUser();
-      await addTeamMember(teamId, userId);
-
-      // Grant team access to the secured feature and populate cache
-      await grantTeamAccess(teamId, `urn:${submissionId}:dataset:${securedFeatureId}`);
-      const teamFeatureService = new TeamFeatureService(connection);
-      await teamFeatureService.refreshCacheForTeam(teamId);
-
-      return { submissionId, unsecuredFeatureId, securedFeatureId, teamId, userId };
-    }
-
     it('should return only unsecured features for anonymous search (systemUserId=null)', async () => {
       const { unsecuredFeatureId, securedFeatureId } = await setupSearchScenario();
 

--- a/api/src/__integration__/db/team-feature-search.integration.ts
+++ b/api/src/__integration__/db/team-feature-search.integration.ts
@@ -141,15 +141,23 @@ describe('Team feature cache + search (integration)', function () {
     return result.rows.map((r: { submission_feature_id: number }) => r.submission_feature_id);
   }
 
+  /**
+   * Composite helper: create a submission with one secured feature and a team.
+   * Covers the common setup pattern used by mutation and cache tests.
+   */
+  async function setupSecuredFeatureWithTeam(teamName: string) {
+    const submissionId = await createTestSubmission(connection);
+    const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: teamName });
+    await secureFeature(featureId);
+    const teamId = await createTeam(teamName);
+    return { submissionId, featureId, teamId };
+  }
+
   // ── Cache population tests ─────────────────────────────────────────────
 
   describe('TeamFeatureService cache refresh', () => {
     it('should populate team_feature for exact URN match', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
-      await secureFeature(featureId);
-
-      const teamId = await createTeam('Exact URN Team');
+      const { submissionId, featureId, teamId } = await setupSecuredFeatureWithTeam('Exact URN Team');
       await grantTeamAccess(teamId, `urn:${submissionId}:dataset:${featureId}`);
 
       const service = new TeamFeatureService(connection);
@@ -230,11 +238,7 @@ describe('Team feature cache + search (integration)', function () {
 
   describe('Cache refresh via service-layer mutations', () => {
     it('should populate cache when creating a policy with statements via PolicyService', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Policy Create Test' });
-      await secureFeature(featureId);
-
-      const teamId = await createTeam('Policy Create Team');
+      const { submissionId, featureId, teamId } = await setupSecuredFeatureWithTeam('Policy Create Test');
 
       // Create policy via service — triggers refreshCacheForPolicy
       const policyService = new PolicyService(connection);
@@ -280,11 +284,7 @@ describe('Team feature cache + search (integration)', function () {
     });
 
     it('should clear cache when policy is deleted via PolicyService', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Policy Delete Test' });
-      await secureFeature(featureId);
-
-      const teamId = await createTeam('Policy Delete Team');
+      const { submissionId, featureId, teamId } = await setupSecuredFeatureWithTeam('Policy Delete Test');
 
       const policyService = new PolicyService(connection);
       const policy = await policyService.createPolicyWithStatements({ name: `test-policy-delete-${Date.now()}` }, [
@@ -303,11 +303,7 @@ describe('Team feature cache + search (integration)', function () {
     });
 
     it('should clear cache when team-policy is deleted via TeamPolicyService', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'TP Delete Test' });
-      await secureFeature(featureId);
-
-      const teamId = await createTeam('TP Delete Team');
+      const { submissionId, featureId, teamId } = await setupSecuredFeatureWithTeam('TP Delete Test');
 
       const policyService = new PolicyService(connection);
       const policy = await policyService.createPolicyWithStatements({ name: `test-tp-delete-${Date.now()}` }, [

--- a/api/src/__integration__/db/team-feature-search.integration.ts
+++ b/api/src/__integration__/db/team-feature-search.integration.ts
@@ -231,30 +231,34 @@ describe('Team feature cache + search (integration)', function () {
     });
   });
 
-  // ── Mutation hook tests ──────────────────────────────────────────────────
+  // ── Mutation + cache refresh tests ───────────────────────────────────────
   //
-  // Verifies that creating/deleting policies and team-policy associations
-  // through the service layer automatically refreshes the team_feature cache.
+  // Verifies that after policy/team-policy mutations, refreshing the cache
+  // produces the correct team_feature rows. In production the refresh is
+  // async (pg-boss job), but integration tests call refreshCacheForTeam
+  // directly so assertions see deterministic state.
 
-  describe('Cache refresh via service-layer mutations', () => {
-    it('should populate cache when creating a policy with statements via PolicyService', async () => {
+  describe('Cache refresh after service-layer mutations', () => {
+    it('should populate cache after creating a policy and assigning it to a team', async () => {
       const { submissionId, featureId, teamId } = await setupSecuredFeatureWithTeam('Policy Create Test');
 
-      // Create policy via service — triggers refreshCacheForPolicy
       const policyService = new PolicyService(connection);
       const policy = await policyService.createPolicyWithStatements({ name: `test-policy-create-${Date.now()}` }, [
         { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId}` }
       ]);
 
-      // Assign policy to team via service — triggers refreshCacheForTeam
       const teamPolicyService = new TeamPolicyService(connection);
       await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policy.policy_id });
+
+      // Manually refresh — in production the queue job does this asynchronously
+      const teamFeatureService = new TeamFeatureService(connection);
+      await teamFeatureService.refreshCacheForTeam(teamId);
 
       const cached = await getTeamFeatureIds(teamId);
       expect(cached).to.deep.equal([featureId]);
     });
 
-    it('should update cache when policy statements are updated via PolicyService', async () => {
+    it('should update cache after policy statements are changed', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Feature A' });
       const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Feature B' });
@@ -263,7 +267,6 @@ describe('Team feature cache + search (integration)', function () {
 
       const teamId = await createTeam('Policy Update Team');
 
-      // Create policy granting access to feature 1 only
       const policyService = new PolicyService(connection);
       const policy = await policyService.createPolicyWithStatements({ name: `test-policy-update-${Date.now()}` }, [
         { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId1}` }
@@ -272,18 +275,23 @@ describe('Team feature cache + search (integration)', function () {
       const teamPolicyService = new TeamPolicyService(connection);
       await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policy.policy_id });
 
+      const teamFeatureService = new TeamFeatureService(connection);
+      await teamFeatureService.refreshCacheForTeam(teamId);
+
       expect(await getTeamFeatureIds(teamId)).to.deep.equal([featureId1]);
 
-      // Update policy to grant access to feature 2 instead — triggers cache refresh
+      // Update policy to grant access to feature 2 instead
       await policyService.updatePolicyWithStatements(policy.policy_id, { name: policy.name }, [
         { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId2}` }
       ]);
+
+      await teamFeatureService.refreshCacheForTeam(teamId);
 
       const cached = await getTeamFeatureIds(teamId);
       expect(cached).to.deep.equal([featureId2]);
     });
 
-    it('should clear cache when policy is deleted via PolicyService', async () => {
+    it('should clear cache after policy is deleted', async () => {
       const { submissionId, featureId, teamId } = await setupSecuredFeatureWithTeam('Policy Delete Test');
 
       const policyService = new PolicyService(connection);
@@ -294,15 +302,19 @@ describe('Team feature cache + search (integration)', function () {
       const teamPolicyService = new TeamPolicyService(connection);
       await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policy.policy_id });
 
+      const teamFeatureService = new TeamFeatureService(connection);
+      await teamFeatureService.refreshCacheForTeam(teamId);
+
       expect(await getTeamFeatureIds(teamId)).to.deep.equal([featureId]);
 
-      // Delete policy — triggers cache refresh for affected teams
+      // Delete policy, then refresh cache
       await policyService.deletePolicy(policy.policy_id);
+      await teamFeatureService.refreshCacheForTeam(teamId);
 
       expect(await getTeamFeatureIds(teamId)).to.deep.equal([]);
     });
 
-    it('should clear cache when team-policy is deleted via TeamPolicyService', async () => {
+    it('should clear cache after team-policy is deleted', async () => {
       const { submissionId, featureId, teamId } = await setupSecuredFeatureWithTeam('TP Delete Test');
 
       const policyService = new PolicyService(connection);
@@ -316,10 +328,14 @@ describe('Team feature cache + search (integration)', function () {
         policy_id: policy.policy_id
       });
 
+      const teamFeatureService = new TeamFeatureService(connection);
+      await teamFeatureService.refreshCacheForTeam(teamId);
+
       expect(await getTeamFeatureIds(teamId)).to.deep.equal([featureId]);
 
-      // Delete team-policy — triggers cache refresh for the team
+      // Delete team-policy, then refresh cache
       await teamPolicyService.deleteTeamPolicy(teamPolicy.team_policy_id);
+      await teamFeatureService.refreshCacheForTeam(teamId);
 
       expect(await getTeamFeatureIds(teamId)).to.deep.equal([]);
     });

--- a/api/src/__integration__/db/team-feature-search.integration.ts
+++ b/api/src/__integration__/db/team-feature-search.integration.ts
@@ -1,0 +1,503 @@
+// Integration test for team_feature cache population and search filtering —
+// verifies that TeamFeatureService correctly resolves URN wildcards into cached
+// team_feature rows, and that SearchFeatureService respects those cache entries
+// when filtering secured features by authenticated user.
+//
+// Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
+//
+// Run: make test-db
+// Requires: make web (database must be running with seed data)
+
+import { expect } from 'chai';
+import SQL from 'sql-template-strings';
+import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { PolicyEffect } from '../../models/policy-statement';
+import { PolicyService } from '../../services/access-policy/policy-service';
+import { TeamFeatureService } from '../../services/access-policy/team-feature-service';
+import { TeamPolicyService } from '../../services/access-policy/team-policy-service';
+import { SearchFeatureService } from '../../services/search-feature-service';
+import { ISearchFeaturesFilters } from '../../services/search-feature-service.interface';
+import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
+
+describe('Team feature cache + search (integration)', function () {
+  this.timeout(15000);
+
+  let connection: IDBConnection;
+
+  before(() => {
+    initDBPool(defaultPoolConfig);
+  });
+
+  beforeEach(async () => {
+    connection = getAPIUserDBConnection();
+    await connection.open();
+  });
+
+  afterEach(async () => {
+    await connection.rollback();
+    connection.release();
+  });
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  /**
+   * Mark a submission feature as secured.
+   * Uses security_rule_id 1 from seed data.
+   */
+  async function secureFeature(submissionFeatureId: number): Promise<void> {
+    const systemUserId = connection.systemUserId();
+
+    await connection.sql(SQL`
+      INSERT INTO submission_feature_security (submission_feature_id, security_rule_id, create_user)
+      VALUES (${submissionFeatureId}, 1, ${systemUserId});
+    `);
+  }
+
+  /**
+   * Create a team and return its UUID.
+   */
+  async function createTeam(name: string): Promise<string> {
+    const systemUserId = connection.systemUserId();
+
+    const result = await connection.sql(SQL`
+      INSERT INTO team (name, create_user)
+      VALUES (${name}, ${systemUserId})
+      RETURNING team_id;
+    `);
+
+    return result.rows[0].team_id;
+  }
+
+  /**
+   * Create a system_user and return its system_user_id.
+   */
+  let _userSeq = 0;
+  async function createUser(): Promise<number> {
+    const apiUserId = connection.systemUserId();
+    const guid = `test-tf-${Date.now()}-${++_userSeq}`;
+
+    const result = await connection.sql(SQL`
+      INSERT INTO "system_user" (user_identity_source_id, user_identifier, user_guid, record_effective_date, create_user)
+      SELECT user_identity_source_id, ${guid}, ${guid}, now(), ${apiUserId}
+      FROM user_identity_source
+      WHERE record_end_date IS NULL
+      LIMIT 1
+      RETURNING system_user_id;
+    `);
+
+    return result.rows[0].system_user_id;
+  }
+
+  /**
+   * Add a user to a team.
+   */
+  async function addTeamMember(teamId: string, userId: number): Promise<void> {
+    const apiUserId = connection.systemUserId();
+
+    await connection.sql(SQL`
+      INSERT INTO team_member (system_user_id, team_id, create_user)
+      VALUES (${userId}, ${teamId}, ${apiUserId});
+    `);
+  }
+
+  /**
+   * Create a policy with a single ALLOW statement for the given URN,
+   * assign it to a team via team_policy.
+   * The policy_statement trigger auto-decomposes the URN into indexed columns.
+   */
+  async function grantTeamAccess(teamId: string, urn: string): Promise<{ policyId: string }> {
+    const userId = connection.systemUserId();
+
+    const policy = await connection.sql(SQL`
+      INSERT INTO policy (name, create_user)
+      VALUES (${`test-policy-${Date.now()}-${++_userSeq}`}, ${userId})
+      RETURNING policy_id;
+    `);
+    const policyId = policy.rows[0].policy_id;
+
+    await connection.sql(SQL`
+      INSERT INTO policy_statement (policy_id, effect, submission_feature_urn, create_user)
+      VALUES (${policyId}, 'allow', ${urn}, ${userId});
+    `);
+
+    await connection.sql(SQL`
+      INSERT INTO team_policy (team_id, policy_id, create_user)
+      VALUES (${teamId}, ${policyId}, ${userId});
+    `);
+
+    return { policyId };
+  }
+
+  /**
+   * Get all submission_feature_ids cached in team_feature for a given team.
+   */
+  async function getTeamFeatureIds(teamId: string): Promise<number[]> {
+    const result = await connection.sql(SQL`
+      SELECT submission_feature_id FROM team_feature
+      WHERE team_id = ${teamId}
+      ORDER BY submission_feature_id;
+    `);
+
+    return result.rows.map((r: { submission_feature_id: number }) => r.submission_feature_id);
+  }
+
+  // ── Cache population tests ─────────────────────────────────────────────
+
+  describe('TeamFeatureService cache refresh', () => {
+    it('should populate team_feature for exact URN match', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
+      await secureFeature(featureId);
+
+      const teamId = await createTeam('Exact URN Team');
+      await grantTeamAccess(teamId, `urn:${submissionId}:dataset:${featureId}`);
+
+      const service = new TeamFeatureService(connection);
+      await service.refreshCacheForTeam(teamId);
+
+      const cached = await getTeamFeatureIds(teamId);
+      expect(cached).to.deep.equal([featureId]);
+    });
+
+    it('should populate team_feature for wildcard URN (urn:*:*:*)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset A' });
+      const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset B' });
+      await secureFeature(featureId1);
+      await secureFeature(featureId2);
+
+      const teamId = await createTeam('Wildcard URN Team');
+      await grantTeamAccess(teamId, 'urn:*:*:*');
+
+      const service = new TeamFeatureService(connection);
+      await service.refreshCacheForTeam(teamId);
+
+      const cached = await getTeamFeatureIds(teamId);
+      expect(cached).to.include(featureId1);
+      expect(cached).to.include(featureId2);
+    });
+
+    it('should only cache secured features, not unsecured', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
+      const unsecuredFeatureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Open' });
+      await secureFeature(securedFeatureId);
+      // unsecuredFeatureId is NOT secured
+
+      const teamId = await createTeam('Mixed Features Team');
+      await grantTeamAccess(teamId, 'urn:*:*:*');
+
+      const service = new TeamFeatureService(connection);
+      await service.refreshCacheForTeam(teamId);
+
+      const cached = await getTeamFeatureIds(teamId);
+      expect(cached).to.include(securedFeatureId);
+      expect(cached).to.not.include(unsecuredFeatureId);
+    });
+
+    it('should clear stale entries and repopulate on re-refresh', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Feature 1' });
+      const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Feature 2' });
+      await secureFeature(featureId1);
+      await secureFeature(featureId2);
+
+      const teamId = await createTeam('Refresh Team');
+
+      // Grant access to feature 1 only (exact URN)
+      await grantTeamAccess(teamId, `urn:${submissionId}:dataset:${featureId1}`);
+
+      const service = new TeamFeatureService(connection);
+      await service.refreshCacheForTeam(teamId);
+
+      expect(await getTeamFeatureIds(teamId)).to.deep.equal([featureId1]);
+
+      // Now add a second policy granting access to feature 2
+      await grantTeamAccess(teamId, `urn:${submissionId}:dataset:${featureId2}`);
+      await service.refreshCacheForTeam(teamId);
+
+      const cached = await getTeamFeatureIds(teamId);
+      expect(cached).to.include(featureId1);
+      expect(cached).to.include(featureId2);
+      expect(cached).to.have.length(2);
+    });
+  });
+
+  // ── Mutation hook tests ──────────────────────────────────────────────────
+  //
+  // Verifies that creating/deleting policies and team-policy associations
+  // through the service layer automatically refreshes the team_feature cache.
+
+  describe('Cache refresh via service-layer mutations', () => {
+    it('should populate cache when creating a policy with statements via PolicyService', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Policy Create Test' });
+      await secureFeature(featureId);
+
+      const teamId = await createTeam('Policy Create Team');
+
+      // Create policy via service — triggers refreshCacheForPolicy
+      const policyService = new PolicyService(connection);
+      const policy = await policyService.createPolicyWithStatements({ name: `test-policy-create-${Date.now()}` }, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId}` }
+      ]);
+
+      // Assign policy to team via service — triggers refreshCacheForTeam
+      const teamPolicyService = new TeamPolicyService(connection);
+      await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policy.policy_id });
+
+      const cached = await getTeamFeatureIds(teamId);
+      expect(cached).to.deep.equal([featureId]);
+    });
+
+    it('should update cache when policy statements are updated via PolicyService', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Feature A' });
+      const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Feature B' });
+      await secureFeature(featureId1);
+      await secureFeature(featureId2);
+
+      const teamId = await createTeam('Policy Update Team');
+
+      // Create policy granting access to feature 1 only
+      const policyService = new PolicyService(connection);
+      const policy = await policyService.createPolicyWithStatements({ name: `test-policy-update-${Date.now()}` }, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId1}` }
+      ]);
+
+      const teamPolicyService = new TeamPolicyService(connection);
+      await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policy.policy_id });
+
+      expect(await getTeamFeatureIds(teamId)).to.deep.equal([featureId1]);
+
+      // Update policy to grant access to feature 2 instead — triggers cache refresh
+      await policyService.updatePolicyWithStatements(policy.policy_id, { name: policy.name }, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId2}` }
+      ]);
+
+      const cached = await getTeamFeatureIds(teamId);
+      expect(cached).to.deep.equal([featureId2]);
+    });
+
+    it('should clear cache when policy is deleted via PolicyService', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Policy Delete Test' });
+      await secureFeature(featureId);
+
+      const teamId = await createTeam('Policy Delete Team');
+
+      const policyService = new PolicyService(connection);
+      const policy = await policyService.createPolicyWithStatements({ name: `test-policy-delete-${Date.now()}` }, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId}` }
+      ]);
+
+      const teamPolicyService = new TeamPolicyService(connection);
+      await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policy.policy_id });
+
+      expect(await getTeamFeatureIds(teamId)).to.deep.equal([featureId]);
+
+      // Delete policy — triggers cache refresh for affected teams
+      await policyService.deletePolicy(policy.policy_id);
+
+      expect(await getTeamFeatureIds(teamId)).to.deep.equal([]);
+    });
+
+    it('should clear cache when team-policy is deleted via TeamPolicyService', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'TP Delete Test' });
+      await secureFeature(featureId);
+
+      const teamId = await createTeam('TP Delete Team');
+
+      const policyService = new PolicyService(connection);
+      const policy = await policyService.createPolicyWithStatements({ name: `test-tp-delete-${Date.now()}` }, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: `urn:${submissionId}:dataset:${featureId}` }
+      ]);
+
+      const teamPolicyService = new TeamPolicyService(connection);
+      const teamPolicy = await teamPolicyService.createTeamPolicy({
+        team_id: teamId,
+        policy_id: policy.policy_id
+      });
+
+      expect(await getTeamFeatureIds(teamId)).to.deep.equal([featureId]);
+
+      // Delete team-policy — triggers cache refresh for the team
+      await teamPolicyService.deleteTeamPolicy(teamPolicy.team_policy_id);
+
+      expect(await getTeamFeatureIds(teamId)).to.deep.equal([]);
+    });
+  });
+
+  // ── Inherited security tests ─────────────────────────────────────────────
+  //
+  // Validates the `secured_features` recursive CTE: a child feature inherits
+  // is_secured from its parent, and unrelated features are NOT marked secured.
+
+  describe('secured_features CTE — inherited security', () => {
+    it('should mark child as secured when parent has a security rule', async () => {
+      const submissionId = await createTestSubmission(connection);
+
+      // Parent dataset — secured
+      const parentId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Parent' });
+      await secureFeature(parentId);
+
+      // Child sample_site — NOT directly secured, but inherits from parent
+      const childId = await createTestFeature(
+        connection,
+        submissionId,
+        'sample_site',
+        { name: 'Child Site' },
+        parentId
+      );
+
+      // Unrelated unsecured feature in the same submission
+      const unrelatedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Open Dataset' });
+
+      const searchService = new SearchFeatureService(connection);
+      const filters: ISearchFeaturesFilters = { feature_types: ['dataset', 'sample_site'] };
+
+      // Search without security filtering (no systemUserId) to see raw is_secured flags
+      const features = await searchService.searchFeatures(filters);
+
+      const child = features.find((f) => f.submission_feature_id === childId);
+      const parent = features.find((f) => f.submission_feature_id === parentId);
+      const unrelated = features.find((f) => f.submission_feature_id === unrelatedId);
+
+      // Parent is directly secured
+      expect(parent, 'parent should be in results').to.exist;
+      expect(parent!.is_secured, 'parent should be secured').to.equal(true);
+
+      // Child inherits security from parent via recursive CTE
+      expect(child, 'child should be in results').to.exist;
+      expect(child!.is_secured, 'child should inherit secured from parent').to.equal(true);
+
+      // Unrelated feature must NOT be marked secured (per-row, not global)
+      expect(unrelated, 'unrelated should be in results').to.exist;
+      expect(unrelated!.is_secured, 'unrelated should NOT be secured').to.equal(false);
+    });
+
+    it('should mark deeply nested grandchild as secured', async () => {
+      const submissionId = await createTestSubmission(connection);
+
+      // Grandparent dataset — secured
+      const grandparentId = await createTestFeature(connection, submissionId, 'dataset', {
+        name: 'Secured Grandparent'
+      });
+      await secureFeature(grandparentId);
+
+      // Parent sample_site — child of grandparent
+      const parentId = await createTestFeature(
+        connection,
+        submissionId,
+        'sample_site',
+        { name: 'Middle Parent' },
+        grandparentId
+      );
+
+      // Grandchild telemetry — child of parent
+      const grandchildId = await createTestFeature(
+        connection,
+        submissionId,
+        'telemetry',
+        { name: 'Deep Grandchild' },
+        parentId
+      );
+
+      const searchService = new SearchFeatureService(connection);
+      const filters: ISearchFeaturesFilters = { feature_types: ['dataset', 'sample_site', 'telemetry'] };
+
+      const features = await searchService.searchFeatures(filters);
+
+      const grandchild = features.find((f) => f.submission_feature_id === grandchildId);
+      expect(grandchild, 'grandchild should be in results').to.exist;
+      expect(grandchild!.is_secured, 'grandchild should inherit secured from grandparent').to.equal(true);
+    });
+  });
+
+  // ── Search filtering tests ─────────────────────────────────────────────
+
+  describe('Search with team_feature filtering', () => {
+    /**
+     * Shared setup: creates a submission with one unsecured and one secured feature,
+     * a team with a user, and a policy granting the team access to the secured feature.
+     * Returns all IDs needed for assertions.
+     */
+    async function setupSearchScenario() {
+      const submissionId = await createTestSubmission(connection);
+      const unsecuredFeatureId = await createTestFeature(connection, submissionId, 'dataset', {
+        name: 'Open Dataset'
+      });
+      const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', {
+        name: 'Secured Dataset'
+      });
+      await secureFeature(securedFeatureId);
+
+      const teamId = await createTeam('Search Test Team');
+      const userId = await createUser();
+      await addTeamMember(teamId, userId);
+
+      // Grant team access to the secured feature and populate cache
+      await grantTeamAccess(teamId, `urn:${submissionId}:dataset:${securedFeatureId}`);
+      const teamFeatureService = new TeamFeatureService(connection);
+      await teamFeatureService.refreshCacheForTeam(teamId);
+
+      return { submissionId, unsecuredFeatureId, securedFeatureId, teamId, userId };
+    }
+
+    it('should return only unsecured features for anonymous search (systemUserId=null)', async () => {
+      const { unsecuredFeatureId, securedFeatureId } = await setupSearchScenario();
+
+      const searchService = new SearchFeatureService(connection);
+      const filters: ISearchFeaturesFilters = { feature_types: ['dataset'] };
+
+      const features = await searchService.searchFeatures(filters, undefined, null);
+      const featureIds = features.map((f) => f.submission_feature_id);
+
+      expect(featureIds).to.include(unsecuredFeatureId);
+      expect(featureIds).to.not.include(securedFeatureId);
+    });
+
+    it('should return unsecured + authorized secured features for authenticated user', async () => {
+      const { unsecuredFeatureId, securedFeatureId, userId } = await setupSearchScenario();
+
+      const searchService = new SearchFeatureService(connection);
+      const filters: ISearchFeaturesFilters = { feature_types: ['dataset'] };
+
+      const features = await searchService.searchFeatures(filters, undefined, userId);
+      const featureIds = features.map((f) => f.submission_feature_id);
+
+      expect(featureIds).to.include(unsecuredFeatureId);
+      expect(featureIds).to.include(securedFeatureId);
+    });
+
+    it('should return only unsecured features for authenticated user without policies', async () => {
+      const { unsecuredFeatureId, securedFeatureId } = await setupSearchScenario();
+
+      // Create a user who is NOT in any team with policies
+      const unaffiliatedUserId = await createUser();
+
+      const searchService = new SearchFeatureService(connection);
+      const filters: ISearchFeaturesFilters = { feature_types: ['dataset'] };
+
+      const features = await searchService.searchFeatures(filters, undefined, unaffiliatedUserId);
+      const featureIds = features.map((f) => f.submission_feature_id);
+
+      expect(featureIds).to.include(unsecuredFeatureId);
+      expect(featureIds).to.not.include(securedFeatureId);
+    });
+
+    it('should include count that reflects security filtering', async () => {
+      const { userId } = await setupSearchScenario();
+
+      const searchService = new SearchFeatureService(connection);
+      const filters: ISearchFeaturesFilters = { feature_types: ['dataset'] };
+
+      // Anonymous count should be less than authenticated count (secured feature excluded)
+      const anonCount = await searchService.getSearchFeaturesCount(filters, null);
+      const authCount = await searchService.getSearchFeaturesCount(filters, userId);
+
+      expect(authCount).to.be.greaterThan(anonCount);
+    });
+  });
+});

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -118,7 +118,9 @@ describe('Download Worker', function () {
 
       // 3. Delete submission_upload and its children (child of submission via FK)
       if (createdSubmissionIds.length > 0) {
-        const uploadSubIds = db('biohub.submission_upload').select('submission_upload_id').whereIn('submission_id', createdSubmissionIds);
+        const uploadSubIds = db('biohub.submission_upload')
+          .select('submission_upload_id')
+          .whereIn('submission_id', createdSubmissionIds);
         await db('biohub.submission_validation').whereIn('submission_upload_id', uploadSubIds).del();
         await db('biohub.submission_upload_status').whereIn('submission_upload_id', uploadSubIds).del();
         await db('biohub.submission_upload').whereIn('submission_id', createdSubmissionIds).del();

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -116,7 +116,15 @@ describe('Download Worker', function () {
         await db('biohub.artifact').whereIn('artifact_id', createdArtifactIds).del();
       }
 
-      // 3. Delete submissions
+      // 3. Delete submission_upload and its children (child of submission via FK)
+      if (createdSubmissionIds.length > 0) {
+        const uploadSubIds = db('biohub.submission_upload').select('submission_upload_id').whereIn('submission_id', createdSubmissionIds);
+        await db('biohub.submission_validation').whereIn('submission_upload_id', uploadSubIds).del();
+        await db('biohub.submission_upload_status').whereIn('submission_upload_id', uploadSubIds).del();
+        await db('biohub.submission_upload').whereIn('submission_id', createdSubmissionIds).del();
+      }
+
+      // 4. Delete submissions
       if (createdSubmissionIds.length > 0) {
         await db('biohub.submission').whereIn('submission_id', createdSubmissionIds).del();
       }
@@ -181,10 +189,20 @@ describe('Download Worker', function () {
       })
       .returning('upload_id');
 
+    const [team] = await db('biohub.team')
+      .insert({ name: `${TEST_PREFIX}-${Date.now()}`, create_user: SYSTEM_USER_ID })
+      .returning('team_id');
+
+    const slug = String(Date.now()).slice(-8);
+    const [ticket] = await db('biohub.ticket')
+      .insert({ ticket_slug: slug, subject: TEST_PREFIX, team_id: team.team_id, create_user: SYSTEM_USER_ID })
+      .returning('ticket_id');
+
     const [bridge] = await db('biohub.submission_upload')
       .insert({
         submission_id: submissionId,
         upload_id: upload.upload_id,
+        ticket_id: ticket.ticket_id,
         create_user: SYSTEM_USER_ID
       })
       .returning('submission_upload_id');

--- a/api/src/__integration__/system/malware-scan-worker.integration.ts
+++ b/api/src/__integration__/system/malware-scan-worker.integration.ts
@@ -89,7 +89,9 @@ describe('Malware Scan Worker', function () {
       }
       if (createdUploadIds.length > 0) {
         // Delete children of submission_upload before submission_upload itself
-        const uploadSubIds = db('biohub.submission_upload').select('submission_upload_id').whereIn('upload_id', createdUploadIds);
+        const uploadSubIds = db('biohub.submission_upload')
+          .select('submission_upload_id')
+          .whereIn('upload_id', createdUploadIds);
         await db('biohub.submission_validation').whereIn('submission_upload_id', uploadSubIds).del();
         await db('biohub.submission_upload_status').whereIn('submission_upload_id', uploadSubIds).del();
         await db('biohub.submission_upload').whereIn('upload_id', createdUploadIds).del();

--- a/api/src/__integration__/system/malware-scan-worker.integration.ts
+++ b/api/src/__integration__/system/malware-scan-worker.integration.ts
@@ -88,6 +88,10 @@ describe('Malware Scan Worker', function () {
         await db('biohub.artifact').whereIn('artifact_id', createdArtifactIds).del();
       }
       if (createdUploadIds.length > 0) {
+        // Delete children of submission_upload before submission_upload itself
+        const uploadSubIds = db('biohub.submission_upload').select('submission_upload_id').whereIn('upload_id', createdUploadIds);
+        await db('biohub.submission_validation').whereIn('submission_upload_id', uploadSubIds).del();
+        await db('biohub.submission_upload_status').whereIn('submission_upload_id', uploadSubIds).del();
         await db('biohub.submission_upload').whereIn('upload_id', createdUploadIds).del();
         await db('biohub.upload').whereIn('upload_id', createdUploadIds).del();
       }
@@ -167,9 +171,19 @@ describe('Malware Scan Worker', function () {
       .returning('submission_id');
     createdSubmissionIds.push(submission.submission_id);
 
+    const [team] = await db('biohub.team')
+      .insert({ name: `integration-test-${Date.now()}`, create_user: SYSTEM_USER_ID })
+      .returning('team_id');
+
+    const slug = String(Date.now()).slice(-8);
+    const [ticket] = await db('biohub.ticket')
+      .insert({ ticket_slug: slug, subject: 'integration-test', team_id: team.team_id, create_user: SYSTEM_USER_ID })
+      .returning('ticket_id');
+
     await db('biohub.submission_upload').insert({
       submission_id: submission.submission_id,
       upload_id: upload.upload_id,
+      ticket_id: ticket.ticket_id,
       create_user: SYSTEM_USER_ID
     });
 

--- a/api/src/__integration__/system/process-submission-features-worker.integration.ts
+++ b/api/src/__integration__/system/process-submission-features-worker.integration.ts
@@ -205,8 +205,18 @@ describe('Process Submission Features Worker', function () {
       archive_status: 'completed'
     });
 
-    // 5. submission_upload (links submission to upload)
-    const ticketId = randomUUID();
+    // 5. team + ticket (submission_upload requires a real ticket row)
+    const [team] = await db('biohub.team')
+      .insert({ name: `${TEST_PREFIX}-${Date.now()}`, create_user: SYSTEM_USER_ID })
+      .returning('team_id');
+
+    const slug = String(Date.now()).slice(-8);
+    const [ticket] = await db('biohub.ticket')
+      .insert({ ticket_slug: slug, subject: TEST_PREFIX, team_id: team.team_id, create_user: SYSTEM_USER_ID })
+      .returning('ticket_id');
+    const ticketId = ticket.ticket_id;
+
+    // 6. submission_upload (links submission to upload)
     const [submissionUpload] = await db('biohub.submission_upload')
       .insert({
         submission_id: submission.submission_id,
@@ -447,8 +457,23 @@ describe('SubmissionIngestionService pipeline (system)', function () {
           VALUES (${uploadId}, ${artifactId}, 'completed')`
     );
 
-    // 5. submission_upload
-    const ticketId = randomUUID();
+    // 5. team + ticket (ticket FK requires a real ticket row, which requires a team)
+    const teamResult = await connection.sql<{ team_id: string }>(
+      SQL`INSERT INTO biohub.team (name, create_user)
+          VALUES (${TEST_PREFIX + '-' + Date.now()}, ${SYSTEM_USER_ID})
+          RETURNING team_id`
+    );
+    const teamId = teamResult.rows[0].team_id;
+
+    const slug = String(Date.now()).slice(-8);
+    const ticketResult = await connection.sql<{ ticket_id: string }>(
+      SQL`INSERT INTO biohub.ticket (ticket_slug, subject, team_id, create_user)
+          VALUES (${slug}, ${TEST_PREFIX}, ${teamId}, ${SYSTEM_USER_ID})
+          RETURNING ticket_id`
+    );
+    const ticketId = ticketResult.rows[0].ticket_id;
+
+    // 6. submission_upload
     const submissionUploadResult = await connection.sql<{ submission_upload_id: string }>(
       SQL`INSERT INTO biohub.submission_upload (submission_id, upload_id, ticket_id)
           VALUES (${submissionId}, ${uploadId}, ${ticketId})
@@ -456,7 +481,7 @@ describe('SubmissionIngestionService pipeline (system)', function () {
     );
     const submissionUploadId = submissionUploadResult.rows[0].submission_upload_id;
 
-    // 6. upload_artifact
+    // 7. upload_artifact
     await connection.sql(
       SQL`INSERT INTO biohub.upload_artifact (upload_id, artifact_id, role)
           VALUES (${uploadId}, ${artifactId}, 'feature')`

--- a/api/src/paths/search/feature/index.test.ts
+++ b/api/src/paths/search/feature/index.test.ts
@@ -230,6 +230,83 @@ describe('searchFeatures', () => {
     });
   });
 
+  it('should use getDBConnection when Bearer token is present and pass systemUserId', async () => {
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub().resolves(),
+      rollback: sinon.stub().resolves(),
+      release: sinon.stub().resolves(),
+      open: sinon.stub().resolves(),
+      systemUserId: () => 42
+    });
+    sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.keycloak_token = { sub: 'user-uuid' };
+
+    const mockResults: SearchFeatureResultWithRelevancy[] = [
+      {
+        submission_feature_id: 1,
+        submission_id: 10,
+        uuid: '550e8400-e29b-41d4-a716-446655440001',
+        feature_type_id: 1,
+        feature_type_name: 'dataset',
+        feature_name: 'Moose Study',
+        feature_description: 'A study of moose',
+        submission_name: 'Wildlife Project',
+        is_secured: false,
+        relevancy_score: 0.75,
+        create_date: dayjs().toISOString()
+      }
+    ];
+
+    mockReq.body = {
+      filters: { keyword: 'moose' },
+      pagination: { page: '1', limit: '10' }
+    };
+
+    const searchStub = sinon.stub(SearchFeatureService.prototype, 'searchFeatures').resolves(mockResults);
+    const countStub = sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(1);
+
+    const requestHandler = search.searchFeatures();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(searchStub).to.have.been.calledOnce;
+    expect(searchStub.firstCall.args[2]).to.equal(42);
+    expect(countStub).to.have.been.calledOnce;
+    expect(countStub.firstCall.args[1]).to.equal(42);
+  });
+
+  it('should pass null systemUserId for anonymous requests', async () => {
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub().resolves(),
+      rollback: sinon.stub().resolves(),
+      release: sinon.stub().resolves(),
+      open: sinon.stub().resolves()
+    });
+    sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+    mockReq.body = {
+      filters: { keyword: 'moose' },
+      pagination: { page: '1', limit: '10' }
+    };
+
+    const searchStub = sinon.stub(SearchFeatureService.prototype, 'searchFeatures').resolves([]);
+    const countStub = sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(0);
+
+    const requestHandler = search.searchFeatures();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(searchStub).to.have.been.calledOnce;
+    expect(searchStub.firstCall.args[2]).to.equal(null);
+    expect(countStub).to.have.been.calledOnce;
+    expect(countStub.firstCall.args[1]).to.equal(null);
+  });
+
   it('should handle errors and rollback', async () => {
     const dbConnectionObj = getMockDBConnection({
       commit: sinon.stub().resolves(),

--- a/api/src/paths/search/feature/index.ts
+++ b/api/src/paths/search/feature/index.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
-import { getAPIUserDBConnection } from '../../../database/db';
+import { getAPIUserDBConnection, getDBConnection } from '../../../database/db';
 import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
 import {
   featureSearchRequestBodySchema,
@@ -18,6 +18,11 @@ export const POST: Operation = [searchFeatures()];
 POST.apiDoc = {
   description: 'Search for features by keyword and optional filters.',
   tags: ['search'],
+  security: [
+    {
+      OptionalBearer: []
+    }
+  ],
   requestBody: featureSearchRequestBodySchema,
   responses: {
     200: {
@@ -33,14 +38,22 @@ POST.apiDoc = {
 /**
  * Search for features by keywords and/or property filters.
  *
+ * Supports optional authentication via OptionalBearer. When authenticated,
+ * secured features the user has access to (via team_feature cache) are
+ * included alongside unsecured features. Anonymous requests see only
+ * unsecured features.
+ *
  * @returns {RequestHandler}
  */
 export function searchFeatures(): RequestHandler {
   return async (req, res) => {
-    const connection = getAPIUserDBConnection();
+    const isAuthenticated = !!req.keycloak_token;
+    const connection = isAuthenticated ? getDBConnection(req.keycloak_token) : getAPIUserDBConnection();
 
     try {
       await connection.open();
+
+      const systemUserId = isAuthenticated ? connection.systemUserId() : null;
 
       const filters = req.body.filters as ISearchFeaturesFilters;
 
@@ -49,8 +62,8 @@ export function searchFeatures(): RequestHandler {
       const pagination = makePaginationOptionsFromBody(req);
 
       const [features, count] = await Promise.all([
-        service.searchFeatures(filters, pagination),
-        service.getSearchFeaturesCount(filters)
+        service.searchFeatures(filters, pagination, systemUserId),
+        service.getSearchFeaturesCount(filters, systemUserId)
       ]);
       await connection.commit();
 

--- a/api/src/queue/jobs/index.ts
+++ b/api/src/queue/jobs/index.ts
@@ -39,7 +39,16 @@ export const JobQueues = {
    * Dead letter queue for failed index-submission-features jobs.
    * Jobs are moved here after all retries are exhausted.
    */
-  INDEX_SUBMISSION_FEATURES_FAILED: 'index-submission-features-failed'
+  INDEX_SUBMISSION_FEATURES_FAILED: 'index-submission-features-failed',
+  /**
+   * Refresh team_feature cache job queue for async cache rebuild after policy mutations.
+   */
+  REFRESH_TEAM_FEATURE_CACHE: 'refresh-team-feature-cache',
+  /**
+   * Dead letter queue for failed refresh-team-feature-cache jobs.
+   * Jobs are moved here after all retries are exhausted.
+   */
+  REFRESH_TEAM_FEATURE_CACHE_FAILED: 'refresh-team-feature-cache-failed'
 } as const;
 
 export type JobQueueName = (typeof JobQueues)[keyof typeof JobQueues];

--- a/api/src/queue/jobs/refresh-team-feature-cache-job.test.ts
+++ b/api/src/queue/jobs/refresh-team-feature-cache-job.test.ts
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import PgBoss from 'pg-boss';
+import sinon from 'sinon';
+import * as db from '../../database/db';
+import { TeamFeatureService } from '../../services/access-policy/team-feature-service';
+import { getMockDBConnection } from '../../__mocks__/db';
+import {
+  IRefreshTeamFeatureCacheJobData,
+  refreshTeamFeatureCacheFailedHandler,
+  refreshTeamFeatureCacheJobHandler
+} from './refresh-team-feature-cache-job';
+
+describe('refresh-team-feature-cache-job', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const createMockJob = (data: Partial<IRefreshTeamFeatureCacheJobData> = {}, jobId = 'test-job-id') =>
+    ({
+      id: jobId,
+      name: 'refresh-team-feature-cache',
+      data: { teamId: '22222222-2222-2222-2222-222222222222', ...data }
+    } as PgBoss.Job<IRefreshTeamFeatureCacheJobData>);
+
+  describe('refreshTeamFeatureCacheJobHandler', () => {
+    it('opens connection, refreshes cache, commits, and releases', async () => {
+      const mockDBConnection = getMockDBConnection();
+      mockDBConnection.open = sinon.stub().resolves();
+      mockDBConnection.commit = sinon.stub().resolves();
+      mockDBConnection.release = sinon.stub();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
+
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await refreshTeamFeatureCacheJobHandler([createMockJob()]);
+
+      expect(mockDBConnection.open).to.have.been.calledOnce;
+      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(mockDBConnection.commit).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+    });
+
+    it('rolls back and releases on error, then rethrows', async () => {
+      const mockDBConnection = getMockDBConnection();
+      mockDBConnection.open = sinon.stub().resolves();
+      mockDBConnection.rollback = sinon.stub().resolves();
+      mockDBConnection.release = sinon.stub();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
+
+      const error = new Error('DB failure');
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').rejects(error);
+
+      try {
+        await refreshTeamFeatureCacheJobHandler([createMockJob()]);
+        expect.fail('Should have thrown');
+      } catch (thrown) {
+        expect(thrown).to.equal(error);
+      }
+
+      expect(mockDBConnection.rollback).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+    });
+
+    it('passes the correct teamId from job data', async () => {
+      const mockDBConnection = getMockDBConnection();
+      mockDBConnection.open = sinon.stub().resolves();
+      mockDBConnection.commit = sinon.stub().resolves();
+      mockDBConnection.release = sinon.stub();
+
+      sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
+
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      const customTeamId = '99999999-9999-9999-9999-999999999999';
+      await refreshTeamFeatureCacheJobHandler([createMockJob({ teamId: customTeamId })]);
+
+      expect(refreshStub).to.have.been.calledOnceWith(customTeamId);
+    });
+  });
+
+  describe('refreshTeamFeatureCacheFailedHandler', () => {
+    it('logs warning without throwing', async () => {
+      const mockJob = {
+        ...createMockJob(),
+        output: 'Some error output'
+      } as PgBoss.Job<IRefreshTeamFeatureCacheJobData>;
+
+      // Should not throw — DLQ handler only logs
+      await refreshTeamFeatureCacheFailedHandler([mockJob]);
+    });
+  });
+});

--- a/api/src/queue/jobs/refresh-team-feature-cache-job.ts
+++ b/api/src/queue/jobs/refresh-team-feature-cache-job.ts
@@ -1,0 +1,103 @@
+import PgBoss from 'pg-boss';
+import { getAPIUserDBConnection } from '../../database/db';
+import { TeamFeatureService } from '../../services/access-policy/team-feature-service';
+import { getLogger } from '../../utils/logger';
+
+const defaultLog = getLogger('queue/jobs/refresh-team-feature-cache-job');
+
+/**
+ * Refresh team_feature cache job data interface.
+ * Contains the team UUID whose cache needs rebuilding.
+ */
+export interface IRefreshTeamFeatureCacheJobData {
+  /** The team UUID whose cache needs refreshing */
+  teamId: string;
+}
+
+/**
+ * Refresh team_feature cache job handler.
+ *
+ * Rebuilds the team_feature cache for a single team via delete+insert.
+ * Runs outside the HTTP request path so policy mutations aren't blocked
+ * by potentially large cache rebuilds (millions of rows at scale).
+ *
+ * Global singleton key (`team-feature-refresh`) ensures only one refresh
+ * runs at a time across all workers — prevents concurrent bulk delete+insert
+ * operations from swamping the DB regardless of worker replica count.
+ *
+ * @param {PgBoss.Job<IRefreshTeamFeatureCacheJobData>[]} jobs The jobs to process
+ * @return {*}  {Promise<void>}
+ */
+export const refreshTeamFeatureCacheJobHandler: PgBoss.WorkHandler<IRefreshTeamFeatureCacheJobData> = async (jobs) => {
+  for (const job of jobs) {
+    const { teamId } = job.data;
+
+    defaultLog.info({
+      label: 'refreshTeamFeatureCacheJobHandler',
+      message: 'Processing refresh team feature cache job',
+      jobId: job.id,
+      teamId
+    });
+
+    const connection = getAPIUserDBConnection();
+
+    try {
+      await connection.open();
+
+      const teamFeatureService = new TeamFeatureService(connection);
+      await teamFeatureService.refreshCacheForTeam(teamId);
+
+      await connection.commit();
+
+      defaultLog.info({
+        label: 'refreshTeamFeatureCacheJobHandler',
+        message: 'Refresh team feature cache job completed successfully',
+        jobId: job.id,
+        teamId
+      });
+    } catch (error) {
+      await connection.rollback();
+
+      defaultLog.error({
+        label: 'refreshTeamFeatureCacheJobHandler',
+        message: 'Refresh team feature cache job failed',
+        jobId: job.id,
+        teamId,
+        error
+      });
+
+      throw error; // pg-boss will handle retry based on configuration
+    } finally {
+      connection.release();
+    }
+  }
+};
+
+/**
+ * Dead Letter Queue handler for failed refresh team feature cache jobs.
+ *
+ * Cache staleness is not critical — the source of truth (team_policy +
+ * policy_statement) is intact, and a subsequent policy mutation will trigger
+ * another refresh. This handler only logs the failure.
+ *
+ * @param {PgBoss.Job<IRefreshTeamFeatureCacheJobData>[]} jobs The failed jobs
+ * @return {*}  {Promise<void>}
+ */
+export const refreshTeamFeatureCacheFailedHandler: PgBoss.WorkHandler<IRefreshTeamFeatureCacheJobData> = async (
+  jobs
+) => {
+  for (const job of jobs) {
+    const { teamId } = job.data;
+
+    // Cast to access output field available on failed jobs
+    const jobOutput = (job as PgBoss.JobWithMetadata<IRefreshTeamFeatureCacheJobData>).output;
+
+    defaultLog.warn({
+      label: 'refreshTeamFeatureCacheFailedHandler',
+      message: 'Refresh team feature cache job failed after all retries',
+      jobId: job.id,
+      teamId,
+      output: jobOutput ?? 'Job failed after all retries'
+    });
+  }
+};

--- a/api/src/queue/publisher.ts
+++ b/api/src/queue/publisher.ts
@@ -8,6 +8,7 @@ import { JobQueues } from './jobs';
 import { IIndexSubmissionFeaturesJobData } from './jobs/index-submission-features-job';
 import { IMalwareScanJobData } from './jobs/malware-scan-job';
 import { IProcessDownloadJobData } from './jobs/process-download-job';
+import { IRefreshTeamFeatureCacheJobData } from './jobs/refresh-team-feature-cache-job';
 import { getPgBoss } from './pg-boss-service';
 
 const defaultLog = getLogger('queue/publisher');
@@ -422,6 +423,87 @@ export const publishIndexSubmissionFeaturesJob = async (
       label: 'publishIndexSubmissionFeaturesJob',
       message: 'Failed to publish job',
       submissionId: data.submissionId,
+      error
+    });
+
+    return { status: 'error', message: errorMessage };
+  }
+};
+
+/**
+ * Options for refresh team feature cache jobs.
+ * Generous timeout — large teams may have millions of cached features to rebuild.
+ */
+const REFRESH_TEAM_FEATURE_CACHE_OPTIONS: IPublishOptions = {
+  retryLimit: 3,
+  retryDelay: 60,
+  retryBackoff: true,
+  expireInSeconds: 60 * 30 // 30 minutes
+};
+
+/**
+ * Publish a refresh-team-feature-cache job to the queue.
+ *
+ * Queues async cache rebuild for a single team's team_feature rows.
+ * Cache refresh is eventually consistent — policy mutations publish a job
+ * rather than refreshing synchronously, because refresh can process millions
+ * of rows and would block the HTTP response.
+ *
+ * Uses global singletonKey ('team-feature-refresh') so only one refresh
+ * runs at a time across all workers, preventing concurrent bulk delete+insert
+ * operations from swamping the DB regardless of worker replica count.
+ *
+ * Uses the caller's DB connection via pg-boss's `db` option so the job insert
+ * participates in the same transaction — if the caller rolls back, the job
+ * is never visible (no ghost jobs).
+ *
+ * @param {IDBConnection} connection Database connection for transactional job insert
+ * @param {IRefreshTeamFeatureCacheJobData} data Job data containing teamId
+ * @param {IPublishOptions} [options={}] Job options
+ * @return {*}  {Promise<PublishJobResult>}
+ */
+export const publishRefreshTeamFeatureCacheJob = async (
+  connection: IDBConnection,
+  data: IRefreshTeamFeatureCacheJobData,
+  options: IPublishOptions = {}
+): Promise<PublishJobResult> => {
+  try {
+    const boss = getPgBoss();
+    const mergedOptions = { ...REFRESH_TEAM_FEATURE_CACHE_OPTIONS, ...options };
+
+    await boss.createQueue(JobQueues.REFRESH_TEAM_FEATURE_CACHE);
+
+    const jobId = await boss.send(JobQueues.REFRESH_TEAM_FEATURE_CACHE, data, {
+      ...mergedOptions,
+      singletonKey: 'team-feature-refresh',
+      db: { executeSql: (text: string, values: any[]) => connection.query(text, values) }
+    });
+
+    if (jobId) {
+      defaultLog.info({
+        label: 'publishRefreshTeamFeatureCacheJob',
+        message: 'Refresh team feature cache job published',
+        jobId,
+        teamId: data.teamId
+      });
+
+      return { status: 'published', jobId };
+    }
+
+    defaultLog.warn({
+      label: 'publishRefreshTeamFeatureCacheJob',
+      message: 'Job not published (duplicate or throttled)',
+      teamId: data.teamId
+    });
+
+    return { status: 'duplicate', message: 'Job already exists for team feature cache refresh' };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    defaultLog.error({
+      label: 'publishRefreshTeamFeatureCacheJob',
+      message: 'Failed to publish job',
+      teamId: data.teamId,
       error
     });
 

--- a/api/src/queue/worker.test.ts
+++ b/api/src/queue/worker.test.ts
@@ -5,6 +5,7 @@ import { JobQueues } from './jobs';
 import * as indexSubmissionFeaturesJob from './jobs/index-submission-features-job';
 import * as malwareScanJob from './jobs/malware-scan-job';
 import * as processSubmissionFeaturesJob from './jobs/process-submission-features-job';
+import * as refreshTeamFeatureCacheJob from './jobs/refresh-team-feature-cache-job';
 import * as pgBossService from './pg-boss-service';
 import { registerWorkers } from './worker';
 
@@ -52,8 +53,8 @@ describe('worker', () => {
       await registerWorkers();
 
       // createQueue is called for all queues (including dead letter queues)
-      // 8 queues: PROCESS_SUBMISSION_FEATURES + FAILED, MALWARE_SCAN + FAILED, PROCESS_DOWNLOAD + FAILED, INDEX_SUBMISSION_FEATURES + FAILED
-      expect(createQueueStub.callCount).to.equal(8);
+      // 10 queues: PROCESS_SUBMISSION_FEATURES + FAILED, MALWARE_SCAN + FAILED, PROCESS_DOWNLOAD + FAILED, INDEX_SUBMISSION_FEATURES + FAILED, REFRESH_TEAM_FEATURE_CACHE + FAILED
+      expect(createQueueStub.callCount).to.equal(10);
       expect(createQueueStub.firstCall.args[0]).to.equal(JobQueues.PROCESS_SUBMISSION_FEATURES_FAILED);
       expect(createQueueStub.secondCall.args[0]).to.equal(JobQueues.PROCESS_SUBMISSION_FEATURES);
       expect(createQueueStub.thirdCall.args[0]).to.equal(JobQueues.MALWARE_SCAN_FAILED);
@@ -62,6 +63,8 @@ describe('worker', () => {
       expect(createQueueStub.getCall(5).args[0]).to.equal(JobQueues.PROCESS_DOWNLOAD);
       expect(createQueueStub.getCall(6).args[0]).to.equal(JobQueues.INDEX_SUBMISSION_FEATURES_FAILED);
       expect(createQueueStub.getCall(7).args[0]).to.equal(JobQueues.INDEX_SUBMISSION_FEATURES);
+      expect(createQueueStub.getCall(8).args[0]).to.equal(JobQueues.REFRESH_TEAM_FEATURE_CACHE_FAILED);
+      expect(createQueueStub.getCall(9).args[0]).to.equal(JobQueues.REFRESH_TEAM_FEATURE_CACHE);
     });
 
     it('configures dead letter queue for process-submission-features', async () => {
@@ -127,6 +130,40 @@ describe('worker', () => {
       expect(queueConfig.deadLetter).to.equal(JobQueues.INDEX_SUBMISSION_FEATURES_FAILED);
       expect(queueConfig.retryLimit).to.equal(3);
       expect(queueConfig.retryBackoff).to.equal(true);
+    });
+
+    it('registers the refresh team feature cache job handler with pg-boss', async () => {
+      const workStub = sinon.stub().resolves();
+      const createQueueStub = sinon.stub().resolves();
+      const mockBoss = { work: workStub, createQueue: createQueueStub };
+
+      sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
+
+      await registerWorkers();
+
+      // Refresh team feature cache handlers are registered after index submission features
+      expect(workStub.getCall(8).args[0]).to.equal(JobQueues.REFRESH_TEAM_FEATURE_CACHE);
+      expect(workStub.getCall(8).args[1]).to.equal(refreshTeamFeatureCacheJob.refreshTeamFeatureCacheJobHandler);
+
+      expect(workStub.getCall(9).args[0]).to.equal(JobQueues.REFRESH_TEAM_FEATURE_CACHE_FAILED);
+      expect(workStub.getCall(9).args[1]).to.equal(refreshTeamFeatureCacheJob.refreshTeamFeatureCacheFailedHandler);
+    });
+
+    it('configures dead letter queue for refresh-team-feature-cache', async () => {
+      const workStub = sinon.stub().resolves();
+      const createQueueStub = sinon.stub().resolves();
+      const mockBoss = { work: workStub, createQueue: createQueueStub };
+
+      sinon.stub(pgBossService, 'getPgBoss').returns(mockBoss as any);
+
+      await registerWorkers();
+
+      // 10th createQueue call (REFRESH_TEAM_FEATURE_CACHE) should have DLQ config with short policy
+      const queueConfig = createQueueStub.getCall(9).args[1];
+      expect(queueConfig.deadLetter).to.equal(JobQueues.REFRESH_TEAM_FEATURE_CACHE_FAILED);
+      expect(queueConfig.retryLimit).to.equal(3);
+      expect(queueConfig.retryBackoff).to.equal(true);
+      expect(queueConfig.policy).to.equal('short');
     });
   });
 });

--- a/api/src/queue/worker.ts
+++ b/api/src/queue/worker.ts
@@ -16,6 +16,11 @@ import {
   processSubmissionFeaturesFailedHandler,
   processSubmissionFeaturesJobHandler
 } from './jobs/process-submission-features-job';
+import {
+  IRefreshTeamFeatureCacheJobData,
+  refreshTeamFeatureCacheFailedHandler,
+  refreshTeamFeatureCacheJobHandler
+} from './jobs/refresh-team-feature-cache-job';
 import { getPgBoss } from './pg-boss-service';
 
 const defaultLog = getLogger('queue/worker');
@@ -107,6 +112,31 @@ export const registerWorkers = async (): Promise<void> => {
   await boss.work<IIndexSubmissionFeaturesJobData>(
     JobQueues.INDEX_SUBMISSION_FEATURES_FAILED,
     indexSubmissionFeaturesFailedHandler
+  );
+
+  // Create dead letter queue first (must exist before main queue references it)
+  await boss.createQueue(JobQueues.REFRESH_TEAM_FEATURE_CACHE_FAILED);
+
+  // Create main queue with dead letter queue and retry configuration.
+  // policy: 'short' — enforces singleton_key uniqueness for queued (created) jobs.
+  await boss.createQueue(JobQueues.REFRESH_TEAM_FEATURE_CACHE, {
+    deadLetter: JobQueues.REFRESH_TEAM_FEATURE_CACHE_FAILED,
+    retryLimit: 3,
+    retryDelay: 60,
+    retryBackoff: true,
+    policy: 'short'
+  });
+
+  // Register refresh team feature cache job handler
+  await boss.work<IRefreshTeamFeatureCacheJobData>(
+    JobQueues.REFRESH_TEAM_FEATURE_CACHE,
+    refreshTeamFeatureCacheJobHandler
+  );
+
+  // Register dead letter queue handler for failed refresh team feature cache jobs
+  await boss.work<IRefreshTeamFeatureCacheJobData>(
+    JobQueues.REFRESH_TEAM_FEATURE_CACHE_FAILED,
+    refreshTeamFeatureCacheFailedHandler
   );
 
   defaultLog.info({

--- a/api/src/repositories/authorization/team-feature-repository.test.ts
+++ b/api/src/repositories/authorization/team-feature-repository.test.ts
@@ -33,7 +33,7 @@ describe('TeamFeatureRepository', () => {
       const mockConnection = getMockDBConnection({ sql: sqlStub });
 
       const repository = new TeamFeatureRepository(mockConnection);
-      await repository.populateTeamFeatureCache('22222222-2222-2222-2222-222222222222');
+      await repository.populateTeamFeatureCacheBatch('22222222-2222-2222-2222-222222222222', [1, 2, 3]);
 
       expect(sqlStub).to.have.been.calledOnce;
     });

--- a/api/src/repositories/authorization/team-feature-repository.test.ts
+++ b/api/src/repositories/authorization/team-feature-repository.test.ts
@@ -1,0 +1,41 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import { QueryResult } from 'pg';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../../__mocks__/db';
+import { TeamFeatureRepository } from './team-feature-repository';
+
+chai.use(sinonChai);
+
+describe('TeamFeatureRepository', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('deleteTeamFeaturesByTeamId', () => {
+    it('calls knex delete for the given team id', async () => {
+      const mockResponse = { rowCount: 3, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const knexStub = sinon.stub().resolves(mockResponse);
+      const mockConnection = getMockDBConnection({ knex: knexStub });
+
+      const repository = new TeamFeatureRepository(mockConnection);
+      await repository.deleteTeamFeaturesByTeamId('22222222-2222-2222-2222-222222222222');
+
+      expect(knexStub).to.have.been.calledOnce;
+    });
+  });
+
+  describe('populateTeamFeatureCache', () => {
+    it('calls sql to insert resolved features for the given team id', async () => {
+      const mockResponse = { rowCount: 5, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const sqlStub = sinon.stub().resolves(mockResponse);
+      const mockConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repository = new TeamFeatureRepository(mockConnection);
+      await repository.populateTeamFeatureCache('22222222-2222-2222-2222-222222222222');
+
+      expect(sqlStub).to.have.been.calledOnce;
+    });
+  });
+});

--- a/api/src/repositories/authorization/team-feature-repository.ts
+++ b/api/src/repositories/authorization/team-feature-repository.ts
@@ -40,14 +40,6 @@ export class TeamFeatureRepository extends BaseRepository {
    * need cache entries. Uses decomposed URN columns on policy_statement
    * (urn_submission_id, urn_feature_type, urn_feature_id) for indexed matching.
    *
-   * Uses EXISTS semi-join so each submission_feature drives the outer scan exactly
-   * once — PostgreSQL short-circuits on the first matching policy statement. This
-   * avoids the hash aggregate that SELECT DISTINCT would build over the full
-   * (multiplied) result set when JOINing through team_policy → policy →
-   * policy_statement. At 10M features × 5 policies, EXISTS prevents 50M
-   * intermediate rows from materializing. Rows are unique by construction, so no
-   * ON CONFLICT clause is needed.
-   *
    * @param {string} teamId - The team UUID to populate cache for.
    * @return {Promise<void>}
    * @memberof TeamFeatureRepository

--- a/api/src/repositories/authorization/team-feature-repository.ts
+++ b/api/src/repositories/authorization/team-feature-repository.ts
@@ -32,42 +32,21 @@ export class TeamFeatureRepository extends BaseRepository {
   }
 
   /**
-   * Populate the team_feature cache for a specific team by resolving all active
-   * policy statement URNs (including wildcards) to concrete submission_feature_ids.
+   * Get submission IDs that contain secured features matching a team's policy
+   * grants. Used to partition the cache rebuild into per-submission batches
+   * so each recursive walk stays small.
    *
-   * Only secured features (those with an active submission_feature_security row)
-   * are cached — unsecured features are already visible to everyone and don't
-   * need cache entries. Uses decomposed URN columns on policy_statement
-   * (urn_submission_id, urn_feature_type, urn_feature_id) for indexed matching.
-   *
-   * @param {string} teamId - The team UUID to populate cache for.
-   * @return {Promise<void>}
+   * @param {string} teamId - The team UUID to resolve grants for.
+   * @return {Promise<number[]>} Submission IDs with secured features the team may access.
    * @memberof TeamFeatureRepository
    */
-  async populateTeamFeatureCache(teamId: string): Promise<void> {
+  async getSecuredSubmissionIds(teamId: string): Promise<number[]> {
     const sql = SQL`
-      WITH RECURSIVE secured_features AS (
-        -- Base: features with a direct security row
-        SELECT sf.submission_feature_id
-        FROM submission_feature sf
+      SELECT DISTINCT sf.submission_id
+      FROM submission_feature sf
         JOIN submission_feature_security sfs
           ON sfs.submission_feature_id = sf.submission_feature_id
           AND sfs.record_end_date IS NULL
-        WHERE sf.record_end_date IS NULL
-
-        UNION
-
-        -- Recursive: children inherit security from their parent
-        SELECT child.submission_feature_id
-        FROM submission_feature child
-        INNER JOIN secured_features sec ON child.parent_submission_feature_id = sec.submission_feature_id
-        WHERE child.record_end_date IS NULL
-      )
-      INSERT INTO team_feature (team_id, submission_feature_id)
-      SELECT ${teamId}::uuid, sf.submission_feature_id
-      FROM submission_feature sf
-        JOIN feature_type ft ON ft.feature_type_id = sf.feature_type_id
-        JOIN secured_features sec ON sec.submission_feature_id = sf.submission_feature_id
       WHERE sf.record_end_date IS NULL
         AND EXISTS (
           SELECT 1
@@ -78,9 +57,70 @@ export class TeamFeatureRepository extends BaseRepository {
             AND tp.record_end_date IS NULL
             AND ps.effect = 'allow'
             AND (ps.urn_submission_id = sf.submission_id::text OR ps.urn_submission_id = '*')
-            AND (ps.urn_feature_type = ft.name OR ps.urn_feature_type = '*')
-            AND (ps.urn_feature_id = sf.submission_feature_id::text OR ps.urn_feature_id = '*')
         )
+    `;
+
+    const response = await this.connection.sql(sql);
+    return response.rows.map((row: { submission_id: number }) => row.submission_id);
+  }
+
+  /**
+   * Populate the team_feature cache for a batch of submissions.
+   *
+   * Runs the recursive secured-feature walk scoped to the given submission IDs,
+   * so each invocation only materializes a bounded subset of the feature tree.
+   * The full URN check (submission, feature_type, feature_id) runs at the end
+   * to filter down to features the team's policy actually grants.
+   *
+   * Cannot pre-filter by feature_type or feature_id at the recursion base
+   * because children may have different types than their secured ancestor.
+   *
+   * @param {string} teamId - The team UUID to populate cache for.
+   * @param {number[]} submissionIds - Submission IDs to scope the recursive walk to.
+   * @return {Promise<void>}
+   * @memberof TeamFeatureRepository
+   */
+  async populateTeamFeatureCacheBatch(teamId: string, submissionIds: number[]): Promise<void> {
+    const sql = SQL`
+      WITH RECURSIVE
+      team_grants AS (
+        SELECT ps.urn_submission_id, ps.urn_feature_type, ps.urn_feature_id
+        FROM team_policy tp
+          JOIN policy p ON p.policy_id = tp.policy_id AND p.record_end_date IS NULL
+          JOIN policy_statement ps ON ps.policy_id = p.policy_id AND ps.record_end_date IS NULL
+        WHERE tp.team_id = ${teamId}
+          AND tp.record_end_date IS NULL
+          AND ps.effect = 'allow'
+      ),
+      -- Recursive CTE: walk secured subtrees within this batch of submissions
+      secured_features AS (
+        SELECT sf.submission_feature_id
+        FROM submission_feature sf
+          JOIN submission_feature_security sfs
+            ON sfs.submission_feature_id = sf.submission_feature_id
+            AND sfs.record_end_date IS NULL
+        WHERE sf.record_end_date IS NULL
+          AND sf.submission_id = ANY(${submissionIds})
+
+        UNION
+
+        SELECT child.submission_feature_id
+        FROM submission_feature child
+          JOIN secured_features sec ON child.parent_submission_feature_id = sec.submission_feature_id
+        WHERE child.record_end_date IS NULL
+      )
+      -- Final: insert only features that pass the full URN policy check
+      INSERT INTO team_feature (team_id, submission_feature_id)
+      SELECT ${teamId}::uuid, st.submission_feature_id
+      FROM secured_features st
+        JOIN submission_feature sf ON sf.submission_feature_id = st.submission_feature_id
+        JOIN feature_type ft ON ft.feature_type_id = sf.feature_type_id
+      WHERE EXISTS (
+        SELECT 1 FROM team_grants tg
+        WHERE (tg.urn_submission_id = sf.submission_id::text OR tg.urn_submission_id = '*')
+          AND (tg.urn_feature_type = ft.name OR tg.urn_feature_type = '*')
+          AND (tg.urn_feature_id = sf.submission_feature_id::text OR tg.urn_feature_id = '*')
+      )
     `;
 
     await this.connection.sql(sql);

--- a/api/src/repositories/authorization/team-feature-repository.ts
+++ b/api/src/repositories/authorization/team-feature-repository.ts
@@ -40,6 +40,14 @@ export class TeamFeatureRepository extends BaseRepository {
    * need cache entries. Uses decomposed URN columns on policy_statement
    * (urn_submission_id, urn_feature_type, urn_feature_id) for indexed matching.
    *
+   * Uses EXISTS semi-join so each submission_feature drives the outer scan exactly
+   * once — PostgreSQL short-circuits on the first matching policy statement. This
+   * avoids the hash aggregate that SELECT DISTINCT would build over the full
+   * (multiplied) result set when JOINing through team_policy → policy →
+   * policy_statement. At 10M features × 5 policies, EXISTS prevents 50M
+   * intermediate rows from materializing. Rows are unique by construction, so no
+   * ON CONFLICT clause is needed.
+   *
    * @param {string} teamId - The team UUID to populate cache for.
    * @return {Promise<void>}
    * @memberof TeamFeatureRepository
@@ -64,20 +72,23 @@ export class TeamFeatureRepository extends BaseRepository {
         WHERE child.record_end_date IS NULL
       )
       INSERT INTO team_feature (team_id, submission_feature_id)
-      SELECT DISTINCT ${teamId}::uuid, sf.submission_feature_id
-      FROM team_policy tp
-        JOIN policy p ON p.policy_id = tp.policy_id AND p.record_end_date IS NULL
-        JOIN policy_statement ps ON ps.policy_id = p.policy_id AND ps.record_end_date IS NULL
-        JOIN submission_feature sf ON sf.record_end_date IS NULL
+      SELECT ${teamId}::uuid, sf.submission_feature_id
+      FROM submission_feature sf
         JOIN feature_type ft ON ft.feature_type_id = sf.feature_type_id
         JOIN secured_features sec ON sec.submission_feature_id = sf.submission_feature_id
-      WHERE tp.team_id = ${teamId}
-        AND tp.record_end_date IS NULL
-        AND ps.effect = 'allow'
-        AND (ps.urn_submission_id = sf.submission_id::text OR ps.urn_submission_id = '*')
-        AND (ps.urn_feature_type = ft.name OR ps.urn_feature_type = '*')
-        AND (ps.urn_feature_id = sf.submission_feature_id::text OR ps.urn_feature_id = '*')
-      ON CONFLICT (team_id, submission_feature_id) DO NOTHING
+      WHERE sf.record_end_date IS NULL
+        AND EXISTS (
+          SELECT 1
+          FROM team_policy tp
+            JOIN policy p ON p.policy_id = tp.policy_id AND p.record_end_date IS NULL
+            JOIN policy_statement ps ON ps.policy_id = p.policy_id AND ps.record_end_date IS NULL
+          WHERE tp.team_id = ${teamId}
+            AND tp.record_end_date IS NULL
+            AND ps.effect = 'allow'
+            AND (ps.urn_submission_id = sf.submission_id::text OR ps.urn_submission_id = '*')
+            AND (ps.urn_feature_type = ft.name OR ps.urn_feature_type = '*')
+            AND (ps.urn_feature_id = sf.submission_feature_id::text OR ps.urn_feature_id = '*')
+        )
     `;
 
     await this.connection.sql(sql);

--- a/api/src/repositories/authorization/team-feature-repository.ts
+++ b/api/src/repositories/authorization/team-feature-repository.ts
@@ -1,0 +1,70 @@
+import SQL from 'sql-template-strings';
+import { getKnex } from '../../database/db';
+import { BaseRepository } from '../base-repository';
+
+/**
+ * A repository class for managing the team_feature cache table.
+ *
+ * team_feature is a materialized cache — not a source of truth. It maps teams
+ * to the secured submission features they can access by resolving URN wildcards
+ * from policy_statement. This lets search use simple JOINs instead of per-row
+ * URN matching.
+ *
+ * @export
+ * @class TeamFeatureRepository
+ * @extends {BaseRepository}
+ */
+export class TeamFeatureRepository extends BaseRepository {
+  /**
+   * Hard-delete all cached team_feature rows for a specific team.
+   * Called before repopulating to ensure cache consistency during a
+   * delete-and-reinsert rebuild cycle.
+   *
+   * @param {string} teamId - The team UUID whose cache entries to remove.
+   * @return {Promise<void>}
+   * @memberof TeamFeatureRepository
+   */
+  async deleteTeamFeaturesByTeamId(teamId: string): Promise<void> {
+    const knex = getKnex();
+    const query = knex.table('team_feature').where('team_id', teamId).del();
+
+    await this.connection.knex(query);
+  }
+
+  /**
+   * Populate the team_feature cache for a specific team by resolving all active
+   * policy statement URNs (including wildcards) to concrete submission_feature_ids.
+   *
+   * Only secured features (those with an active submission_feature_security row)
+   * are cached — unsecured features are already visible to everyone and don't
+   * need cache entries. Uses decomposed URN columns on policy_statement
+   * (urn_submission_id, urn_feature_type, urn_feature_id) for indexed matching.
+   *
+   * @param {string} teamId - The team UUID to populate cache for.
+   * @return {Promise<void>}
+   * @memberof TeamFeatureRepository
+   */
+  async populateTeamFeatureCache(teamId: string): Promise<void> {
+    const sql = SQL`
+      INSERT INTO team_feature (team_id, submission_feature_id)
+      SELECT DISTINCT ${teamId}::uuid, sf.submission_feature_id
+      FROM team_policy tp
+        JOIN policy p ON p.policy_id = tp.policy_id AND p.record_end_date IS NULL
+        JOIN policy_statement ps ON ps.policy_id = p.policy_id AND ps.record_end_date IS NULL
+        JOIN submission_feature sf ON sf.record_end_date IS NULL
+        JOIN feature_type ft ON ft.feature_type_id = sf.feature_type_id
+        JOIN submission_feature_security sfs
+          ON sfs.submission_feature_id = sf.submission_feature_id
+          AND sfs.record_end_date IS NULL
+      WHERE tp.team_id = ${teamId}
+        AND tp.record_end_date IS NULL
+        AND ps.effect = 'allow'
+        AND (ps.urn_submission_id = sf.submission_id::text OR ps.urn_submission_id = '*')
+        AND (ps.urn_feature_type = ft.name OR ps.urn_feature_type = '*')
+        AND (ps.urn_feature_id = sf.submission_feature_id::text OR ps.urn_feature_id = '*')
+      ON CONFLICT (team_id, submission_feature_id) DO NOTHING
+    `;
+
+    await this.connection.sql(sql);
+  }
+}

--- a/api/src/repositories/authorization/team-feature-repository.ts
+++ b/api/src/repositories/authorization/team-feature-repository.ts
@@ -46,6 +46,23 @@ export class TeamFeatureRepository extends BaseRepository {
    */
   async populateTeamFeatureCache(teamId: string): Promise<void> {
     const sql = SQL`
+      WITH RECURSIVE secured_features AS (
+        -- Base: features with a direct security row
+        SELECT sf.submission_feature_id
+        FROM submission_feature sf
+        JOIN submission_feature_security sfs
+          ON sfs.submission_feature_id = sf.submission_feature_id
+          AND sfs.record_end_date IS NULL
+        WHERE sf.record_end_date IS NULL
+
+        UNION
+
+        -- Recursive: children inherit security from their parent
+        SELECT child.submission_feature_id
+        FROM submission_feature child
+        INNER JOIN secured_features sec ON child.parent_submission_feature_id = sec.submission_feature_id
+        WHERE child.record_end_date IS NULL
+      )
       INSERT INTO team_feature (team_id, submission_feature_id)
       SELECT DISTINCT ${teamId}::uuid, sf.submission_feature_id
       FROM team_policy tp
@@ -53,9 +70,7 @@ export class TeamFeatureRepository extends BaseRepository {
         JOIN policy_statement ps ON ps.policy_id = p.policy_id AND ps.record_end_date IS NULL
         JOIN submission_feature sf ON sf.record_end_date IS NULL
         JOIN feature_type ft ON ft.feature_type_id = sf.feature_type_id
-        JOIN submission_feature_security sfs
-          ON sfs.submission_feature_id = sf.submission_feature_id
-          AND sfs.record_end_date IS NULL
+        JOIN secured_features sec ON sec.submission_feature_id = sf.submission_feature_id
       WHERE tp.team_id = ${teamId}
         AND tp.record_end_date IS NULL
         AND ps.effect = 'allow'

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -297,11 +297,7 @@ export class DownloadRepository extends BaseRepository {
    * Returns which of the given feature IDs are secured — directly or by
    * inheriting security from an ancestor.
    *
-   * Walks DOWN from secured roots to all descendants, the opposite direction
-   * of buildSecurityCheck() (which walks UP from a feature to its ancestors).
-   * Using a different traversal direction makes this a genuine cross-check:
-   * if the two methods disagree, there's a bug.
-   *
+   * Walks DOWN from secured roots to all descendants via a recursive CTE.
    * Scoped to submissions containing the candidate features to avoid walking
    * every secured tree in the system.
    *

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -155,7 +155,8 @@ export class SearchFeatureRepository extends BaseRepository {
    */
   async searchFeaturesByFilters(
     filters: ISearchFeaturesFilters,
-    pagination?: ApiPaginationOptions
+    pagination?: ApiPaginationOptions,
+    systemUserId?: number | null
   ): Promise<SearchFeatureResultWithRelevancy[]> {
     defaultLog.debug({ label: 'searchFeaturesByFilters', filters, pagination });
 
@@ -165,7 +166,7 @@ export class SearchFeatureRepository extends BaseRepository {
     }
 
     const knex = getKnex();
-    let query = this.buildSearchQuery(knex, filters);
+    let query = this.buildSearchQuery(knex, filters, systemUserId);
 
     // Apply pagination and sorting using base repository method
     query = this.applyPagination(query, pagination);
@@ -180,10 +181,10 @@ export class SearchFeatureRepository extends BaseRepository {
    * @param {ISearchFeaturesFilters} filters - Search filters to count results for
    * @returns {Promise<number>} Promise resolving to the count of matching features
    */
-  async searchFeaturesByFiltersCount(filters: ISearchFeaturesFilters): Promise<number> {
+  async searchFeaturesByFiltersCount(filters: ISearchFeaturesFilters, systemUserId?: number | null): Promise<number> {
     defaultLog.debug({ label: 'searchFeaturesByFiltersCount', filters });
     const knex = getKnex();
-    const query = this.buildSearchQuery(knex, filters);
+    const query = this.buildSearchQuery(knex, filters, systemUserId);
     const countQuery = knex.from(query.as('sf_filtered')).select(knex.raw('count(*)::integer as count'));
     const response = await this.connection.knex(countQuery);
     return response.rows[0]?.count ?? 0;
@@ -219,12 +220,16 @@ export class SearchFeatureRepository extends BaseRepository {
    * @param {ISearchFeaturesFilters} filters - Search filters to apply
    * @returns {Knex.QueryBuilder} Knex query builder with all filters applied
    */
-  private buildSearchQuery(knex: Knex, filters: ISearchFeaturesFilters): Knex.QueryBuilder {
+  private buildSearchQuery(
+    knex: Knex,
+    filters: ISearchFeaturesFilters,
+    systemUserId?: number | null
+  ): Knex.QueryBuilder {
     const keyword = filters.keyword ?? '';
     const featureTypes = filters.feature_types ?? [];
     const speciesFilters = filters.species ?? [];
     const propertyGroups = filters.properties ?? [];
-    return this.buildQueryWithCTEs(knex, keyword, featureTypes, speciesFilters, propertyGroups);
+    return this.buildQueryWithCTEs(knex, keyword, featureTypes, speciesFilters, propertyGroups, systemUserId);
   }
 
   /**
@@ -241,7 +246,8 @@ export class SearchFeatureRepository extends BaseRepository {
     keyword: string,
     featureTypes: string[],
     speciesFilters: string[],
-    propertyGroups: ISearchFeaturePropertyGroup[]
+    propertyGroups: ISearchFeaturePropertyGroup[],
+    systemUserId?: number | null
   ): Knex.QueryBuilder {
     const activeCteCount = [keyword.trim(), featureTypes.length, speciesFilters.length, propertyGroups.length].filter(
       (v) => {
@@ -351,7 +357,7 @@ export class SearchFeatureRepository extends BaseRepository {
           );
       });
 
-    return query
+    const finalQuery = query
       .select(
         'submission_feature_id',
         'submission_id',
@@ -366,6 +372,24 @@ export class SearchFeatureRepository extends BaseRepository {
         'create_date'
       )
       .from('aggregated_results');
+
+    // Apply security filter when systemUserId is explicitly provided.
+    // undefined = no filtering (backward-compatible for internal callers like searchFeatureIdsByFilters).
+    // null = anonymous user, only unsecured features visible.
+    // number = authenticated user, unsecured + team_feature-authorized secured features visible.
+    if (systemUserId !== undefined) {
+      const accessFilter = this.buildUserAccessFilter(knex, systemUserId);
+
+      if (accessFilter) {
+        finalQuery.where((qb) => {
+          qb.where('is_secured', false).orWhereIn('submission_feature_id', accessFilter);
+        });
+      } else {
+        finalQuery.where('is_secured', false);
+      }
+    }
+
+    return finalQuery;
   }
 
   /**
@@ -649,6 +673,31 @@ export class SearchFeatureRepository extends BaseRepository {
         return query;
       }
     }
+  }
+
+  /**
+   * Builds a subquery returning submission_feature_ids the user can access via the
+   * team_feature cache (team membership → team_feature). Used to gate secured features
+   * in search results — only features cached for the user's teams are visible.
+   *
+   * Returns null when systemUserId is null (anonymous), meaning no secured features
+   * are accessible. The caller uses null to simplify the WHERE clause to
+   * `is_secured = false` (unsecured only).
+   *
+   * @param knex - Knex instance
+   * @param systemUserId - Authenticated user's ID, or null for anonymous
+   * @returns Knex subquery selecting accessible submission_feature_ids, or null for anonymous
+   */
+  private buildUserAccessFilter(knex: Knex, systemUserId: number | null): Knex.QueryBuilder | null {
+    if (!systemUserId) {
+      return null;
+    }
+
+    return knex('team_feature as tf')
+      .select('tf.submission_feature_id')
+      .join('team_member as tm', 'tm.team_id', 'tf.team_id')
+      .where('tm.system_user_id', systemUserId)
+      .whereNull('tm.record_end_date');
   }
 
   /**

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -234,6 +234,11 @@ export class SearchFeatureRepository extends BaseRepository {
 
   /**
    * Combines all filter CTEs into a single query with intersection and relevancy aggregation.
+   *
+   * Security is resolved via a top-level `secured_features` recursive CTE that walks down
+   * from directly-secured features to their descendants. Each filter CTE derives `is_secured`
+   * with a simple EXISTS against this CTE — no per-row LATERAL subquery needed.
+   *
    * @param {Knex} knex - Knex instance
    * @param {string} keyword - Search keyword for full-text search
    * @param {string[]} featureTypes - Feature type names to filter by
@@ -257,6 +262,21 @@ export class SearchFeatureRepository extends BaseRepository {
 
     const query = knex
       .queryBuilder()
+      .withRecursive(
+        'secured_features',
+        knex.raw(`
+        SELECT sf.submission_feature_id
+        FROM submission_feature sf
+        JOIN submission_feature_security sfs
+          ON sfs.submission_feature_id = sf.submission_feature_id
+          AND sfs.record_end_date IS NULL
+        UNION
+        SELECT child.submission_feature_id
+        FROM submission_feature child
+        JOIN secured_features parent
+          ON child.parent_submission_feature_id = parent.submission_feature_id
+      `)
+      )
       .with('keyword_results', (qb) => {
         if (keyword.trim()) {
           qb.from(this.buildKeywordSearchCTE(keyword, knex).as('kw_results'));
@@ -423,14 +443,15 @@ export class SearchFeatureRepository extends BaseRepository {
         knex.raw(`sf.data->>'name' as feature_name`),
         knex.raw(`sf.data->>'description' as feature_description`),
         's.name as submission_name',
-        'security_check.is_secured',
+        knex.raw(
+          'EXISTS (SELECT 1 FROM secured_features sec WHERE sec.submission_feature_id = sf.submission_feature_id) as is_secured'
+        ),
         'sf.create_date',
         knex.raw(`ts_rank(${tsVector}, ${tsQuery}) as relevancy_score`)
       )
       .join('submission_feature as sf', 'ss.submission_feature_id', 'sf.submission_feature_id')
       .join('submission as s', 'sf.submission_id', 's.submission_id')
       .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
-      .crossJoin(knex.raw('LATERAL (?) as security_check', [this.buildSecurityCheck(knex)]))
       .whereRaw(`${tsVector} @@ ${tsQuery}`);
   }
 
@@ -452,13 +473,14 @@ export class SearchFeatureRepository extends BaseRepository {
         knex.raw(`sf.data->>'name' as feature_name`),
         knex.raw(`sf.data->>'description' as feature_description`),
         's.name as submission_name',
-        'security_check.is_secured',
+        knex.raw(
+          'EXISTS (SELECT 1 FROM secured_features sec WHERE sec.submission_feature_id = sf.submission_feature_id) as is_secured'
+        ),
         'sf.create_date',
         knex.raw('1.0 as relevancy_score')
       )
       .join('submission as s', 'sf.submission_id', 's.submission_id')
       .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
-      .crossJoin(knex.raw('LATERAL (?) as security_check', [this.buildSecurityCheck(knex)]))
       .whereIn('ft.name', featureTypes);
   }
 
@@ -481,7 +503,9 @@ export class SearchFeatureRepository extends BaseRepository {
         knex.raw(`sf.data->>'name' as feature_name`),
         knex.raw(`sf.data->>'description' as feature_description`),
         's.name as submission_name',
-        'security_check.is_secured',
+        knex.raw(
+          'EXISTS (SELECT 1 FROM secured_features sec WHERE sec.submission_feature_id = sf.submission_feature_id) as is_secured'
+        ),
         'sf.create_date',
         knex.raw('1.0 as relevancy_score')
       )
@@ -489,7 +513,6 @@ export class SearchFeatureRepository extends BaseRepository {
       .join('submission as s', 'sf.submission_id', 's.submission_id')
       .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
       .join('feature_property as fp', 'ss.feature_property_id', 'fp.feature_property_id')
-      .crossJoin(knex.raw('LATERAL (?) as security_check', [this.buildSecurityCheck(knex)]))
       .where('fp.name', 'species')
       .whereIn('ss.value', speciesFilters);
   }
@@ -602,7 +625,9 @@ export class SearchFeatureRepository extends BaseRepository {
         knex.raw(`sf.data->>'name' as feature_name`),
         knex.raw(`sf.data->>'description' as feature_description`),
         's.name as submission_name',
-        'security_check.is_secured',
+        knex.raw(
+          'EXISTS (SELECT 1 FROM secured_features sec WHERE sec.submission_feature_id = sf.submission_feature_id) as is_secured'
+        ),
         'sf.create_date',
         knex.raw('1.0 as relevancy_score')
       )
@@ -610,7 +635,6 @@ export class SearchFeatureRepository extends BaseRepository {
       .join('submission as s', 'sf.submission_id', 's.submission_id')
       .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
       .join('feature_property as fp', 'ss.feature_property_id', 'fp.feature_property_id')
-      .crossJoin(knex.raw('LATERAL (?) as security_check', [this.buildSecurityCheck(knex)]))
       .where('fp.name', propertyName);
   }
 
@@ -698,31 +722,5 @@ export class SearchFeatureRepository extends BaseRepository {
       .join('team_member as tm', 'tm.team_id', 'tf.team_id')
       .where('tm.system_user_id', systemUserId)
       .whereNull('tm.record_end_date');
-  }
-
-  /**
-   * Builds the security check subquery to determine if a feature or its ancestors are secured.
-   * Uses recursive CTE to traverse up the feature hierarchy.
-   * @param knex - Knex instance
-   * @returns Knex raw query for lateral security check
-   */
-  private buildSecurityCheck(knex: Knex): Knex.Raw {
-    return knex.raw(`
-      WITH RECURSIVE ancestors AS (
-        SELECT sf.submission_feature_id as ancestor_id, sf.parent_submission_feature_id
-        FROM submission_feature sf
-        WHERE sf.submission_feature_id = sf.submission_feature_id
-        UNION ALL
-        SELECT sf2.submission_feature_id, sf2.parent_submission_feature_id
-        FROM submission_feature sf2
-        INNER JOIN ancestors a ON sf2.submission_feature_id = a.parent_submission_feature_id
-      )
-      SELECT EXISTS (
-        SELECT 1
-        FROM ancestors a
-        INNER JOIN submission_feature_security sfs ON a.ancestor_id = sfs.submission_feature_id
-        WHERE sfs.record_end_date IS NULL
-      ) as is_secured
-    `);
   }
 }

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -5,12 +5,13 @@ import sinonChai from 'sinon-chai';
 import { CreatePolicy, Policy, UpdatePolicy } from '../../models/policy';
 import { PolicyEffect, PolicyStatement } from '../../models/policy-statement';
 import { PolicyConditionOperator, PolicyStatementCondition } from '../../models/policy-statement-condition';
+import * as publisher from '../../queue/publisher';
 import { PolicyRepository } from '../../repositories/authorization/policy-repository';
 import { PolicyStatementConditionRepository } from '../../repositories/authorization/policy-statement-condition-repository';
 import { PolicyStatementRepository } from '../../repositories/authorization/policy-statement-repository';
+import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { PolicyService } from './policy-service';
-import { TeamFeatureService } from './team-feature-service';
 
 chai.use(sinonChai);
 
@@ -115,45 +116,61 @@ describe('PolicyService', () => {
 
   describe('deletePolicy', () => {
     it('should call repository.deletePolicy', async () => {
-      sinon.stub(TeamFeatureService.prototype, 'getTeamIdsForPolicy').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
       const stub = sinon.stub(PolicyRepository.prototype, 'deletePolicy').resolves();
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
 
       await policyService.deletePolicy('1');
 
       expect(stub).to.have.been.calledWith('1');
     });
 
-    it('fetches team IDs before delete, then refreshes cache for each team', async () => {
+    it('fetches team IDs before delete, then publishes cache refresh for each team', async () => {
       const policyId = '11111111-1111-1111-1111-111111111111';
-      const teamIds = ['22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333'];
       const callOrder: string[] = [];
 
-      sinon.stub(TeamFeatureService.prototype, 'getTeamIdsForPolicy').callsFake(async () => {
-        callOrder.push('getTeamIds');
-        return teamIds;
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').callsFake(async () => {
+        callOrder.push('getTeamPolicies');
+        return [
+          {
+            team_policy_id: 'tp1',
+            team_id: '22222222-2222-2222-2222-222222222222',
+            policy_id: policyId,
+            team_name: 'Team A',
+            policy_name: 'Policy A'
+          },
+          {
+            team_policy_id: 'tp2',
+            team_id: '33333333-3333-3333-3333-333333333333',
+            policy_id: policyId,
+            team_name: 'Team B',
+            policy_name: 'Policy A'
+          }
+        ];
       });
       sinon.stub(PolicyRepository.prototype, 'deletePolicy').callsFake(async () => {
         callOrder.push('delete');
       });
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').callsFake(async () => {
-        callOrder.push('refresh');
+      const publishStub = sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').callsFake(async () => {
+        callOrder.push('publish');
+        return { status: 'published', jobId: 'test-job-id' };
       });
 
       await policyService.deletePolicy(policyId);
 
-      // Verify ordering: fetch teams → delete policy → refresh each team
-      expect(callOrder).to.eql(['getTeamIds', 'delete', 'refresh', 'refresh']);
+      // Verify ordering: fetch teams → delete policy → publish per team
+      expect(callOrder).to.eql(['getTeamPolicies', 'delete', 'publish', 'publish']);
+      expect(publishStub.firstCall.args[1]).to.eql({ teamId: '22222222-2222-2222-2222-222222222222' });
+      expect(publishStub.secondCall.args[1]).to.eql({ teamId: '33333333-3333-3333-3333-333333333333' });
     });
 
-    it('does not call refreshCacheForTeam when policy has no teams', async () => {
-      sinon.stub(TeamFeatureService.prototype, 'getTeamIdsForPolicy').resolves([]);
+    it('does not publish cache refresh when policy has no teams', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
       sinon.stub(PolicyRepository.prototype, 'deletePolicy').resolves();
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      const publishStub = sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob');
 
       await policyService.deletePolicy('1');
 
-      expect(refreshStub).to.not.have.been.called;
+      expect(publishStub).to.not.have.been.called;
     });
   });
 
@@ -301,7 +318,8 @@ describe('PolicyService', () => {
       const insertConditionStub = sinon
         .stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition')
         .resolves(mockCondition);
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const result = await policyService.createPolicyWithStatements(
         { name: 'New Policy', description: 'Desc' } as CreatePolicy,
@@ -326,7 +344,8 @@ describe('PolicyService', () => {
     it('should call repository.insertPolicy and return policy with empty statements when none provided', async () => {
       const mockPolicy: Policy = { policy_id: '1', name: 'Empty Policy', description: 'No statements' };
       const insertPolicyStub = sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const result = await policyService.createPolicyWithStatements(
         { name: 'Empty Policy', description: 'No statements' } as CreatePolicy,
@@ -337,15 +356,27 @@ describe('PolicyService', () => {
       expect(result).to.eql({ ...mockPolicy, statements: [] });
     });
 
-    it('refreshes team_feature cache with the correct policy ID', async () => {
+    it('publishes cache refresh for each affected team', async () => {
       const mockPolicy: Policy = { policy_id: '1', name: 'Policy', description: null };
 
       sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        {
+          team_policy_id: 'tp1',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '1',
+          team_name: 'Team A',
+          policy_name: 'Policy'
+        }
+      ]);
+      const publishStub = sinon
+        .stub(publisher, 'publishRefreshTeamFeatureCacheJob')
+        .resolves({ status: 'published', jobId: 'j1' });
 
       await policyService.createPolicyWithStatements({ name: 'Policy' } as CreatePolicy, []);
 
-      expect(refreshStub).to.have.been.calledOnceWith('1');
+      expect(publishStub).to.have.been.calledOnce;
+      expect(publishStub.firstCall.args[1]).to.eql({ teamId: '22222222-2222-2222-2222-222222222222' });
     });
   });
 
@@ -375,7 +406,8 @@ describe('PolicyService', () => {
       const insertStatementStub = sinon
         .stub(PolicyStatementRepository.prototype, 'insertPolicyStatement')
         .resolves(newStatement);
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const result = await policyService.updatePolicyWithStatements(
         '1',
@@ -405,7 +437,8 @@ describe('PolicyService', () => {
         .stub(PolicyStatementRepository.prototype, 'getPolicyStatements')
         .resolves(existingStatements);
       const deleteStub = sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const result = await policyService.updatePolicyWithStatements(
         '1',
@@ -419,16 +452,28 @@ describe('PolicyService', () => {
       expect(result).to.eql({ ...mockPolicy, statements: [] });
     });
 
-    it('refreshes team_feature cache with the correct policy ID', async () => {
+    it('publishes cache refresh for each affected team', async () => {
       const mockPolicy: Policy = { policy_id: '1', name: 'Policy', description: null };
 
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        {
+          team_policy_id: 'tp1',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '1',
+          team_name: 'Team A',
+          policy_name: 'Policy'
+        }
+      ]);
+      const publishStub = sinon
+        .stub(publisher, 'publishRefreshTeamFeatureCacheJob')
+        .resolves({ status: 'published', jobId: 'j1' });
 
       await policyService.updatePolicyWithStatements('1', { name: 'Policy' } as UpdatePolicy, []);
 
-      expect(refreshStub).to.have.been.calledOnceWith('1');
+      expect(publishStub).to.have.been.calledOnce;
+      expect(publishStub.firstCall.args[1]).to.eql({ teamId: '22222222-2222-2222-2222-222222222222' });
     });
   });
 });

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -10,6 +10,7 @@ import { PolicyStatementConditionRepository } from '../../repositories/authoriza
 import { PolicyStatementRepository } from '../../repositories/authorization/policy-statement-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { PolicyService } from './policy-service';
+import { TeamFeatureService } from './team-feature-service';
 
 chai.use(sinonChai);
 
@@ -114,11 +115,45 @@ describe('PolicyService', () => {
 
   describe('deletePolicy', () => {
     it('should call repository.deletePolicy', async () => {
+      sinon.stub(TeamFeatureService.prototype, 'getTeamIdsForPolicy').resolves([]);
       const stub = sinon.stub(PolicyRepository.prototype, 'deletePolicy').resolves();
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
 
       await policyService.deletePolicy('1');
 
       expect(stub).to.have.been.calledWith('1');
+    });
+
+    it('fetches team IDs before delete, then refreshes cache for each team', async () => {
+      const policyId = '11111111-1111-1111-1111-111111111111';
+      const teamIds = ['22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333'];
+      const callOrder: string[] = [];
+
+      sinon.stub(TeamFeatureService.prototype, 'getTeamIdsForPolicy').callsFake(async () => {
+        callOrder.push('getTeamIds');
+        return teamIds;
+      });
+      sinon.stub(PolicyRepository.prototype, 'deletePolicy').callsFake(async () => {
+        callOrder.push('delete');
+      });
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').callsFake(async () => {
+        callOrder.push('refresh');
+      });
+
+      await policyService.deletePolicy(policyId);
+
+      // Verify ordering: fetch teams → delete policy → refresh each team
+      expect(callOrder).to.eql(['getTeamIds', 'delete', 'refresh', 'refresh']);
+    });
+
+    it('does not call refreshCacheForTeam when policy has no teams', async () => {
+      sinon.stub(TeamFeatureService.prototype, 'getTeamIdsForPolicy').resolves([]);
+      sinon.stub(PolicyRepository.prototype, 'deletePolicy').resolves();
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await policyService.deletePolicy('1');
+
+      expect(refreshStub).to.not.have.been.called;
     });
   });
 
@@ -266,6 +301,7 @@ describe('PolicyService', () => {
       const insertConditionStub = sinon
         .stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition')
         .resolves(mockCondition);
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
 
       const result = await policyService.createPolicyWithStatements(
         { name: 'New Policy', description: 'Desc' } as CreatePolicy,
@@ -290,6 +326,7 @@ describe('PolicyService', () => {
     it('should call repository.insertPolicy and return policy with empty statements when none provided', async () => {
       const mockPolicy: Policy = { policy_id: '1', name: 'Empty Policy', description: 'No statements' };
       const insertPolicyStub = sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
 
       const result = await policyService.createPolicyWithStatements(
         { name: 'Empty Policy', description: 'No statements' } as CreatePolicy,
@@ -298,6 +335,17 @@ describe('PolicyService', () => {
 
       expect(insertPolicyStub).to.have.been.calledWith({ name: 'Empty Policy', description: 'No statements' });
       expect(result).to.eql({ ...mockPolicy, statements: [] });
+    });
+
+    it('refreshes team_feature cache with the correct policy ID', async () => {
+      const mockPolicy: Policy = { policy_id: '1', name: 'Policy', description: null };
+
+      sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+
+      await policyService.createPolicyWithStatements({ name: 'Policy' } as CreatePolicy, []);
+
+      expect(refreshStub).to.have.been.calledOnceWith('1');
     });
   });
 
@@ -327,6 +375,7 @@ describe('PolicyService', () => {
       const insertStatementStub = sinon
         .stub(PolicyStatementRepository.prototype, 'insertPolicyStatement')
         .resolves(newStatement);
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
 
       const result = await policyService.updatePolicyWithStatements(
         '1',
@@ -356,6 +405,7 @@ describe('PolicyService', () => {
         .stub(PolicyStatementRepository.prototype, 'getPolicyStatements')
         .resolves(existingStatements);
       const deleteStub = sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
 
       const result = await policyService.updatePolicyWithStatements(
         '1',
@@ -367,6 +417,18 @@ describe('PolicyService', () => {
       expect(getPolicyStatementsStub).to.have.been.calledWith('1');
       expect(deleteStub).to.have.been.calledTwice;
       expect(result).to.eql({ ...mockPolicy, statements: [] });
+    });
+
+    it('refreshes team_feature cache with the correct policy ID', async () => {
+      const mockPolicy: Policy = { policy_id: '1', name: 'Policy', description: null };
+
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForPolicy').resolves();
+
+      await policyService.updatePolicyWithStatements('1', { name: 'Policy' } as UpdatePolicy, []);
+
+      expect(refreshStub).to.have.been.calledOnceWith('1');
     });
   });
 });

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -1,7 +1,9 @@
 import { IDBConnection } from '../../database/db';
 import { parseFeatureUrn } from '../../database/urn-utils';
 import { CreatePolicy, Policy, UpdatePolicy } from '../../models/policy';
+import { publishRefreshTeamFeatureCacheJob } from '../../queue/publisher';
 import { PolicyRepository } from '../../repositories/authorization/policy-repository';
+import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 import {
@@ -12,18 +14,19 @@ import {
 } from './policy-service.interface';
 import { PolicyStatementConditionService } from './policy-statement-condition-service';
 import { PolicyStatementService } from './policy-statement-service';
-import { TeamFeatureService } from './team-feature-service';
 
 export class PolicyService extends DBService {
   policyRepository: PolicyRepository;
   policyStatementService: PolicyStatementService;
   policyStatementConditionService: PolicyStatementConditionService;
+  teamPolicyRepository: TeamPolicyRepository;
 
   constructor(connection: IDBConnection) {
     super(connection);
     this.policyRepository = new PolicyRepository(connection);
     this.policyStatementService = new PolicyStatementService(connection);
     this.policyStatementConditionService = new PolicyStatementConditionService(connection);
+    this.teamPolicyRepository = new TeamPolicyRepository(connection);
   }
 
   /**
@@ -108,16 +111,14 @@ export class PolicyService extends DBService {
    * @memberof PolicyService
    */
   async deletePolicy(policyId: string): Promise<void> {
-    const teamFeatureService = new TeamFeatureService(this.connection);
-
     // Must fetch affected teams BEFORE the soft-delete removes the team_policy association
-    const teamIds = await teamFeatureService.getTeamIdsForPolicy(policyId);
+    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policyId] });
 
     await this.policyRepository.deletePolicy(policyId);
 
-    // Refresh cache for each affected team after the policy is gone
-    for (const teamId of teamIds) {
-      await teamFeatureService.refreshCacheForTeam(teamId);
+    // Queue async cache refresh for each affected team
+    for (const tp of teamPolicies) {
+      await publishRefreshTeamFeatureCacheJob(this.connection, { teamId: tp.team_id });
     }
   }
 
@@ -213,9 +214,11 @@ export class PolicyService extends DBService {
       })
     );
 
-    // Refresh team_feature cache so secured search results reflect the new policy statements
-    const teamFeatureService = new TeamFeatureService(this.connection);
-    await teamFeatureService.refreshCacheForPolicy(policy.policy_id);
+    // Queue async cache refresh for teams affected by the new policy
+    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policy.policy_id] });
+    for (const tp of teamPolicies) {
+      await publishRefreshTeamFeatureCacheJob(this.connection, { teamId: tp.team_id });
+    }
 
     return { ...policy, statements: createdStatements };
   }
@@ -267,9 +270,11 @@ export class PolicyService extends DBService {
       })
     );
 
-    // Refresh team_feature cache so secured search results reflect the updated policy statements
-    const teamFeatureService = new TeamFeatureService(this.connection);
-    await teamFeatureService.refreshCacheForPolicy(policyId);
+    // Queue async cache refresh for teams affected by the updated policy
+    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policyId] });
+    for (const tp of teamPolicies) {
+      await publishRefreshTeamFeatureCacheJob(this.connection, { teamId: tp.team_id });
+    }
 
     return { ...policy, statements: createdStatements };
   }

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -12,6 +12,7 @@ import {
 } from './policy-service.interface';
 import { PolicyStatementConditionService } from './policy-statement-condition-service';
 import { PolicyStatementService } from './policy-statement-service';
+import { TeamFeatureService } from './team-feature-service';
 
 export class PolicyService extends DBService {
   policyRepository: PolicyRepository;
@@ -98,12 +99,26 @@ export class PolicyService extends DBService {
   /**
    * Delete a policy record.
    *
+   * Fetches affected team IDs before soft-deleting, because after the delete
+   * the team_policy JOIN won't find the policy. Then refreshes the team_feature
+   * cache for each affected team so secured search results stay in sync.
+   *
    * @param {string} policyId - The id of the policy to delete
    * @return {Promise<void>}
    * @memberof PolicyService
    */
-  deletePolicy(policyId: string): Promise<void> {
-    return this.policyRepository.deletePolicy(policyId);
+  async deletePolicy(policyId: string): Promise<void> {
+    const teamFeatureService = new TeamFeatureService(this.connection);
+
+    // Must fetch affected teams BEFORE the soft-delete removes the team_policy association
+    const teamIds = await teamFeatureService.getTeamIdsForPolicy(policyId);
+
+    await this.policyRepository.deletePolicy(policyId);
+
+    // Refresh cache for each affected team after the policy is gone
+    for (const teamId of teamIds) {
+      await teamFeatureService.refreshCacheForTeam(teamId);
+    }
   }
 
   /**
@@ -198,6 +213,10 @@ export class PolicyService extends DBService {
       })
     );
 
+    // Refresh team_feature cache so secured search results reflect the new policy statements
+    const teamFeatureService = new TeamFeatureService(this.connection);
+    await teamFeatureService.refreshCacheForPolicy(policy.policy_id);
+
     return { ...policy, statements: createdStatements };
   }
 
@@ -247,6 +266,10 @@ export class PolicyService extends DBService {
         return { ...statement, conditions };
       })
     );
+
+    // Refresh team_feature cache so secured search results reflect the updated policy statements
+    const teamFeatureService = new TeamFeatureService(this.connection);
+    await teamFeatureService.refreshCacheForPolicy(policyId);
 
     return { ...policy, statements: createdStatements };
   }

--- a/api/src/services/access-policy/team-feature-service.test.ts
+++ b/api/src/services/access-policy/team-feature-service.test.ts
@@ -29,12 +29,10 @@ describe('TeamFeatureService', () => {
         .callsFake(async () => {
           callOrder.push('delete');
         });
-      const getIdsStub = sinon
-        .stub(TeamFeatureRepository.prototype, 'getSecuredSubmissionIds')
-        .callsFake(async () => {
-          callOrder.push('getIds');
-          return [1, 2, 3];
-        });
+      const getIdsStub = sinon.stub(TeamFeatureRepository.prototype, 'getSecuredSubmissionIds').callsFake(async () => {
+        callOrder.push('getIds');
+        return [1, 2, 3];
+      });
       const populateStub = sinon
         .stub(TeamFeatureRepository.prototype, 'populateTeamFeatureCacheBatch')
         .callsFake(async () => {

--- a/api/src/services/access-policy/team-feature-service.test.ts
+++ b/api/src/services/access-policy/team-feature-service.test.ts
@@ -3,7 +3,6 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { TeamFeatureRepository } from '../../repositories/authorization/team-feature-repository';
-import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamFeatureService } from './team-feature-service';
 
@@ -41,74 +40,6 @@ describe('TeamFeatureService', () => {
       expect(deleteStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
       expect(populateStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
       expect(callOrder).to.eql(['delete', 'populate']);
-    });
-  });
-
-  describe('refreshCacheForPolicy', () => {
-    it('refreshes cache for each team that has the policy', async () => {
-      const mockTeamPolicies = [
-        {
-          team_policy_id: '11111111-1111-1111-1111-111111111111',
-          team_id: '22222222-2222-2222-2222-222222222222',
-          policy_id: '33333333-3333-3333-3333-333333333333',
-          team_name: 'Team A',
-          policy_name: 'Policy A'
-        },
-        {
-          team_policy_id: '44444444-4444-4444-4444-444444444444',
-          team_id: '55555555-5555-5555-5555-555555555555',
-          policy_id: '33333333-3333-3333-3333-333333333333',
-          team_name: 'Team B',
-          policy_name: 'Policy A'
-        }
-      ];
-
-      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(mockTeamPolicies);
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
-
-      await service.refreshCacheForPolicy('33333333-3333-3333-3333-333333333333');
-
-      expect(refreshStub).to.have.been.calledTwice;
-      expect(refreshStub.firstCall).to.have.been.calledWith('22222222-2222-2222-2222-222222222222');
-      expect(refreshStub.secondCall).to.have.been.calledWith('55555555-5555-5555-5555-555555555555');
-    });
-
-    it('does not call refreshCacheForTeam when no teams have the policy', async () => {
-      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
-
-      await service.refreshCacheForPolicy('33333333-3333-3333-3333-333333333333');
-
-      expect(refreshStub).to.not.have.been.called;
-    });
-  });
-
-  describe('getTeamIdsForPolicy', () => {
-    it('returns team ids for the given policy', async () => {
-      const mockTeamPolicies = [
-        {
-          team_policy_id: '11111111-1111-1111-1111-111111111111',
-          team_id: '22222222-2222-2222-2222-222222222222',
-          policy_id: '33333333-3333-3333-3333-333333333333',
-          team_name: 'Team A',
-          policy_name: 'Policy A'
-        }
-      ];
-
-      const stub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(mockTeamPolicies);
-
-      const result = await service.getTeamIdsForPolicy('33333333-3333-3333-3333-333333333333');
-
-      expect(stub).to.have.been.calledOnceWith({ policyIds: ['33333333-3333-3333-3333-333333333333'] });
-      expect(result).to.eql(['22222222-2222-2222-2222-222222222222']);
-    });
-
-    it('returns empty array when no teams have the policy', async () => {
-      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
-
-      const result = await service.getTeamIdsForPolicy('33333333-3333-3333-3333-333333333333');
-
-      expect(result).to.eql([]);
     });
   });
 });

--- a/api/src/services/access-policy/team-feature-service.test.ts
+++ b/api/src/services/access-policy/team-feature-service.test.ts
@@ -21,7 +21,7 @@ describe('TeamFeatureService', () => {
   });
 
   describe('refreshCacheForTeam', () => {
-    it('calls delete then populate in order', async () => {
+    it('calls delete, gets submission ids, then populates in batches', async () => {
       const callOrder: string[] = [];
 
       const deleteStub = sinon
@@ -29,8 +29,14 @@ describe('TeamFeatureService', () => {
         .callsFake(async () => {
           callOrder.push('delete');
         });
+      const getIdsStub = sinon
+        .stub(TeamFeatureRepository.prototype, 'getSecuredSubmissionIds')
+        .callsFake(async () => {
+          callOrder.push('getIds');
+          return [1, 2, 3];
+        });
       const populateStub = sinon
-        .stub(TeamFeatureRepository.prototype, 'populateTeamFeatureCache')
+        .stub(TeamFeatureRepository.prototype, 'populateTeamFeatureCacheBatch')
         .callsFake(async () => {
           callOrder.push('populate');
         });
@@ -38,8 +44,9 @@ describe('TeamFeatureService', () => {
       await service.refreshCacheForTeam('22222222-2222-2222-2222-222222222222');
 
       expect(deleteStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
-      expect(populateStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
-      expect(callOrder).to.eql(['delete', 'populate']);
+      expect(getIdsStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(populateStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222', [1, 2, 3]);
+      expect(callOrder).to.eql(['delete', 'getIds', 'populate']);
     });
   });
 });

--- a/api/src/services/access-policy/team-feature-service.test.ts
+++ b/api/src/services/access-policy/team-feature-service.test.ts
@@ -1,0 +1,114 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { TeamFeatureRepository } from '../../repositories/authorization/team-feature-repository';
+import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
+import { getMockDBConnection } from '../../__mocks__/db';
+import { TeamFeatureService } from './team-feature-service';
+
+chai.use(sinonChai);
+
+describe('TeamFeatureService', () => {
+  let service: TeamFeatureService;
+
+  beforeEach(() => {
+    const mockDBConnection = getMockDBConnection();
+    service = new TeamFeatureService(mockDBConnection);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('refreshCacheForTeam', () => {
+    it('calls delete then populate in order', async () => {
+      const callOrder: string[] = [];
+
+      const deleteStub = sinon
+        .stub(TeamFeatureRepository.prototype, 'deleteTeamFeaturesByTeamId')
+        .callsFake(async () => {
+          callOrder.push('delete');
+        });
+      const populateStub = sinon
+        .stub(TeamFeatureRepository.prototype, 'populateTeamFeatureCache')
+        .callsFake(async () => {
+          callOrder.push('populate');
+        });
+
+      await service.refreshCacheForTeam('22222222-2222-2222-2222-222222222222');
+
+      expect(deleteStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(populateStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(callOrder).to.eql(['delete', 'populate']);
+    });
+  });
+
+  describe('refreshCacheForPolicy', () => {
+    it('refreshes cache for each team that has the policy', async () => {
+      const mockTeamPolicies = [
+        {
+          team_policy_id: '11111111-1111-1111-1111-111111111111',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '33333333-3333-3333-3333-333333333333',
+          team_name: 'Team A',
+          policy_name: 'Policy A'
+        },
+        {
+          team_policy_id: '44444444-4444-4444-4444-444444444444',
+          team_id: '55555555-5555-5555-5555-555555555555',
+          policy_id: '33333333-3333-3333-3333-333333333333',
+          team_name: 'Team B',
+          policy_name: 'Policy A'
+        }
+      ];
+
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(mockTeamPolicies);
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await service.refreshCacheForPolicy('33333333-3333-3333-3333-333333333333');
+
+      expect(refreshStub).to.have.been.calledTwice;
+      expect(refreshStub.firstCall).to.have.been.calledWith('22222222-2222-2222-2222-222222222222');
+      expect(refreshStub.secondCall).to.have.been.calledWith('55555555-5555-5555-5555-555555555555');
+    });
+
+    it('does not call refreshCacheForTeam when no teams have the policy', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await service.refreshCacheForPolicy('33333333-3333-3333-3333-333333333333');
+
+      expect(refreshStub).to.not.have.been.called;
+    });
+  });
+
+  describe('getTeamIdsForPolicy', () => {
+    it('returns team ids for the given policy', async () => {
+      const mockTeamPolicies = [
+        {
+          team_policy_id: '11111111-1111-1111-1111-111111111111',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '33333333-3333-3333-3333-333333333333',
+          team_name: 'Team A',
+          policy_name: 'Policy A'
+        }
+      ];
+
+      const stub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(mockTeamPolicies);
+
+      const result = await service.getTeamIdsForPolicy('33333333-3333-3333-3333-333333333333');
+
+      expect(stub).to.have.been.calledOnceWith({ policyIds: ['33333333-3333-3333-3333-333333333333'] });
+      expect(result).to.eql(['22222222-2222-2222-2222-222222222222']);
+    });
+
+    it('returns empty array when no teams have the policy', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+
+      const result = await service.getTeamIdsForPolicy('33333333-3333-3333-3333-333333333333');
+
+      expect(result).to.eql([]);
+    });
+  });
+});

--- a/api/src/services/access-policy/team-feature-service.ts
+++ b/api/src/services/access-policy/team-feature-service.ts
@@ -2,6 +2,8 @@ import { IDBConnection } from '../../database/db';
 import { TeamFeatureRepository } from '../../repositories/authorization/team-feature-repository';
 import { DBService } from '../db-service';
 
+const SUBMISSION_BATCH_SIZE = 1000;
+
 /**
  * Service for managing the team_feature cache.
  *
@@ -30,9 +32,9 @@ export class TeamFeatureService extends DBService {
   /**
    * Refresh the team_feature cache for a specific team.
    *
-   * Deletes existing cache entries and repopulates from current policy
-   * statements. Cache resolves URN wildcards to concrete submission_feature_ids
-   * for fast search JOINs instead of per-row URN matching.
+   * Deletes existing cache entries, then repopulates in batches by submission.
+   * Each batch runs its own recursive walk scoped to a subset of submissions,
+   * bounding memory usage instead of materializing all secured features at once.
    *
    * @param {string} teamId - The team UUID to refresh cache for.
    * @return {Promise<void>}
@@ -40,6 +42,12 @@ export class TeamFeatureService extends DBService {
    */
   async refreshCacheForTeam(teamId: string): Promise<void> {
     await this.teamFeatureRepository.deleteTeamFeaturesByTeamId(teamId);
-    await this.teamFeatureRepository.populateTeamFeatureCache(teamId);
+
+    const submissionIds = await this.teamFeatureRepository.getSecuredSubmissionIds(teamId);
+
+    for (let i = 0; i < submissionIds.length; i += SUBMISSION_BATCH_SIZE) {
+      const batch = submissionIds.slice(i, i + SUBMISSION_BATCH_SIZE);
+      await this.teamFeatureRepository.populateTeamFeatureCacheBatch(teamId, batch);
+    }
   }
 }

--- a/api/src/services/access-policy/team-feature-service.ts
+++ b/api/src/services/access-policy/team-feature-service.ts
@@ -1,0 +1,74 @@
+import { IDBConnection } from '../../database/db';
+import { TeamFeatureRepository } from '../../repositories/authorization/team-feature-repository';
+import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
+import { DBService } from '../db-service';
+
+/**
+ * Service for managing the team_feature cache.
+ *
+ * team_feature is a materialized cache that maps teams to the secured
+ * submission features they can access. It can always be fully rebuilt from
+ * team_policy → policy_statement → submission_feature URN matching.
+ * The delete-and-reinsert pattern ensures consistency.
+ *
+ * @export
+ * @class TeamFeatureService
+ * @extends {DBService}
+ */
+export class TeamFeatureService extends DBService {
+  teamFeatureRepository: TeamFeatureRepository;
+  teamPolicyRepository: TeamPolicyRepository;
+
+  constructor(connection: IDBConnection) {
+    super(connection);
+    this.teamFeatureRepository = new TeamFeatureRepository(connection);
+    this.teamPolicyRepository = new TeamPolicyRepository(connection);
+  }
+
+  /**
+   * Refresh the team_feature cache for a specific team.
+   *
+   * Deletes existing cache entries and repopulates from current policy
+   * statements. Cache resolves URN wildcards to concrete submission_feature_ids
+   * for fast search JOINs instead of per-row URN matching.
+   *
+   * @param {string} teamId - The team UUID to refresh cache for.
+   * @return {Promise<void>}
+   * @memberof TeamFeatureService
+   */
+  async refreshCacheForTeam(teamId: string): Promise<void> {
+    await this.teamFeatureRepository.deleteTeamFeaturesByTeamId(teamId);
+    await this.teamFeatureRepository.populateTeamFeatureCache(teamId);
+  }
+
+  /**
+   * Refresh the team_feature cache for all teams that have a specific policy.
+   * Called after policy create/update/delete to keep cache in sync with
+   * policy changes.
+   *
+   * @param {string} policyId - The policy UUID whose teams need cache refresh.
+   * @return {Promise<void>}
+   * @memberof TeamFeatureService
+   */
+  async refreshCacheForPolicy(policyId: string): Promise<void> {
+    const teamIds = await this.getTeamIdsForPolicy(policyId);
+
+    for (const teamId of teamIds) {
+      await this.refreshCacheForTeam(teamId);
+    }
+  }
+
+  /**
+   * Get all team_ids that have a specific policy assigned (via team_policy).
+   * Used to determine which teams need cache refresh after a policy mutation.
+   *
+   * @param {string} policyId - The policy UUID to look up.
+   * @return {Promise<string[]>} - Array of team UUIDs.
+   * @memberof TeamFeatureService
+   */
+  async getTeamIdsForPolicy(policyId: string): Promise<string[]> {
+    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policyId] });
+
+    return teamPolicies.map((tp) => tp.team_id);
+  }
+}

--- a/api/src/services/access-policy/team-feature-service.ts
+++ b/api/src/services/access-policy/team-feature-service.ts
@@ -1,6 +1,5 @@
 import { IDBConnection } from '../../database/db';
 import { TeamFeatureRepository } from '../../repositories/authorization/team-feature-repository';
-import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { DBService } from '../db-service';
 
 /**
@@ -11,18 +10,21 @@ import { DBService } from '../db-service';
  * team_policy → policy_statement → submission_feature URN matching.
  * The delete-and-reinsert pattern ensures consistency.
  *
+ * Callers should not invoke this service directly from HTTP request handlers.
+ * Policy/team-policy mutations publish a queue job instead, so the potentially
+ * large cache rebuild runs outside the request path. The job handler calls
+ * refreshCacheForTeam via this service.
+ *
  * @export
  * @class TeamFeatureService
  * @extends {DBService}
  */
 export class TeamFeatureService extends DBService {
   teamFeatureRepository: TeamFeatureRepository;
-  teamPolicyRepository: TeamPolicyRepository;
 
   constructor(connection: IDBConnection) {
     super(connection);
     this.teamFeatureRepository = new TeamFeatureRepository(connection);
-    this.teamPolicyRepository = new TeamPolicyRepository(connection);
   }
 
   /**
@@ -39,36 +41,5 @@ export class TeamFeatureService extends DBService {
   async refreshCacheForTeam(teamId: string): Promise<void> {
     await this.teamFeatureRepository.deleteTeamFeaturesByTeamId(teamId);
     await this.teamFeatureRepository.populateTeamFeatureCache(teamId);
-  }
-
-  /**
-   * Refresh the team_feature cache for all teams that have a specific policy.
-   * Called after policy create/update/delete to keep cache in sync with
-   * policy changes.
-   *
-   * @param {string} policyId - The policy UUID whose teams need cache refresh.
-   * @return {Promise<void>}
-   * @memberof TeamFeatureService
-   */
-  async refreshCacheForPolicy(policyId: string): Promise<void> {
-    const teamIds = await this.getTeamIdsForPolicy(policyId);
-
-    for (const teamId of teamIds) {
-      await this.refreshCacheForTeam(teamId);
-    }
-  }
-
-  /**
-   * Get all team_ids that have a specific policy assigned (via team_policy).
-   * Used to determine which teams need cache refresh after a policy mutation.
-   *
-   * @param {string} policyId - The policy UUID to look up.
-   * @return {Promise<string[]>} - Array of team UUIDs.
-   * @memberof TeamFeatureService
-   */
-  async getTeamIdsForPolicy(policyId: string): Promise<string[]> {
-    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policyId] });
-
-    return teamPolicies.map((tp) => tp.team_id);
   }
 }

--- a/api/src/services/access-policy/team-policy-service.test.ts
+++ b/api/src/services/access-policy/team-policy-service.test.ts
@@ -3,9 +3,9 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
+import * as publisher from '../../queue/publisher';
 import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
-import { TeamFeatureService } from './team-feature-service';
 import { TeamPolicyService } from './team-policy-service';
 
 chai.use(sinonChai);
@@ -33,7 +33,7 @@ describe('TeamPolicyService', () => {
 
       const getExistingStub = sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
       const stub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves(mockTeamPolicy);
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -62,7 +62,7 @@ describe('TeamPolicyService', () => {
         .stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId')
         .resolves([existingTeamPolicy]);
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy');
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -82,7 +82,7 @@ describe('TeamPolicyService', () => {
       });
     });
 
-    it('refreshes team_feature cache after new insert', async () => {
+    it('publishes cache refresh after new insert', async () => {
       const mockTeamPolicy: TeamPolicy = {
         team_policy_id: '11111111-1111-1111-1111-111111111111',
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -91,17 +91,20 @@ describe('TeamPolicyService', () => {
 
       sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
       sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves(mockTeamPolicy);
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      const publishStub = sinon
+        .stub(publisher, 'publishRefreshTeamFeatureCacheJob')
+        .resolves({ status: 'published', jobId: 'j1' });
 
       await service.createTeamPolicy({
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '33333333-3333-3333-3333-333333333333'
       });
 
-      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(publishStub).to.have.been.calledOnce;
+      expect(publishStub.firstCall.args[1]).to.eql({ teamId: '22222222-2222-2222-2222-222222222222' });
     });
 
-    it('refreshes team_feature cache even on idempotent return', async () => {
+    it('publishes cache refresh even on idempotent return', async () => {
       const existingTeamPolicy: TeamPolicyDetails = {
         team_policy_id: '11111111-1111-1111-1111-111111111111',
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -111,14 +114,17 @@ describe('TeamPolicyService', () => {
       };
 
       sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([existingTeamPolicy]);
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      const publishStub = sinon
+        .stub(publisher, 'publishRefreshTeamFeatureCacheJob')
+        .resolves({ status: 'published', jobId: 'j1' });
 
       await service.createTeamPolicy({
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '33333333-3333-3333-3333-333333333333'
       });
 
-      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(publishStub).to.have.been.calledOnce;
+      expect(publishStub.firstCall.args[1]).to.eql({ teamId: '22222222-2222-2222-2222-222222222222' });
     });
   });
 
@@ -154,7 +160,7 @@ describe('TeamPolicyService', () => {
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -204,7 +210,7 @@ describe('TeamPolicyService', () => {
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -228,28 +234,33 @@ describe('TeamPolicyService', () => {
       ]);
     });
 
-    it('refreshes team_feature cache with the correct team ID', async () => {
+    it('publishes cache refresh with the correct team ID', async () => {
       sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
       sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves({
         team_policy_id: '11111111-1111-1111-1111-111111111111',
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '33333333-3333-3333-3333-333333333333'
       });
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      const publishStub = sinon
+        .stub(publisher, 'publishRefreshTeamFeatureCacheJob')
+        .resolves({ status: 'published', jobId: 'j1' });
 
       await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333'
       ]);
 
-      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(publishStub).to.have.been.calledOnce;
+      expect(publishStub.firstCall.args[1]).to.eql({ teamId: '22222222-2222-2222-2222-222222222222' });
     });
 
     it('skips cache refresh when policyIds array is empty', async () => {
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      const publishStub = sinon
+        .stub(publisher, 'publishRefreshTeamFeatureCacheJob')
+        .resolves({ status: 'published', jobId: 'j1' });
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', []);
 
-      expect(refreshStub).to.not.have.been.called;
+      expect(publishStub).to.not.have.been.called;
       expect(result).to.eql([]);
     });
   });
@@ -345,14 +356,14 @@ describe('TeamPolicyService', () => {
         policy_id: '33333333-3333-3333-3333-333333333333'
       });
       const stub = sinon.stub(TeamPolicyRepository.prototype, 'deleteTeamPolicy').resolves();
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').resolves({ status: 'published', jobId: 'j1' });
 
       await service.deleteTeamPolicy('11111111-1111-1111-1111-111111111111');
 
       expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
     });
 
-    it('fetches team_id before delete, then refreshes cache for that team', async () => {
+    it('fetches team_id before delete, then publishes cache refresh', async () => {
       const callOrder: string[] = [];
 
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicy').callsFake(async () => {
@@ -366,28 +377,32 @@ describe('TeamPolicyService', () => {
       sinon.stub(TeamPolicyRepository.prototype, 'deleteTeamPolicy').callsFake(async () => {
         callOrder.push('delete');
       });
-      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').callsFake(async () => {
-        callOrder.push('refresh');
+      sinon.stub(publisher, 'publishRefreshTeamFeatureCacheJob').callsFake(async () => {
+        callOrder.push('publish');
+        return { status: 'published', jobId: 'j1' };
       });
 
       await service.deleteTeamPolicy('11111111-1111-1111-1111-111111111111');
 
-      // Verify ordering: fetch team_id → delete → refresh cache
-      expect(callOrder).to.eql(['getTeamPolicy', 'delete', 'refresh']);
+      // Verify ordering: fetch team_id → delete → publish cache refresh
+      expect(callOrder).to.eql(['getTeamPolicy', 'delete', 'publish']);
     });
 
-    it('refreshes cache for the correct team', async () => {
+    it('publishes cache refresh for the correct team', async () => {
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicy').resolves({
         team_policy_id: '11111111-1111-1111-1111-111111111111',
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '33333333-3333-3333-3333-333333333333'
       });
       sinon.stub(TeamPolicyRepository.prototype, 'deleteTeamPolicy').resolves();
-      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+      const publishStub = sinon
+        .stub(publisher, 'publishRefreshTeamFeatureCacheJob')
+        .resolves({ status: 'published', jobId: 'j1' });
 
       await service.deleteTeamPolicy('11111111-1111-1111-1111-111111111111');
 
-      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+      expect(publishStub).to.have.been.calledOnce;
+      expect(publishStub.firstCall.args[1]).to.eql({ teamId: '22222222-2222-2222-2222-222222222222' });
     });
   });
 });

--- a/api/src/services/access-policy/team-policy-service.test.ts
+++ b/api/src/services/access-policy/team-policy-service.test.ts
@@ -5,6 +5,7 @@ import sinonChai from 'sinon-chai';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
 import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
+import { TeamFeatureService } from './team-feature-service';
 import { TeamPolicyService } from './team-policy-service';
 
 chai.use(sinonChai);
@@ -32,6 +33,7 @@ describe('TeamPolicyService', () => {
 
       const getExistingStub = sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
       const stub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves(mockTeamPolicy);
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -60,6 +62,7 @@ describe('TeamPolicyService', () => {
         .stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId')
         .resolves([existingTeamPolicy]);
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy');
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -77,6 +80,45 @@ describe('TeamPolicyService', () => {
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '33333333-3333-3333-3333-333333333333'
       });
+    });
+
+    it('refreshes team_feature cache after new insert', async () => {
+      const mockTeamPolicy: TeamPolicy = {
+        team_policy_id: '11111111-1111-1111-1111-111111111111',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      };
+
+      sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves(mockTeamPolicy);
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await service.createTeamPolicy({
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
+
+      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+    });
+
+    it('refreshes team_feature cache even on idempotent return', async () => {
+      const existingTeamPolicy: TeamPolicyDetails = {
+        team_policy_id: '11111111-1111-1111-1111-111111111111',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333',
+        team_name: 'Team A',
+        policy_name: 'Policy A'
+      };
+
+      sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([existingTeamPolicy]);
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await service.createTeamPolicy({
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
+
+      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
     });
   });
 
@@ -112,6 +154,7 @@ describe('TeamPolicyService', () => {
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -161,6 +204,7 @@ describe('TeamPolicyService', () => {
         team_id: '22222222-2222-2222-2222-222222222222',
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -182,6 +226,31 @@ describe('TeamPolicyService', () => {
           policy_id: '55555555-5555-5555-5555-555555555555'
         }
       ]);
+    });
+
+    it('refreshes team_feature cache with the correct team ID', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves({
+        team_policy_id: '11111111-1111-1111-1111-111111111111',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
+        '33333333-3333-3333-3333-333333333333'
+      ]);
+
+      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
+    });
+
+    it('skips cache refresh when policyIds array is empty', async () => {
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', []);
+
+      expect(refreshStub).to.not.have.been.called;
+      expect(result).to.eql([]);
     });
   });
 
@@ -270,11 +339,55 @@ describe('TeamPolicyService', () => {
 
   describe('deleteTeamPolicy', () => {
     it('should call repository.deleteTeamPolicy', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicy').resolves({
+        team_policy_id: '11111111-1111-1111-1111-111111111111',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
       const stub = sinon.stub(TeamPolicyRepository.prototype, 'deleteTeamPolicy').resolves();
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
 
       await service.deleteTeamPolicy('11111111-1111-1111-1111-111111111111');
 
       expect(stub).to.have.been.calledWith('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('fetches team_id before delete, then refreshes cache for that team', async () => {
+      const callOrder: string[] = [];
+
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicy').callsFake(async () => {
+        callOrder.push('getTeamPolicy');
+        return {
+          team_policy_id: '11111111-1111-1111-1111-111111111111',
+          team_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '33333333-3333-3333-3333-333333333333'
+        };
+      });
+      sinon.stub(TeamPolicyRepository.prototype, 'deleteTeamPolicy').callsFake(async () => {
+        callOrder.push('delete');
+      });
+      sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').callsFake(async () => {
+        callOrder.push('refresh');
+      });
+
+      await service.deleteTeamPolicy('11111111-1111-1111-1111-111111111111');
+
+      // Verify ordering: fetch team_id → delete → refresh cache
+      expect(callOrder).to.eql(['getTeamPolicy', 'delete', 'refresh']);
+    });
+
+    it('refreshes cache for the correct team', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicy').resolves({
+        team_policy_id: '11111111-1111-1111-1111-111111111111',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
+      sinon.stub(TeamPolicyRepository.prototype, 'deleteTeamPolicy').resolves();
+      const refreshStub = sinon.stub(TeamFeatureService.prototype, 'refreshCacheForTeam').resolves();
+
+      await service.deleteTeamPolicy('11111111-1111-1111-1111-111111111111');
+
+      expect(refreshStub).to.have.been.calledOnceWith('22222222-2222-2222-2222-222222222222');
     });
   });
 });

--- a/api/src/services/access-policy/team-policy-service.ts
+++ b/api/src/services/access-policy/team-policy-service.ts
@@ -3,6 +3,7 @@ import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } fro
 import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
+import { TeamFeatureService } from './team-feature-service';
 import { TeamPolicyFilters } from './team-policy-service.interface';
 
 export class TeamPolicyService extends DBService {
@@ -27,6 +28,11 @@ export class TeamPolicyService extends DBService {
 
     if (existingPolicies.length > 0) {
       const existingPolicy = existingPolicies[0];
+
+      // Refresh cache even on idempotent return — the cache may be stale
+      const teamFeatureService = new TeamFeatureService(this.connection);
+      await teamFeatureService.refreshCacheForTeam(teamPolicyData.team_id);
+
       return {
         team_policy_id: existingPolicy.team_policy_id,
         team_id: existingPolicy.team_id,
@@ -34,7 +40,13 @@ export class TeamPolicyService extends DBService {
       };
     }
 
-    return this.teamPolicyRepository.insertTeamPolicy(teamPolicyData);
+    const result = await this.teamPolicyRepository.insertTeamPolicy(teamPolicyData);
+
+    // Refresh team_feature cache so secured search results reflect the new team-policy association
+    const teamFeatureService = new TeamFeatureService(this.connection);
+    await teamFeatureService.refreshCacheForTeam(teamPolicyData.team_id);
+
+    return result;
   }
 
   /**
@@ -59,11 +71,17 @@ export class TeamPolicyService extends DBService {
 
     const policyIdsToCreate = uniquePolicyIds.filter((policyId) => !existingPolicyIds.has(policyId));
 
-    return Promise.all(
+    const result = await Promise.all(
       policyIdsToCreate.map((policyId) =>
         this.teamPolicyRepository.insertTeamPolicy({ team_id: teamId, policy_id: policyId })
       )
     );
+
+    // Refresh team_feature cache so secured search results reflect the new team-policy associations
+    const teamFeatureService = new TeamFeatureService(this.connection);
+    await teamFeatureService.refreshCacheForTeam(teamId);
+
+    return result;
   }
 
   /**
@@ -130,11 +148,21 @@ export class TeamPolicyService extends DBService {
   /**
    * Delete a team policy record.
    *
+   * Fetches the team_id before deleting so the team_feature cache can be
+   * refreshed afterward — ensuring secured search results stay in sync
+   * when a policy is removed from a team.
+   *
    * @param {string} teamPolicyId - The id of the team policy to delete
    * @return {Promise<void>}
    * @memberof TeamPolicyService
    */
   async deleteTeamPolicy(teamPolicyId: string): Promise<void> {
+    // Fetch team_id before the soft-delete so we know which team's cache to refresh
+    const teamPolicy = await this.teamPolicyRepository.getTeamPolicy(teamPolicyId);
+
     await this.teamPolicyRepository.deleteTeamPolicy(teamPolicyId);
+
+    const teamFeatureService = new TeamFeatureService(this.connection);
+    await teamFeatureService.refreshCacheForTeam(teamPolicy.team_id);
   }
 }

--- a/api/src/services/access-policy/team-policy-service.ts
+++ b/api/src/services/access-policy/team-policy-service.ts
@@ -1,9 +1,9 @@
 import { IDBConnection } from '../../database/db';
 import { CreateTeamPolicy, TeamPolicy, TeamPolicyDetails, UpdateTeamPolicy } from '../../models/team-policy';
+import { publishRefreshTeamFeatureCacheJob } from '../../queue/publisher';
 import { TeamPolicyRepository } from '../../repositories/authorization/team-policy-repository';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
-import { TeamFeatureService } from './team-feature-service';
 import { TeamPolicyFilters } from './team-policy-service.interface';
 
 export class TeamPolicyService extends DBService {
@@ -29,9 +29,8 @@ export class TeamPolicyService extends DBService {
     if (existingPolicies.length > 0) {
       const existingPolicy = existingPolicies[0];
 
-      // Refresh cache even on idempotent return — the cache may be stale
-      const teamFeatureService = new TeamFeatureService(this.connection);
-      await teamFeatureService.refreshCacheForTeam(teamPolicyData.team_id);
+      // Queue cache refresh even on idempotent return — the cache may be stale
+      await publishRefreshTeamFeatureCacheJob(this.connection, { teamId: teamPolicyData.team_id });
 
       return {
         team_policy_id: existingPolicy.team_policy_id,
@@ -42,9 +41,8 @@ export class TeamPolicyService extends DBService {
 
     const result = await this.teamPolicyRepository.insertTeamPolicy(teamPolicyData);
 
-    // Refresh team_feature cache so secured search results reflect the new team-policy association
-    const teamFeatureService = new TeamFeatureService(this.connection);
-    await teamFeatureService.refreshCacheForTeam(teamPolicyData.team_id);
+    // Queue async cache refresh so secured search results reflect the new team-policy association
+    await publishRefreshTeamFeatureCacheJob(this.connection, { teamId: teamPolicyData.team_id });
 
     return result;
   }
@@ -77,9 +75,8 @@ export class TeamPolicyService extends DBService {
       )
     );
 
-    // Refresh team_feature cache so secured search results reflect the new team-policy associations
-    const teamFeatureService = new TeamFeatureService(this.connection);
-    await teamFeatureService.refreshCacheForTeam(teamId);
+    // Queue async cache refresh so secured search results reflect the new team-policy associations
+    await publishRefreshTeamFeatureCacheJob(this.connection, { teamId });
 
     return result;
   }
@@ -162,7 +159,7 @@ export class TeamPolicyService extends DBService {
 
     await this.teamPolicyRepository.deleteTeamPolicy(teamPolicyId);
 
-    const teamFeatureService = new TeamFeatureService(this.connection);
-    await teamFeatureService.refreshCacheForTeam(teamPolicy.team_id);
+    // Queue async cache refresh so secured search results reflect the removed team-policy association
+    await publishRefreshTeamFeatureCacheJob(this.connection, { teamId: teamPolicy.team_id });
   }
 }

--- a/api/src/services/search-feature-service.test.ts
+++ b/api/src/services/search-feature-service.test.ts
@@ -620,7 +620,29 @@ describe('SearchFeatureService', () => {
 
       await searchFeatureService.searchFeatures({ keyword: 'data' }, { page: 1, limit: 10 });
 
-      expect(searchStub).to.be.calledOnceWith({ keyword: 'data' }, { page: 1, limit: 10 });
+      expect(searchStub).to.be.calledOnceWith({ keyword: 'data' }, { page: 1, limit: 10 }, undefined);
+    });
+
+    it('should forward systemUserId to repository when provided', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchFeatureService = new SearchFeatureService(mockDBConnection);
+
+      const searchStub = sinon.stub(SearchFeatureRepository.prototype, 'searchFeaturesByFilters').resolves([]);
+
+      await searchFeatureService.searchFeatures({ keyword: 'moose' }, undefined, 42);
+
+      expect(searchStub).to.be.calledOnceWith({ keyword: 'moose' }, undefined, 42);
+    });
+
+    it('should forward null systemUserId to repository for anonymous searches', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchFeatureService = new SearchFeatureService(mockDBConnection);
+
+      const searchStub = sinon.stub(SearchFeatureRepository.prototype, 'searchFeaturesByFilters').resolves([]);
+
+      await searchFeatureService.searchFeatures({ keyword: 'moose' }, undefined, null);
+
+      expect(searchStub).to.be.calledOnceWith({ keyword: 'moose' }, undefined, null);
     });
 
     it('should return empty array for no matches', async () => {
@@ -700,6 +722,28 @@ describe('SearchFeatureService', () => {
       const result = await searchFeatureService.getSearchFeaturesCount({ keyword: 'nonexistent' });
 
       expect(result).to.equal(0);
+    });
+
+    it('should forward systemUserId to repository when provided', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchFeatureService = new SearchFeatureService(mockDBConnection);
+
+      const countStub = sinon.stub(SearchFeatureRepository.prototype, 'searchFeaturesByFiltersCount').resolves(5);
+
+      await searchFeatureService.getSearchFeaturesCount({ keyword: 'moose' }, 42);
+
+      expect(countStub).to.be.calledOnceWith({ keyword: 'moose' }, 42);
+    });
+
+    it('should forward null systemUserId to repository for anonymous searches', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const searchFeatureService = new SearchFeatureService(mockDBConnection);
+
+      const countStub = sinon.stub(SearchFeatureRepository.prototype, 'searchFeaturesByFiltersCount').resolves(3);
+
+      await searchFeatureService.getSearchFeaturesCount({ keyword: 'moose' }, null);
+
+      expect(countStub).to.be.calledOnceWith({ keyword: 'moose' }, null);
     });
   });
 });

--- a/api/src/services/search-feature-service.ts
+++ b/api/src/services/search-feature-service.ts
@@ -39,16 +39,23 @@ export class SearchFeatureService extends DBService {
    * Accepts multiple filter types (keywords, property filters, ITIS TSNs, property types)
    * and returns results matching all criteria with aggregated relevancy scores.
    *
+   * When systemUserId is provided, secured features are filtered by team_feature access:
+   * - null (anonymous): only unsecured features returned
+   * - number (authenticated): unsecured + team-authorized secured features returned
+   * - undefined (not passed): no security filtering (backward-compatible for internal callers)
+   *
    * @param {ISearchFeaturesFilters} filters - Search filter criteria
    * @param {ApiPaginationOptions} [pagination] - Optional pagination settings
+   * @param {number | null} [systemUserId] - Authenticated user's ID, null for anonymous, undefined to skip filtering
    * @return {Promise<SearchFeatureResultWithRelevancy[]>} Array of features sorted by relevancy
    */
   async searchFeatures(
     filters: ISearchFeaturesFilters,
-    pagination?: ApiPaginationOptions
+    pagination?: ApiPaginationOptions,
+    systemUserId?: number | null
   ): Promise<SearchFeatureResultWithRelevancy[]> {
     defaultLog.debug({ label: 'searchFeatures', filters, pagination });
-    return this.searchFeatureRepository.searchFeaturesByFilters(filters, pagination);
+    return this.searchFeatureRepository.searchFeaturesByFilters(filters, pagination, systemUserId);
   }
 
   /**
@@ -56,12 +63,16 @@ export class SearchFeatureService extends DBService {
    * Accepts multiple filter types (keywords, property filters, ITIS TSNs, property types)
    * and returns the count of results matching all criteria.
    *
+   * Security filtering follows the same rules as searchFeatures — count must match the
+   * filtered result set so pagination numbers are accurate.
+   *
    * @param {ISearchFeaturesFilters} filters - Search filter criteria
+   * @param {number | null} [systemUserId] - Authenticated user's ID, null for anonymous, undefined to skip filtering
    * @return {Promise<number>} Total count of matching features
    */
-  async getSearchFeaturesCount(filters: ISearchFeaturesFilters): Promise<number> {
+  async getSearchFeaturesCount(filters: ISearchFeaturesFilters, systemUserId?: number | null): Promise<number> {
     defaultLog.debug({ label: 'getSearchFeaturesCount', filters });
-    return this.searchFeatureRepository.searchFeaturesByFiltersCount(filters);
+    return this.searchFeatureRepository.searchFeaturesByFiltersCount(filters, systemUserId);
   }
 
   /**

--- a/database/src/migrations/20260310165917_team_feature_cache.ts
+++ b/database/src/migrations/20260310165917_team_feature_cache.ts
@@ -1,19 +1,11 @@
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 
-/**
- * Migration to create the team_feature cache table.
- *
- * team_feature is a materialized cache that maps team_id to submission_feature_id
- * by resolving URN wildcards from policy_statement. This allows the search query
- * to use simple JOINs instead of per-row URN matching when filtering secured
- * features by user access.
- *
- * The cache is rebuilt (delete + reinsert) whenever policies or team-policy
- * associations change. It is not a source of truth — it can always be
- * reconstructed from team_policy → policy_statement → submission_feature.
- *
- * See: SIMSBIOHUB-863
- */
+// SIMSBIOHUB-863: team_feature is a cache table, not a source table.
+// No surrogate PK, no audit columns, no triggers, no FKs.
+// Derived data — always rebuildable from team_policy + policy_statement.
+// Audit infrastructure (tr_audit_trigger, tr_journal_trigger, create_user, etc.)
+// is omitted because it adds O(N) per-row overhead on bulk refresh with no value:
+// the source of truth (team_policy, policy_statement) is already audited upstream.
 
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`--sql
@@ -22,60 +14,26 @@ export async function up(knex: Knex): Promise<void> {
     --------------------------------------------------------------------------------
     -- Create team_feature cache table
     --------------------------------------------------------------------------------
+
     CREATE TABLE team_feature (
-      team_feature_id       integer GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
       team_id               uuid NOT NULL,
       submission_feature_id integer NOT NULL,
-      create_date           timestamptz(6) DEFAULT now() NOT NULL,
-      create_user           integer NOT NULL,
-      update_date           timestamptz(6),
-      update_user           integer,
-      revision_count        integer DEFAULT 0 NOT NULL,
-      CONSTRAINT team_feature_pk PRIMARY KEY (team_feature_id)
+      CONSTRAINT team_feature_pk PRIMARY KEY (team_id, submission_feature_id)
     );
-
-    --------------------------------------------------------------------------------
-    -- Create team_feature indexes and constraints
-    --------------------------------------------------------------------------------
-    CREATE INDEX team_feature_idx1 ON team_feature(team_id);
-    CREATE INDEX team_feature_idx2 ON team_feature(submission_feature_id);
-
-    CREATE UNIQUE INDEX team_feature_nuk1
-      ON team_feature(team_id, submission_feature_id);
-
-    ALTER TABLE team_feature ADD CONSTRAINT team_feature_fk1
-      FOREIGN KEY (team_id) REFERENCES team(team_id);
-
-    ALTER TABLE team_feature ADD CONSTRAINT team_feature_fk2
-      FOREIGN KEY (submission_feature_id) REFERENCES submission_feature(submission_feature_id);
-
-    --------------------------------------------------------------------------------
-    -- Create team_feature triggers
-    --------------------------------------------------------------------------------
-    CREATE TRIGGER audit_team_feature
-      BEFORE INSERT OR UPDATE OR DELETE ON team_feature
-      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_audit_trigger();
-
-    CREATE TRIGGER journal_team_feature
-      AFTER INSERT OR UPDATE OR DELETE ON team_feature
-      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_journal_trigger();
 
     --------------------------------------------------------------------------------
     -- Table and column comments
     --------------------------------------------------------------------------------
-    COMMENT ON TABLE team_feature IS 'Materialized cache mapping teams to the secured submission features they can access. Rebuilt from team_policy + policy_statement URN resolution whenever policies change.';
-    COMMENT ON COLUMN team_feature.team_feature_id IS 'System generated surrogate primary key identifier.';
-    COMMENT ON COLUMN team_feature.team_id IS 'Foreign key to the team table.';
-    COMMENT ON COLUMN team_feature.submission_feature_id IS 'Foreign key to the submission_feature table.';
+
+    COMMENT ON TABLE team_feature IS 'Materialized cache mapping teams to the secured submission features they can access. Rebuilt via delete+insert from team_policy + policy_statement URN resolution whenever policies change. Cache table — no audit columns or triggers (source of truth is audited upstream).';
+    COMMENT ON COLUMN team_feature.team_id IS 'The team UUID. Leading column in composite PK — supports lookups by team_id used in buildUserAccessFilter.';
+    COMMENT ON COLUMN team_feature.submission_feature_id IS 'The submission feature ID granted to the team by policy resolution.';
   `);
 }
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`--sql
     SET SEARCH_PATH = biohub, public;
-
-    DROP TRIGGER IF EXISTS journal_team_feature ON team_feature;
-    DROP TRIGGER IF EXISTS audit_team_feature ON team_feature;
 
     DROP TABLE IF EXISTS team_feature;
   `);

--- a/database/src/migrations/20260310165917_team_feature_cache.ts
+++ b/database/src/migrations/20260310165917_team_feature_cache.ts
@@ -1,0 +1,82 @@
+import { Knex } from 'knex';
+
+/**
+ * Migration to create the team_feature cache table.
+ *
+ * team_feature is a materialized cache that maps team_id to submission_feature_id
+ * by resolving URN wildcards from policy_statement. This allows the search query
+ * to use simple JOINs instead of per-row URN matching when filtering secured
+ * features by user access.
+ *
+ * The cache is rebuilt (delete + reinsert) whenever policies or team-policy
+ * associations change. It is not a source of truth — it can always be
+ * reconstructed from team_policy → policy_statement → submission_feature.
+ *
+ * See: SIMSBIOHUB-863
+ */
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Create team_feature cache table
+    --------------------------------------------------------------------------------
+    CREATE TABLE team_feature (
+      team_feature_id       integer GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+      team_id               uuid NOT NULL,
+      submission_feature_id integer NOT NULL,
+      create_date           timestamptz(6) DEFAULT now() NOT NULL,
+      create_user           integer NOT NULL,
+      update_date           timestamptz(6),
+      update_user           integer,
+      revision_count        integer DEFAULT 0 NOT NULL,
+      CONSTRAINT team_feature_pk PRIMARY KEY (team_feature_id)
+    );
+
+    --------------------------------------------------------------------------------
+    -- Create team_feature indexes and constraints
+    --------------------------------------------------------------------------------
+    CREATE INDEX team_feature_idx1 ON team_feature(team_id);
+    CREATE INDEX team_feature_idx2 ON team_feature(submission_feature_id);
+
+    CREATE UNIQUE INDEX team_feature_nuk1
+      ON team_feature(team_id, submission_feature_id);
+
+    ALTER TABLE team_feature ADD CONSTRAINT team_feature_fk1
+      FOREIGN KEY (team_id) REFERENCES team(team_id);
+
+    ALTER TABLE team_feature ADD CONSTRAINT team_feature_fk2
+      FOREIGN KEY (submission_feature_id) REFERENCES submission_feature(submission_feature_id);
+
+    --------------------------------------------------------------------------------
+    -- Create team_feature triggers
+    --------------------------------------------------------------------------------
+    CREATE TRIGGER audit_team_feature
+      BEFORE INSERT OR UPDATE OR DELETE ON team_feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_audit_trigger();
+
+    CREATE TRIGGER journal_team_feature
+      AFTER INSERT OR UPDATE OR DELETE ON team_feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_journal_trigger();
+
+    --------------------------------------------------------------------------------
+    -- Table and column comments
+    --------------------------------------------------------------------------------
+    COMMENT ON TABLE team_feature IS 'Materialized cache mapping teams to the secured submission features they can access. Rebuilt from team_policy + policy_statement URN resolution whenever policies change.';
+    COMMENT ON COLUMN team_feature.team_feature_id IS 'System generated surrogate primary key identifier.';
+    COMMENT ON COLUMN team_feature.team_id IS 'Foreign key to the team table.';
+    COMMENT ON COLUMN team_feature.submission_feature_id IS 'Foreign key to the submission_feature table.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    DROP TRIGGER IF EXISTS journal_team_feature ON team_feature;
+    DROP TRIGGER IF EXISTS audit_team_feature ON team_feature;
+
+    DROP TABLE IF EXISTS team_feature;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-863](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-863)

## Description of Changes

As an authenticated BioHub client who has been granted access to secured records via one or more policies, I want to use the front-end search page in BioHub and see my secured records in the results. 

Acceptance Criteria 

1. Secured Cache Table

WHEN a policy is created
THEN the secured records made available under that policy should be cached in a new table called team_feature, that joins team_id and the submission_feature_id 

2. Front-End Search 

WHEN a client is logged into BioHub
THEN The search should query both the submission_feature table as well as the cached secured submissions table for any team_id that they belong to
WHEN The client has an active data policy 
THEN Those records secured under that policy should be displayed in the search results alongside the unsecured features. 

## Testing Notes

- {List any relevant testing considerations, necessary pre-reqs, and areas of the app to focus on. Specifically, include anything that will help the reviewers of this PR verify the code is functioning as expected.}
