### PR TITLE
SIMSBIOHUB-880: Add Ticket ID to Upload Submission

### DIFF
--- a/api/src/__integration__/db/cart-checkout.integration.ts
+++ b/api/src/__integration__/db/cart-checkout.integration.ts
@@ -66,9 +66,11 @@ describe('Cart checkout (integration)', function () {
     `);
     const uploadId = uploadResult.rows[0].upload_id;
 
+    const ticket_id = await getOrCreateIntegrationTicketId(connection, uploadId, systemUserId);
+
     const bridgeResult = await connection.sql(SQL`
-      INSERT INTO submission_upload (submission_id, upload_id, create_user)
-      VALUES (${submissionId}, ${uploadId}, ${systemUserId})
+      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+      VALUES (${submissionId}, ${uploadId}, ${ticket_id}, ${systemUserId})
       RETURNING submission_upload_id;
     `);
     const submissionUploadId = bridgeResult.rows[0].submission_upload_id;
@@ -170,3 +172,99 @@ describe('Cart checkout (integration)', function () {
     }
   });
 });
+
+/**
+ * Integration tests insert into `submission_upload` directly.
+ * Since `submission_upload.ticket_id` is now NOT NULL, ensure a ticket exists first.
+ */
+async function getOrCreateIntegrationTicketId(connection: IDBConnection, uploadId: string, systemUserId: number) {
+  const teamName = 'Integration Ticket Team';
+  const subject = `Submission Upload - ${uploadId}`;
+
+  const existingTicket = await connection.sql(SQL`
+    SELECT ticket_id
+    FROM ticket
+    WHERE subject = ${subject}
+      AND record_end_date IS NULL
+    LIMIT 1;
+  `);
+
+  const existingTicketId = existingTicket.rows[0]?.ticket_id as string | undefined;
+  if (existingTicketId) {
+    return existingTicketId;
+  }
+
+  const existingTeam = await connection.sql(SQL`
+    SELECT team_id
+    FROM team
+    WHERE name = ${teamName}
+      AND record_end_date IS NULL
+    LIMIT 1;
+  `);
+
+  const existingTeamId = existingTeam.rows[0]?.team_id as string | undefined;
+  const teamId =
+    existingTeamId ??
+    (
+      await connection.sql(SQL`
+        INSERT INTO team (name, description, create_user)
+        VALUES (${teamName}, 'Integration test team for ticket linking.', ${systemUserId})
+        RETURNING team_id;
+      `)
+    ).rows[0].team_id;
+
+  const nextSlug = await connection.sql(SQL`
+    WITH
+      day_context AS (
+        SELECT TO_CHAR((now() AT TIME ZONE 'UTC')::date, 'DDD') AS day_of_year
+      ),
+      latest AS (
+        SELECT
+          COALESCE(MAX(RIGHT(ticket_slug, 5)::integer), -1) AS last_value
+        FROM ticket, day_context
+        WHERE ticket_slug LIKE day_context.day_of_year || '%'
+      ),
+      next_value AS (
+        SELECT
+          day_context.day_of_year,
+          latest.last_value + 1 AS next_sequence
+        FROM day_context, latest
+      )
+    SELECT
+      day_of_year || LPAD(next_sequence::text, 5, '0') AS ticket_slug
+    FROM next_value;
+  `);
+
+  const ticketSlug = nextSlug.rows[0].ticket_slug as string;
+
+  const createdTicket = await connection.sql(SQL`
+    INSERT INTO ticket (
+      ticket_slug,
+      subject,
+      description,
+      team_id,
+      priority,
+      status,
+      create_user
+    )
+    VALUES (
+      ${ticketSlug},
+      ${subject},
+      NULL,
+      ${teamId},
+      'medium',
+      'open',
+      ${systemUserId}
+    )
+    RETURNING ticket_id;
+  `);
+
+  const ticketId = createdTicket.rows[0].ticket_id as string;
+
+  await connection.sql(SQL`
+    INSERT INTO ticket_status (ticket_id, status, create_user)
+    VALUES (${ticketId}, 'open', ${systemUserId});
+  `);
+
+  return ticketId;
+}

--- a/api/src/__integration__/db/cart-checkout.integration.ts
+++ b/api/src/__integration__/db/cart-checkout.integration.ts
@@ -13,6 +13,7 @@ import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } 
 import { HTTP400 } from '../../errors/http-error';
 import { CartService } from '../../services/cart-service';
 import { DownloadService } from '../../services/download/download-service';
+import { getOrCreateIntegrationTicketId } from '../helpers/test-submission-helpers';
 
 describe('Cart checkout (integration)', function () {
   this.timeout(15000);
@@ -66,7 +67,7 @@ describe('Cart checkout (integration)', function () {
     `);
     const uploadId = uploadResult.rows[0].upload_id;
 
-    const ticket_id = await getOrCreateIntegrationTicketId(connection, uploadId, systemUserId);
+    const ticket_id = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
 
     const bridgeResult = await connection.sql(SQL`
       INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
@@ -172,99 +173,3 @@ describe('Cart checkout (integration)', function () {
     }
   });
 });
-
-/**
- * Integration tests insert into `submission_upload` directly.
- * Since `submission_upload.ticket_id` is now NOT NULL, ensure a ticket exists first.
- */
-async function getOrCreateIntegrationTicketId(connection: IDBConnection, uploadId: string, systemUserId: number) {
-  const teamName = 'Integration Ticket Team';
-  const subject = `Submission Upload - ${uploadId}`;
-
-  const existingTicket = await connection.sql(SQL`
-    SELECT ticket_id
-    FROM ticket
-    WHERE subject = ${subject}
-      AND record_end_date IS NULL
-    LIMIT 1;
-  `);
-
-  const existingTicketId = existingTicket.rows[0]?.ticket_id as string | undefined;
-  if (existingTicketId) {
-    return existingTicketId;
-  }
-
-  const existingTeam = await connection.sql(SQL`
-    SELECT team_id
-    FROM team
-    WHERE name = ${teamName}
-      AND record_end_date IS NULL
-    LIMIT 1;
-  `);
-
-  const existingTeamId = existingTeam.rows[0]?.team_id as string | undefined;
-  const teamId =
-    existingTeamId ??
-    (
-      await connection.sql(SQL`
-        INSERT INTO team (name, description, create_user)
-        VALUES (${teamName}, 'Integration test team for ticket linking.', ${systemUserId})
-        RETURNING team_id;
-      `)
-    ).rows[0].team_id;
-
-  const nextSlug = await connection.sql(SQL`
-    WITH
-      day_context AS (
-        SELECT TO_CHAR((now() AT TIME ZONE 'UTC')::date, 'DDD') AS day_of_year
-      ),
-      latest AS (
-        SELECT
-          COALESCE(MAX(RIGHT(ticket_slug, 5)::integer), -1) AS last_value
-        FROM ticket, day_context
-        WHERE ticket_slug LIKE day_context.day_of_year || '%'
-      ),
-      next_value AS (
-        SELECT
-          day_context.day_of_year,
-          latest.last_value + 1 AS next_sequence
-        FROM day_context, latest
-      )
-    SELECT
-      day_of_year || LPAD(next_sequence::text, 5, '0') AS ticket_slug
-    FROM next_value;
-  `);
-
-  const ticketSlug = nextSlug.rows[0].ticket_slug as string;
-
-  const createdTicket = await connection.sql(SQL`
-    INSERT INTO ticket (
-      ticket_slug,
-      subject,
-      description,
-      team_id,
-      priority,
-      status,
-      create_user
-    )
-    VALUES (
-      ${ticketSlug},
-      ${subject},
-      NULL,
-      ${teamId},
-      'medium',
-      'open',
-      ${systemUserId}
-    )
-    RETURNING ticket_id;
-  `);
-
-  const ticketId = createdTicket.rows[0].ticket_id as string;
-
-  await connection.sql(SQL`
-    INSERT INTO ticket_status (ticket_id, status, create_user)
-    VALUES (${ticketId}, 'open', ${systemUserId});
-  `);
-
-  return ticketId;
-}

--- a/api/src/__integration__/db/search-feature-repository.integration.ts
+++ b/api/src/__integration__/db/search-feature-repository.integration.ts
@@ -61,9 +61,11 @@ describe('SearchFeatureRepository (integration)', function () {
     `);
     const uploadId = uploadResult.rows[0].upload_id;
 
+    const ticket_id = await getOrCreateIntegrationTicketId(connection, uploadId, systemUserId);
+
     const bridgeResult = await connection.sql(SQL`
-      INSERT INTO submission_upload (submission_id, upload_id, create_user)
-      VALUES (${submissionId}, ${uploadId}, ${systemUserId})
+      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+      VALUES (${submissionId}, ${uploadId}, ${ticket_id}, ${systemUserId})
       RETURNING submission_upload_id;
     `);
     const submissionUploadId = bridgeResult.rows[0].submission_upload_id;
@@ -193,3 +195,99 @@ describe('SearchFeatureRepository (integration)', function () {
     });
   });
 });
+
+/**
+ * Integration tests insert into `submission_upload` directly.
+ * Since `submission_upload.ticket_id` is now NOT NULL, ensure a ticket exists first.
+ */
+async function getOrCreateIntegrationTicketId(connection: IDBConnection, uploadId: string, systemUserId: number) {
+  const teamName = 'Integration Ticket Team';
+  const subject = `Submission Upload - ${uploadId}`;
+
+  const existingTicket = await connection.sql(SQL`
+    SELECT ticket_id
+    FROM ticket
+    WHERE subject = ${subject}
+      AND record_end_date IS NULL
+    LIMIT 1;
+  `);
+
+  const existingTicketId = existingTicket.rows[0]?.ticket_id as string | undefined;
+  if (existingTicketId) {
+    return existingTicketId;
+  }
+
+  const existingTeam = await connection.sql(SQL`
+    SELECT team_id
+    FROM team
+    WHERE name = ${teamName}
+      AND record_end_date IS NULL
+    LIMIT 1;
+  `);
+
+  const existingTeamId = existingTeam.rows[0]?.team_id as string | undefined;
+  const teamId =
+    existingTeamId ??
+    (
+      await connection.sql(SQL`
+        INSERT INTO team (name, description, create_user)
+        VALUES (${teamName}, 'Integration test team for ticket linking.', ${systemUserId})
+        RETURNING team_id;
+      `)
+    ).rows[0].team_id;
+
+  const nextSlug = await connection.sql(SQL`
+    WITH
+      day_context AS (
+        SELECT TO_CHAR((now() AT TIME ZONE 'UTC')::date, 'DDD') AS day_of_year
+      ),
+      latest AS (
+        SELECT
+          COALESCE(MAX(RIGHT(ticket_slug, 5)::integer), -1) AS last_value
+        FROM ticket, day_context
+        WHERE ticket_slug LIKE day_context.day_of_year || '%'
+      ),
+      next_value AS (
+        SELECT
+          day_context.day_of_year,
+          latest.last_value + 1 AS next_sequence
+        FROM day_context, latest
+      )
+    SELECT
+      day_of_year || LPAD(next_sequence::text, 5, '0') AS ticket_slug
+    FROM next_value;
+  `);
+
+  const ticketSlug = nextSlug.rows[0].ticket_slug as string;
+
+  const createdTicket = await connection.sql(SQL`
+    INSERT INTO ticket (
+      ticket_slug,
+      subject,
+      description,
+      team_id,
+      priority,
+      status,
+      create_user
+    )
+    VALUES (
+      ${ticketSlug},
+      ${subject},
+      NULL,
+      ${teamId},
+      'medium',
+      'open',
+      ${systemUserId}
+    )
+    RETURNING ticket_id;
+  `);
+
+  const ticketId = createdTicket.rows[0].ticket_id as string;
+
+  await connection.sql(SQL`
+    INSERT INTO ticket_status (ticket_id, status, create_user)
+    VALUES (${ticketId}, 'open', ${systemUserId});
+  `);
+
+  return ticketId;
+}

--- a/api/src/__integration__/db/search-feature-repository.integration.ts
+++ b/api/src/__integration__/db/search-feature-repository.integration.ts
@@ -11,6 +11,7 @@ import { expect } from 'chai';
 import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
 import { SearchFeatureRepository } from '../../repositories/search-feature-repository';
+import { getOrCreateIntegrationTicketId } from '../helpers/test-submission-helpers';
 
 describe('SearchFeatureRepository (integration)', function () {
   this.timeout(15000);
@@ -61,7 +62,7 @@ describe('SearchFeatureRepository (integration)', function () {
     `);
     const uploadId = uploadResult.rows[0].upload_id;
 
-    const ticket_id = await getOrCreateIntegrationTicketId(connection, uploadId, systemUserId);
+    const ticket_id = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
 
     const bridgeResult = await connection.sql(SQL`
       INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
@@ -195,99 +196,3 @@ describe('SearchFeatureRepository (integration)', function () {
     });
   });
 });
-
-/**
- * Integration tests insert into `submission_upload` directly.
- * Since `submission_upload.ticket_id` is now NOT NULL, ensure a ticket exists first.
- */
-async function getOrCreateIntegrationTicketId(connection: IDBConnection, uploadId: string, systemUserId: number) {
-  const teamName = 'Integration Ticket Team';
-  const subject = `Submission Upload - ${uploadId}`;
-
-  const existingTicket = await connection.sql(SQL`
-    SELECT ticket_id
-    FROM ticket
-    WHERE subject = ${subject}
-      AND record_end_date IS NULL
-    LIMIT 1;
-  `);
-
-  const existingTicketId = existingTicket.rows[0]?.ticket_id as string | undefined;
-  if (existingTicketId) {
-    return existingTicketId;
-  }
-
-  const existingTeam = await connection.sql(SQL`
-    SELECT team_id
-    FROM team
-    WHERE name = ${teamName}
-      AND record_end_date IS NULL
-    LIMIT 1;
-  `);
-
-  const existingTeamId = existingTeam.rows[0]?.team_id as string | undefined;
-  const teamId =
-    existingTeamId ??
-    (
-      await connection.sql(SQL`
-        INSERT INTO team (name, description, create_user)
-        VALUES (${teamName}, 'Integration test team for ticket linking.', ${systemUserId})
-        RETURNING team_id;
-      `)
-    ).rows[0].team_id;
-
-  const nextSlug = await connection.sql(SQL`
-    WITH
-      day_context AS (
-        SELECT TO_CHAR((now() AT TIME ZONE 'UTC')::date, 'DDD') AS day_of_year
-      ),
-      latest AS (
-        SELECT
-          COALESCE(MAX(RIGHT(ticket_slug, 5)::integer), -1) AS last_value
-        FROM ticket, day_context
-        WHERE ticket_slug LIKE day_context.day_of_year || '%'
-      ),
-      next_value AS (
-        SELECT
-          day_context.day_of_year,
-          latest.last_value + 1 AS next_sequence
-        FROM day_context, latest
-      )
-    SELECT
-      day_of_year || LPAD(next_sequence::text, 5, '0') AS ticket_slug
-    FROM next_value;
-  `);
-
-  const ticketSlug = nextSlug.rows[0].ticket_slug as string;
-
-  const createdTicket = await connection.sql(SQL`
-    INSERT INTO ticket (
-      ticket_slug,
-      subject,
-      description,
-      team_id,
-      priority,
-      status,
-      create_user
-    )
-    VALUES (
-      ${ticketSlug},
-      ${subject},
-      NULL,
-      ${teamId},
-      'medium',
-      'open',
-      ${systemUserId}
-    )
-    RETURNING ticket_id;
-  `);
-
-  const ticketId = createdTicket.rows[0].ticket_id as string;
-
-  await connection.sql(SQL`
-    INSERT INTO ticket_status (ticket_id, status, create_user)
-    VALUES (${ticketId}, 'open', ${systemUserId});
-  `);
-
-  return ticketId;
-}

--- a/api/src/__integration__/helpers/test-submission-helpers.ts
+++ b/api/src/__integration__/helpers/test-submission-helpers.ts
@@ -39,9 +39,16 @@ export async function createTestFeature(
   `);
   const uploadId = uploadResult.rows[0].upload_id;
 
+  const ticket_id = await getOrCreateIntegrationTicketId(connection, uploadId, systemUserId);
+
   const bridgeResult = await connection.sql(SQL`
-    INSERT INTO submission_upload (submission_id, upload_id, create_user)
-    VALUES (${submissionId}, ${uploadId}, ${systemUserId})
+    INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+    VALUES (
+      ${submissionId},
+      ${uploadId},
+      ${ticket_id},
+      ${systemUserId}
+    )
     RETURNING submission_upload_id;
   `);
   const submissionUploadId = bridgeResult.rows[0].submission_upload_id;
@@ -61,4 +68,100 @@ export async function createTestFeature(
   `);
 
   return result.rows[0].submission_feature_id;
+}
+
+/**
+ * Integration tests insert into `submission_upload` directly.
+ * Since `submission_upload.ticket_id` is now NOT NULL, ensure a ticket exists first.
+ */
+async function getOrCreateIntegrationTicketId(connection: IDBConnection, uploadId: string, systemUserId: number) {
+  const teamName = 'Integration Ticket Team';
+  const subject = `Submission Upload - ${uploadId}`;
+
+  const existingTicket = await connection.sql(SQL`
+    SELECT ticket_id
+    FROM ticket
+    WHERE subject = ${subject}
+      AND record_end_date IS NULL
+    LIMIT 1;
+  `);
+
+  const existingTicketId = existingTicket.rows[0]?.ticket_id as string | undefined;
+  if (existingTicketId) {
+    return existingTicketId;
+  }
+
+  const existingTeam = await connection.sql(SQL`
+    SELECT team_id
+    FROM team
+    WHERE name = ${teamName}
+      AND record_end_date IS NULL
+    LIMIT 1;
+  `);
+
+  const existingTeamId = existingTeam.rows[0]?.team_id as string | undefined;
+  const teamId =
+    existingTeamId ??
+    (
+      await connection.sql(SQL`
+        INSERT INTO team (name, description, create_user)
+        VALUES (${teamName}, 'Integration test team for ticket linking.', ${systemUserId})
+        RETURNING team_id;
+      `)
+    ).rows[0].team_id;
+
+  const nextSlug = await connection.sql(SQL`
+    WITH
+      day_context AS (
+        SELECT TO_CHAR((now() AT TIME ZONE 'UTC')::date, 'DDD') AS day_of_year
+      ),
+      latest AS (
+        SELECT
+          COALESCE(MAX(RIGHT(ticket_slug, 5)::integer), -1) AS last_value
+        FROM ticket, day_context
+        WHERE ticket_slug LIKE day_context.day_of_year || '%'
+      ),
+      next_value AS (
+        SELECT
+          day_context.day_of_year,
+          latest.last_value + 1 AS next_sequence
+        FROM day_context, latest
+      )
+    SELECT
+      day_of_year || LPAD(next_sequence::text, 5, '0') AS ticket_slug
+    FROM next_value;
+  `);
+
+  const ticketSlug = nextSlug.rows[0].ticket_slug as string;
+
+  const createdTicket = await connection.sql(SQL`
+    INSERT INTO ticket (
+      ticket_slug,
+      subject,
+      description,
+      team_id,
+      priority,
+      status,
+      create_user
+    )
+    VALUES (
+      ${ticketSlug},
+      ${subject},
+      NULL,
+      ${teamId},
+      'medium',
+      'open',
+      ${systemUserId}
+    )
+    RETURNING ticket_id;
+  `);
+
+  const ticketId = createdTicket.rows[0].ticket_id as string;
+
+  await connection.sql(SQL`
+    INSERT INTO ticket_status (ticket_id, status, create_user)
+    VALUES (${ticketId}, 'open', ${systemUserId});
+  `);
+
+  return ticketId;
 }

--- a/api/src/__integration__/helpers/test-submission-helpers.ts
+++ b/api/src/__integration__/helpers/test-submission-helpers.ts
@@ -39,7 +39,7 @@ export async function createTestFeature(
   `);
   const uploadId = uploadResult.rows[0].upload_id;
 
-  const ticket_id = await getOrCreateIntegrationTicketId(connection, uploadId, systemUserId);
+  const ticket_id = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
 
   const bridgeResult = await connection.sql(SQL`
     INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
@@ -71,17 +71,43 @@ export async function createTestFeature(
 }
 
 /**
- * Integration tests insert into `submission_upload` directly.
- * Since `submission_upload.ticket_id` is now NOT NULL, ensure a ticket exists first.
+ * Get an existing integration ticket for a submission or create one if missing.
+ *
+ * This helper supports integration tests that insert into `submission_upload` directly now that
+ * `submission_upload.ticket_id` is required. It is idempotent per submission by matching on a
+ * stable subject + description pair.
+ *
+ * @param {IDBConnection} connection Active database connection used by the test.
+ * @param {number} submissionId Submission primary key (`submission.submission_id`).
+ * @param {string} uploadId Upload UUID (`upload.upload_id`).
+ * @param {number} systemUserId System user id used for `create_user` fields.
+ * @returns {Promise<string>} The `ticket.ticket_id` to associate with `submission_upload`.
  */
-async function getOrCreateIntegrationTicketId(connection: IDBConnection, uploadId: string, systemUserId: number) {
+export async function getOrCreateIntegrationTicketId(
+  connection: IDBConnection,
+  submissionId: number,
+  uploadId: string,
+  systemUserId: number
+): Promise<string> {
   const teamName = 'Integration Ticket Team';
-  const subject = `Submission Upload - ${uploadId}`;
+  const subject = 'New Submission';
+
+  const submissionResult = await connection.sql(SQL`
+    SELECT uuid
+    FROM submission
+    WHERE submission_id = ${submissionId}
+    LIMIT 1;
+  `);
+
+  const submissionUuid = submissionResult.rows[0]?.uuid as string | undefined;
+  const description = `Submission ID: ${submissionId}. Submission UUID: ${
+    submissionUuid ?? 'unknown'
+  }. Upload UUID: ${uploadId}`;
 
   const existingTicket = await connection.sql(SQL`
     SELECT ticket_id
     FROM ticket
-    WHERE subject = ${subject}
+    WHERE subject = ${subject} AND description = ${description}
       AND record_end_date IS NULL
     LIMIT 1;
   `);
@@ -147,7 +173,7 @@ async function getOrCreateIntegrationTicketId(connection: IDBConnection, uploadI
     VALUES (
       ${ticketSlug},
       ${subject},
-      NULL,
+      ${description},
       ${teamId},
       'medium',
       'open',

--- a/api/src/__integration__/system/process-submission-features-worker.integration.ts
+++ b/api/src/__integration__/system/process-submission-features-worker.integration.ts
@@ -154,6 +154,7 @@ describe('Process Submission Features Worker', function () {
     submissionId: number;
     uploadId: string;
     submissionUploadId: string;
+    ticketId: string;
     artifactId: string;
     objectKey: string;
   }> {
@@ -205,10 +206,12 @@ describe('Process Submission Features Worker', function () {
     });
 
     // 5. submission_upload (links submission to upload)
+    const ticketId = randomUUID();
     const [submissionUpload] = await db('biohub.submission_upload')
       .insert({
         submission_id: submission.submission_id,
-        upload_id: upload.upload_id
+        upload_id: upload.upload_id,
+        ticket_id: ticketId
       })
       .returning('submission_upload_id');
 
@@ -223,6 +226,7 @@ describe('Process Submission Features Worker', function () {
       submissionId: submission.submission_id,
       uploadId: upload.upload_id,
       submissionUploadId: submissionUpload.submission_upload_id,
+      ticketId,
       artifactId: artifact.artifact_id,
       objectKey
     };
@@ -252,7 +256,7 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
 
     // Publish job (needs IDBConnection for submission_validation tracking)
     const connection = getAPIUserDBConnection();
@@ -261,7 +265,8 @@ describe('Process Submission Features Worker', function () {
       const result = await publishProcessSubmissionFeaturesJob(connection, {
         submission_upload_id: submissionUploadId,
         submission_id: submissionId,
-        upload_id: uploadId
+        upload_id: uploadId,
+        ticket_id: ticketId
       });
       await connection.commit();
       expect(result.status).to.equal('published');
@@ -337,7 +342,7 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
 
     const connection = getAPIUserDBConnection();
     try {
@@ -345,7 +350,8 @@ describe('Process Submission Features Worker', function () {
       const result = await publishProcessSubmissionFeaturesJob(connection, {
         submission_upload_id: submissionUploadId,
         submission_id: submissionId,
-        upload_id: uploadId
+        upload_id: uploadId,
+        ticket_id: ticketId
       });
       await connection.commit();
       expect(result.status).to.equal('published');
@@ -403,7 +409,7 @@ describe('SubmissionIngestionService pipeline (system)', function () {
    */
   async function setupSubmissionWithTar(
     tarBuffer: Buffer
-  ): Promise<{ submissionId: number; uploadId: string; submissionUploadId: string }> {
+  ): Promise<{ submissionId: number; uploadId: string; submissionUploadId: string; ticketId: string }> {
     const objectKey = `${TEST_PREFIX}/${Date.now()}/archive.tar`;
 
     await storageService.uploadBuffer(BucketType.MAIN, tarBuffer, 'application/x-tar', objectKey);
@@ -442,9 +448,10 @@ describe('SubmissionIngestionService pipeline (system)', function () {
     );
 
     // 5. submission_upload
+    const ticketId = randomUUID();
     const submissionUploadResult = await connection.sql<{ submission_upload_id: string }>(
-      SQL`INSERT INTO biohub.submission_upload (submission_id, upload_id)
-          VALUES (${submissionId}, ${uploadId})
+      SQL`INSERT INTO biohub.submission_upload (submission_id, upload_id, ticket_id)
+          VALUES (${submissionId}, ${uploadId}, ${ticketId})
           RETURNING submission_upload_id`
     );
     const submissionUploadId = submissionUploadResult.rows[0].submission_upload_id;
@@ -455,7 +462,7 @@ describe('SubmissionIngestionService pipeline (system)', function () {
           VALUES (${uploadId}, ${artifactId}, 'feature')`
     );
 
-    return { submissionId, uploadId, submissionUploadId };
+    return { submissionId, uploadId, submissionUploadId, ticketId };
   }
 
   it('should process a valid submission and create features', async () => {
@@ -495,11 +502,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
     const result = await service.processSubmission({
       submission_upload_id: submissionUploadId,
       submission_id: submissionId,
-      upload_id: uploadId
+      upload_id: uploadId,
+      ticket_id: ticketId
     });
 
     expect(result.valid).to.be.true;
@@ -544,11 +552,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
     const result = await service.processSubmission({
       submission_upload_id: submissionUploadId,
       submission_id: submissionId,
-      upload_id: uploadId
+      upload_id: uploadId,
+      ticket_id: ticketId
     });
 
     expect(result.valid).to.be.false;
@@ -599,11 +608,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       { name: 'files/photo.jpg', content: 'fake-image-bytes' }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
     const result = await service.processSubmission({
       submission_upload_id: submissionUploadId,
       submission_id: submissionId,
-      upload_id: uploadId
+      upload_id: uploadId,
+      ticket_id: ticketId
     });
 
     // Track S3 media upload for cleanup
@@ -677,11 +687,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       // No files/missing.pdf in archive
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
     const result = await service.processSubmission({
       submission_upload_id: submissionUploadId,
       submission_id: submissionId,
-      upload_id: uploadId
+      upload_id: uploadId,
+      ticket_id: ticketId
     });
 
     expect(result.valid).to.be.false;
@@ -720,11 +731,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
     const result = await service.processSubmission({
       submission_upload_id: submissionUploadId,
       submission_id: submissionId,
-      upload_id: uploadId
+      upload_id: uploadId,
+      ticket_id: ticketId
     });
 
     expect(result.valid).to.be.true;
@@ -774,11 +786,12 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId } = await setupSubmissionWithTar(tarBuffer);
+    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
     const result = await service.processSubmission({
       submission_upload_id: submissionUploadId,
       submission_id: submissionId,
-      upload_id: uploadId
+      upload_id: uploadId,
+      ticket_id: ticketId
     });
 
     expect(result.valid).to.be.false;

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -8,6 +8,7 @@ export const SubmissionUpload = z.object({
   submission_upload_id: z.string().uuid(),
   submission_id: z.number(),
   upload_id: z.string().uuid(),
+  ticket_id: z.string().uuid(),
   record_end_date: z.coerce.date().nullable().optional()
 });
 export type SubmissionUpload = z.infer<typeof SubmissionUpload>;
@@ -17,7 +18,8 @@ export type SubmissionUpload = z.infer<typeof SubmissionUpload>;
  */
 export const CreateSubmissionUpload = z.object({
   submission_id: z.number(),
-  upload_id: z.string().uuid()
+  upload_id: z.string().uuid(),
+  ticket_id: z.string().uuid()
 });
 export type CreateSubmissionUpload = z.infer<typeof CreateSubmissionUpload>;
 
@@ -26,7 +28,8 @@ export type CreateSubmissionUpload = z.infer<typeof CreateSubmissionUpload>;
  */
 export const UpdateSubmissionUpload = z.object({
   submission_id: z.number().optional(),
-  upload_id: z.string().uuid().optional()
+  upload_id: z.string().uuid().optional(),
+  ticket_id: z.string().uuid().optional()
 });
 export type UpdateSubmissionUpload = z.infer<typeof UpdateSubmissionUpload>;
 

--- a/api/src/paths/submission/intake.test.ts
+++ b/api/src/paths/submission/intake.test.ts
@@ -8,6 +8,7 @@ import { SystemUser } from '../../repositories/user-repository';
 import { RegionService } from '../../services/region-service';
 import { SearchFeatureService } from '../../services/search-feature-service';
 import { SubmissionService } from '../../services/submission-service';
+import { TicketService } from '../../services/ticket-service';
 import { SubmissionUploadService } from '../../services/upload/submission-upload-service';
 import { UploadService } from '../../services/upload/upload-service';
 import { ValidationService } from '../../services/validation-service';
@@ -147,6 +148,9 @@ describe('intake', () => {
         });
 
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'some-uuid' });
+      sinon.stub(TicketService.prototype, 'createTicket').resolves({
+        ticket_id: '11111111-1111-1111-1111-111111111111'
+      } as any);
 
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')

--- a/api/src/paths/submission/intake.ts
+++ b/api/src/paths/submission/intake.ts
@@ -9,6 +9,7 @@ import { authorizeRequestHandler } from '../../request-handlers/security/authori
 import { RegionService } from '../../services/region-service';
 import { SearchFeatureService } from '../../services/search-feature-service';
 import { SubmissionService } from '../../services/submission-service';
+import { TicketService } from '../../services/ticket-service';
 import { SubmissionUploadService } from '../../services/upload/submission-upload-service';
 import { UploadService } from '../../services/upload/upload-service';
 import { ValidationService } from '../../services/validation-service';
@@ -181,11 +182,19 @@ export function submissionIntake(): RequestHandler {
         s3_upload_id: ''
       });
 
+      const ticketService = new TicketService(connection);
+      const ticket = await ticketService.createTicket({
+        subject: `Submission Upload - ${submissionName}`,
+        description: null,
+        priority: 'medium'
+      });
+
       // Create submission_upload bridge record (required for submission_upload_id FK on features)
       const submissionUploadService = new SubmissionUploadService(connection);
       const { submission_upload_id } = await submissionUploadService.insertSubmissionUpload({
         submission_id: submissionRecord.submission_id,
-        upload_id
+        upload_id,
+        ticket_id: ticket.ticket_id
       });
 
       // insert each submission feature record

--- a/api/src/paths/submission/intake.ts
+++ b/api/src/paths/submission/intake.ts
@@ -184,8 +184,8 @@ export function submissionIntake(): RequestHandler {
 
       const ticketService = new TicketService(connection);
       const ticket = await ticketService.createTicket({
-        subject: `Submission Upload - ${submissionName}`,
-        description: null,
+        subject: 'New Submission',
+        description: `Submission ID: ${submissionRecord.submission_id}. Submission UUID: ${submissionRecord.uuid}. Upload UUID: ${upload_id}`,
         priority: 'medium'
       });
 

--- a/api/src/queue/jobs/process-submission-features-job.test.ts
+++ b/api/src/queue/jobs/process-submission-features-job.test.ts
@@ -23,7 +23,8 @@ describe('process-submission-features-job', () => {
   const defaultSubmissionUpload: SubmissionUpload = {
     submission_upload_id: 'test-sub-upload-id',
     submission_id: 123,
-    upload_id: 'test-upload-id'
+    upload_id: 'test-upload-id',
+    ticket_id: '11111111-1111-1111-1111-111111111111'
   };
 
   describe('processSubmissionFeaturesJobHandler', () => {
@@ -82,7 +83,8 @@ describe('process-submission-features-job', () => {
       const jobData: SubmissionUpload = {
         submission_upload_id: 'my-sub-upload-id',
         submission_id: 456,
-        upload_id: 'my-upload-id'
+        upload_id: 'my-upload-id',
+        ticket_id: '22222222-2222-2222-2222-222222222222'
       };
       const mockJobs = [createMockJob(jobData)];
 

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -25,7 +25,8 @@ describe('publisher', () => {
   const defaultSubmissionUpload: SubmissionUpload = {
     submission_upload_id: 'sub-upload-uuid-1',
     submission_id: 123,
-    upload_id: 'upload-uuid-1'
+    upload_id: 'upload-uuid-1',
+    ticket_id: '11111111-1111-1111-1111-111111111111'
   };
 
   describe('publishProcessSubmissionFeaturesJob', () => {

--- a/api/src/repositories/upload/submission-upload-repository.test.ts
+++ b/api/src/repositories/upload/submission-upload-repository.test.ts
@@ -35,7 +35,8 @@ describe('SubmissionUploadRepository', () => {
       const mockRow: SubmissionUpload = {
         submission_upload_id: 'id-1',
         submission_id: 123,
-        upload_id: 'upload-id'
+        upload_id: 'upload-id',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
       };
       const mockQueryResponse = { rowCount: 1, rows: [mockRow] } as any as Promise<QueryResult<any>>;
       const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
@@ -65,7 +66,8 @@ describe('SubmissionUploadRepository', () => {
       const mockRow = {
         submission_upload_id: 'upload-id',
         submission_id: 123,
-        upload_id: 'upload-uuid'
+        upload_id: 'upload-uuid',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
       };
       const mockQueryResponse = { rowCount: 1, rows: [mockRow] } as any as Promise<QueryResult<any>>;
       const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
@@ -81,8 +83,18 @@ describe('SubmissionUploadRepository', () => {
       const mockQueryResponse = {
         rowCount: 2,
         rows: [
-          { submission_upload_id: 'id-1', submission_id: 123, upload_id: 'a-1' },
-          { submission_upload_id: 'id-2', submission_id: 123, upload_id: 'a-2' }
+          {
+            submission_upload_id: 'id-1',
+            submission_id: 123,
+            upload_id: 'a-1',
+            ticket_id: '11111111-1111-1111-1111-111111111111'
+          },
+          {
+            submission_upload_id: 'id-2',
+            submission_id: 123,
+            upload_id: 'a-2',
+            ticket_id: '22222222-2222-2222-2222-222222222222'
+          }
         ]
       } as any as Promise<QueryResult<any>>;
 
@@ -94,15 +106,32 @@ describe('SubmissionUploadRepository', () => {
       const result = await repo.getSubmissionUploadsBySubmissionId(123);
 
       expect(result).to.eql([
-        { submission_upload_id: 'id-1', submission_id: 123, upload_id: 'a-1' },
-        { submission_upload_id: 'id-2', submission_id: 123, upload_id: 'a-2' }
+        {
+          submission_upload_id: 'id-1',
+          submission_id: 123,
+          upload_id: 'a-1',
+          ticket_id: '11111111-1111-1111-1111-111111111111'
+        },
+        {
+          submission_upload_id: 'id-2',
+          submission_id: 123,
+          upload_id: 'a-2',
+          ticket_id: '22222222-2222-2222-2222-222222222222'
+        }
       ]);
     });
 
     it('applies type filter and returns filtered records', async () => {
       const mockQueryResponse = {
         rowCount: 1,
-        rows: [{ submission_upload_id: 'id-1', submission_id: 123, upload_id: 'a-1' }]
+        rows: [
+          {
+            submission_upload_id: 'id-1',
+            submission_id: 123,
+            upload_id: 'a-1',
+            ticket_id: '11111111-1111-1111-1111-111111111111'
+          }
+        ]
       } as any as Promise<QueryResult<any>>;
 
       const mockDBConnection = getMockDBConnection({
@@ -112,13 +141,30 @@ describe('SubmissionUploadRepository', () => {
 
       const filters = { role: UploadArtifactRoleEnum.FEATURE };
       const result = await repo.getSubmissionUploadsBySubmissionId(123, filters);
-      expect(result).to.eql([{ submission_upload_id: 'id-1', submission_id: 123, upload_id: 'a-1' }]);
+      expect(result).to.eql([
+        {
+          submission_upload_id: 'id-1',
+          submission_id: 123,
+          upload_id: 'a-1',
+          ticket_id: '11111111-1111-1111-1111-111111111111'
+        }
+      ]);
     });
 
     it('applies pagination', async () => {
       const mockRows = [
-        { submission_upload_id: 'id-1', submission_id: 123, upload_id: 'a-1' },
-        { submission_upload_id: 'id-2', submission_id: 123, upload_id: 'a-2' }
+        {
+          submission_upload_id: 'id-1',
+          submission_id: 123,
+          upload_id: 'a-1',
+          ticket_id: '11111111-1111-1111-1111-111111111111'
+        },
+        {
+          submission_upload_id: 'id-2',
+          submission_id: 123,
+          upload_id: 'a-2',
+          ticket_id: '22222222-2222-2222-2222-222222222222'
+        }
       ];
       const mockQueryResponse = {
         rowCount: 2,
@@ -142,7 +188,11 @@ describe('SubmissionUploadRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
       const repo = new SubmissionUploadRepository(mockDBConnection);
 
-      const payload: CreateSubmissionUpload = { submission_id: 123, upload_id: 'a-1' };
+      const payload: CreateSubmissionUpload = {
+        submission_id: 123,
+        upload_id: 'a-1',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
+      };
 
       try {
         await repo.insertSubmissionUpload(payload);
@@ -159,7 +209,11 @@ describe('SubmissionUploadRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
       const repo = new SubmissionUploadRepository(mockDBConnection);
 
-      const payload: CreateSubmissionUpload = { submission_id: 123, upload_id: 'a-1' };
+      const payload: CreateSubmissionUpload = {
+        submission_id: 123,
+        upload_id: 'a-1',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
+      };
       const result = await repo.insertSubmissionUpload(payload);
 
       expect(result).to.eql(mockRow);

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -24,7 +24,8 @@ export class SubmissionUploadRepository extends BaseRepository {
       SELECT
         submission_upload_id,
         submission_id,
-        upload_id
+        upload_id,
+        ticket_id
       FROM
         submission_upload
       WHERE
@@ -70,6 +71,7 @@ export class SubmissionUploadRepository extends BaseRepository {
         su.submission_upload_id,
         su.submission_id,
         su.upload_id,
+        su.ticket_id,
         su.record_end_date
       FROM
         submission_upload su
@@ -117,7 +119,8 @@ export class SubmissionUploadRepository extends BaseRepository {
       .select(
         'submission_upload.submission_upload_id',
         'submission_upload.submission_id',
-        'submission_upload.upload_id'
+        'submission_upload.upload_id',
+        'submission_upload.ticket_id'
       )
       .from('submission_upload')
       .join('upload_artifact as ua', 'ua.upload_id', 'submission_upload.upload_id')
@@ -147,10 +150,12 @@ export class SubmissionUploadRepository extends BaseRepository {
     const sqlStatement = SQL`
       INSERT INTO submission_upload (
         submission_id,
-        upload_id
+        upload_id,
+        ticket_id
       ) VALUES (
         ${submissionUpload.submission_id},
-        ${submissionUpload.upload_id}
+        ${submissionUpload.upload_id},
+        ${submissionUpload.ticket_id}
       )
       RETURNING submission_upload_id;
     `;
@@ -172,21 +177,25 @@ export class SubmissionUploadRepository extends BaseRepository {
    *
    * @param {number} submissionId - The ID of the submission.
    * @param {string} uploadId - The ID of the upload.
+   * @param {string} ticketId - The ID of the associated ticket.
    * @returns {Promise<{ submission_upload_id: string }[]>} - The list of newly created submission_upload records.
    * @throws {ApiExecuteSQLError} - If the insert fails.
    */
   async insertSubmissionUploadsForUploadId(
     submissionId: number,
-    uploadId: string
+    uploadId: string,
+    ticketId: string
   ): Promise<{ submission_upload_id: string }[]> {
     const sqlStatement = SQL`
       INSERT INTO submission_upload (
         submission_id,
-        upload_id
+        upload_id,
+        ticket_id
       )
       SELECT
         ${submissionId},
-        ua.upload_id
+        ua.upload_id,
+        ${ticketId}
       FROM upload_artifact ua
       WHERE ua.upload_id = ${uploadId}
       RETURNING submission_upload_id;
@@ -222,7 +231,8 @@ export class SubmissionUploadRepository extends BaseRepository {
       UPDATE submission_upload
       SET
         submission_id = COALESCE(${submissionUpload.submission_id}, submission_id),
-        upload_id = COALESCE(${submissionUpload.upload_id}, upload_id)
+        upload_id = COALESCE(${submissionUpload.upload_id}, upload_id),
+        ticket_id = COALESCE(${submissionUpload.ticket_id}, ticket_id)
       WHERE
         submission_upload_id = ${submissionUploadId}
       RETURNING submission_upload_id;
@@ -253,7 +263,8 @@ export class SubmissionUploadRepository extends BaseRepository {
       SELECT
         submission_upload_id,
         submission_id,
-        upload_id
+        upload_id,
+        ticket_id
       FROM
         submission_upload
       WHERE

--- a/api/src/services/ingestion/submission-ingestion-service.test.ts
+++ b/api/src/services/ingestion/submission-ingestion-service.test.ts
@@ -98,7 +98,8 @@ describe('SubmissionIngestionService', () => {
     const mockSubmissionUpload = {
       submission_upload_id: 'sub-upload-uuid-1',
       submission_id: 123,
-      upload_id: 'upload-1'
+      upload_id: 'upload-1',
+      ticket_id: '11111111-1111-1111-1111-111111111111'
     };
     const mockObjectKey = 'submissions/123/uploads/upload-1.tar';
 

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -370,7 +370,8 @@ describe('ArtifactSecurityService', () => {
       sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
         submission_upload_id: 'su-1',
         submission_id: 123,
-        upload_id: 'upload-1'
+        upload_id: 'upload-1',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
       });
       const publishStub = sinon
         .stub(publisher, 'publishProcessSubmissionFeaturesJob')
@@ -384,7 +385,8 @@ describe('ArtifactSecurityService', () => {
       expect(publishStub.firstCall.args[1]).to.deep.equal({
         submission_upload_id: 'su-1',
         submission_id: 123,
-        upload_id: 'upload-1'
+        upload_id: 'upload-1',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
       });
     });
 
@@ -474,7 +476,8 @@ describe('ArtifactSecurityService', () => {
       sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
         submission_upload_id: 'su-1',
         submission_id: 999,
-        upload_id: 'upload-1'
+        upload_id: 'upload-1',
+        ticket_id: '22222222-2222-2222-2222-222222222222'
       });
       const publishStub = sinon
         .stub(publisher, 'publishProcessSubmissionFeaturesJob')
@@ -487,7 +490,8 @@ describe('ArtifactSecurityService', () => {
       expect(publishStub.firstCall.args[1]).to.deep.equal({
         submission_upload_id: 'su-1',
         submission_id: 999,
-        upload_id: 'upload-1'
+        upload_id: 'upload-1',
+        ticket_id: '22222222-2222-2222-2222-222222222222'
       });
     });
 

--- a/api/src/services/upload/submission-upload-service.test.ts
+++ b/api/src/services/upload/submission-upload-service.test.ts
@@ -27,7 +27,8 @@ describe('SubmissionUploadService', () => {
       const fakeSubmissionUpload: SubmissionUpload = {
         submission_upload_id: 'artifact-1',
         submission_id: 1,
-        upload_id: 'upload-1'
+        upload_id: 'upload-1',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
       };
 
       const stub = sinon
@@ -59,12 +60,14 @@ describe('SubmissionUploadService', () => {
         {
           submission_upload_id: 'artifact-1',
           submission_id: mockSubmissionId,
-          upload_id: 'upload-1'
+          upload_id: 'upload-1',
+          ticket_id: '11111111-1111-1111-1111-111111111111'
         },
         {
           submission_upload_id: 'artifact-2',
           submission_id: mockSubmissionId,
-          upload_id: 'upload-2'
+          upload_id: 'upload-2',
+          ticket_id: '22222222-2222-2222-2222-222222222222'
         }
       ];
 
@@ -96,7 +99,8 @@ describe('SubmissionUploadService', () => {
     it('should insert a new submission_upload record and return its ID', async () => {
       const fakeInput: CreateSubmissionUpload = {
         submission_id: 1,
-        upload_id: 'upload-1'
+        upload_id: 'upload-1',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
       };
 
       const stub = sinon
@@ -112,7 +116,8 @@ describe('SubmissionUploadService', () => {
     it('should throw an error if repository fails', async () => {
       const fakeInput: CreateSubmissionUpload = {
         submission_id: 1,
-        upload_id: 'upload-1'
+        upload_id: 'upload-1',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
       };
 
       sinon.stub(SubmissionUploadRepository.prototype, 'insertSubmissionUpload').throws(new Error('Insert failed'));
@@ -130,7 +135,8 @@ describe('SubmissionUploadService', () => {
     it('should update an existing submission_upload record and return its ID', async () => {
       const fakeInput: UpdateSubmissionUpload = {
         submission_id: 2,
-        upload_id: 'upload-2'
+        upload_id: 'upload-2',
+        ticket_id: '22222222-2222-2222-2222-222222222222'
       };
 
       const stub = sinon
@@ -146,7 +152,8 @@ describe('SubmissionUploadService', () => {
     it('should throw an error if repository fails', async () => {
       const fakeInput: UpdateSubmissionUpload = {
         submission_id: 2,
-        upload_id: 'upload-2'
+        upload_id: 'upload-2',
+        ticket_id: '22222222-2222-2222-2222-222222222222'
       };
 
       sinon.stub(SubmissionUploadRepository.prototype, 'updateSubmissionUpload').throws(new Error('Update failed'));

--- a/api/src/services/upload/upload-ingestion-service.test.ts
+++ b/api/src/services/upload/upload-ingestion-service.test.ts
@@ -18,6 +18,7 @@ import * as fileUtils from '../../utils/file-utils';
 import * as submissionUploadUtils from '../../utils/submission-upload-utils';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { SubmissionService } from '../submission-service';
+import { TicketService } from '../ticket-service';
 import { ArtifactSecurityService } from './artifact-security-service';
 import { ArtifactService } from './artifact-service';
 import { SubmissionUploadReviewStatusService } from './submission-upload-review-status-service';
@@ -64,6 +65,9 @@ describe('UploadIngestionService', () => {
         uuid: mockSubmission.uuid
       } as ISubmissionModel);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: mockUploadId });
+      sinon.stub(TicketService.prototype, 'createTicket').resolves({
+        ticket_id: '11111111-1111-1111-1111-111111111111'
+      } as any);
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
         .resolves({ submission_upload_id: 'submission-upload-id-1' });
@@ -135,6 +139,9 @@ describe('UploadIngestionService', () => {
         uuid: mockSubmission.uuid
       } as ISubmissionModel);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'upload-456' });
+      sinon.stub(TicketService.prototype, 'createTicket').resolves({
+        ticket_id: '11111111-1111-1111-1111-111111111111'
+      } as any);
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
         .resolves({ submission_upload_id: 'submission-upload-id-1' });
@@ -161,6 +168,9 @@ describe('UploadIngestionService', () => {
         uuid: mockSubmission.uuid
       } as ISubmissionModel);
       sinon.stub(UploadService.prototype, 'insertUpload').resolves({ upload_id: 'upload-456' });
+      sinon.stub(TicketService.prototype, 'createTicket').resolves({
+        ticket_id: '11111111-1111-1111-1111-111111111111'
+      } as any);
       sinon
         .stub(SubmissionUploadService.prototype, 'insertSubmissionUpload')
         .resolves({ submission_upload_id: 'submission-upload-id-1' });

--- a/api/src/services/upload/upload-ingestion-service.ts
+++ b/api/src/services/upload/upload-ingestion-service.ts
@@ -99,8 +99,8 @@ export class UploadIngestionService extends DBService {
 
     // 2. Create ticket for admin visibility into this upload
     const ticket = await this.ticketService.createTicket({
-      subject: `Submission Upload - ${submissionUuid}`,
-      description: null,
+      subject: 'New Submission',
+      description: `Submission ID: ${submissionId}. Submission UUID: ${submissionUuid}. Upload UUID: ${upload_id}`,
       priority: 'medium'
     });
 

--- a/api/src/services/upload/upload-ingestion-service.ts
+++ b/api/src/services/upload/upload-ingestion-service.ts
@@ -11,6 +11,7 @@ import { getSecurityObjectStoreBucketName, getSecurityS3Client } from '../../uti
 import { generateMultipartUploadPresignedUrls } from '../../utils/submission-upload-utils';
 import { DBService } from '../db-service';
 import { SubmissionService } from '../submission-service';
+import { TicketService } from '../ticket-service';
 import { ArtifactSecurityService } from './artifact-security-service';
 import { ArtifactService } from './artifact-service';
 import { SubmissionUploadReviewStatusService } from './submission-upload-review-status-service';
@@ -37,6 +38,7 @@ export class UploadIngestionService extends DBService {
   submissionUploadService = new SubmissionUploadService(this.connection);
   submissionUploadReviewStatusService = new SubmissionUploadReviewStatusService(this.connection);
   artifactSecurityService = new ArtifactSecurityService(this.connection);
+  ticketService = new TicketService(this.connection);
 
   /**
    * Create a new archive upload along with a new submission record.
@@ -95,19 +97,27 @@ export class UploadIngestionService extends DBService {
       s3_upload_id: null
     });
 
-    // 2. Bind submission → upload
-    const { submission_upload_id } = await this.submissionUploadService.insertSubmissionUpload({
-      submission_id: submissionId,
-      upload_id
+    // 2. Create ticket for admin visibility into this upload
+    const ticket = await this.ticketService.createTicket({
+      subject: `Submission Upload - ${submissionUuid}`,
+      description: null,
+      priority: 'medium'
     });
 
-    // 3. Create initial review status (submitted = unreviewed)
+    // 3. Bind submission → upload
+    const { submission_upload_id } = await this.submissionUploadService.insertSubmissionUpload({
+      submission_id: submissionId,
+      upload_id,
+      ticket_id: ticket.ticket_id
+    });
+
+    // 4. Create initial review status (submitted = unreviewed)
     await this.submissionUploadReviewStatusService.insertSubmissionUploadReviewStatus({
       submission_upload_id,
       status: 'submitted'
     });
 
-    // 4. Create placeholder artifact for archive
+    // 5. Create placeholder artifact for archive
     const key = `submissions/${submissionId}/uploads/${upload_id}.tar`;
     const artifact = await this.artifactService.insertArtifact({
       bucket: getSecurityObjectStoreBucketName(),
@@ -118,14 +128,14 @@ export class UploadIngestionService extends DBService {
       uploaded_at: null
     });
 
-    // 5. Create upload_archive metadata
+    // 6. Create upload_archive metadata
     const { upload_archive_id } = await this.uploadArchiveService.insertUploadArchive({
       upload_id,
       artifact_id: artifact.artifact_id,
       archive_status: ProcessStatusStatusEnum.DRAFT
     });
 
-    // 6. Initialize multipart upload
+    // 7. Initialize multipart upload
     const {
       uploadId: s3UploadId,
       presignedUrls,
@@ -137,10 +147,10 @@ export class UploadIngestionService extends DBService {
       bytes
     });
 
-    // 7. Persist S3 upload ID
+    // 8. Persist S3 upload ID
     await this.uploadService.updateUpload(upload_id, { s3_upload_id: s3UploadId });
 
-    // 8. Response submissionId is the submission UUID (callers pass it for clarity; API returns it for client use).
+    // 9. Response submissionId is the submission UUID (callers pass it for clarity; API returns it for client use).
     return {
       submissionId: submissionUuid,
       submissionUploadId: submission_upload_id,

--- a/database/src/migrations/20260318120000_add_ticket_id_to_submission_upload.ts
+++ b/database/src/migrations/20260318120000_add_ticket_id_to_submission_upload.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE submission_upload ADD COLUMN ticket_id uuid NOT NULL;
+
+    COMMENT ON COLUMN submission_upload.ticket_id IS 'Foreign key to the ticket associated with this submission upload.';
+
+    ALTER TABLE submission_upload ADD CONSTRAINT submission_upload_ticket_fk
+      FOREIGN KEY (ticket_id) REFERENCES ticket(ticket_id);
+
+    CREATE INDEX submission_upload_ticket_idx ON submission_upload(ticket_id);
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    DROP INDEX IF EXISTS submission_upload_ticket_idx;
+
+    ALTER TABLE submission_upload DROP CONSTRAINT IF EXISTS submission_upload_ticket_fk;
+
+    ALTER TABLE submission_upload DROP COLUMN IF EXISTS ticket_id;
+  `);
+}

--- a/database/src/seeds/04_mock_test_data.ts
+++ b/database/src/seeds/04_mock_test_data.ts
@@ -188,15 +188,105 @@ export const insertSubmissionUploadRecord = async (
   submission_id: number,
   upload_id: string
 ): Promise<string> => {
+  const ticket_id = await ensureTicketForSubmissionUpload(knex, { submission_id, upload_id });
+
   const [{ submission_upload_id }] = await knex('submission_upload')
     .insert({
       submission_id,
       upload_id,
-      create_user: 1
+      create_user: 1,
+      ticket_id
     })
     .returning('submission_upload_id');
 
   return submission_upload_id;
+};
+
+const ensureTicketForSubmissionUpload = async (
+  knex: Knex,
+  input: { submission_id: number; upload_id: string }
+): Promise<string> => {
+  // Use an existing system_user for create_user to satisfy NOT NULL constraints.
+  const createUserRow = await knex('system_user').whereNull('record_end_date').select('system_user_id').first();
+  const create_user = createUserRow?.system_user_id ?? 1;
+
+  // Keep a stable team across seed runs so we only need one FK target.
+  const teamName = 'Seed Submission Upload Team';
+  const team = await knex('team').where({ name: teamName }).whereNull('record_end_date').first();
+  const team_id =
+    team?.team_id ??
+    (
+      await knex('team')
+        .insert({
+          name: teamName,
+          description: 'Auto-generated team for submission_upload seed tickets.',
+          create_user
+        })
+        .returning(['team_id'])
+    )[0].team_id;
+
+  // Make subject unique per upload UUID so rerunning seeds can reuse the same ticket.
+  const subject = `Submission Upload - ${input.upload_id}`;
+  const existing = await knex('ticket').where({ subject }).whereNull('record_end_date').first();
+  if (existing?.ticket_id) {
+    return existing.ticket_id;
+  }
+
+  const ticket_slug = await generateUniqueTicketSlug(knex);
+
+  const [created] = await knex('ticket')
+    .insert({
+      ticket_slug,
+      subject,
+      description: null,
+      team_id,
+      priority: 'medium',
+      status: 'open',
+      create_user
+    })
+    .returning(['ticket_id']);
+
+  const ticket_id = created.ticket_id as string;
+
+  await knex('ticket_status').insert({
+    ticket_id,
+    status: 'open',
+    create_user
+  });
+
+  return ticket_id;
+};
+
+/**
+ * Generate an unused DDDNNNNN ticket slug for the current UTC day.
+ * (DDD = day-of-year, NNNNN = per-day sequence)
+ */
+const generateUniqueTicketSlug = async (knex: Knex): Promise<string> => {
+  const now = new Date();
+  const utcYearStart = Date.UTC(now.getUTCFullYear(), 0, 0);
+  const utcToday = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const dayOfYear = Math.floor((utcToday - utcYearStart) / (1000 * 60 * 60 * 24));
+  const dayPrefix = dayOfYear.toString().padStart(3, '0');
+
+  const row = await knex('ticket')
+    .whereRaw('ticket_slug LIKE ?', [`${dayPrefix}%`])
+    .select(knex.raw('COALESCE(MAX(RIGHT(ticket_slug, 5)::integer), -1) as last_value'))
+    .first();
+
+  const lastValueRaw = row?.last_value;
+  const nextSequenceInit = lastValueRaw === undefined || lastValueRaw === null ? -1 : Number(lastValueRaw);
+  let nextSequence = Number.isNaN(nextSequenceInit) ? -1 : nextSequenceInit;
+  // Ensure uniqueness even if another process inserted the candidate.
+  while (nextSequence < 100000) {
+    nextSequence += 1;
+    const candidate = `${dayPrefix}${nextSequence.toString().padStart(5, '0')}`;
+    const exists = await knex('ticket').where({ ticket_slug: candidate }).whereNull('record_end_date').first();
+    if (!exists) {
+      return candidate;
+    }
+  }
+
+  throw new Error('Unable to generate a unique ticket_slug for seed data');
 };
 
 export const insertSampleSiteRecord = async (


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-880](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-880)

## Description of Changes

- Added `submission_upload.ticket_id` with a migration, foreign key to `ticket(ticket_id)`, and index.
- Updated submission upload models/repository so `ticket_id` is required on create and returned on reads.
- On upload creation, now create a ticket first and persist the `ticket_id` on `submission_upload` in both:
  - `UploadIngestionService._startArchiveUploadForSubmission`
  - Legacy `submissionIntake` flow
- Updated unit tests/fixtures that use `SubmissionUpload` to include `ticket_id`.

## Testing Notes

- Create a new submission upload (new submission and existing submission paths) and confirm a ticket is created.
- Verify the new `submission_upload` row stores the created `ticket_id` and references a valid ticket record.