### PR TITLE
SIMSBIOHUB-912: Anonymous Download UI

### DIFF
--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -61,7 +61,10 @@ describe('paths/download/index', () => {
       await requestHandler(mockReq, mockRes, mockNext);
 
       expect(mockRes.statusValue).to.equal(201);
-      expect(mockRes.jsonValue).to.eql({ download_id: 'uuid-1' });
+      expect(mockRes.jsonValue).to.eql({
+        download_id: 'uuid-1',
+        download_url: 'http://localhost:6100/api/download/uuid-1'
+      });
     });
 
     it('should pass search filters to createDownloadRequest', async () => {

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -157,11 +157,15 @@ POST.apiDoc = {
         'application/json': {
           schema: {
             type: 'object',
-            required: ['download_id'],
+            required: ['download_id', 'download_url'],
             properties: {
               download_id: {
                 type: 'string',
                 format: 'uuid'
+              },
+              download_url: {
+                type: 'string',
+                description: 'Relative API path to check download status'
               }
             }
           }
@@ -226,7 +230,14 @@ export function createDownload(): RequestHandler {
 
       await connection.commit();
 
-      return res.status(201).json({ download_id: downloadId.download_id });
+      const apiHost = process.env.API_HOST || 'localhost';
+      const apiPort = process.env.API_PORT || '6100';
+      const baseUrl = apiHost === 'localhost' ? `http://${apiHost}:${apiPort}` : `https://${apiHost}`;
+
+      return res.status(201).json({
+        download_id: downloadId.download_id,
+        download_url: `${baseUrl}/api/download/${downloadId.download_id}`
+      });
     } catch (error) {
       defaultLog.error({ label: 'createDownload', message: 'error', error });
       await connection.rollback();

--- a/app/src/features/search/result/SearchResultPage.tsx
+++ b/app/src/features/search/result/SearchResultPage.tsx
@@ -3,9 +3,11 @@ import { PageHeader } from 'components/header/PageHeader';
 import { URL_PARAMS, UrlParamKey } from 'constants/query-params';
 import { APIError } from 'hooks/api/useAxios';
 import { useApi } from 'hooks/useApi';
-import { useCartContext, useCodesContext, useDialogContext } from 'hooks/useContext';
+import { useAuthStateContext } from 'hooks/useAuthStateContext';
+import { useCartContext, useCodesContext, useConfigContext, useDialogContext } from 'hooks/useContext';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { normalizeQueryParam } from 'utils/query-param';
+import { DownloadUrlDisplay } from './components/DownloadUrlDisplay';
 import { SearchResultOptions } from './content/option/SearchResultOptions';
 import { SearchResultToolbar } from './content/toolbar/SearchResultToolbar';
 import { SearchResultHeader } from './header/SearchResultHeader';
@@ -30,6 +32,8 @@ export const SearchResultPage = () => {
   const navigate = useNavigate();
   const { rows, isLoading, searchParams, setSearchParams, removeSearchParam, pagination, filters } = useSearchResults();
   const api = useApi();
+  const { auth } = useAuthStateContext();
+  const config = useConfigContext();
   const { codesDataLoader } = useCodesContext();
   const { features, pagination: cartPagination, addToCart, checkout } = useCartContext();
   const dialogContext = useDialogContext();
@@ -206,21 +210,38 @@ export const SearchResultPage = () => {
    * Download all features matching the current search filters in one click.
    * Bypasses the shopping cart — sends filters to POST /api/download which resolves
    * them to feature IDs server-side and creates a download record.
+   *
+   * Anonymous users have no "My Downloads" page, so the download UUID is their only
+   * credential. Instead of an ephemeral snackbar, they get a persistent dialog with
+   * the API status URL they can use with curl to check progress and get download links.
    */
   const handleDownloadAll = useCallback(async () => {
     try {
       setIsDownloading(true);
-      await api.search.createDownload(filters);
-      dialogContext.setSnackbar({
-        snackbarMessage: 'Download started. You can track its progress in your downloads.',
-        open: true
-      });
+      const { download_id: downloadId } = await api.search.createDownload(filters);
+
+      if (auth.isAuthenticated) {
+        dialogContext.setSnackbar({
+          snackbarMessage: 'Download started. You can track its progress in your downloads.',
+          open: true
+        });
+      } else {
+        const downloadUrl = `${config.API_HOST}/api/download/${downloadId}`;
+        dialogContext.setOkDialog({
+          dialogTitle: 'Download Started',
+          dialogText:
+            'Your download is being prepared. Use this URL to check its status and get download links when ready.',
+          dialogContent: <DownloadUrlDisplay url={downloadUrl} />,
+          open: true,
+          onClose: () => dialogContext.setOkDialog({ open: false })
+        });
+      }
     } catch (error) {
       dialogContext.setSnackbar({ snackbarMessage: (error as APIError).message, open: true });
     } finally {
       setIsDownloading(false);
     }
-  }, [filters, api.search, dialogContext]);
+  }, [filters, api.search, dialogContext, auth.isAuthenticated, config.API_HOST]);
 
   const handleCheckout = useCallback(async () => {
     try {

--- a/app/src/features/search/result/SearchResultPage.tsx
+++ b/app/src/features/search/result/SearchResultPage.tsx
@@ -4,7 +4,7 @@ import { URL_PARAMS, UrlParamKey } from 'constants/query-params';
 import { APIError } from 'hooks/api/useAxios';
 import { useApi } from 'hooks/useApi';
 import { useAuthStateContext } from 'hooks/useAuthStateContext';
-import { useCartContext, useCodesContext, useConfigContext, useDialogContext } from 'hooks/useContext';
+import { useCartContext, useCodesContext, useDialogContext } from 'hooks/useContext';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { normalizeQueryParam } from 'utils/query-param';
 import { DownloadUrlDisplay } from './components/DownloadUrlDisplay';
@@ -33,7 +33,7 @@ export const SearchResultPage = () => {
   const { rows, isLoading, searchParams, setSearchParams, removeSearchParam, pagination, filters } = useSearchResults();
   const api = useApi();
   const { auth } = useAuthStateContext();
-  const config = useConfigContext();
+
   const { codesDataLoader } = useCodesContext();
   const { features, pagination: cartPagination, addToCart, checkout } = useCartContext();
   const dialogContext = useDialogContext();
@@ -218,7 +218,7 @@ export const SearchResultPage = () => {
   const handleDownloadAll = useCallback(async () => {
     try {
       setIsDownloading(true);
-      const { download_id: downloadId } = await api.search.createDownload(filters);
+      const { download_url: downloadUrl } = await api.search.createDownload(filters);
 
       if (auth.isAuthenticated) {
         dialogContext.setSnackbar({
@@ -226,7 +226,6 @@ export const SearchResultPage = () => {
           open: true
         });
       } else {
-        const downloadUrl = `${config.API_HOST}/api/download/${downloadId}`;
         dialogContext.setOkDialog({
           dialogTitle: 'Download Started',
           dialogText:
@@ -241,7 +240,7 @@ export const SearchResultPage = () => {
     } finally {
       setIsDownloading(false);
     }
-  }, [filters, api.search, dialogContext, auth.isAuthenticated, config.API_HOST]);
+  }, [filters, api.search, dialogContext, auth.isAuthenticated]);
 
   const handleCheckout = useCallback(async () => {
     try {

--- a/app/src/features/search/result/components/DownloadUrlDisplay.test.tsx
+++ b/app/src/features/search/result/components/DownloadUrlDisplay.test.tsx
@@ -1,0 +1,105 @@
+import { act, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { render } from 'test-helpers/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DownloadUrlDisplay } from './DownloadUrlDisplay';
+
+const TEST_URL = 'http://localhost:7100/api/download/abc-123';
+
+describe('DownloadUrlDisplay', () => {
+  let originalClipboard: Clipboard;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      writable: true,
+      configurable: true
+    });
+    cleanup();
+  });
+
+  it('renders the URL text', () => {
+    const { getByTestId } = render(<DownloadUrlDisplay url={TEST_URL} />);
+
+    expect(getByTestId('download-url-text')).toHaveTextContent(TEST_URL);
+  });
+
+  it('copies URL to clipboard when copy button is clicked', async () => {
+    const { getByTestId } = render(<DownloadUrlDisplay url={TEST_URL} />);
+
+    fireEvent.click(getByTestId('copy-url-button'));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(TEST_URL);
+    });
+  });
+
+  it('shows copied feedback after successful copy', async () => {
+    const { getByTestId } = render(<DownloadUrlDisplay url={TEST_URL} />);
+
+    fireEvent.click(getByTestId('copy-url-button'));
+
+    await waitFor(() => {
+      expect(getByTestId('copy-url-button')).toHaveAttribute('aria-label', 'Copied');
+    });
+  });
+
+  it('resets copied state after 2 seconds', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const { getByTestId } = render(<DownloadUrlDisplay url={TEST_URL} />);
+
+    fireEvent.click(getByTestId('copy-url-button'));
+
+    await waitFor(() => {
+      expect(getByTestId('copy-url-button')).toHaveAttribute('aria-label', 'Copied');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2001);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('copy-url-button')).toHaveAttribute('aria-label', 'Copy download URL');
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('does not show copied feedback when clipboard write fails', async () => {
+    (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('NotAllowedError'));
+
+    const { getByTestId } = render(<DownloadUrlDisplay url={TEST_URL} />);
+
+    fireEvent.click(getByTestId('copy-url-button'));
+
+    // Wait for the promise rejection to be handled, then verify label stayed unchanged
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(TEST_URL);
+    });
+
+    expect(getByTestId('copy-url-button')).toHaveAttribute('aria-label', 'Copy download URL');
+  });
+
+  it('hides copy button when clipboard API is unavailable', () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true
+    });
+
+    const { getByTestId, queryByTestId } = render(<DownloadUrlDisplay url={TEST_URL} />);
+
+    expect(queryByTestId('copy-url-button')).not.toBeInTheDocument();
+    expect(getByTestId('download-url-text')).toHaveTextContent(TEST_URL);
+  });
+});

--- a/app/src/features/search/result/components/DownloadUrlDisplay.test.tsx
+++ b/app/src/features/search/result/components/DownloadUrlDisplay.test.tsx
@@ -10,6 +10,7 @@ describe('DownloadUrlDisplay', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     originalClipboard = navigator.clipboard;
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
@@ -19,6 +20,8 @@ describe('DownloadUrlDisplay', () => {
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
     Object.defineProperty(navigator, 'clipboard', {
       value: originalClipboard,
       writable: true,
@@ -54,8 +57,6 @@ describe('DownloadUrlDisplay', () => {
   });
 
   it('resets copied state after 2 seconds', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-
     const { getByTestId } = render(<DownloadUrlDisplay url={TEST_URL} />);
 
     fireEvent.click(getByTestId('copy-url-button'));
@@ -71,8 +72,6 @@ describe('DownloadUrlDisplay', () => {
     await waitFor(() => {
       expect(getByTestId('copy-url-button')).toHaveAttribute('aria-label', 'Copy download URL');
     });
-
-    vi.useRealTimers();
   });
 
   it('does not show copied feedback when clipboard write fails', async () => {
@@ -82,7 +81,6 @@ describe('DownloadUrlDisplay', () => {
 
     fireEvent.click(getByTestId('copy-url-button'));
 
-    // Wait for the promise rejection to be handled, then verify label stayed unchanged
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(TEST_URL);
     });

--- a/app/src/features/search/result/components/DownloadUrlDisplay.tsx
+++ b/app/src/features/search/result/components/DownloadUrlDisplay.tsx
@@ -1,0 +1,63 @@
+import { mdiCheck, mdiContentCopy } from '@mdi/js';
+import Icon from '@mdi/react';
+import { Box, IconButton, Typography } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+
+interface DownloadUrlDisplayProps {
+  url: string;
+}
+
+/**
+ * Renders a download status URL with a copy-to-clipboard button.
+ *
+ * Anonymous users have no "My Downloads" page — the download UUID is their only
+ * credential. This component surfaces the API status URL so they can check
+ * download progress and retrieve signed download links when ready via curl.
+ *
+ * Clipboard API requires a secure context (HTTPS). On HTTP (local dev), the
+ * copy button is hidden and the URL text is fully selectable as a fallback.
+ */
+export const DownloadUrlDisplay = ({ url }: DownloadUrlDisplayProps) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clipboardAvailable = typeof navigator !== 'undefined' && !!navigator.clipboard;
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard write failed (e.g. permission denied) — URL is still selectable as text
+    }
+  };
+
+  return (
+    <Box
+      data-testid="download-url-display"
+      sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2, p: 1.5, bgcolor: 'action.hover', borderRadius: 1 }}>
+      <Typography
+        data-testid="download-url-text"
+        sx={{ fontFamily: 'monospace', fontSize: '0.85rem', wordBreak: 'break-all', flex: 1, userSelect: 'all' }}>
+        {url}
+      </Typography>
+      {clipboardAvailable && (
+        <IconButton
+          data-testid="copy-url-button"
+          size="small"
+          onClick={handleCopy}
+          aria-label={copied ? 'Copied' : 'Copy download URL'}>
+          <Icon path={copied ? mdiCheck : mdiContentCopy} size={0.8} />
+        </IconButton>
+      )}
+    </Box>
+  );
+};

--- a/app/src/hooks/api/useSearchApi.test.ts
+++ b/app/src/hooks/api/useSearchApi.test.ts
@@ -250,7 +250,10 @@ describe('useSearchApi', () => {
 
   describe('createDownload', () => {
     it('should POST filters to /api/download and return download_id', async () => {
-      const mockResponse: CreateDownloadResponse = { download_id: '550e8400-e29b-41d4-a716-446655440099' };
+      const mockResponse: CreateDownloadResponse = {
+        download_id: '550e8400-e29b-41d4-a716-446655440099',
+        download_url: 'https://localhost/api/download/550e8400-e29b-41d4-a716-446655440099'
+      };
 
       mock.onPost('/api/download').reply(201, mockResponse);
 
@@ -261,7 +264,10 @@ describe('useSearchApi', () => {
     });
 
     it('should resolve with download_id from response', async () => {
-      const mockResponse: CreateDownloadResponse = { download_id: 'uuid-abc-123' };
+      const mockResponse: CreateDownloadResponse = {
+        download_id: 'uuid-abc-123',
+        download_url: 'https://localhost/api/download/uuid-abc-123'
+      };
 
       mock.onPost('/api/download').reply(201, mockResponse);
 

--- a/app/src/interfaces/useSearchApi.interface.ts
+++ b/app/src/interfaces/useSearchApi.interface.ts
@@ -58,6 +58,7 @@ export interface ISearchFeaturePropertyGroup {
  */
 export interface CreateDownloadResponse {
   download_id: string;
+  download_url: string;
 }
 
 /** Request parameters for advanced feature search */


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-912](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-912)[SIMSBIOHUB-912](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-912)

## Description of Changes

Anonymous users can create downloads via the "Download All" button on the search results page. The API correctly returns a `download_id` UUID, but the frontend discards it and shows a snackbar message — "Download started. You can track its progress in your downloads." — that assumes the user is authenticated. Anonymous users have no "My Downloads" page, so the UUID disappears and they have no way to check status or retrieve their files.

Acceptance Criteria

Accurate snackbar for authenticated users

WHEN an authenticated user clicks "Download All"
THEN the existing snackbar message is shown (no change)

Actionable feedback for anonymous users

WHEN an anonymous user clicks "Download All"
THEN the response `download_id` is captured
AND the user is shown a persistent, actionable way to access their download status URL (`/api/download/{downloadId}`)
NOTE: A snackbar alone is insufficient — it disappears and the UUID is lost

Download status URL is usable

WHEN an anonymous user has the download status URL
THEN they can check download progress and retrieve signed fragment URLs when ready
NOTE: `GET /api/download/{downloadId}` already supports this (OptionalBearer, returns signed URLs for anonymous ready downloads)

## Testing Notes

As an anonymous user go to the search page an click the "Download All" button.
