### PR TITLE
SIMSBIOHUB-929: Add Keycloak Client ID to DB Setup in PR Deployments

### DIFF
--- a/infrastructure/database-setup/templates/job.yaml
+++ b/infrastructure/database-setup/templates/job.yaml
@@ -89,6 +89,8 @@ spec:
               value: {{ .Values.environment.name }}-{{ .Chart.AppVersion }}-{{ .Values.environment.changeId }}
             - name: DB_SCHEMA
               value: {{ .Values.app.dbSchema }}
+            - name: KEYCLOAK_CLIENT_ID
+              value: {{ .Values.app.keycloak.clientId }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.image }}:{{ include "app.imageTag" . }}"
           imagePullPolicy: Always
           {{- if .Values.app.database.useCrunchy }}

--- a/infrastructure/database-setup/values.yaml
+++ b/infrastructure/database-setup/values.yaml
@@ -15,6 +15,10 @@ app:
   name: biohub-platform-db-setup
   nodeEnv: "" # NODE_ENV specification variable
 
+  # Keycloak
+  keycloak:
+    clientId: bio-hub-browser-4230 # Client ID for seed contributors
+
   dbSchema: biohub # Database schema
 
   database:


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-929

## Description of Changes

- The helm chart does not pass the `KEYCLOAK_CLIENT_ID` env to the db setup pod, so migrations fail in the PR deploys.
- Adds the missing env var to helm
- This will let any seed users create submissions on behalf of a contributor system in the deployed environments

## Testing Notes

- The DB Setup for this PR's deployment should succeed