### PR TITLE
SIMSBIOHUB-943: Bug fix to prevent seeds in prod

### DIFF
--- a/database/src/knexfile.ts
+++ b/database/src/knexfile.ts
@@ -24,7 +24,7 @@ export default {
       directory: './migrations'
     },
     seeds: {
-      directory: ['./seeds', './procedures']
+      directory: ['./seeds']
     }
   },
   production: {
@@ -47,8 +47,8 @@ export default {
       directory: './migrations'
     },
     seeds: {
-      // In production, only scripts in the `procedures` directory should run.
-      directory: ['./procedures']
+      // In production, do not run seeds
+      directory: []
     }
   }
 };

--- a/database/src/knexfile.ts
+++ b/database/src/knexfile.ts
@@ -24,7 +24,7 @@ export default {
       directory: './migrations'
     },
     seeds: {
-      directory: ['./seeds']
+      directory: ['./seeds', './procedures']
     }
   },
   production: {
@@ -45,6 +45,10 @@ export default {
       tableName: 'migration',
       schemaName: 'public',
       directory: './migrations'
+    },
+    seeds: {
+      // In production, only scripts in the `procedures` directory should run.
+      directory: ['./procedures']
     }
   }
 };

--- a/database/src/seeds/07_access_policy.ts
+++ b/database/src/seeds/07_access_policy.ts
@@ -203,9 +203,17 @@ export async function seed(knex: Knex): Promise<void> {
    * Pattern mirrors docs/SIMSBIOHUB-914/sql/scale-data-scopes.sql
    * ------------------------------------------------------------------ */
 
-  // 3a. Mark the first 3 datasets as secured (submission_feature_ids 1, 4, 7)
-  //     These are the parent datasets whose children (sample_site, telemetry) inherit security.
-  const securedDatasetIds = [1, 4, 7];
+  // 3a. Mark the first 3 dataset features as secured.
+  //     Resolve IDs dynamically instead of hardcoding (IDs are not stable across environments).
+  const securedDatasetRows = await knex('submission_feature as sf')
+    .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id')
+    .where('ft.name', 'dataset')
+    .whereNull('sf.record_end_date')
+    .orderBy('sf.submission_feature_id', 'asc')
+    .select('sf.submission_feature_id')
+    .limit(3);
+
+  const securedDatasetIds = securedDatasetRows.map((row) => row.submission_feature_id);
 
   // Use first security rule available
   const firstRule = await knex('security_rule').whereNull('record_end_date').select('security_rule_id').first();


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-943

## Description of Changes

- If `seeds` is excluded, Knexfile defaults to running files in the the `seeds/` subdirectory.
- This explicitly sets the `seeds` parameter in `Knexfile.ts` to not run the seed files when `NODE_ENV=production`

## Testing Notes

- `make clean postgres` succeeds