### PR TITLE
SIMSBIOHUB-932: Add Secured Features to Cart

### DIFF
--- a/api/src/__integration__/db/cart-submission-feature-service.integration.ts
+++ b/api/src/__integration__/db/cart-submission-feature-service.integration.ts
@@ -1,0 +1,478 @@
+// Integration test for cart submission feature security — verifies the auth-aware walk-up CTE
+// correctly gates secured features at insert time, computes the `secured` flag on read,
+// and counts all features regardless of security status.
+//
+// Tests the full SQL execution path: recursive ancestor walk-up, security_scope_anchor →
+// team_security_scope → team_member join, and the bulk CTE for read-side `secured` computation.
+//
+// Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
+//
+// Run: make test-db
+// Requires: make web (database must be running with seed data)
+
+import { expect } from 'chai';
+import SQL from 'sql-template-strings';
+import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { CartRepository } from '../../repositories/cart-repository';
+import { SecurityScopeRepository } from '../../repositories/authorization/security-scope-repository';
+import { CartSubmissionFeatureService } from '../../services/cart-submission-feature-service';
+import { computeScopeHash } from '../../utils/scope-hash';
+import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
+
+describe('Cart submission feature security (integration)', function () {
+  this.timeout(15000);
+
+  let connection: IDBConnection;
+  let cartRepo: CartRepository;
+  let scopeRepo: SecurityScopeRepository;
+  let cartFeatureService: CartSubmissionFeatureService;
+
+  before(() => {
+    initDBPool(defaultPoolConfig);
+  });
+
+  beforeEach(async () => {
+    connection = getAPIUserDBConnection();
+    await connection.open();
+    cartRepo = new CartRepository(connection);
+    scopeRepo = new SecurityScopeRepository(connection);
+    cartFeatureService = new CartSubmissionFeatureService(connection);
+  });
+
+  afterEach(async () => {
+    await connection.rollback();
+    connection.release();
+  });
+
+  // ── Helpers ──────────────────────────────────────────────────────────
+
+  /**
+   * Create an empty active cart and return its cart_id.
+   */
+  async function createActiveCart(systemUserId: number | null): Promise<string> {
+    const cart = await cartRepo.createCart(systemUserId);
+    return cart.cart_id;
+  }
+
+  /**
+   * Mark a submission feature as secured.
+   * Uses security_rule_id 1 from seed data.
+   */
+  async function secureFeature(submissionFeatureId: number): Promise<void> {
+    const systemUserId = connection.systemUserId();
+    await connection.sql(SQL`
+      INSERT INTO submission_feature_security (submission_feature_id, security_rule_id, create_user)
+      VALUES (${submissionFeatureId}, 1, ${systemUserId});
+    `);
+  }
+
+  async function createTeam(name: string): Promise<string> {
+    const systemUserId = connection.systemUserId();
+    const result = await connection.sql(SQL`
+      INSERT INTO team (name, create_user)
+      VALUES (${name}, ${systemUserId})
+      RETURNING team_id;
+    `);
+    return result.rows[0].team_id;
+  }
+
+  async function addTeamMember(teamId: string, systemUserId: number): Promise<void> {
+    const apiUserId = connection.systemUserId();
+    await connection.sql(SQL`
+      INSERT INTO team_member (team_id, system_user_id, create_user)
+      VALUES (${teamId}, ${systemUserId}, ${apiUserId});
+    `);
+  }
+
+  async function createPolicy(name: string): Promise<string> {
+    const systemUserId = connection.systemUserId();
+    const result = await connection.sql(SQL`
+      INSERT INTO policy (name, create_user)
+      VALUES (${name}, ${systemUserId})
+      RETURNING policy_id;
+    `);
+    return result.rows[0].policy_id;
+  }
+
+  async function createPolicyStatement(policyId: string, urn: string): Promise<string> {
+    const systemUserId = connection.systemUserId();
+    const result = await connection.sql(SQL`
+      INSERT INTO policy_statement (policy_id, effect, submission_feature_urn, create_user)
+      VALUES (${policyId}, 'allow', ${urn}, ${systemUserId})
+      RETURNING policy_statement_id;
+    `);
+    return result.rows[0].policy_statement_id;
+  }
+
+  async function createTeamPolicy(teamId: string, policyId: string): Promise<void> {
+    const systemUserId = connection.systemUserId();
+    await connection.sql(SQL`
+      INSERT INTO team_policy (team_id, policy_id, create_user)
+      VALUES (${teamId}, ${policyId}, ${systemUserId});
+    `);
+  }
+
+  /**
+   * Compute anchors for a scope using the repository's keyset-paginated API.
+   * Bypasses pg-boss — runs synchronously within the test transaction.
+   */
+  async function computeAnchors(scopeId: string): Promise<void> {
+    const urn = await scopeRepo.resolveUrnForScope(scopeId);
+
+    if (!urn) {
+      return;
+    }
+
+    let lastId = 0;
+
+    while (true) {
+      const batch = await scopeRepo.computeAnchorBatch(scopeId, urn, lastId);
+
+      if (!batch) {
+        break;
+      }
+
+      lastId = batch.pageLastId;
+    }
+  }
+
+  /**
+   * Set up the full scope chain for a policy statement, bypassing pg-boss:
+   * 1. Create or get security_scope (deduped by scope_hash)
+   * 2. Map policy_statement → security_scope
+   * 3. Compute anchors synchronously
+   */
+  async function setupScopeChain(policyStatementId: string, urn: string): Promise<string> {
+    const scopeHash = computeScopeHash(urn);
+    const inserted = await scopeRepo.insertSecurityScope(scopeHash);
+
+    const scopeId = inserted
+      ? inserted.security_scope_id
+      : (await scopeRepo.getSecurityScopeByScopeHash(scopeHash)).security_scope_id;
+
+    await scopeRepo.insertPolicyStatementScope(policyStatementId, scopeId);
+    await computeAnchors(scopeId);
+
+    return scopeId;
+  }
+
+  /**
+   * Full RBAC setup: policy → statement → scope chain → team → member → team_policy → team scopes.
+   * Returns all created IDs for assertions.
+   */
+  async function setupFullAccess(
+    urn: string,
+    userId: number,
+    teamName: string
+  ): Promise<{ policyId: string; scopeId: string; teamId: string }> {
+    const policyId = await createPolicy(`${teamName}-policy`);
+    const stmtId = await createPolicyStatement(policyId, urn);
+    const scopeId = await setupScopeChain(stmtId, urn);
+
+    const teamId = await createTeam(teamName);
+    await addTeamMember(teamId, userId);
+    await createTeamPolicy(teamId, policyId);
+    await scopeRepo.insertTeamSecurityScopesForPolicy(teamId, policyId);
+
+    return { policyId, scopeId, teamId };
+  }
+
+  let _userSeq = 0;
+  /**
+   * Create a separate system_user for testing scope access without the API connection user.
+   * Note: "system_user" must be quoted — it is a PostgreSQL reserved keyword.
+   */
+  async function createOtherUser(): Promise<number> {
+    const apiUserId = connection.systemUserId();
+    const guid = `test-cart-sec-${Date.now()}-${++_userSeq}`;
+    const result = await connection.sql(SQL`
+      INSERT INTO "system_user" (user_identity_source_id, user_identifier, user_guid, record_effective_date, create_user)
+      SELECT user_identity_source_id, ${guid}, ${guid}, now(), ${apiUserId}
+      FROM user_identity_source
+      WHERE record_end_date IS NULL
+      LIMIT 1
+      RETURNING system_user_id;
+    `);
+    return result.rows[0].system_user_id;
+  }
+
+  /**
+   * Get features currently in a cart via raw SQL (bypasses the service under test).
+   */
+  async function getCartFeatureIds(cartId: string): Promise<number[]> {
+    const result = await connection.sql(SQL`
+      SELECT submission_feature_id
+      FROM cart_submission_feature
+      WHERE cart_id = ${cartId}
+      ORDER BY submission_feature_id;
+    `);
+    return result.rows.map((r: { submission_feature_id: number }) => r.submission_feature_id);
+  }
+
+  // ── addSubmissionFeaturesToCart — anonymous ──────────────────────────
+
+  describe('addSubmissionFeaturesToCart — anonymous', () => {
+    it('should add an unsecured feature to cart', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public Dataset' });
+
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([featureId]);
+    });
+
+    it('should exclude a directly secured feature', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
+      await secureFeature(featureId);
+
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([]);
+    });
+
+    it('should exclude a feature with inherited security from a secured parent', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const parentId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Parent' });
+      const childId = await createTestFeature(connection, submissionId, 'species_observation', { name: 'Child' }, parentId);
+      await secureFeature(parentId);
+
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [childId], null);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([]);
+    });
+  });
+
+  // ── addSubmissionFeaturesToCart — authenticated ─────────────────────
+
+  describe('addSubmissionFeaturesToCart — authenticated', () => {
+    it('should add a secured feature when user has scope access', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
+      await secureFeature(featureId);
+
+      const userId = await createOtherUser();
+      await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'scope-access-team');
+
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], userId);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([featureId]);
+    });
+
+    it('should exclude a secured feature when user has NO scope access', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
+      await secureFeature(featureId);
+
+      // User exists but is not a member of any team with scope access
+      const userId = await createOtherUser();
+
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], userId);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([]);
+    });
+
+    it('should add an unsecured feature with secured: false', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public Dataset' });
+
+      const userId = await createOtherUser();
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], userId);
+
+      const features = await cartFeatureService.getCartSubmissionFeatures(cartId);
+      expect(features).to.have.length(1);
+      expect(features[0].submission_feature_id).to.equal(featureId);
+      expect(features[0].secured).to.equal(false);
+    });
+
+    it('should add only authorized features from a mixed batch', async () => {
+      const submissionId = await createTestSubmission(connection);
+
+      // Unsecured feature — always allowed
+      const unsecuredId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public' });
+
+      // Directly secured feature — user has scope access
+      const securedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
+      await secureFeature(securedId);
+
+      // Inherited security — parent secured, child has no direct rule
+      const securedParentId = await createTestFeature(connection, submissionId, 'dataset', {
+        name: 'Secured Parent'
+      });
+      const inheritedChildId = await createTestFeature(
+        connection,
+        submissionId,
+        'species_observation',
+        { name: 'Inherited Child' },
+        securedParentId
+      );
+      await secureFeature(securedParentId);
+
+      // Note: securedId's scope access covers it directly; inheritedChildId's access
+      // comes via ancestor walk-up to securedParentId which is also in the same submission
+
+      const userId = await createOtherUser();
+      // Grant scope for the first secured feature's submission but NOT the second
+      // Use wildcard URN that covers the whole submission — all secured features accessible
+      await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'mixed-batch-team');
+
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.addSubmissionFeaturesToCart(
+        cartId,
+        [unsecuredId, securedId, inheritedChildId],
+        userId
+      );
+
+      const ids = await getCartFeatureIds(cartId);
+      // All three should be added: unsecured passes through, secured + inherited pass via scope access
+      expect(ids).to.include.members([unsecuredId, securedId, inheritedChildId]);
+      expect(ids).to.have.length(3);
+    });
+
+    it('should add only features from the scoped submission when user has partial authorization across submissions', async () => {
+      // Submission A — user has scope access
+      const submissionA = await createTestSubmission(connection);
+      const securedA = await createTestFeature(connection, submissionA, 'dataset', { name: 'Secured A' });
+      await secureFeature(securedA);
+
+      // Submission B — user has NO scope access
+      const submissionB = await createTestSubmission(connection);
+      const securedB = await createTestFeature(connection, submissionB, 'dataset', { name: 'Secured B' });
+      await secureFeature(securedB);
+
+      const userId = await createOtherUser();
+      // Grant scope only for submission A
+      await setupFullAccess(`urn:${submissionA}:*:*`, userId, 'partial-auth-team');
+
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [securedA, securedB], userId);
+
+      const ids = await getCartFeatureIds(cartId);
+      // Only the feature from the scoped submission should be added
+      expect(ids).to.deep.equal([securedA]);
+    });
+  });
+
+  // ── getCartSubmissionFeatures — secured flag ───────────────────────
+
+  describe('getCartSubmissionFeatures — secured flag', () => {
+    it('should return secured: true for secured features and secured: false for unsecured', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const unsecuredId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public' });
+      const securedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
+      await secureFeature(securedId);
+
+      const userId = await createOtherUser();
+      await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'secured-flag-team');
+
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [unsecuredId, securedId], userId);
+
+      const features = await cartFeatureService.getCartSubmissionFeatures(cartId);
+      expect(features).to.have.length(2);
+
+      const unsecuredFeature = features.find((f) => f.submission_feature_id === unsecuredId);
+      const securedFeature = features.find((f) => f.submission_feature_id === securedId);
+
+      expect(unsecuredFeature?.secured).to.equal(false);
+      expect(securedFeature?.secured).to.equal(true);
+    });
+
+    it('should reflect security changes after feature was added to cart', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Initially Public' });
+
+      // Add while unsecured (anonymous can add it)
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+
+      // Verify initially unsecured
+      let features = await cartFeatureService.getCartSubmissionFeatures(cartId);
+      expect(features[0].secured).to.equal(false);
+
+      // Apply security after the feature is already in the cart
+      await secureFeature(featureId);
+
+      // Read-side CTE should now compute secured: true
+      features = await cartFeatureService.getCartSubmissionFeatures(cartId);
+      expect(features[0].secured).to.equal(true);
+    });
+
+    it('should filter by submissionFeatureId when provided', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureA = await createTestFeature(connection, submissionId, 'dataset', { name: 'A' });
+      const featureB = await createTestFeature(connection, submissionId, 'dataset', { name: 'B' });
+
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureA, featureB], null);
+
+      const filtered = await cartFeatureService.getCartSubmissionFeatures(cartId, undefined, featureA);
+      expect(filtered).to.have.length(1);
+      expect(filtered[0].submission_feature_id).to.equal(featureA);
+    });
+  });
+
+  // ── getCartSubmissionFeatureCount ──────────────────────────────────
+
+  describe('getCartSubmissionFeatureCount', () => {
+    it('should count all features including secured ones', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const unsecuredId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public' });
+      const securedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
+      await secureFeature(securedId);
+
+      const userId = await createOtherUser();
+      await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'count-team');
+
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [unsecuredId, securedId], userId);
+
+      const count = await cartFeatureService.getCartSubmissionFeatureCount(cartId);
+      expect(count).to.equal(2);
+    });
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('should handle idempotent add (same feature twice) without error', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset' });
+
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([featureId]);
+    });
+
+    it('should not add features to an inactive (checked-out) cart', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset' });
+
+      const cartId = await createActiveCart(null);
+
+      // Mark the cart as checked_out
+      await connection.sql(SQL`
+        UPDATE cart SET cart_status = 'checked_out' WHERE cart_id = ${cartId};
+      `);
+
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([]);
+    });
+  });
+});

--- a/api/src/__integration__/db/cart-submission-feature-service.integration.ts
+++ b/api/src/__integration__/db/cart-submission-feature-service.integration.ts
@@ -209,15 +209,15 @@ describe('Cart submission feature security (integration)', function () {
     return result.rows.map((r: { submission_feature_id: number }) => r.submission_feature_id);
   }
 
-  // ── addSubmissionFeaturesToCart — anonymous ──────────────────────────
+  // ── createCartSubmissionFeatures — anonymous ──────────────────────────
 
-  describe('addSubmissionFeaturesToCart — anonymous', () => {
+  describe('createCartSubmissionFeatures — anonymous', () => {
     it('should add an unsecured feature to cart', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public Dataset' });
 
       const cartId = await createActiveCart(null);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([featureId]);
@@ -229,7 +229,7 @@ describe('Cart submission feature security (integration)', function () {
       await secureFeature(featureId);
 
       const cartId = await createActiveCart(null);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([]);
@@ -248,16 +248,16 @@ describe('Cart submission feature security (integration)', function () {
       await secureFeature(parentId);
 
       const cartId = await createActiveCart(null);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [childId], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [childId], null);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([]);
     });
   });
 
-  // ── addSubmissionFeaturesToCart — authenticated ─────────────────────
+  // ── createCartSubmissionFeatures — authenticated ─────────────────────
 
-  describe('addSubmissionFeaturesToCart — authenticated', () => {
+  describe('createCartSubmissionFeatures — authenticated', () => {
     it('should add a secured feature when user has scope access', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
@@ -267,7 +267,7 @@ describe('Cart submission feature security (integration)', function () {
       await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'scope-access-team');
 
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], userId);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([featureId]);
@@ -282,7 +282,7 @@ describe('Cart submission feature security (integration)', function () {
       const userId = await createOtherUser();
 
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], userId);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([]);
@@ -294,7 +294,7 @@ describe('Cart submission feature security (integration)', function () {
 
       const userId = await createOtherUser();
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], userId);
 
       const features = await cartFeatureService.getCartSubmissionFeatures(cartId);
       expect(features).to.have.length(1);
@@ -334,7 +334,7 @@ describe('Cart submission feature security (integration)', function () {
       await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'mixed-batch-team');
 
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [unsecuredId, securedId, inheritedChildId], userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [unsecuredId, securedId, inheritedChildId], userId);
 
       const ids = await getCartFeatureIds(cartId);
       // All three should be added: unsecured passes through, secured + inherited pass via scope access
@@ -358,7 +358,7 @@ describe('Cart submission feature security (integration)', function () {
       await setupFullAccess(`urn:${submissionA}:*:*`, userId, 'partial-auth-team');
 
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [securedA, securedB], userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [securedA, securedB], userId);
 
       const ids = await getCartFeatureIds(cartId);
       // Only the feature from the scoped submission should be added
@@ -379,7 +379,7 @@ describe('Cart submission feature security (integration)', function () {
       await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'secured-flag-team');
 
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [unsecuredId, securedId], userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [unsecuredId, securedId], userId);
 
       const features = await cartFeatureService.getCartSubmissionFeatures(cartId);
       expect(features).to.have.length(2);
@@ -397,7 +397,7 @@ describe('Cart submission feature security (integration)', function () {
 
       // Add while unsecured (anonymous can add it)
       const cartId = await createActiveCart(null);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
 
       // Verify initially unsecured
       let features = await cartFeatureService.getCartSubmissionFeatures(cartId);
@@ -417,7 +417,7 @@ describe('Cart submission feature security (integration)', function () {
       const featureB = await createTestFeature(connection, submissionId, 'dataset', { name: 'B' });
 
       const cartId = await createActiveCart(null);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureA, featureB], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureA, featureB], null);
 
       const filtered = await cartFeatureService.getCartSubmissionFeatures(cartId, undefined, featureA);
       expect(filtered).to.have.length(1);
@@ -438,7 +438,7 @@ describe('Cart submission feature security (integration)', function () {
       await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'count-team');
 
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [unsecuredId, securedId], userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [unsecuredId, securedId], userId);
 
       const count = await cartFeatureService.getCartSubmissionFeatureCount(cartId);
       expect(count).to.equal(2);
@@ -453,8 +453,8 @@ describe('Cart submission feature security (integration)', function () {
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset' });
 
       const cartId = await createActiveCart(null);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([featureId]);
@@ -471,7 +471,7 @@ describe('Cart submission feature security (integration)', function () {
         UPDATE cart SET cart_status = 'checked_out' WHERE cart_id = ${cartId};
       `);
 
-      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [featureId], null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([]);

--- a/api/src/__integration__/db/cart-submission-feature-service.integration.ts
+++ b/api/src/__integration__/db/cart-submission-feature-service.integration.ts
@@ -13,8 +13,8 @@
 import { expect } from 'chai';
 import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
-import { CartRepository } from '../../repositories/cart-repository';
 import { SecurityScopeRepository } from '../../repositories/authorization/security-scope-repository';
+import { CartRepository } from '../../repositories/cart-repository';
 import { CartSubmissionFeatureService } from '../../services/cart-submission-feature-service';
 import { computeScopeHash } from '../../utils/scope-hash';
 import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
@@ -238,7 +238,13 @@ describe('Cart submission feature security (integration)', function () {
     it('should exclude a feature with inherited security from a secured parent', async () => {
       const submissionId = await createTestSubmission(connection);
       const parentId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Parent' });
-      const childId = await createTestFeature(connection, submissionId, 'species_observation', { name: 'Child' }, parentId);
+      const childId = await createTestFeature(
+        connection,
+        submissionId,
+        'species_observation',
+        { name: 'Child' },
+        parentId
+      );
       await secureFeature(parentId);
 
       const cartId = await createActiveCart(null);
@@ -328,11 +334,7 @@ describe('Cart submission feature security (integration)', function () {
       await setupFullAccess(`urn:${submissionId}:*:*`, userId, 'mixed-batch-team');
 
       const cartId = await createActiveCart(userId);
-      await cartFeatureService.addSubmissionFeaturesToCart(
-        cartId,
-        [unsecuredId, securedId, inheritedChildId],
-        userId
-      );
+      await cartFeatureService.addSubmissionFeaturesToCart(cartId, [unsecuredId, securedId, inheritedChildId], userId);
 
       const ids = await getCartFeatureIds(cartId);
       // All three should be added: unsecured passes through, secured + inherited pass via scope access

--- a/api/src/database/db.ts
+++ b/api/src/database/db.ts
@@ -162,7 +162,7 @@ export interface IDBConnection {
    * @memberof IDBConnection
    */
   knex: <T extends pg.QueryResultRow = any>(
-    queryBuilder: Knex.QueryBuilder,
+    queryBuilder: Knex.QueryBuilder | Knex.Raw,
     zodSchema?: z.Schema<T, any, any>
   ) => Promise<pg.QueryResult<T>>;
   /**
@@ -377,7 +377,7 @@ export const getDBConnection = function (keycloakToken: object): IDBConnection {
    * @return {*}  {Promise<pg.QueryResult<T>>}
    */
   const _knex = async <T extends pg.QueryResultRow = any>(
-    queryBuilder: Knex.QueryBuilder,
+    queryBuilder: Knex.QueryBuilder | Knex.Raw,
     ZodSchema?: z.ZodSchema<T, any, any>
   ) => {
     const { sql, bindings } = queryBuilder.toSQL().toNative();

--- a/api/src/paths/cart/{cartId}/feature/index.test.ts
+++ b/api/src/paths/cart/{cartId}/feature/index.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { addSubmissionFeaturesToCart, clearCartSubmissionFeatures, getCartSubmissionFeatures } from '.';
+import { clearCartSubmissionFeatures, createCartSubmissionFeatures, getCartSubmissionFeatures } from '.';
 import * as db from '../../../../database/db';
 import { HTTP500 } from '../../../../errors/http-error';
 import { CartSubmissionFeature } from '../../../../models/cart';
@@ -203,7 +203,7 @@ describe('cart/{cartId}', () => {
     });
   });
 
-  describe('addSubmissionFeaturesToCart', () => {
+  describe('createCartSubmissionFeatures', () => {
     it('throws error if DB connection fails to open', async () => {
       const mockDBConnection = getMockDBConnection({
         commit: sinon.stub(),
@@ -213,7 +213,7 @@ describe('cart/{cartId}', () => {
       sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
       sinon.stub(mockDBConnection, 'open').rejects(new Error('DB open failed'));
 
-      const requestHandler = addSubmissionFeaturesToCart();
+      const requestHandler = createCartSubmissionFeatures();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
       mockReq.params.cartId = 'fake-cart-id';
       mockReq.body = { features: ['uuid-1', 'uuid-2'] };
@@ -237,11 +237,11 @@ describe('cart/{cartId}', () => {
       });
       sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
 
-      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
+      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'createCartSubmissionFeatures').resolves();
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatures').resolves([]);
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureCount').resolves(0);
 
-      const requestHandler = addSubmissionFeaturesToCart();
+      const requestHandler = createCartSubmissionFeatures();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
       mockReq.params.cartId = 'fake-cart-id';
       mockReq.body = { features: [1, 2] };
@@ -264,11 +264,11 @@ describe('cart/{cartId}', () => {
       });
       sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
 
-      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
+      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'createCartSubmissionFeatures').resolves();
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatures').resolves([]);
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureCount').resolves(0);
 
-      const requestHandler = addSubmissionFeaturesToCart();
+      const requestHandler = createCartSubmissionFeatures();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
       mockReq.params.cartId = 'fake-cart-id';
       mockReq.body = { features: [1, 2] };
@@ -289,11 +289,11 @@ describe('cart/{cartId}', () => {
       });
       sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
 
-      sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
+      sinon.stub(CartSubmissionFeatureService.prototype, 'createCartSubmissionFeatures').resolves();
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatures').resolves([]);
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureCount').resolves(0);
 
-      const requestHandler = addSubmissionFeaturesToCart();
+      const requestHandler = createCartSubmissionFeatures();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
       mockReq.params.cartId = 'fake-cart-id';
       mockReq.body = { features: [] };
@@ -307,7 +307,7 @@ describe('cart/{cartId}', () => {
       expect(mockRes.jsonValue).to.have.property('pagination');
     });
 
-    it('rolls back and rethrows if CartService.addSubmissionFeaturesToCart throws an error', async () => {
+    it('rolls back and rethrows if CartService.createCartSubmissionFeatures throws an error', async () => {
       const mockDBConnection = getMockDBConnection({
         commit: sinon.stub(),
         rollback: sinon.stub(),
@@ -317,10 +317,10 @@ describe('cart/{cartId}', () => {
       sinon.stub(mockDBConnection, 'open').resolves();
 
       sinon
-        .stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart')
+        .stub(CartSubmissionFeatureService.prototype, 'createCartSubmissionFeatures')
         .rejects(new Error('Service error'));
 
-      const requestHandler = addSubmissionFeaturesToCart();
+      const requestHandler = createCartSubmissionFeatures();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
       mockReq.params.cartId = 'fake-cart-id';
       mockReq.body = { features: ['uuid-1'] };

--- a/api/src/paths/cart/{cartId}/feature/index.test.ts
+++ b/api/src/paths/cart/{cartId}/feature/index.test.ts
@@ -228,30 +228,57 @@ describe('cart/{cartId}', () => {
       }
     });
 
-    it('adds and removes features successfully from the cart', async () => {
+    it('adds features successfully and passes systemUserId when authenticated', async () => {
       const mockDBConnection = getMockDBConnection({
         commit: sinon.stub(),
         rollback: sinon.stub(),
-        release: sinon.stub()
+        release: sinon.stub(),
+        systemUserId: sinon.stub().returns(42)
       });
       sinon.stub(db, 'getDBConnection').returns(mockDBConnection);
 
-      sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
+      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatures').resolves([]);
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureCount').resolves(0);
 
       const requestHandler = addSubmissionFeaturesToCart();
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
       mockReq.params.cartId = 'fake-cart-id';
-      mockReq.body = { features: ['uuid-1', 'uuid-2'] };
+      mockReq.body = { features: [1, 2] };
+      mockReq.keycloak_token = { sub: 'user-guid' };
 
       await requestHandler(mockReq, mockRes, mockNext);
 
+      expect(addStub).to.have.been.calledOnce;
+      expect(addStub.firstCall.args[2]).to.equal(42);
       expect(mockDBConnection.commit).to.have.been.calledOnce;
       expect(mockDBConnection.release).to.have.been.calledOnce;
       expect(mockRes.statusValue).to.equal(200);
-      expect(mockRes.jsonValue).to.have.property('features');
-      expect(mockRes.jsonValue).to.have.property('pagination');
+    });
+
+    it('passes null systemUserId when anonymous', async () => {
+      const mockDBConnection = getMockDBConnection({
+        commit: sinon.stub(),
+        rollback: sinon.stub(),
+        release: sinon.stub()
+      });
+      sinon.stub(db, 'getAPIUserDBConnection').returns(mockDBConnection);
+
+      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
+      sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatures').resolves([]);
+      sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureCount').resolves(0);
+
+      const requestHandler = addSubmissionFeaturesToCart();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params.cartId = 'fake-cart-id';
+      mockReq.body = { features: [1, 2] };
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(addStub).to.have.been.calledOnce;
+      expect(addStub.firstCall.args[2]).to.be.null;
+      expect(mockDBConnection.commit).to.have.been.calledOnce;
+      expect(mockRes.statusValue).to.equal(200);
     });
 
     it('handles empty add and remove arrays', async () => {

--- a/api/src/paths/cart/{cartId}/feature/index.ts
+++ b/api/src/paths/cart/{cartId}/feature/index.ts
@@ -114,7 +114,7 @@ export const POST: Operation = [
       ]
     };
   }),
-  addSubmissionFeaturesToCart()
+  createCartSubmissionFeatures()
 ];
 
 POST.apiDoc = {
@@ -160,7 +160,7 @@ POST.apiDoc = {
  *
  * @returns {RequestHandler}
  */
-export function addSubmissionFeaturesToCart(): RequestHandler {
+export function createCartSubmissionFeatures(): RequestHandler {
   return async (req, res) => {
     const isAuthenticated = !!req.keycloak_token;
     const connection = isAuthenticated ? getDBConnection(req.keycloak_token) : getAPIUserDBConnection();
@@ -175,14 +175,14 @@ export function addSubmissionFeaturesToCart(): RequestHandler {
 
       const cartSubmissionFeatureService = new CartSubmissionFeatureService(connection);
 
-      await cartSubmissionFeatureService.addSubmissionFeaturesToCart(cartId, features, systemUserId);
+      await cartSubmissionFeatureService.createCartSubmissionFeatures(cartId, features, systemUserId);
       const response = await cartSubmissionFeatureService.getPaginatedCartFeaturesResponse(cartId, pagination);
 
       await connection.commit();
 
       return res.status(200).json(response);
     } catch (error) {
-      defaultLog.error({ label: 'addSubmissionFeaturesToCart', message: 'Error updating cart features', error });
+      defaultLog.error({ label: 'createCartSubmissionFeatures', message: 'Error updating cart features', error });
       await connection.rollback();
       throw error;
     } finally {

--- a/api/src/paths/cart/{cartId}/feature/index.ts
+++ b/api/src/paths/cart/{cartId}/feature/index.ts
@@ -171,10 +171,11 @@ export function addSubmissionFeaturesToCart(): RequestHandler {
       const features = req.body.features.map(Number);
       const cartId = req.params.cartId;
       const pagination = makePaginationOptionsFromRequest(req);
+      const systemUserId = isAuthenticated ? connection.systemUserId() : null;
 
       const cartSubmissionFeatureService = new CartSubmissionFeatureService(connection);
 
-      await cartSubmissionFeatureService.addSubmissionFeaturesToCart(cartId, features);
+      await cartSubmissionFeatureService.addSubmissionFeaturesToCart(cartId, features, systemUserId);
       const response = await cartSubmissionFeatureService.getPaginatedCartFeaturesResponse(cartId, pagination);
 
       await connection.commit();

--- a/api/src/repositories/cart-submission-feature-repository.test.ts
+++ b/api/src/repositories/cart-submission-feature-repository.test.ts
@@ -25,12 +25,12 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      const result = await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3]);
+      const result = await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3], null);
 
       expect(result).to.be.undefined;
     });
 
-    it('should exclude actively secured features in the insert SQL', async () => {
+    it('should use anonymous SQL with recursive ancestor walk-up when systemUserId is null', async () => {
       const sqlStub = sinon.stub().resolves({
         rowCount: 1,
         rows: []
@@ -40,15 +40,40 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3]);
+      await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3], null);
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlArg = sqlStub.firstCall.args[0] as { text?: string };
       const sqlText = sqlArg.text || '';
 
-      expect(sqlText).to.contain('WHERE NOT EXISTS');
-      expect(sqlText).to.contain('submission_feature_security');
-      expect(sqlText).to.contain('sfs.record_end_date IS NULL');
+      // Anonymous path uses NOT EXISTS with recursive ancestor walk
+      expect(sqlText).to.include('NOT EXISTS');
+      expect(sqlText).to.include('RECURSIVE');
+      expect(sqlText).to.include('ancestors');
+      expect(sqlText).to.include('submission_feature_security');
+    });
+
+    it('should use authenticated SQL with scope check when systemUserId is provided', async () => {
+      const sqlStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: []
+      } as unknown as QueryResult<any>);
+
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repo = new CartSubmissionFeatureRepository(mockDBConnection);
+
+      await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3], 42);
+
+      expect(sqlStub).to.have.been.calledOnce;
+      const sqlArg = sqlStub.firstCall.args[0] as { text?: string };
+      const sqlText = sqlArg.text || '';
+
+      // Authenticated path checks scope access via security_scope_anchor → team_security_scope → team_member
+      expect(sqlText).to.include('security_scope_anchor');
+      expect(sqlText).to.include('team_security_scope');
+      expect(sqlText).to.include('team_member');
+      expect(sqlText).to.include('RECURSIVE');
     });
   });
 
@@ -119,7 +144,7 @@ describe('CartSubmissionFeatureRepository', () => {
   });
 
   describe('getCartSubmissionFeatures', () => {
-    it('should return submission features from the cart', async () => {
+    it('should return all features including secured ones', async () => {
       const mockRows: CartSubmissionFeature[] = [
         {
           submission_feature_id: 1,
@@ -151,6 +176,9 @@ describe('CartSubmissionFeatureRepository', () => {
       const result = await repo.getCartSubmissionFeatures('cart-1', { page: 1, limit: 25 });
 
       expect(result).to.eql(mockRows);
+      // Secured feature is included — no longer filtered out
+      expect(result).to.have.length(2);
+      expect(result[1].secured).to.be.true;
     });
 
     it('should return only the matching feature when submissionFeatureId is provided', async () => {
@@ -179,7 +207,7 @@ describe('CartSubmissionFeatureRepository', () => {
   });
 
   describe('getCartSubmissionFeatureCount', () => {
-    it('should return the correct count', async () => {
+    it('should return the count of all features in the cart', async () => {
       const mockQueryResponse = {
         rowCount: 1,
         rows: [{ count: 5 }]

--- a/api/src/repositories/cart-submission-feature-repository.test.ts
+++ b/api/src/repositories/cart-submission-feature-repository.test.ts
@@ -14,7 +14,7 @@ describe('CartSubmissionFeatureRepository', () => {
     sinon.restore();
   });
 
-  describe('addUnsecuredSubmissionFeaturesToCart', () => {
+  describe('createUnsecuredCartSubmissionFeatures', () => {
     it('should insert multiple submission features without error', async () => {
       const mockQueryResponse = {
         rowCount: 3,
@@ -25,7 +25,7 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      const result = await repo.addUnsecuredSubmissionFeaturesToCart('cart-1', [1, 2, 3]);
+      const result = await repo.createUnsecuredCartSubmissionFeatures('cart-1', [1, 2, 3]);
 
       expect(result).to.be.undefined;
     });
@@ -40,7 +40,7 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      await repo.addUnsecuredSubmissionFeaturesToCart('cart-1', [1, 2, 3]);
+      await repo.createUnsecuredCartSubmissionFeatures('cart-1', [1, 2, 3]);
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlArg = sqlStub.firstCall.args[0] as { text?: string };
@@ -53,7 +53,7 @@ describe('CartSubmissionFeatureRepository', () => {
     });
   });
 
-  describe('addSubmissionFeaturesToCartWithScopeCheck', () => {
+  describe('createCartSubmissionFeaturesWithScopeCheck', () => {
     it('should use scope check SQL with recursive ancestor walk', async () => {
       const sqlStub = sinon.stub().resolves({
         rowCount: 1,
@@ -64,7 +64,7 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      await repo.addSubmissionFeaturesToCartWithScopeCheck('cart-1', [1, 2, 3], 42);
+      await repo.createCartSubmissionFeaturesWithScopeCheck('cart-1', [1, 2, 3], 42);
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlArg = sqlStub.firstCall.args[0] as { text?: string };

--- a/api/src/repositories/cart-submission-feature-repository.test.ts
+++ b/api/src/repositories/cart-submission-feature-repository.test.ts
@@ -48,8 +48,10 @@ describe('CartSubmissionFeatureRepository', () => {
 
       expect(sqlText).to.include('NOT EXISTS');
       expect(sqlText).to.include('RECURSIVE');
-      expect(sqlText).to.include('ancestors');
+      expect(sqlText).to.include('ancestor_chain');
       expect(sqlText).to.include('submission_feature_security');
+      expect(sqlText).to.include('record_effective_date');
+      expect(sqlText).to.include('record_end_date');
     });
   });
 

--- a/api/src/repositories/cart-submission-feature-repository.test.ts
+++ b/api/src/repositories/cart-submission-feature-repository.test.ts
@@ -21,7 +21,7 @@ describe('CartSubmissionFeatureRepository', () => {
         rows: []
       } as unknown as QueryResult<any>;
 
-      const mockDBConnection = getMockDBConnection({ sql: async () => mockQueryResponse });
+      const mockDBConnection = getMockDBConnection({ knex: async () => mockQueryResponse });
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
@@ -31,20 +31,19 @@ describe('CartSubmissionFeatureRepository', () => {
     });
 
     it('should use NOT EXISTS with recursive ancestor walk to block secured features', async () => {
-      const sqlStub = sinon.stub().resolves({
+      const knexStub = sinon.stub().resolves({
         rowCount: 1,
         rows: []
       } as unknown as QueryResult<any>);
 
-      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
       await repo.createUnsecuredCartSubmissionFeatures('cart-1', [1, 2, 3]);
 
-      expect(sqlStub).to.have.been.calledOnce;
-      const sqlArg = sqlStub.firstCall.args[0] as { text?: string };
-      const sqlText = sqlArg.text || '';
+      expect(knexStub).to.have.been.calledOnce;
+      const sqlText = knexStub.firstCall.args[0].toString();
 
       expect(sqlText).to.include('NOT EXISTS');
       expect(sqlText).to.include('RECURSIVE');
@@ -57,20 +56,19 @@ describe('CartSubmissionFeatureRepository', () => {
 
   describe('createCartSubmissionFeaturesWithScopeCheck', () => {
     it('should use scope check SQL with recursive ancestor walk', async () => {
-      const sqlStub = sinon.stub().resolves({
+      const knexStub = sinon.stub().resolves({
         rowCount: 1,
         rows: []
       } as unknown as QueryResult<any>);
 
-      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
       await repo.createCartSubmissionFeaturesWithScopeCheck('cart-1', [1, 2, 3], 42);
 
-      expect(sqlStub).to.have.been.calledOnce;
-      const sqlArg = sqlStub.firstCall.args[0] as { text?: string };
-      const sqlText = sqlArg.text || '';
+      expect(knexStub).to.have.been.calledOnce;
+      const sqlText = knexStub.firstCall.args[0].toString();
 
       expect(sqlText).to.include('security_scope_anchor');
       expect(sqlText).to.include('team_security_scope');

--- a/api/src/repositories/cart-submission-feature-repository.test.ts
+++ b/api/src/repositories/cart-submission-feature-repository.test.ts
@@ -14,7 +14,7 @@ describe('CartSubmissionFeatureRepository', () => {
     sinon.restore();
   });
 
-  describe('addSubmissionFeaturesToCart', () => {
+  describe('addUnsecuredSubmissionFeaturesToCart', () => {
     it('should insert multiple submission features without error', async () => {
       const mockQueryResponse = {
         rowCount: 3,
@@ -25,12 +25,12 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      const result = await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3], null);
+      const result = await repo.addUnsecuredSubmissionFeaturesToCart('cart-1', [1, 2, 3]);
 
       expect(result).to.be.undefined;
     });
 
-    it('should use anonymous SQL with recursive ancestor walk-up when systemUserId is null', async () => {
+    it('should use NOT EXISTS with recursive ancestor walk to block secured features', async () => {
       const sqlStub = sinon.stub().resolves({
         rowCount: 1,
         rows: []
@@ -40,20 +40,21 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3], null);
+      await repo.addUnsecuredSubmissionFeaturesToCart('cart-1', [1, 2, 3]);
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlArg = sqlStub.firstCall.args[0] as { text?: string };
       const sqlText = sqlArg.text || '';
 
-      // Anonymous path uses NOT EXISTS with recursive ancestor walk
       expect(sqlText).to.include('NOT EXISTS');
       expect(sqlText).to.include('RECURSIVE');
       expect(sqlText).to.include('ancestors');
       expect(sqlText).to.include('submission_feature_security');
     });
+  });
 
-    it('should use authenticated SQL with scope check when systemUserId is provided', async () => {
+  describe('addSubmissionFeaturesToCartWithScopeCheck', () => {
+    it('should use scope check SQL with recursive ancestor walk', async () => {
       const sqlStub = sinon.stub().resolves({
         rowCount: 1,
         rows: []
@@ -63,13 +64,12 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
-      await repo.addSubmissionFeaturesToCart('cart-1', [1, 2, 3], 42);
+      await repo.addSubmissionFeaturesToCartWithScopeCheck('cart-1', [1, 2, 3], 42);
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlArg = sqlStub.firstCall.args[0] as { text?: string };
       const sqlText = sqlArg.text || '';
 
-      // Authenticated path checks scope access via security_scope_anchor → team_security_scope → team_member
       expect(sqlText).to.include('security_scope_anchor');
       expect(sqlText).to.include('team_security_scope');
       expect(sqlText).to.include('team_member');

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -25,7 +25,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
    * @return {Promise<void>}
    * @memberof CartSubmissionFeatureRepository
    */
-  async addUnsecuredSubmissionFeaturesToCart(cartId: string, submissionFeatureIds: number[]): Promise<void> {
+  async createUnsecuredCartSubmissionFeatures(cartId: string, submissionFeatureIds: number[]): Promise<void> {
     const sql = SQL`
       WITH w_cart AS (
         SELECT cart_id
@@ -79,7 +79,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
    * @return {Promise<void>}
    * @memberof CartSubmissionFeatureRepository
    */
-  async addSubmissionFeaturesToCartWithScopeCheck(
+  async createCartSubmissionFeaturesWithScopeCheck(
     cartId: string,
     submissionFeatureIds: number[],
     systemUserId: number

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -1,4 +1,4 @@
-import SQL from 'sql-template-strings';
+import { Knex } from 'knex';
 import z from 'zod';
 import { getKnex } from '../database/db';
 import { CartStatus, CartSubmissionFeature } from '../models/cart';
@@ -53,44 +53,34 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
    * @memberof CartSubmissionFeatureRepository
    */
   async createUnsecuredCartSubmissionFeatures(cartId: string, submissionFeatureIds: number[]): Promise<void> {
-    const sql = SQL`
+    const knex = getKnex();
+
+    const query = knex.raw(
+      `
       WITH w_cart AS (
         SELECT cart_id
         FROM cart
-        WHERE cart_id = ${cartId}
-          AND cart_status = ${CartStatus.ACTIVE}
+        WHERE cart_id = ?
+          AND cart_status = ?
       ),
       w_features AS (
-        SELECT unnest(${submissionFeatureIds}::INTEGER[]) AS submission_feature_id
+        SELECT unnest(?::INTEGER[]) AS submission_feature_id
       ),
       w_valid_features AS (
         SELECT wf.submission_feature_id
         FROM w_features wf
-        WHERE NOT EXISTS (
-          WITH RECURSIVE ancestor_chain(id) AS (
-            SELECT wf.submission_feature_id
-            UNION ALL
-            SELECT p.parent_submission_feature_id
-            FROM ancestor_chain ac
-            JOIN submission_feature p ON p.submission_feature_id = ac.id
-            WHERE p.parent_submission_feature_id IS NOT NULL
-              AND p.record_end_date IS NULL
-          )
-          SELECT 1 FROM ancestor_chain ac
-          JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
-          JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = ac.id
-          WHERE sfs.record_end_date IS NULL
-            AND sf_sec.record_effective_date <= now()
-        )
+        WHERE NOT ${isEffectivelySecured('wf.submission_feature_id')}
       )
       INSERT INTO cart_submission_feature (cart_id, submission_feature_id)
       SELECT wc.cart_id, wvf.submission_feature_id
       FROM w_cart wc
       CROSS JOIN w_valid_features wvf
       ON CONFLICT (cart_id, submission_feature_id) DO NOTHING
-    `;
+    `,
+      [cartId, CartStatus.ACTIVE, submissionFeatureIds]
+    );
 
-    await this.connection.sql(sql);
+    await this.connection.knex(query as unknown as Knex.QueryBuilder);
   }
 
   /**
@@ -110,62 +100,52 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
     submissionFeatureIds: number[],
     systemUserId: number
   ): Promise<void> {
-    const sql = SQL`
+    const knex = getKnex();
+
+    const query = knex.raw(
+      `
       WITH w_cart AS (
         SELECT cart_id
         FROM cart
-        WHERE cart_id = ${cartId}
-          AND cart_status = ${CartStatus.ACTIVE}
+        WHERE cart_id = ?
+          AND cart_status = ?
       ),
       w_features AS (
-        SELECT unnest(${submissionFeatureIds}::INTEGER[]) AS submission_feature_id
+        SELECT unnest(?::INTEGER[]) AS submission_feature_id
       ),
       w_valid_features AS (
         SELECT wf.submission_feature_id
         FROM w_features wf
-        WHERE EXISTS (
-          SELECT 1
-          FROM (
-            WITH RECURSIVE ancestors AS (
-              SELECT sf_inner.submission_feature_id AS ancestor_id,
-                     sf_inner.parent_submission_feature_id
-              FROM submission_feature sf_inner
-              WHERE sf_inner.submission_feature_id = wf.submission_feature_id
+        WHERE
+          NOT ${isEffectivelySecured('wf.submission_feature_id')}
+          OR EXISTS (
+            WITH RECURSIVE ancestor_chain(id) AS (
+              SELECT wf.submission_feature_id
               UNION ALL
-              SELECT p.submission_feature_id, p.parent_submission_feature_id
-              FROM submission_feature p
-              JOIN ancestors a ON p.submission_feature_id = a.parent_submission_feature_id
+              SELECT p.parent_submission_feature_id
+              FROM ancestor_chain ac
+              JOIN submission_feature p ON p.submission_feature_id = ac.id
+              WHERE p.parent_submission_feature_id IS NOT NULL
+                AND p.record_end_date IS NULL
             )
-            SELECT array_agg(ancestor_id) AS ancestor_ids
-            FROM ancestors
-          ) anc
-          WHERE
-            NOT EXISTS (
-              SELECT 1 FROM submission_feature_security sfs
-              JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = sfs.submission_feature_id
-              WHERE sfs.record_end_date IS NULL
-                AND sf_sec.record_effective_date <= now()
-                AND sfs.submission_feature_id = ANY(anc.ancestor_ids)
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM security_scope_anchor ssa
-                JOIN team_security_scope tss ON tss.security_scope_id = ssa.security_scope_id
-                JOIN team_member tm ON tm.team_id = tss.team_id
-                  AND tm.system_user_id = ${systemUserId}
-                  AND tm.record_end_date IS NULL
-              WHERE ssa.anchor_submission_feature_id = ANY(anc.ancestor_ids)
-            )
-        )
+            SELECT 1 FROM ancestor_chain ac
+            JOIN security_scope_anchor ssa ON ssa.anchor_submission_feature_id = ac.id
+            JOIN team_security_scope tss ON tss.security_scope_id = ssa.security_scope_id
+            JOIN team_member tm ON tm.team_id = tss.team_id
+              AND tm.system_user_id = ?
+              AND tm.record_end_date IS NULL
+          )
       )
       INSERT INTO cart_submission_feature (cart_id, submission_feature_id)
       SELECT wc.cart_id, wvf.submission_feature_id
       FROM w_cart wc
       CROSS JOIN w_valid_features wvf
       ON CONFLICT (cart_id, submission_feature_id) DO NOTHING
-    `;
+    `,
+      [cartId, CartStatus.ACTIVE, submissionFeatureIds, systemUserId]
+    );
 
-    await this.connection.sql(sql);
+    await this.connection.knex(query as unknown as Knex.QueryBuilder);
   }
 
   /**

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -1,4 +1,3 @@
-import { Knex } from 'knex';
 import z from 'zod';
 import { getKnex } from '../database/db';
 import { CartStatus, CartSubmissionFeature } from '../models/cart';
@@ -54,7 +53,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       [cartId, CartStatus.ACTIVE, submissionFeatureIds]
     );
 
-    await this.connection.knex(query as unknown as Knex.QueryBuilder);
+    await this.connection.knex(query);
   }
 
   /**
@@ -119,7 +118,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       [cartId, CartStatus.ACTIVE, submissionFeatureIds, systemUserId]
     );
 
-    await this.connection.knex(query as unknown as Knex.QueryBuilder);
+    await this.connection.knex(query);
   }
 
   /**

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -6,6 +6,33 @@ import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 
 /**
+ * Per-candidate "effectively secured" check: walks UP from a feature through its
+ * ancestors to determine if it or any ancestor has an active security rule
+ * whose feature is past its effective date.
+ *
+ * @param featureIdExpr SQL expression for the starting submission_feature_id
+ *   (e.g. 'wf.submission_feature_id' or 'sf.submission_feature_id')
+ */
+function isEffectivelySecured(featureIdExpr: string): string {
+  return `EXISTS (
+    WITH RECURSIVE ancestor_chain(id) AS (
+      SELECT ${featureIdExpr}
+      UNION ALL
+      SELECT p.parent_submission_feature_id
+      FROM ancestor_chain ac
+      JOIN submission_feature p ON p.submission_feature_id = ac.id
+      WHERE p.parent_submission_feature_id IS NOT NULL
+        AND p.record_end_date IS NULL
+    )
+    SELECT 1 FROM ancestor_chain ac
+    JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
+    JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = ac.id
+    WHERE sfs.record_end_date IS NULL
+      AND sf_sec.record_effective_date <= now()
+  )`;
+}
+
+/**
  * CartSubmissionFeature repository class.
  * Handles interactions with the cart_submission_feature table for adding, removing, and querying submission features for a cart.
  *
@@ -40,21 +67,20 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
         SELECT wf.submission_feature_id
         FROM w_features wf
         WHERE NOT EXISTS (
-          WITH RECURSIVE ancestors AS (
-            SELECT sf_inner.submission_feature_id AS ancestor_id,
-                   sf_inner.parent_submission_feature_id
-            FROM submission_feature sf_inner
-            WHERE sf_inner.submission_feature_id = wf.submission_feature_id
+          WITH RECURSIVE ancestor_chain(id) AS (
+            SELECT wf.submission_feature_id
             UNION ALL
-            SELECT p.submission_feature_id, p.parent_submission_feature_id
-            FROM submission_feature p
-            JOIN ancestors a ON p.submission_feature_id = a.parent_submission_feature_id
+            SELECT p.parent_submission_feature_id
+            FROM ancestor_chain ac
+            JOIN submission_feature p ON p.submission_feature_id = ac.id
+            WHERE p.parent_submission_feature_id IS NOT NULL
+              AND p.record_end_date IS NULL
           )
-          SELECT 1
-          FROM ancestors a
-          INNER JOIN submission_feature_security sfs
-            ON sfs.submission_feature_id = a.ancestor_id
+          SELECT 1 FROM ancestor_chain ac
+          JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
+          JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = ac.id
           WHERE sfs.record_end_date IS NULL
+            AND sf_sec.record_effective_date <= now()
         )
       )
       INSERT INTO cart_submission_feature (cart_id, submission_feature_id)
@@ -116,7 +142,9 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
           WHERE
             NOT EXISTS (
               SELECT 1 FROM submission_feature_security sfs
+              JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = sfs.submission_feature_id
               WHERE sfs.record_end_date IS NULL
+                AND sf_sec.record_effective_date <= now()
                 AND sfs.submission_feature_id = ANY(anc.ancestor_ids)
             )
             OR EXISTS (
@@ -243,20 +271,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
         'sf.submission_id',
         'sf.feature_type_id',
         'ft.name as feature_type_name',
-        knex.raw(`EXISTS (
-          WITH RECURSIVE ancestor_chain(id) AS (
-            SELECT sf.submission_feature_id
-            UNION ALL
-            SELECT p.parent_submission_feature_id
-            FROM ancestor_chain ac
-            JOIN submission_feature p ON p.submission_feature_id = ac.id
-            WHERE p.parent_submission_feature_id IS NOT NULL
-              AND p.record_end_date IS NULL
-          )
-          SELECT 1 FROM ancestor_chain ac
-          JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
-          WHERE sfs.record_end_date IS NULL
-        ) AS secured`)
+        knex.raw(`${isEffectivelySecured('sf.submission_feature_id')} AS secured`)
       )
       .from('page')
       .join('submission_feature as sf', 'sf.submission_feature_id', 'page.submission_feature_id')

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -4,33 +4,7 @@ import { getKnex } from '../database/db';
 import { CartStatus, CartSubmissionFeature } from '../models/cart';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
-
-/**
- * Per-candidate "effectively secured" check: walks UP from a feature through its
- * ancestors to determine if it or any ancestor has an active security rule
- * whose feature is past its effective date.
- *
- * @param featureIdExpr SQL expression for the starting submission_feature_id
- *   (e.g. 'wf.submission_feature_id' or 'sf.submission_feature_id')
- */
-function isEffectivelySecured(featureIdExpr: string): string {
-  return `EXISTS (
-    WITH RECURSIVE ancestor_chain(id) AS (
-      SELECT ${featureIdExpr}
-      UNION ALL
-      SELECT p.parent_submission_feature_id
-      FROM ancestor_chain ac
-      JOIN submission_feature p ON p.submission_feature_id = ac.id
-      WHERE p.parent_submission_feature_id IS NOT NULL
-        AND p.record_end_date IS NULL
-    )
-    SELECT 1 FROM ancestor_chain ac
-    JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
-    JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = ac.id
-    WHERE sfs.record_end_date IS NULL
-      AND sf_sec.record_effective_date <= now()
-  )`;
-}
+import { isEffectivelySecured } from './sql-fragments';
 
 /**
  * CartSubmissionFeature repository class.

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -15,44 +15,18 @@ import { BaseRepository } from './base-repository';
  */
 export class CartSubmissionFeatureRepository extends BaseRepository {
   /**
-   * Add multiple submission features to an active cart with auth-aware security gating.
+   * Add unsecured submission features to an active cart (anonymous path).
+   * Walks up the ancestor chain from each candidate feature; if any ancestor has an
+   * active submission_feature_security row, the feature is excluded.
    * Ignores existing relationships (idempotent via ON CONFLICT DO NOTHING).
-   *
-   * Security is enforced at insert time only — features already in the cart are NOT
-   * re-evaluated on subsequent reads. A feature is "effectively secured" if it or any
-   * ancestor has an active submission_feature_security row (record_end_date IS NULL).
-   *
-   * Anonymous users (systemUserId = null): all effectively secured features are blocked.
-   * Authenticated users: effectively secured features are allowed only if the user has
-   * scope access via security_scope_anchor → team_security_scope → team_member.
-   * Unsecured features are always allowed regardless of auth state.
    *
    * @param {string} cartId - The ID of the cart
    * @param {number[]} submissionFeatureIds - The list of submission feature IDs to add
-   * @param {number | null} systemUserId - The authenticated user's ID, or null for anonymous
-   * @return {Promise<void>} - Resolves when the features are added to the cart
+   * @return {Promise<void>}
    * @memberof CartSubmissionFeatureRepository
    */
-  async addSubmissionFeaturesToCart(
-    cartId: string,
-    submissionFeatureIds: number[],
-    systemUserId: number | null
-  ): Promise<void> {
-    const sql =
-      systemUserId === null
-        ? this.buildAnonymousAddSql(cartId, submissionFeatureIds)
-        : this.buildAuthenticatedAddSql(cartId, submissionFeatureIds, systemUserId);
-
-    await this.connection.sql(sql);
-  }
-
-  /**
-   * Anonymous path: block all effectively secured features.
-   * Walks up the ancestor chain from each candidate feature; if any ancestor has an
-   * active submission_feature_security row, the feature is excluded.
-   */
-  private buildAnonymousAddSql(cartId: string, submissionFeatureIds: number[]) {
-    return SQL`
+  async addUnsecuredSubmissionFeaturesToCart(cartId: string, submissionFeatureIds: number[]): Promise<void> {
+    const sql = SQL`
       WITH w_cart AS (
         SELECT cart_id
         FROM cart
@@ -89,15 +63,28 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       CROSS JOIN w_valid_features wvf
       ON CONFLICT (cart_id, submission_feature_id) DO NOTHING
     `;
+
+    await this.connection.sql(sql);
   }
 
   /**
-   * Authenticated path: allow features that are unsecured OR where the user has scope access.
-   * Walks up the ancestor chain, then checks security_scope_anchor → team_security_scope →
-   * team_member to determine if the user's team grants access to the secured subtree.
+   * Add submission features to an active cart with scope-based access check (authenticated path).
+   * Allows features that are unsecured OR where the user has scope access via
+   * security_scope_anchor → team_security_scope → team_member.
+   * Ignores existing relationships (idempotent via ON CONFLICT DO NOTHING).
+   *
+   * @param {string} cartId - The ID of the cart
+   * @param {number[]} submissionFeatureIds - The list of submission feature IDs to add
+   * @param {number} systemUserId - The authenticated user's ID
+   * @return {Promise<void>}
+   * @memberof CartSubmissionFeatureRepository
    */
-  private buildAuthenticatedAddSql(cartId: string, submissionFeatureIds: number[], systemUserId: number) {
-    return SQL`
+  async addSubmissionFeaturesToCartWithScopeCheck(
+    cartId: string,
+    submissionFeatureIds: number[],
+    systemUserId: number
+  ): Promise<void> {
+    const sql = SQL`
       WITH w_cart AS (
         SELECT cart_id
         FROM cart
@@ -149,6 +136,8 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       CROSS JOIN w_valid_features wvf
       ON CONFLICT (cart_id, submission_feature_id) DO NOTHING
     `;
+
+    await this.connection.sql(sql);
   }
 
   /**
@@ -231,62 +220,49 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
   ): Promise<CartSubmissionFeature[]> {
     const knex = getKnex();
 
-    const baseQuery = knex
-      .withRecursive(
-        'cart_ancestors',
-        knex.raw(
-          `
-        SELECT csf2.submission_feature_id AS cart_feature_id,
-               sf2.submission_feature_id AS ancestor_id,
-               sf2.parent_submission_feature_id
-        FROM cart_submission_feature csf2
-        JOIN submission_feature sf2 ON sf2.submission_feature_id = csf2.submission_feature_id
-        JOIN cart c2 ON c2.cart_id = csf2.cart_id
-        WHERE csf2.cart_id = ?
-          AND c2.cart_status = ?
-        UNION ALL
-        SELECT ca.cart_feature_id,
-               p.submission_feature_id,
-               p.parent_submission_feature_id
-        FROM submission_feature p
-        JOIN cart_ancestors ca ON p.submission_feature_id = ca.parent_submission_feature_id
-      `,
-          [cartId, CartStatus.ACTIVE]
-        )
-      )
-      .with(
-        'effectively_secured',
-        knex.raw(`
-        SELECT DISTINCT ca.cart_feature_id AS submission_feature_id
-        FROM cart_ancestors ca
-        INNER JOIN submission_feature_security sfs
-          ON sfs.submission_feature_id = ca.ancestor_id
-        WHERE sfs.record_end_date IS NULL
-      `)
-      )
-      .select(
-        'csf.cart_submission_feature_id',
-        'sf.submission_feature_id',
-        'sf.submission_id',
-        'sf.feature_type_id',
-        'ft.name as feature_type_name',
-        knex.raw('CASE WHEN es.submission_feature_id IS NOT NULL THEN TRUE ELSE FALSE END AS secured')
-      )
-      .from('submission_feature as sf')
-      .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id')
-      .join('cart_submission_feature as csf', 'csf.submission_feature_id', 'sf.submission_feature_id')
+    // Step 1: Build the base page of cart features (paginated BEFORE the recursive ancestor walk)
+    const pageQuery = knex
+      .select('csf.cart_submission_feature_id', 'csf.submission_feature_id')
+      .from('cart_submission_feature as csf')
       .join('cart as c', 'c.cart_id', 'csf.cart_id')
-      .leftJoin('effectively_secured as es', 'es.submission_feature_id', 'sf.submission_feature_id')
       .where('csf.cart_id', cartId)
       .andWhere('c.cart_status', CartStatus.ACTIVE);
 
     if (submissionFeatureId) {
-      baseQuery.andWhere('sf.submission_feature_id', submissionFeatureId);
+      pageQuery.andWhere('csf.submission_feature_id', submissionFeatureId);
     }
 
-    const paginatedQuery = this.applyPagination(baseQuery, pagination);
+    const paginatedPageQuery = this.applyPagination(pageQuery, pagination);
 
-    const response = await this.connection.knex(paginatedQuery, CartSubmissionFeature);
+    // Step 2: Join feature metadata, check security via per-row correlated EXISTS
+    const query = knex
+      .with('page', paginatedPageQuery)
+      .select(
+        'page.cart_submission_feature_id',
+        'sf.submission_feature_id',
+        'sf.submission_id',
+        'sf.feature_type_id',
+        'ft.name as feature_type_name',
+        knex.raw(`EXISTS (
+          WITH RECURSIVE ancestor_chain(id) AS (
+            SELECT sf.submission_feature_id
+            UNION ALL
+            SELECT p.parent_submission_feature_id
+            FROM ancestor_chain ac
+            JOIN submission_feature p ON p.submission_feature_id = ac.id
+            WHERE p.parent_submission_feature_id IS NOT NULL
+              AND p.record_end_date IS NULL
+          )
+          SELECT 1 FROM ancestor_chain ac
+          JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
+          WHERE sfs.record_end_date IS NULL
+        ) AS secured`)
+      )
+      .from('page')
+      .join('submission_feature as sf', 'sf.submission_feature_id', 'page.submission_feature_id')
+      .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id');
+
+    const response = await this.connection.knex(query, CartSubmissionFeature);
 
     return response.rows;
   }

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -15,16 +15,44 @@ import { BaseRepository } from './base-repository';
  */
 export class CartSubmissionFeatureRepository extends BaseRepository {
   /**
-   * Add multiple submission features to an active cart.
-   * Ignores existing relationships (idempotent).
+   * Add multiple submission features to an active cart with auth-aware security gating.
+   * Ignores existing relationships (idempotent via ON CONFLICT DO NOTHING).
+   *
+   * Security is enforced at insert time only — features already in the cart are NOT
+   * re-evaluated on subsequent reads. A feature is "effectively secured" if it or any
+   * ancestor has an active submission_feature_security row (record_end_date IS NULL).
+   *
+   * Anonymous users (systemUserId = null): all effectively secured features are blocked.
+   * Authenticated users: effectively secured features are allowed only if the user has
+   * scope access via security_scope_anchor → team_security_scope → team_member.
+   * Unsecured features are always allowed regardless of auth state.
    *
    * @param {string} cartId - The ID of the cart
    * @param {number[]} submissionFeatureIds - The list of submission feature IDs to add
+   * @param {number | null} systemUserId - The authenticated user's ID, or null for anonymous
    * @return {Promise<void>} - Resolves when the features are added to the cart
    * @memberof CartSubmissionFeatureRepository
    */
-  async addSubmissionFeaturesToCart(cartId: string, submissionFeatureIds: number[]): Promise<void> {
-    const sql = SQL`
+  async addSubmissionFeaturesToCart(
+    cartId: string,
+    submissionFeatureIds: number[],
+    systemUserId: number | null
+  ): Promise<void> {
+    const sql =
+      systemUserId === null
+        ? this.buildAnonymousAddSql(cartId, submissionFeatureIds)
+        : this.buildAuthenticatedAddSql(cartId, submissionFeatureIds, systemUserId);
+
+    await this.connection.sql(sql);
+  }
+
+  /**
+   * Anonymous path: block all effectively secured features.
+   * Walks up the ancestor chain from each candidate feature; if any ancestor has an
+   * active submission_feature_security row, the feature is excluded.
+   */
+  private buildAnonymousAddSql(cartId: string, submissionFeatureIds: number[]) {
+    return SQL`
       WITH w_cart AS (
         SELECT cart_id
         FROM cart
@@ -32,18 +60,86 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
           AND cart_status = ${CartStatus.ACTIVE}
       ),
       w_features AS (
-        SELECT unnest(${submissionFeatureIds}::integer[]) AS submission_feature_id
+        SELECT unnest(${submissionFeatureIds}::INTEGER[]) AS submission_feature_id
       ),
       w_valid_features AS (
         SELECT wf.submission_feature_id
         FROM w_features wf
         WHERE NOT EXISTS (
+          WITH RECURSIVE ancestors AS (
+            SELECT sf_inner.submission_feature_id AS ancestor_id,
+                   sf_inner.parent_submission_feature_id
+            FROM submission_feature sf_inner
+            WHERE sf_inner.submission_feature_id = wf.submission_feature_id
+            UNION ALL
+            SELECT p.submission_feature_id, p.parent_submission_feature_id
+            FROM submission_feature p
+            JOIN ancestors a ON p.submission_feature_id = a.parent_submission_feature_id
+          )
           SELECT 1
-          FROM submission_feature_security sfs
-          WHERE sfs.submission_feature_id = wf.submission_feature_id
-            AND (
-              sfs.record_end_date IS NULL
-              OR sfs.record_end_date > now()
+          FROM ancestors a
+          INNER JOIN submission_feature_security sfs
+            ON sfs.submission_feature_id = a.ancestor_id
+          WHERE sfs.record_end_date IS NULL
+        )
+      )
+      INSERT INTO cart_submission_feature (cart_id, submission_feature_id)
+      SELECT wc.cart_id, wvf.submission_feature_id
+      FROM w_cart wc
+      CROSS JOIN w_valid_features wvf
+      ON CONFLICT (cart_id, submission_feature_id) DO NOTHING
+    `;
+  }
+
+  /**
+   * Authenticated path: allow features that are unsecured OR where the user has scope access.
+   * Walks up the ancestor chain, then checks security_scope_anchor → team_security_scope →
+   * team_member to determine if the user's team grants access to the secured subtree.
+   */
+  private buildAuthenticatedAddSql(cartId: string, submissionFeatureIds: number[], systemUserId: number) {
+    return SQL`
+      WITH w_cart AS (
+        SELECT cart_id
+        FROM cart
+        WHERE cart_id = ${cartId}
+          AND cart_status = ${CartStatus.ACTIVE}
+      ),
+      w_features AS (
+        SELECT unnest(${submissionFeatureIds}::INTEGER[]) AS submission_feature_id
+      ),
+      w_valid_features AS (
+        SELECT wf.submission_feature_id
+        FROM w_features wf
+        WHERE EXISTS (
+          SELECT 1
+          FROM (
+            WITH RECURSIVE ancestors AS (
+              SELECT sf_inner.submission_feature_id AS ancestor_id,
+                     sf_inner.parent_submission_feature_id
+              FROM submission_feature sf_inner
+              WHERE sf_inner.submission_feature_id = wf.submission_feature_id
+              UNION ALL
+              SELECT p.submission_feature_id, p.parent_submission_feature_id
+              FROM submission_feature p
+              JOIN ancestors a ON p.submission_feature_id = a.parent_submission_feature_id
+            )
+            SELECT array_agg(ancestor_id) AS ancestor_ids
+            FROM ancestors
+          ) anc
+          WHERE
+            NOT EXISTS (
+              SELECT 1 FROM submission_feature_security sfs
+              WHERE sfs.record_end_date IS NULL
+                AND sfs.submission_feature_id = ANY(anc.ancestor_ids)
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM security_scope_anchor ssa
+                JOIN team_security_scope tss ON tss.security_scope_id = ssa.security_scope_id
+                JOIN team_member tm ON tm.team_id = tss.team_id
+                  AND tm.system_user_id = ${systemUserId}
+                  AND tm.record_end_date IS NULL
+              WHERE ssa.anchor_submission_feature_id = ANY(anc.ancestor_ids)
             )
         )
       )
@@ -53,8 +149,6 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       CROSS JOIN w_valid_features wvf
       ON CONFLICT (cart_id, submission_feature_id) DO NOTHING
     `;
-
-    await this.connection.sql(sql);
   }
 
   /**
@@ -120,7 +214,9 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
 
   /**
    * Get all submission features in an active cart with pagination, optionally filtered by submission feature ID.
-   * Excludes secured features where the submission_feature_id is present in submission_feature_security.
+   * Returns ALL features in the cart — authorization was enforced at insert time, not on read.
+   * The `secured` field reflects current effective security status (feature or any ancestor has
+   * an active submission_feature_security row), computed via a bulk recursive CTE.
    *
    * @param {string} cartId - The ID of the cart
    * @param {ApiPaginationOptions} [pagination] - Optional pagination options
@@ -136,30 +232,53 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
     const knex = getKnex();
 
     const baseQuery = knex
-      .with('secured_features', (qb) => {
-        qb.select('submission_feature_id')
-          .from('submission_feature_security')
-          .where((qb) => {
-            qb.whereNull('record_end_date').orWhere('record_end_date', '>', knex.fn.now());
-          });
-      })
+      .withRecursive(
+        'cart_ancestors',
+        knex.raw(
+          `
+        SELECT csf2.submission_feature_id AS cart_feature_id,
+               sf2.submission_feature_id AS ancestor_id,
+               sf2.parent_submission_feature_id
+        FROM cart_submission_feature csf2
+        JOIN submission_feature sf2 ON sf2.submission_feature_id = csf2.submission_feature_id
+        JOIN cart c2 ON c2.cart_id = csf2.cart_id
+        WHERE csf2.cart_id = ?
+          AND c2.cart_status = ?
+        UNION ALL
+        SELECT ca.cart_feature_id,
+               p.submission_feature_id,
+               p.parent_submission_feature_id
+        FROM submission_feature p
+        JOIN cart_ancestors ca ON p.submission_feature_id = ca.parent_submission_feature_id
+      `,
+          [cartId, CartStatus.ACTIVE]
+        )
+      )
+      .with(
+        'effectively_secured',
+        knex.raw(`
+        SELECT DISTINCT ca.cart_feature_id AS submission_feature_id
+        FROM cart_ancestors ca
+        INNER JOIN submission_feature_security sfs
+          ON sfs.submission_feature_id = ca.ancestor_id
+        WHERE sfs.record_end_date IS NULL
+      `)
+      )
       .select(
         'csf.cart_submission_feature_id',
         'sf.submission_feature_id',
         'sf.submission_id',
         'sf.feature_type_id',
         'ft.name as feature_type_name',
-        knex.raw('FALSE AS secured')
+        knex.raw('CASE WHEN es.submission_feature_id IS NOT NULL THEN TRUE ELSE FALSE END AS secured')
       )
       .from('submission_feature as sf')
-      .leftJoin('secured_features as sf_sec', 'sf_sec.submission_feature_id', 'sf.submission_feature_id')
       .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id')
       .join('cart_submission_feature as csf', 'csf.submission_feature_id', 'sf.submission_feature_id')
       .join('cart as c', 'c.cart_id', 'csf.cart_id')
+      .leftJoin('effectively_secured as es', 'es.submission_feature_id', 'sf.submission_feature_id')
       .where('csf.cart_id', cartId)
-      .andWhere('c.cart_status', CartStatus.ACTIVE)
-      // Filter out secured features
-      .whereNull('sf_sec.submission_feature_id');
+      .andWhere('c.cart_status', CartStatus.ACTIVE);
 
     if (submissionFeatureId) {
       baseQuery.andWhere('sf.submission_feature_id', submissionFeatureId);
@@ -174,7 +293,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
 
   /**
    * Get the total number of submission features in an active cart.
-   * Excludes secured features.
+   * Counts ALL features — authorization was enforced at insert time, not on read.
    *
    * @param {string} cartId - The ID of the cart
    * @return {Promise<number>} - The total number of submission features in the cart
@@ -187,14 +306,6 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       .join('cart as c', 'c.cart_id', 'csf.cart_id')
       .where('csf.cart_id', cartId)
       .andWhere('c.cart_status', CartStatus.ACTIVE)
-      .whereNotExists((qb) => {
-        qb.select('sfs.submission_feature_id')
-          .from('submission_feature_security as sfs')
-          .whereRaw('sfs.submission_feature_id = csf.submission_feature_id')
-          .andWhere((qb) => {
-            qb.whereNull('sfs.record_end_date').orWhere('sfs.record_end_date', '>', knex.fn.now());
-          });
-      })
       .select(knex.raw('count(*)::integer as count'));
 
     const response = await this.connection.knex(query, z.object({ count: z.number() }));

--- a/api/src/repositories/sql-fragments.ts
+++ b/api/src/repositories/sql-fragments.ts
@@ -1,0 +1,40 @@
+/**
+ * Reusable SQL fragment builders for repository queries.
+ *
+ * These return raw SQL strings intended for interpolation into larger queries.
+ * They are NOT parameterized — callers must only pass trusted column references
+ * (e.g. 'sf.submission_feature_id'), never user input.
+ */
+
+/**
+ * Per-row "effectively secured" check: walks UP from a feature through its
+ * ancestors to determine if it or any ancestor has an active security rule
+ * whose feature is past its effective date.
+ *
+ * Returns an `EXISTS (...)` SQL expression suitable for use in WHERE clauses
+ * or as a SELECT column (returns boolean).
+ *
+ * Cost is O(tree_depth) per row (~3–5 levels), bounded by the feature
+ * hierarchy depth regardless of total feature count.
+ *
+ * @param featureIdExpr SQL expression for the starting submission_feature_id
+ *   (e.g. 'wf.submission_feature_id', 'candidate.submission_feature_id')
+ */
+export function isEffectivelySecured(featureIdExpr: string): string {
+  return `EXISTS (
+    WITH RECURSIVE ancestor_chain(id) AS (
+      SELECT ${featureIdExpr}
+      UNION ALL
+      SELECT p.parent_submission_feature_id
+      FROM ancestor_chain ac
+      JOIN submission_feature p ON p.submission_feature_id = ac.id
+      WHERE p.parent_submission_feature_id IS NOT NULL
+        AND p.record_end_date IS NULL
+    )
+    SELECT 1 FROM ancestor_chain ac
+    JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
+    JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = ac.id
+    WHERE sfs.record_end_date IS NULL
+      AND sf_sec.record_effective_date <= now()
+  )`;
+}

--- a/api/src/services/cart-service.test.ts
+++ b/api/src/services/cart-service.test.ts
@@ -144,7 +144,7 @@ describe('CartService', () => {
       };
 
       sinon.stub(CartRepository.prototype, 'createCart').resolves(mockCart);
-      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
+      const addStub = sinon.stub(CartSubmissionFeatureService.prototype, 'createCartSubmissionFeatures').resolves();
       const getStub = sinon
         .stub(CartSubmissionFeatureService.prototype, 'getPaginatedCartFeaturesResponse')
         .resolves(mockPaginationResponse);
@@ -225,7 +225,7 @@ describe('CartService', () => {
       };
 
       sinon.stub(CartRepository.prototype, 'createCart').resolves(mockCart);
-      sinon.stub(CartSubmissionFeatureService.prototype, 'addSubmissionFeaturesToCart').resolves();
+      sinon.stub(CartSubmissionFeatureService.prototype, 'createCartSubmissionFeatures').resolves();
       sinon
         .stub(CartSubmissionFeatureService.prototype, 'getPaginatedCartFeaturesResponse')
         .rejects(new Error('Service error'));

--- a/api/src/services/cart-service.ts
+++ b/api/src/services/cart-service.ts
@@ -90,7 +90,7 @@ export class CartService extends DBService {
     const cart = await this.cartRepository.createCart(systemUserId);
 
     if (submissionFeatureIds.length > 0) {
-      await this.cartSubmissionFeatureService.addSubmissionFeaturesToCart(
+      await this.cartSubmissionFeatureService.createCartSubmissionFeatures(
         cart.cart_id,
         submissionFeatureIds,
         systemUserId

--- a/api/src/services/cart-service.ts
+++ b/api/src/services/cart-service.ts
@@ -90,7 +90,11 @@ export class CartService extends DBService {
     const cart = await this.cartRepository.createCart(systemUserId);
 
     if (submissionFeatureIds.length > 0) {
-      await this.cartSubmissionFeatureService.addSubmissionFeaturesToCart(cart.cart_id, submissionFeatureIds);
+      await this.cartSubmissionFeatureService.addSubmissionFeaturesToCart(
+        cart.cart_id,
+        submissionFeatureIds,
+        systemUserId
+      );
     }
 
     // Fetch paginated features with provided pagination or defaults

--- a/api/src/services/cart-submission-feature-service.test.ts
+++ b/api/src/services/cart-submission-feature-service.test.ts
@@ -17,11 +17,13 @@ describe('CartSubmissionFeatureService', () => {
   });
 
   describe('addSubmissionFeaturesToCart', () => {
-    it('should pass systemUserId to repository for authenticated user', async () => {
+    it('should call scope-checked repository method for authenticated user', async () => {
       const mockDB = getMockDBConnection();
       const service = new CartSubmissionFeatureService(mockDB);
 
-      const stub = sinon.stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCart').resolves();
+      const stub = sinon
+        .stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCartWithScopeCheck')
+        .resolves();
 
       const features: number[] = [1, 2, 3];
       await service.addSubmissionFeaturesToCart('cart-1', features, 42);
@@ -29,16 +31,18 @@ describe('CartSubmissionFeatureService', () => {
       expect(stub).to.have.been.calledOnceWith('cart-1', features, 42);
     });
 
-    it('should pass null systemUserId to repository for anonymous user', async () => {
+    it('should call unsecured repository method for anonymous user', async () => {
       const mockDB = getMockDBConnection();
       const service = new CartSubmissionFeatureService(mockDB);
 
-      const stub = sinon.stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCart').resolves();
+      const stub = sinon
+        .stub(CartSubmissionFeatureRepository.prototype, 'addUnsecuredSubmissionFeaturesToCart')
+        .resolves();
 
       const features: number[] = [1, 2, 3];
       await service.addSubmissionFeaturesToCart('cart-1', features, null);
 
-      expect(stub).to.have.been.calledOnceWith('cart-1', features, null);
+      expect(stub).to.have.been.calledOnceWith('cart-1', features);
     });
 
     it('should propagate repository errors', async () => {
@@ -46,7 +50,7 @@ describe('CartSubmissionFeatureService', () => {
       const service = new CartSubmissionFeatureService(mockDB);
 
       sinon
-        .stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCart')
+        .stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCartWithScopeCheck')
         .rejects(new Error('DB error'));
 
       try {
@@ -62,11 +66,17 @@ describe('CartSubmissionFeatureService', () => {
       const mockDB = getMockDBConnection();
       const service = new CartSubmissionFeatureService(mockDB);
 
-      const stub = sinon.stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCart').resolves();
+      const unsecuredStub = sinon
+        .stub(CartSubmissionFeatureRepository.prototype, 'addUnsecuredSubmissionFeaturesToCart')
+        .resolves();
+      const scopeStub = sinon
+        .stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCartWithScopeCheck')
+        .resolves();
 
       await service.addSubmissionFeaturesToCart('cart-1', [], null);
 
-      expect(stub).not.to.have.been.called;
+      expect(unsecuredStub).not.to.have.been.called;
+      expect(scopeStub).not.to.have.been.called;
     });
   });
 

--- a/api/src/services/cart-submission-feature-service.test.ts
+++ b/api/src/services/cart-submission-feature-service.test.ts
@@ -16,17 +16,17 @@ describe('CartSubmissionFeatureService', () => {
     sinon.restore();
   });
 
-  describe('addSubmissionFeaturesToCart', () => {
+  describe('createCartSubmissionFeatures', () => {
     it('should call scope-checked repository method for authenticated user', async () => {
       const mockDB = getMockDBConnection();
       const service = new CartSubmissionFeatureService(mockDB);
 
       const stub = sinon
-        .stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCartWithScopeCheck')
+        .stub(CartSubmissionFeatureRepository.prototype, 'createCartSubmissionFeaturesWithScopeCheck')
         .resolves();
 
       const features: number[] = [1, 2, 3];
-      await service.addSubmissionFeaturesToCart('cart-1', features, 42);
+      await service.createCartSubmissionFeatures('cart-1', features, 42);
 
       expect(stub).to.have.been.calledOnceWith('cart-1', features, 42);
     });
@@ -36,11 +36,11 @@ describe('CartSubmissionFeatureService', () => {
       const service = new CartSubmissionFeatureService(mockDB);
 
       const stub = sinon
-        .stub(CartSubmissionFeatureRepository.prototype, 'addUnsecuredSubmissionFeaturesToCart')
+        .stub(CartSubmissionFeatureRepository.prototype, 'createUnsecuredCartSubmissionFeatures')
         .resolves();
 
       const features: number[] = [1, 2, 3];
-      await service.addSubmissionFeaturesToCart('cart-1', features, null);
+      await service.createCartSubmissionFeatures('cart-1', features, null);
 
       expect(stub).to.have.been.calledOnceWith('cart-1', features);
     });
@@ -50,11 +50,11 @@ describe('CartSubmissionFeatureService', () => {
       const service = new CartSubmissionFeatureService(mockDB);
 
       sinon
-        .stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCartWithScopeCheck')
+        .stub(CartSubmissionFeatureRepository.prototype, 'createCartSubmissionFeaturesWithScopeCheck')
         .rejects(new Error('DB error'));
 
       try {
-        await service.addSubmissionFeaturesToCart('cart-1', [1, 2], 42);
+        await service.createCartSubmissionFeatures('cart-1', [1, 2], 42);
         throw new Error('Expected to throw');
       } catch (err) {
         expect(err).to.be.instanceOf(Error);
@@ -67,13 +67,13 @@ describe('CartSubmissionFeatureService', () => {
       const service = new CartSubmissionFeatureService(mockDB);
 
       const unsecuredStub = sinon
-        .stub(CartSubmissionFeatureRepository.prototype, 'addUnsecuredSubmissionFeaturesToCart')
+        .stub(CartSubmissionFeatureRepository.prototype, 'createUnsecuredCartSubmissionFeatures')
         .resolves();
       const scopeStub = sinon
-        .stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCartWithScopeCheck')
+        .stub(CartSubmissionFeatureRepository.prototype, 'createCartSubmissionFeaturesWithScopeCheck')
         .resolves();
 
-      await service.addSubmissionFeaturesToCart('cart-1', [], null);
+      await service.createCartSubmissionFeatures('cart-1', [], null);
 
       expect(unsecuredStub).not.to.have.been.called;
       expect(scopeStub).not.to.have.been.called;

--- a/api/src/services/cart-submission-feature-service.test.ts
+++ b/api/src/services/cart-submission-feature-service.test.ts
@@ -17,16 +17,28 @@ describe('CartSubmissionFeatureService', () => {
   });
 
   describe('addSubmissionFeaturesToCart', () => {
-    it('should call repository with correct parameters', async () => {
+    it('should pass systemUserId to repository for authenticated user', async () => {
       const mockDB = getMockDBConnection();
       const service = new CartSubmissionFeatureService(mockDB);
 
       const stub = sinon.stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCart').resolves();
 
       const features: number[] = [1, 2, 3];
-      await service.addSubmissionFeaturesToCart('cart-1', features);
+      await service.addSubmissionFeaturesToCart('cart-1', features, 42);
 
-      expect(stub).to.have.been.calledOnceWith('cart-1', features);
+      expect(stub).to.have.been.calledOnceWith('cart-1', features, 42);
+    });
+
+    it('should pass null systemUserId to repository for anonymous user', async () => {
+      const mockDB = getMockDBConnection();
+      const service = new CartSubmissionFeatureService(mockDB);
+
+      const stub = sinon.stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCart').resolves();
+
+      const features: number[] = [1, 2, 3];
+      await service.addSubmissionFeaturesToCart('cart-1', features, null);
+
+      expect(stub).to.have.been.calledOnceWith('cart-1', features, null);
     });
 
     it('should propagate repository errors', async () => {
@@ -38,7 +50,7 @@ describe('CartSubmissionFeatureService', () => {
         .rejects(new Error('DB error'));
 
       try {
-        await service.addSubmissionFeaturesToCart('cart-1', [1, 2]);
+        await service.addSubmissionFeaturesToCart('cart-1', [1, 2], 42);
         throw new Error('Expected to throw');
       } catch (err) {
         expect(err).to.be.instanceOf(Error);
@@ -52,7 +64,7 @@ describe('CartSubmissionFeatureService', () => {
 
       const stub = sinon.stub(CartSubmissionFeatureRepository.prototype, 'addSubmissionFeaturesToCart').resolves();
 
-      await service.addSubmissionFeaturesToCart('cart-1', []);
+      await service.addSubmissionFeaturesToCart('cart-1', [], null);
 
       expect(stub).not.to.have.been.called;
     });

--- a/api/src/services/cart-submission-feature-service.ts
+++ b/api/src/services/cart-submission-feature-service.ts
@@ -27,6 +27,8 @@ export class CartSubmissionFeatureService extends DBService {
 
   /**
    * Adds multiple submission features to a cart with auth-aware security gating.
+   * Anonymous users can only add unsecured features. Authenticated users can also
+   * add secured features they have scope access to.
    *
    * @param {string} cartId - The ID of the cart
    * @param {number[]} submissionFeatureIds - The list of submission feature IDs to add
@@ -43,7 +45,15 @@ export class CartSubmissionFeatureService extends DBService {
       return;
     }
 
-    await this.cartSubmissionFeatureRepository.addSubmissionFeaturesToCart(cartId, submissionFeatureIds, systemUserId);
+    if (systemUserId === null) {
+      await this.cartSubmissionFeatureRepository.addUnsecuredSubmissionFeaturesToCart(cartId, submissionFeatureIds);
+    } else {
+      await this.cartSubmissionFeatureRepository.addSubmissionFeaturesToCartWithScopeCheck(
+        cartId,
+        submissionFeatureIds,
+        systemUserId
+      );
+    }
   }
 
   /**

--- a/api/src/services/cart-submission-feature-service.ts
+++ b/api/src/services/cart-submission-feature-service.ts
@@ -26,21 +26,24 @@ export class CartSubmissionFeatureService extends DBService {
   }
 
   /**
-   * Adds multiple submission features to a cart.
+   * Adds multiple submission features to a cart with auth-aware security gating.
    *
    * @param {string} cartId - The ID of the cart
    * @param {number[]} submissionFeatureIds - The list of submission feature IDs to add
+   * @param {number | null} systemUserId - The authenticated user's ID, or null for anonymous
    * @return {Promise<void>}
    * @memberof CartSubmissionFeatureService
    */
-  async addSubmissionFeaturesToCart(cartId: string, submissionFeatureIds: number[]): Promise<void> {
+  async addSubmissionFeaturesToCart(
+    cartId: string,
+    submissionFeatureIds: number[],
+    systemUserId: number | null
+  ): Promise<void> {
     if (submissionFeatureIds.length < 1) {
       return;
     }
 
-    // NOTE: SECURED FEATURES ARE OMITTED IN THE SQL
-
-    await this.cartSubmissionFeatureRepository.addSubmissionFeaturesToCart(cartId, submissionFeatureIds);
+    await this.cartSubmissionFeatureRepository.addSubmissionFeaturesToCart(cartId, submissionFeatureIds, systemUserId);
   }
 
   /**

--- a/api/src/services/cart-submission-feature-service.ts
+++ b/api/src/services/cart-submission-feature-service.ts
@@ -36,7 +36,7 @@ export class CartSubmissionFeatureService extends DBService {
    * @return {Promise<void>}
    * @memberof CartSubmissionFeatureService
    */
-  async addSubmissionFeaturesToCart(
+  async createCartSubmissionFeatures(
     cartId: string,
     submissionFeatureIds: number[],
     systemUserId: number | null
@@ -46,9 +46,9 @@ export class CartSubmissionFeatureService extends DBService {
     }
 
     if (systemUserId === null) {
-      await this.cartSubmissionFeatureRepository.addUnsecuredSubmissionFeaturesToCart(cartId, submissionFeatureIds);
+      await this.cartSubmissionFeatureRepository.createUnsecuredCartSubmissionFeatures(cartId, submissionFeatureIds);
     } else {
-      await this.cartSubmissionFeatureRepository.addSubmissionFeaturesToCartWithScopeCheck(
+      await this.cartSubmissionFeatureRepository.createCartSubmissionFeaturesWithScopeCheck(
         cartId,
         submissionFeatureIds,
         systemUserId

--- a/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.test.tsx
+++ b/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup } from '@testing-library/react';
+import { render } from 'test-helpers/test-utils';
+import { CartSubmissionFeature } from 'interfaces/useCartApi.interface';
+import { SearchFeatureResultWithRelevancy } from 'interfaces/useSearchApi.interface';
+import { DownloadSidebarCart } from './DownloadSidebarCart';
+
+vi.mock('hooks/useContext', () => ({
+  useCartContext: vi.fn().mockReturnValue({
+    clearCart: vi.fn(),
+    removeFromCart: vi.fn()
+  })
+}));
+
+describe('DownloadSidebarCart', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows lock icon for CartSubmissionFeature with secured: true', () => {
+    const features: CartSubmissionFeature[] = [
+      {
+        cart_submission_feature_id: 'uuid-1',
+        submission_feature_id: 1,
+        submission_id: 1,
+        feature_type_id: 1,
+        feature_type_name: 'Observation',
+        secured: true
+      }
+    ];
+
+    const { getByTestId } = render(<DownloadSidebarCart features={features} itemCount={1} />);
+
+    expect(getByTestId('secured-icon')).toBeVisible();
+  });
+
+  it('does not show lock icon for CartSubmissionFeature with secured: false', () => {
+    const features: CartSubmissionFeature[] = [
+      {
+        cart_submission_feature_id: 'uuid-1',
+        submission_feature_id: 1,
+        submission_id: 1,
+        feature_type_id: 1,
+        feature_type_name: 'Observation',
+        secured: false
+      }
+    ];
+
+    const { queryByTestId } = render(<DownloadSidebarCart features={features} itemCount={1} />);
+
+    expect(queryByTestId('secured-icon')).not.toBeInTheDocument();
+  });
+
+  it('does not show lock icon for SearchFeatureResultWithRelevancy (no secured property)', () => {
+    const features: SearchFeatureResultWithRelevancy[] = [
+      {
+        submission_feature_id: 1,
+        submission_id: 1,
+        uuid: 'uuid-1',
+        feature_type_id: 1,
+        feature_type_name: 'Observation',
+        feature_name: 'Test',
+        feature_description: null,
+        submission_name: 'Submission',
+        is_secured: true,
+        relevancy_score: 0.9
+      }
+    ];
+
+    const { queryByTestId } = render(<DownloadSidebarCart features={features} itemCount={1} />);
+
+    // SearchFeatureResultWithRelevancy has is_secured, not secured — the guard falls back to false
+    expect(queryByTestId('secured-icon')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.test.tsx
+++ b/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.test.tsx
@@ -50,7 +50,7 @@ describe('DownloadSidebarCart', () => {
     expect(queryByTestId('secured-icon')).not.toBeInTheDocument();
   });
 
-  it('does not show lock icon for SearchFeatureResultWithRelevancy (no secured property)', () => {
+  it('shows lock icon for secured SearchFeatureResultWithRelevancy optimistic cart items', () => {
     const features: SearchFeatureResultWithRelevancy[] = [
       {
         submission_feature_id: 1,
@@ -66,9 +66,8 @@ describe('DownloadSidebarCart', () => {
       }
     ];
 
-    const { queryByTestId } = render(<DownloadSidebarCart features={features} itemCount={1} />);
+    const { getByTestId } = render(<DownloadSidebarCart features={features} itemCount={1} />);
 
-    // SearchFeatureResultWithRelevancy has is_secured, not secured — the guard falls back to false
-    expect(queryByTestId('secured-icon')).not.toBeInTheDocument();
+    expect(getByTestId('secured-icon')).toBeVisible();
   });
 });

--- a/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.tsx
+++ b/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.tsx
@@ -34,6 +34,7 @@ export const DownloadSidebarCart = ({ features, itemCount }: DownloadSidebarCart
             <ListItem key={`${feature.submission_feature_id}-${idx}`} disableGutters sx={{ width: 1 }}>
               <CartFeatureCard
                 label={feature.feature_type_name}
+                secured={'secured' in feature ? feature.secured : false}
                 onRemove={() => void removeFromCart([feature.submission_feature_id])}
               />
             </ListItem>

--- a/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.tsx
+++ b/app/src/features/search/result/sidebar/download/cart/DownloadSidebarCart.tsx
@@ -13,6 +13,16 @@ interface DownloadSidebarCartProps {
 export const DownloadSidebarCart = ({ features, itemCount }: DownloadSidebarCartProps) => {
   const { clearCart, removeFromCart } = useCartContext();
 
+  // Optimistic cart items keep the search-result shape until the cart reloads from the API.
+  // Normalize the secure flag because search results use `is_secured` while cart rows use `secured`.
+  const isFeatureSecured = (feature: CartContextFeature) => {
+    if ('secured' in feature) {
+      return feature.secured;
+    }
+
+    return feature.is_secured;
+  };
+
   return (
     <>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ pb: 1 }}>
@@ -34,7 +44,7 @@ export const DownloadSidebarCart = ({ features, itemCount }: DownloadSidebarCart
             <ListItem key={`${feature.submission_feature_id}-${idx}`} disableGutters sx={{ width: 1 }}>
               <CartFeatureCard
                 label={feature.feature_type_name}
-                secured={'secured' in feature ? feature.secured : false}
+                secured={isFeatureSecured(feature)}
                 onRemove={() => void removeFromCart([feature.submission_feature_id])}
               />
             </ListItem>

--- a/app/src/features/search/result/sidebar/download/feature/CartFeatureCard.test.tsx
+++ b/app/src/features/search/result/sidebar/download/feature/CartFeatureCard.test.tsx
@@ -1,0 +1,27 @@
+import { cleanup } from '@testing-library/react';
+import { render } from 'test-helpers/test-utils';
+import { CartFeatureCard } from './CartFeatureCard';
+
+describe('CartFeatureCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders lock icon when secured is true', () => {
+    const { getByTestId } = render(<CartFeatureCard label="Observation" secured={true} />);
+
+    expect(getByTestId('secured-icon')).toBeVisible();
+  });
+
+  it('does not render lock icon when secured is false', () => {
+    const { queryByTestId } = render(<CartFeatureCard label="Observation" secured={false} />);
+
+    expect(queryByTestId('secured-icon')).not.toBeInTheDocument();
+  });
+
+  it('does not render lock icon when secured is undefined', () => {
+    const { queryByTestId } = render(<CartFeatureCard label="Observation" />);
+
+    expect(queryByTestId('secured-icon')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/features/search/result/sidebar/download/feature/CartFeatureCard.tsx
+++ b/app/src/features/search/result/sidebar/download/feature/CartFeatureCard.tsx
@@ -1,18 +1,22 @@
-import { mdiClose } from '@mdi/js';
+import { mdiClose, mdiLock } from '@mdi/js';
 import Icon from '@mdi/react';
 import { Card, IconButton, Stack, Typography } from '@mui/material';
 import { grey } from '@mui/material/colors';
 
 interface CartFeatureCardProps {
   label?: string;
+  secured?: boolean;
   onRemove?: () => void;
 }
 
-export const CartFeatureCard = ({ label, onRemove }: CartFeatureCardProps) => {
+export const CartFeatureCard = ({ label, secured, onRemove }: CartFeatureCardProps) => {
   return (
     <Card variant="outlined" sx={{ width: 1, backgroundColor: grey[50] }}>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ px: 1.5, py: 0.5 }}>
-        <Typography variant="body2">{label}</Typography>
+        <Stack direction="row" alignItems="center" gap={0.5}>
+          {secured && <Icon path={mdiLock} size={0.75} color="#d32f2f" data-testid="secured-icon" />}
+          <Typography variant="body2">{label}</Typography>
+        </Stack>
         <IconButton size="small" onClick={onRemove} disabled={!onRemove} title="Remove from Cart">
           <Icon path={mdiClose} size={0.8} />
         </IconButton>


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-932](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-932)

## Description of Changes

As a user who can see secured search results, I want to add the secured records to my cart, such that when I click Download, the secured records are included in my download.

Acceptance Criteria

1. Include secured features in cart

WHEN a secured feature is add to a cart
THEN it should behave exactly like an unsecured feature, and be added to the `cart_submission_feature` table

2. Download cart with secured features

WHEN a cart containing secured features is downloaded
THEN the download should include those secured features

3. Ensure no loopholes

WHEN features are added to an authenticated cart,
THEN ensure no secured features are included

## Testing Notes

1. Goto dataset search page 
2. Add a few secure datasets
3. Checkout
