### PR TITLE
SIMSBIOHUB-950: Deprecate `download_feature` table

### DIFF
--- a/api/src/__integration__/db/cart-checkout.integration.ts
+++ b/api/src/__integration__/db/cart-checkout.integration.ts
@@ -148,8 +148,10 @@ describe('Cart checkout (integration)', function () {
     // Verify: getDownloadFeatures resolves both features from the cart
     const features = await downloadService.getDownloadFeatures(result.download_id);
     expect(features).to.have.length(2);
-    const featureIds = features.map((f: { submission_feature_id: number }) => f.submission_feature_id).sort();
-    expect(featureIds).to.deep.equal([featureId1, featureId2].sort());
+    const featureIds = features
+      .map((f: { submission_feature_id: number }) => f.submission_feature_id)
+      .sort((a, b) => a - b);
+    expect(featureIds).to.deep.equal([featureId1, featureId2].sort((a, b) => a - b));
 
     // Verify: cart status is checked_out with checkout metadata
     const cart = await connection.sql(SQL`

--- a/api/src/__integration__/db/cart-checkout.integration.ts
+++ b/api/src/__integration__/db/cart-checkout.integration.ts
@@ -138,17 +138,18 @@ describe('Cart checkout (integration)', function () {
     expect(download).to.not.be.null;
     expect(download!.download_status).to.equal('pending');
 
-    // Verify: both features linked in download_feature
-    const features = await connection.sql(SQL`
-      SELECT submission_feature_id FROM download_feature
-      WHERE download_id = ${result.download_id}
-      ORDER BY submission_feature_id;
+    // Verify: download has cart_id set (features resolved at pipeline time from cart_submission_feature)
+    const downloadRow = await connection.sql(SQL`
+      SELECT cart_id, filters FROM download WHERE download_id = ${result.download_id};
     `);
-    expect(features.rows).to.have.length(2);
-    expect(features.rows.map((r: { submission_feature_id: number }) => r.submission_feature_id)).to.deep.equal([
-      featureId1,
-      featureId2
-    ]);
+    expect(downloadRow.rows[0].cart_id).to.equal(cartId);
+    expect(downloadRow.rows[0].filters).to.be.null;
+
+    // Verify: getDownloadFeatures resolves both features from the cart
+    const features = await downloadService.getDownloadFeatures(result.download_id);
+    expect(features).to.have.length(2);
+    const featureIds = features.map((f: { submission_feature_id: number }) => f.submission_feature_id).sort();
+    expect(featureIds).to.deep.equal([featureId1, featureId2].sort());
 
     // Verify: cart status is checked_out with checkout metadata
     const cart = await connection.sql(SQL`

--- a/api/src/__integration__/db/download-service.integration.ts
+++ b/api/src/__integration__/db/download-service.integration.ts
@@ -1,5 +1,5 @@
 // Integration test for Download services — verifies multi-step download operations
-// (create download, link features, status transitions, fragment planning, auth, claiming)
+// (create download, cart/filter feature resolution, status transitions, fragment planning, auth, claiming)
 // work correctly against the real database.
 //
 // DownloadService = request-time operations (path handlers)
@@ -16,8 +16,11 @@ import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } 
 import { HTTP403, HTTP409 } from '../../errors/http-error';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { DownloadFragmentRepository } from '../../repositories/download/download-fragment-repository';
+import { DownloadRepository } from '../../repositories/download/download-repository';
+import { CartService } from '../../services/cart-service';
 import { DownloadPipelineService } from '../../services/download/download-pipeline-service';
 import { DownloadService } from '../../services/download/download-service';
+import { SearchFeatureService } from '../../services/search-feature-service';
 import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
 
 describe('Download services (integration)', function () {
@@ -26,6 +29,7 @@ describe('Download services (integration)', function () {
   let connection: IDBConnection;
   let service: DownloadPipelineService;
   let crudService: DownloadService;
+  let cartService: CartService;
 
   before(() => {
     initDBPool(defaultPoolConfig);
@@ -36,6 +40,7 @@ describe('Download services (integration)', function () {
     await connection.open();
     service = new DownloadPipelineService(connection);
     crudService = new DownloadService(connection);
+    cartService = new CartService(connection);
   });
 
   afterEach(async () => {
@@ -64,52 +69,69 @@ describe('Download services (integration)', function () {
     }
   }
 
-  describe('createDownloadRequest', () => {
-    it('should create a download record and link submission features', async () => {
+  /**
+   * Helper: create a cart-backed download for the given feature IDs.
+   * Creates a cart via CartService, then creates a download with the cart_id FK.
+   * Returns { download_id } to match the shape callers expect.
+   */
+  async function createCartDownload(
+    featureIds: number[],
+    fragmentSizeBytes?: number
+  ): Promise<{ download_id: string }> {
+    const systemUserId = connection.systemUserId();
+    const cartResponse = await cartService.createCart(systemUserId, featureIds);
+    return crudService.createDownload({
+      cartId: cartResponse.cart.cart_id,
+      fragmentSizeBytes
+    });
+  }
+
+  describe('createDownload', () => {
+    it('should create a cart-based download with cart_id set and filters null', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset A' });
       const featureId2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset B' });
 
-      const result = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId1, featureId2]
-      });
+      const result = await createCartDownload([featureId1, featureId2]);
 
       const download = await crudService.findDownloadById(result.download_id);
       expect(download).to.not.be.null;
       expect(download!.download_status).to.equal(DownloadStatusEnum.PENDING);
-      expect(download!.total_fragments).to.equal(1);
-      expect(download!.completed_fragments).to.equal(0);
 
-      const features = await connection.sql(SQL`
-        SELECT submission_feature_id FROM download_feature
-        WHERE download_id = ${result.download_id}
-        ORDER BY submission_feature_id;
+      // Verify cart_id is set and filters is null
+      const row = await connection.sql(SQL`
+        SELECT cart_id, filters FROM download WHERE download_id = ${result.download_id};
       `);
-      expect(features.rows).to.have.length(2);
-      expect(features.rows.map((r: { submission_feature_id: number }) => r.submission_feature_id)).to.deep.equal([
-        featureId1,
-        featureId2
-      ]);
+      expect(row.rows[0].cart_id).to.not.be.null;
+      expect(row.rows[0].filters).to.be.null;
     });
 
-    it('should fail and not create a download when linking an invalid feature ID', async () => {
-      const before = await connection.sql(SQL`SELECT COUNT(*)::int as count FROM download;`);
-      const countBefore = before.rows[0].count;
+    it('should create a filter-based download with filters set and cart_id null', async () => {
+      const filters = { keyword: 'test-keyword' };
+      const result = await crudService.createDownload({ filters });
 
-      await connection.query('SAVEPOINT before_fk_test');
+      const row = await connection.sql(SQL`
+        SELECT cart_id, filters FROM download WHERE download_id = ${result.download_id};
+      `);
+      expect(row.rows[0].cart_id).to.be.null;
+      expect(row.rows[0].filters).to.not.be.null;
+      expect(row.rows[0].filters.keyword).to.equal('test-keyword');
+    });
 
+    it('should reject download with both cart_id and filters NULL (CHECK constraint)', async () => {
+      // The CHECK constraint on download requires: cart_id IS NOT NULL OR filters IS NOT NULL.
+      // Bypass the service layer and insert directly to test the constraint.
       try {
-        await crudService.createDownloadRequest({ submissionFeatureIds: [999999] });
-        expect.fail('Should have thrown a foreign key violation');
-      } catch (error) {
-        expect(error).to.exist;
+        await connection.sql(SQL`
+          INSERT INTO download (download_status, fragment_size_bytes, cart_id, filters, create_user)
+          VALUES ('pending', 524288000, NULL, NULL, ${connection.systemUserId()});
+        `);
+        expect.fail('Expected CHECK constraint violation');
+      } catch (error: any) {
+        // PG error is wrapped by ApiExecuteSQLError — original error in errors[]
+        const pgMessage = error.errors?.[0]?.message ?? error.message ?? '';
+        expect(pgMessage).to.include('download_feature_source_check');
       }
-
-      await connection.query('ROLLBACK TO SAVEPOINT before_fk_test');
-
-      const after = await connection.sql(SQL`SELECT COUNT(*)::int as count FROM download;`);
-      const countAfter = after.rows[0].count;
-      expect(countAfter).to.equal(countBefore);
     });
   });
 
@@ -117,9 +139,7 @@ describe('Download services (integration)', function () {
     it('should set started_at only when transitioning to processing', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Test' });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       await service.updateDownloadStatus(download_id, DownloadStatusEnum.PROCESSING);
 
@@ -153,9 +173,7 @@ describe('Download services (integration)', function () {
         count: 12,
         timestamp: '2024-01-16T14:30:00Z'
       });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId1, featureId2]
-      });
+      const { download_id } = await createCartDownload([featureId1, featureId2]);
 
       // Link to a team so it appears in getDownloadsByTeamMembership
       await crudService.linkDownloadToNewTeam(
@@ -193,13 +211,11 @@ describe('Download services (integration)', function () {
   });
 
   describe('getDownloadFeatures', () => {
-    it('should return per-feature estimated_byte_size from pre-computed column', async () => {
+    it('should resolve cart-based features with estimated_byte_size from pre-computed column', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Size Test' });
 
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       const sizeData = await crudService.getDownloadFeatures(download_id);
 
@@ -211,17 +227,32 @@ describe('Download services (integration)', function () {
       expect(sizeData[0]).to.not.have.property('data');
     });
 
-    it('should return all linked features regardless of security status', async () => {
-      // Authorization is enforced at creation time via buildSecurityFilter in the search query.
-      // At retrieval time, getDownloadFeatures returns everything that was linked.
+    it('should return all cart features regardless of security status', async () => {
+      // Cart downloads are frozen at checkout — security was enforced when the
+      // user added features to the cart. At resolution time, getDownloadFeatures
+      // returns everything in cart_submission_feature for the download's cart.
+      //
+      // Use raw SQL to insert cart_submission_feature rows because CartService
+      // filters out secured features during addSubmissionFeaturesToCart.
+      const systemUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const openFeatureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Open' });
       const securedFeatureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
       await secureFeature(securedFeatureId);
 
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [openFeatureId, securedFeatureId]
-      });
+      // Create cart directly (bypasses CartService security filtering)
+      const cartResult = await connection.sql(SQL`
+        INSERT INTO cart (system_user_id, cart_status, create_user)
+        VALUES (${systemUserId}, 'active', ${systemUserId})
+        RETURNING cart_id;
+      `);
+      const cartId = cartResult.rows[0].cart_id;
+      await connection.sql(SQL`
+        INSERT INTO cart_submission_feature (cart_id, submission_feature_id, create_user)
+        VALUES (${cartId}, ${openFeatureId}, ${systemUserId}), (${cartId}, ${securedFeatureId}, ${systemUserId});
+      `);
+
+      const { download_id } = await crudService.createDownload({ cartId });
 
       const result = await crudService.getDownloadFeatures(download_id);
 
@@ -231,13 +262,13 @@ describe('Download services (integration)', function () {
       expect(featureIds).to.include(securedFeatureId);
     });
 
-    it('should not leak features across different downloads', async () => {
+    it('should not leak features across different cart-based downloads', async () => {
       const submissionId = await createTestSubmission(connection);
       const featA = await createTestFeature(connection, submissionId, 'dataset', { name: 'DL-A Feature' });
       const featB = await createTestFeature(connection, submissionId, 'dataset', { name: 'DL-B Feature' });
 
-      const dlA = await crudService.createDownloadRequest({ submissionFeatureIds: [featA] });
-      const dlB = await crudService.createDownloadRequest({ submissionFeatureIds: [featB] });
+      const dlA = await createCartDownload([featA]);
+      const dlB = await createCartDownload([featB]);
 
       const resultA = await crudService.getDownloadFeatures(dlA.download_id);
       expect(resultA).to.have.length(1);
@@ -248,14 +279,149 @@ describe('Download services (integration)', function () {
       expect(resultB[0].submission_feature_id).to.equal(featB);
     });
 
-    it('should return empty for a download with no linked features', async () => {
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: []
-      });
+    it('should resolve filter-based features by re-running search query', async () => {
+      // Filter-based downloads store filters JSONB on the download row and re-derive
+      // the feature set at pipeline time by re-running the search CTE.
+      const submissionId = await createTestSubmission(connection);
+      const feat1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Filter Test A' });
+      const feat2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Filter Test B' });
+      // Create a non-matching feature to prove filter selectivity
+      await createTestFeature(connection, submissionId, 'species_observation', { taxon_id: 1234, count: 1 });
+
+      const filters = { feature_types: ['dataset'] };
+      const { download_id } = await crudService.createDownload({ filters });
 
       const result = await crudService.getDownloadFeatures(download_id);
 
-      expect(result).to.have.length(0);
+      // Should include both dataset features but not the species_observation
+      const featureIds = result.map((f: { submission_feature_id: number }) => f.submission_feature_id);
+      expect(featureIds).to.include(feat1);
+      expect(featureIds).to.include(feat2);
+      // All returned features should be datasets
+      for (const f of result) {
+        expect(f.feature_type_name).to.equal('dataset');
+      }
+    });
+
+    it('should not leak features across cart-based and filter-based downloads', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const cartFeat = await createTestFeature(connection, submissionId, 'species_observation', {
+        taxon_id: 9999,
+        count: 1
+      });
+      const filterFeat = await createTestFeature(connection, submissionId, 'dataset', { name: 'Filter Only' });
+
+      // Cart download includes only the observation
+      const cartDl = await createCartDownload([cartFeat]);
+      // Filter download matches only datasets
+      const filterDl = await crudService.createDownload({ filters: { feature_types: ['dataset'] } });
+
+      const cartResult = await crudService.getDownloadFeatures(cartDl.download_id);
+      expect(cartResult).to.have.length(1);
+      expect(cartResult[0].submission_feature_id).to.equal(cartFeat);
+
+      const filterResult = await crudService.getDownloadFeatures(filterDl.download_id);
+      const filterIds = filterResult.map((f: { submission_feature_id: number }) => f.submission_feature_id);
+      expect(filterIds).to.include(filterFeat);
+      expect(filterIds).to.not.include(cartFeat);
+    });
+  });
+
+  describe('estimateDownloadSize (filter-based)', () => {
+    it('should return aggregate total for filter-based downloads via SQL SUM', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const feat1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Size A' });
+      const feat2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Size B' });
+
+      const filters = { feature_types: ['dataset'] };
+      const { download_id } = await crudService.createDownload({ filters });
+
+      const totalBytes = await service.estimateDownloadSize(download_id);
+
+      // Should be > 0 (data_byte_size = octet_length(data::text) + 500 per feature)
+      expect(totalBytes).to.be.greaterThan(0);
+
+      // Cross-check: total should equal sum of individual features
+      const features = await crudService.getDownloadFeatures(download_id);
+      const expectedTotal = features
+        .filter((f: { submission_feature_id: number }) => [feat1, feat2].includes(f.submission_feature_id))
+        .reduce((sum: number, f: { estimated_byte_size: string }) => sum + Number(f.estimated_byte_size), 0);
+      expect(totalBytes).to.be.greaterThanOrEqual(expectedTotal);
+    });
+  });
+
+  describe('cursor streaming (streamDownloadFeatures)', () => {
+    it('should stream cart-based features via DECLARE CURSOR / FETCH / CLOSE', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const feat1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Stream A' });
+      const feat2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Stream B' });
+      const cartResponse = await cartService.createCart(connection.systemUserId(), [feat1, feat2]);
+
+      const downloadRepo = new DownloadRepository(connection);
+
+      // Cursor requires an open transaction — our test connection is already in one
+      const batches: { submission_feature_id: number; feature_type_name: string }[][] = [];
+      for await (const batch of downloadRepo.streamDownloadFeaturesByCartId(cartResponse.cart.cart_id, 1)) {
+        batches.push(batch as any);
+      }
+
+      // With batchSize=1, should yield 2 batches of 1 row each
+      expect(batches).to.have.length(2);
+      const allIds = batches.flat().map((r) => r.submission_feature_id);
+      expect(allIds).to.include(feat1);
+      expect(allIds).to.include(feat2);
+      for (const row of batches.flat()) {
+        expect(row.feature_type_name).to.equal('dataset');
+      }
+    });
+
+    it('should stream filter-based features via DECLARE CURSOR with embedded search CTE', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const feat1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'CursorFilter A' });
+      const feat2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'CursorFilter B' });
+
+      const filters = { feature_types: ['dataset'] };
+      const { download_id } = await crudService.createDownload({ filters });
+
+      const downloadRepo = new DownloadRepository(connection);
+      const searchService = new SearchFeatureService(connection);
+
+      // Build the subquery the same way planFragments does
+      const subquery = searchService.buildSearchFeatureIdsSubquery(filters, connection.systemUserId());
+      const { sql, bindings } = subquery.toSQL().toNative();
+
+      const batches: { submission_feature_id: number; feature_type_name: string }[][] = [];
+      for await (const batch of downloadRepo.streamDownloadFeaturesBySearchQuery(
+        download_id,
+        sql,
+        bindings as any[],
+        1
+      )) {
+        batches.push(batch as any);
+      }
+
+      // With batchSize=1, at least 2 batches
+      expect(batches.length).to.be.greaterThanOrEqual(2);
+      const allIds = batches.flat().map((r) => r.submission_feature_id);
+      expect(allIds).to.include(feat1);
+      expect(allIds).to.include(feat2);
+    });
+
+    it('should yield empty for cart with no features', async () => {
+      const systemUserId = connection.systemUserId();
+      const cartResult = await connection.sql(SQL`
+        INSERT INTO cart (system_user_id, cart_status, create_user)
+        VALUES (${systemUserId}, 'active', ${systemUserId})
+        RETURNING cart_id;
+      `);
+
+      const downloadRepo = new DownloadRepository(connection);
+      const batches: unknown[][] = [];
+      for await (const batch of downloadRepo.streamDownloadFeaturesByCartId(cartResult.rows[0].cart_id)) {
+        batches.push(batch);
+      }
+
+      expect(batches).to.have.length(0);
     });
   });
 
@@ -274,9 +440,7 @@ describe('Download services (integration)', function () {
         parentFeatureId
       );
 
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [childFeatureId]
-      });
+      const { download_id } = await createCartDownload([childFeatureId]);
       const sizeEstimate = await service.estimateDownloadSize(download_id);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -312,9 +476,7 @@ describe('Download services (integration)', function () {
         name: 'Root Dataset'
       });
 
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [rootFeatureId]
-      });
+      const { download_id } = await createCartDownload([rootFeatureId]);
       const sizeEstimate = await service.estimateDownloadSize(download_id);
       await service.planFragments(download_id, sizeEstimate);
 
@@ -370,9 +532,7 @@ describe('Download services (integration)', function () {
   async function createAnonymousDownload(): Promise<string> {
     const submissionId = await createTestSubmission(connection);
     const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Anon' });
-    const { download_id } = await crudService.createDownloadRequest({
-      submissionFeatureIds: [featureId]
-    });
+    const { download_id } = await createCartDownload([featureId]);
     return download_id;
   }
 
@@ -411,9 +571,7 @@ describe('Download services (integration)', function () {
     it('should fail when download already has team associations', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Team DL' });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       const systemUserId = connection.systemUserId();
       // Link to a team (simulates authenticated download creation)
@@ -445,9 +603,7 @@ describe('Download services (integration)', function () {
     it('should authorize team member on team-linked download', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Team DL' });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       const systemUserId = connection.systemUserId();
       await crudService.linkDownloadToNewTeam(download_id, systemUserId, 'Auth test team', 'Auth test team');
@@ -459,9 +615,7 @@ describe('Download services (integration)', function () {
     it('should throw HTTP403 for non-team-member on team-linked download', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Locked' });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       const systemUserId = connection.systemUserId();
       await crudService.linkDownloadToNewTeam(download_id, systemUserId, 'Auth test team', 'Auth test team');
@@ -478,9 +632,7 @@ describe('Download services (integration)', function () {
     it('should throw HTTP403 for unauthenticated access to team-linked download', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Locked' });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       const systemUserId = connection.systemUserId();
       await crudService.linkDownloadToNewTeam(download_id, systemUserId, 'Auth test team', 'Auth test team');
@@ -501,9 +653,7 @@ describe('Download services (integration)', function () {
       const apiUserId = connection.systemUserId();
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Mine' });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       await crudService.linkDownloadToNewTeam(download_id, apiUserId, 'Listing test team', 'Listing test team');
 
@@ -515,9 +665,7 @@ describe('Download services (integration)', function () {
     it('should not return downloads the user has no team membership for', async () => {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Private' });
-      const { download_id } = await crudService.createDownloadRequest({
-        submissionFeatureIds: [featureId]
-      });
+      const { download_id } = await createCartDownload([featureId]);
 
       // Anonymous download (no team link) should not appear in team-based listing
       const otherUserId = await createOtherUser();

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -900,7 +900,9 @@ describe('DownloadPipelineService download pipeline (system)', function () {
    * Helper: create a filter-based download and run the full pipeline, returning the resulting zip.
    * Features are re-derived at pipeline time by re-running the search query with the stored filters.
    */
-  async function executeFilterAndGetZip(filters: Record<string, unknown>): Promise<{ zip: AdmZip; downloadId: string }> {
+  async function executeFilterAndGetZip(
+    filters: Record<string, unknown>
+  ): Promise<{ zip: AdmZip; downloadId: string }> {
     const { download_id } = await crudService.createDownload({ filters });
 
     // Run the three-phase pipeline within the test transaction
@@ -933,14 +935,8 @@ describe('DownloadPipelineService download pipeline (system)', function () {
       start_date: '2024-06-01T00:00:00.000Z'
     });
     // Non-matching feature to prove filter selectivity
-    await createTestFeature(
-      connection,
-      submissionId,
-      'species_observation',
-      { taxon_id: 99999, count: 1 },
-      // species_observation needs a parent to avoid orphan — use first dataset
-      undefined
-    );
+    // Non-matching feature needs no parent for this test — just proves filter selectivity
+    await createTestFeature(connection, submissionId, 'species_observation', { taxon_id: 99999, count: 1 });
 
     const { zip, downloadId } = await executeFilterAndGetZip({ feature_types: ['dataset'] });
     const rootFolder = `biohub-${downloadId}/`;

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -14,6 +14,7 @@ import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { initPgBoss, stopPgBoss } from '../../queue/pg-boss-service';
+import { CartService } from '../../services/cart-service';
 import { DownloadPipelineService } from '../../services/download/download-pipeline-service';
 import { DownloadService } from '../../services/download/download-service';
 import { BucketType, ObjectStorageService } from '../../services/object-storage/object-storage-service';
@@ -77,6 +78,7 @@ describe('Download Worker', function () {
   let db: Knex;
   let storageService: ObjectStorageService;
   const createdDownloadIds: number[] = [];
+  const createdCartIds: string[] = [];
   const createdSubmissionFeatureIds: number[] = [];
   const createdSubmissionIds: number[] = [];
   const createdTicketIds: string[] = [];
@@ -103,9 +105,14 @@ describe('Download Worker', function () {
   after(async () => {
     // Cleanup in reverse dependency order
     try {
-      // 1. Delete downloads (cascades to download_feature, download_fragment, download_fragment_feature)
+      // 1. Delete downloads (cascades to download_fragment, download_fragment_feature)
       if (createdDownloadIds.length > 0) {
         await db('biohub.download').whereIn('download_id', createdDownloadIds).del();
+      }
+
+      // 1b. Delete carts (cascades to cart_submission_feature)
+      if (createdCartIds.length > 0) {
+        await db('biohub.cart').whereIn('cart_id', createdCartIds).del();
       }
 
       // 2. Delete submission features
@@ -215,28 +222,43 @@ describe('Download Worker', function () {
   }
 
   /**
-   * Create a download record, link features, publish the job to pg-boss, and wait for completion.
+   * Create a cart-backed download, publish the job to pg-boss, and wait for completion.
+   * Features are resolved at pipeline time from cart_submission_feature via download.cart_id.
    */
   async function createDownloadAndProcess(
     featureIds: number[],
     downloadOverrides?: Record<string, unknown>
   ): Promise<number> {
+    // Create a cart and link features (raw Knex — system tests don't use IDBConnection)
+    const [cart] = await db('biohub.cart')
+      .insert({
+        system_user_id: SYSTEM_USER_ID,
+        cart_status: 'checked_out',
+        create_user: SYSTEM_USER_ID
+      })
+      .returning('cart_id');
+    createdCartIds.push(cart.cart_id);
+
+    if (featureIds.length > 0) {
+      await db('biohub.cart_submission_feature').insert(
+        featureIds.map((id) => ({
+          cart_id: cart.cart_id,
+          submission_feature_id: id,
+          create_user: SYSTEM_USER_ID
+        }))
+      );
+    }
+
+    // Create download with cart_id FK — pipeline resolves features from cart_submission_feature
     const [download] = await db('biohub.download')
       .insert({
         download_status: 'pending',
+        cart_id: cart.cart_id,
         create_user: SYSTEM_USER_ID,
         ...downloadOverrides
       })
       .returning('download_id');
     createdDownloadIds.push(download.download_id);
-
-    await db('biohub.download_feature').insert(
-      featureIds.map((id) => ({
-        download_id: download.download_id,
-        submission_feature_id: id,
-        create_user: SYSTEM_USER_ID
-      }))
-    );
 
     const boss = await initPgBoss();
     await boss.createQueue('process-download');
@@ -528,6 +550,7 @@ describe('DownloadPipelineService download pipeline (system)', function () {
   let connection: IDBConnection;
   let service: DownloadPipelineService;
   let crudService: DownloadService;
+  let cartService: CartService;
   const storageService = new ObjectStorageService();
   const s3KeysToCleanup: string[] = [];
 
@@ -540,6 +563,7 @@ describe('DownloadPipelineService download pipeline (system)', function () {
     await connection.open();
     service = new DownloadPipelineService(connection);
     crudService = new DownloadService(connection);
+    cartService = new CartService(connection);
   });
 
   afterEach(async () => {
@@ -565,11 +589,13 @@ describe('DownloadPipelineService download pipeline (system)', function () {
   }
 
   /**
-   * Helper: run the full download pipeline and return the resulting zip.
+   * Helper: create a cart-backed download and run the full pipeline, returning the resulting zip.
    */
   async function executeAndGetZip(featureIds: number[]): Promise<{ zip: AdmZip; downloadId: string }> {
-    const { download_id } = await crudService.createDownloadRequest({
-      submissionFeatureIds: featureIds
+    const systemUserId = connection.systemUserId();
+    const cartResponse = await cartService.createCart(systemUserId, featureIds);
+    const { download_id } = await crudService.createDownload({
+      cartId: cartResponse.cart.cart_id
     });
 
     // Run the three-phase pipeline within the test transaction
@@ -868,5 +894,85 @@ describe('DownloadPipelineService download pipeline (system)', function () {
     expect(lines[1]).to.include('BEAR-001');
     // Dataset context
     expect(lines[1]).to.include('Denorm Test Dataset');
+  });
+
+  /**
+   * Helper: create a filter-based download and run the full pipeline, returning the resulting zip.
+   * Features are re-derived at pipeline time by re-running the search query with the stored filters.
+   */
+  async function executeFilterAndGetZip(filters: Record<string, unknown>): Promise<{ zip: AdmZip; downloadId: string }> {
+    const { download_id } = await crudService.createDownload({ filters });
+
+    // Run the three-phase pipeline within the test transaction
+    await service.planDownloadIfNeeded(download_id);
+    const fragments = await service.getFragmentsToProcess(download_id);
+    for (const fragment of fragments) {
+      await service.processFragment(fragment, download_id);
+    }
+    await service.finalizeDownload(download_id);
+
+    const download = await crudService.findDownloadById(download_id);
+    expect(download).to.not.be.null;
+    expect(download!.download_status).to.equal(DownloadStatusEnum.READY);
+
+    const allFragments = await crudService.getFragmentsByDownloadId(download_id);
+    expect(allFragments.length).to.be.greaterThanOrEqual(1);
+    const zip = await downloadAndTrackZip(allFragments[0].s3_key as string);
+    return { zip, downloadId: download_id };
+  }
+
+  it('should process a filter-based download through the full pipeline', async () => {
+    // Create test data — two datasets that will match { feature_types: ['dataset'] }
+    const submissionId = await createTestSubmission(connection);
+    await createTestFeature(connection, submissionId, 'dataset', {
+      name: 'Filter Pipeline Dataset A',
+      start_date: '2024-01-01T00:00:00.000Z'
+    });
+    await createTestFeature(connection, submissionId, 'dataset', {
+      name: 'Filter Pipeline Dataset B',
+      start_date: '2024-06-01T00:00:00.000Z'
+    });
+    // Non-matching feature to prove filter selectivity
+    await createTestFeature(
+      connection,
+      submissionId,
+      'species_observation',
+      { taxon_id: 99999, count: 1 },
+      // species_observation needs a parent to avoid orphan — use first dataset
+      undefined
+    );
+
+    const { zip, downloadId } = await executeFilterAndGetZip({ feature_types: ['dataset'] });
+    const rootFolder = `biohub-${downloadId}/`;
+
+    const entries = zip.getEntries().map((e) => e.entryName);
+
+    // Should contain dataset.csv but NOT species_observation.csv
+    expect(entries).to.include(`${rootFolder}dataset.csv`);
+    const csvEntries = entries.filter((e) => e.endsWith('.csv'));
+    expect(csvEntries).to.have.lengthOf(1);
+
+    const csv = zipEntryText(zip, `${rootFolder}dataset.csv`);
+    const lines = parseCsvLines(csv);
+    // At least header + our 2 rows (other dataset features from seed data or
+    // earlier tests in this transaction may also match the broad filter)
+    expect(lines.length).to.be.greaterThanOrEqual(3);
+    expect(csv).to.include('Filter Pipeline Dataset A');
+    expect(csv).to.include('Filter Pipeline Dataset B');
+    // species_observation should not appear
+    expect(csv).to.not.include('99999');
+
+    // Verify download record metadata
+    const download = await crudService.findDownloadById(downloadId);
+    expect(download!.download_status).to.equal(DownloadStatusEnum.READY);
+    expect(download!.completed_at).to.not.be.null;
+    expect(Number(download!.estimated_total_size_bytes)).to.be.greaterThan(0);
+
+    // Verify the download source is filter-based (no cart_id)
+    const row = await connection.sql(SQL`
+      SELECT cart_id, filters FROM download WHERE download_id = ${downloadId};
+    `);
+    expect(row.rows[0].cart_id).to.be.null;
+    expect(row.rows[0].filters).to.deep.equal({ feature_types: ['dataset'] });
   });
 });

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -19,18 +19,17 @@ export type DownloadRecord = z.infer<typeof DownloadRecord>;
 
 /**
  * Extended download record for the list endpoint.
- * Includes feature_count — the number of submission_feature records linked to the download (AC #1).
+ * feature_count removed — download_feature table dropped (SIMSBIOHUB-950).
+ * Feature count is no longer cheaply derivable without the join table.
  */
-export const DownloadListRecord = DownloadRecord.extend({
-  feature_count: z.number()
-});
+export const DownloadListRecord = DownloadRecord;
 export type DownloadListRecord = z.infer<typeof DownloadListRecord>;
 
 /**
  * Internal row shape returned by the paginated list query.
  * Includes total_count from COUNT(*) OVER() window function — stripped before returning to callers.
  */
-export const DownloadListRow = DownloadListRecord.extend({
+export const DownloadListRow = DownloadRecord.extend({
   total_count: z.number()
 });
 export type DownloadListRow = z.infer<typeof DownloadListRow>;
@@ -59,6 +58,17 @@ export const DownloadFeatureSummary = z.object({
 export type DownloadFeatureSummary = z.infer<typeof DownloadFeatureSummary>;
 
 /**
+ * Minimal projection of a download record for feature resolution.
+ * Used by DownloadService.getDownloadFeatures to branch between
+ * cart-based (frozen snapshot) and filter-based (live re-query) paths.
+ */
+export const DownloadSource = z.object({
+  cart_id: z.string().uuid().nullable(),
+  filters: SearchFeatureFiltersSchema.nullable()
+});
+export type DownloadSource = z.infer<typeof DownloadSource>;
+
+/**
  * Result of estimating a download's total size before processing.
  * Used by planFragments to decide how to split features across zip files.
  *
@@ -74,12 +84,14 @@ export interface DownloadSizeEstimate {
 /**
  * Payload for creating a new download record.
  *
- * Team linking is handled separately via download_team — callers insert
- * into the join table after creating the download record.
+ * Every download must have a feature source: either cartId (cart-based, frozen
+ * at checkout) or filters (filter-based, re-derived at pipeline time).
+ * Team linking is handled separately via download_team.
  */
 export const CreateDownload = z.object({
   fragmentSizeBytes: z.number().optional(),
-  filters: SearchFeatureFiltersSchema.optional()
+  filters: SearchFeatureFiltersSchema.optional(),
+  cartId: z.string().uuid().optional()
 });
 export type CreateDownload = z.infer<typeof CreateDownload>;
 

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -86,7 +86,7 @@ export const CreateDownload = z.object({
 });
 export type CreateDownload = z.infer<typeof CreateDownload>;
 
-export const DownloadTotalSize = z.object({ total: z.string().nullable() });
+export const DownloadTotalSize = z.object({ total: z.number().nullable() });
 export type DownloadTotalSize = z.infer<typeof DownloadTotalSize>;
 
 export const IsAuthorized = z.object({ authorized: z.boolean() });

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -73,19 +73,6 @@ export const DownloadSource = z.object({
 export type DownloadSource = z.infer<typeof DownloadSource>;
 
 /**
- * Result of estimating a download's total size before processing.
- * Used by planFragments to decide how to split features across zip files.
- *
- * Per-feature and total sizes are computed inline in the SQL query.
- */
-export interface DownloadSizeEstimate {
-  /** Total estimated bytes across all features. */
-  totalEstimatedBytes: number;
-  /** The features included in this download with per-feature estimated_byte_size. */
-  features: DownloadFeatureSummary[];
-}
-
-/**
  * Payload for creating a new download record.
  *
  * Every download must have a feature source: either cartId (cart-based, frozen
@@ -98,20 +85,6 @@ export const CreateDownload = z.object({
   cartId: z.string().uuid().optional()
 });
 export type CreateDownload = z.infer<typeof CreateDownload>;
-
-/**
- * Payload for creating a download request through the pipeline.
- *
- * Accepted by the pipeline service's public entry point. Includes the feature
- * selection and optional fragment sizing before the request is persisted and
- * features are linked. Team linking is handled by the caller via download_team.
- */
-export const CreateDownloadRequest = z.object({
-  submissionFeatureIds: z.array(z.number()),
-  fragmentSizeMb: z.number().optional(),
-  filters: SearchFeatureFiltersSchema.optional()
-});
-export type CreateDownloadRequest = z.infer<typeof CreateDownloadRequest>;
 
 export const DownloadTotalSize = z.object({ total: z.string().nullable() });
 export type DownloadTotalSize = z.infer<typeof DownloadTotalSize>;

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -61,10 +61,14 @@ export type DownloadFeatureSummary = z.infer<typeof DownloadFeatureSummary>;
  * Minimal projection of a download record for feature resolution.
  * Used by DownloadService.getDownloadFeatures to branch between
  * cart-based (frozen snapshot) and filter-based (live re-query) paths.
+ *
+ * Includes create_user so the pipeline can recover the creator's security
+ * context for filter-based re-queries without a separate round-trip.
  */
 export const DownloadSource = z.object({
   cart_id: z.string().uuid().nullable(),
-  filters: SearchFeatureFiltersSchema.nullable()
+  filters: SearchFeatureFiltersSchema.nullable(),
+  create_user: z.number()
 });
 export type DownloadSource = z.infer<typeof DownloadSource>;
 
@@ -108,6 +112,9 @@ export const CreateDownloadRequest = z.object({
   filters: SearchFeatureFiltersSchema.optional()
 });
 export type CreateDownloadRequest = z.infer<typeof CreateDownloadRequest>;
+
+export const DownloadTotalSize = z.object({ total: z.string().nullable() });
+export type DownloadTotalSize = z.infer<typeof DownloadTotalSize>;
 
 export const IsAuthorized = z.object({ authorized: z.boolean() });
 export type IsAuthorized = z.infer<typeof IsAuthorized>;

--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -341,8 +341,7 @@ describe('paths/download/index', () => {
           completed_fragments: 1,
           estimated_total_size_bytes: '1000',
           fragment_size_bytes: '1000',
-          create_date: '2026-01-01',
-          feature_count: 5
+          create_date: '2026-01-01'
         }
       ];
 

--- a/api/src/paths/download/index.test.ts
+++ b/api/src/paths/download/index.test.ts
@@ -23,7 +23,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([]);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(0);
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -45,8 +45,8 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(3);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'uuid-1' });
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -65,14 +65,14 @@ describe('paths/download/index', () => {
       });
     });
 
-    it('should pass search filters to createDownloadRequest', async () => {
+    it('should pass search filters to createDownload', async () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([10, 20]);
-      const createDownloadRequestStub = sinon
-        .stub(DownloadService.prototype, 'createDownloadRequest')
-        .resolves({ download_id: 'uuid-2' } as any);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
+      const createDownloadStub = sinon
+        .stub(DownloadService.prototype, 'createDownload')
+        .resolves({ download_id: 'uuid-2' });
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -84,19 +84,17 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(createDownloadRequestStub.firstCall.args[0]).to.have.deep.property('filters', {
-        feature_types: ['dataset']
+      expect(createDownloadStub.firstCall.args[0]).to.deep.equal({
+        filters: { feature_types: ['dataset'] }
       });
     });
 
-    it('should not include systemUserId or teamId in createDownloadRequest for anonymous', async () => {
+    it('should pass null systemUserId to getSearchFeaturesCount for anonymous users', async () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
-      const createDownloadRequestStub = sinon
-        .stub(DownloadService.prototype, 'createDownloadRequest')
-        .resolves({ download_id: 'uuid-1' } as any);
+      const getCountStub = sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'uuid-1' });
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -108,41 +106,17 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      const opts = createDownloadRequestStub.firstCall.args[0];
-      expect(opts).to.not.have.property('systemUserId');
-      expect(opts).to.not.have.property('teamId');
+      expect(getCountStub).to.have.been.calledOnce;
+      expect(getCountStub.firstCall.args[0]).to.deep.equal({ keyword: 'elk' });
+      expect(getCountStub.firstCall.args[1]).to.be.null;
     });
 
-    it('should pass null systemUserId to getSearchFeatureIds for anonymous users', async () => {
-      const dbConnectionObj = getMockDBConnection();
-
-      sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      const getSearchFeatureIdsStub = sinon
-        .stub(SearchFeatureService.prototype, 'getSearchFeatureIds')
-        .resolves([1, 2]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
-      sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
-
-      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
-
-      mockReq.keycloak_token = undefined as any;
-      mockReq.body = { filters: { keyword: 'elk' } };
-
-      const requestHandler = createDownload();
-
-      await requestHandler(mockReq, mockRes, mockNext);
-
-      expect(getSearchFeatureIdsStub).to.have.been.calledOnce;
-      expect(getSearchFeatureIdsStub.firstCall.args[0]).to.deep.equal({ keyword: 'elk' });
-      expect(getSearchFeatureIdsStub.firstCall.args[1]).to.be.null;
-    });
-
-    it('should pass systemUserId to getSearchFeatureIds for authenticated users', async () => {
+    it('should pass systemUserId to getSearchFeaturesCount for authenticated users', async () => {
       const dbConnectionObj = getMockDBConnection({ systemUserId: () => 20 });
 
       sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
-      const getSearchFeatureIdsStub = sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      const getCountStub = sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(1);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'uuid-1' });
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
       sinon.stub(DownloadService.prototype, 'linkDownloadToNewTeam').resolves();
 
@@ -155,16 +129,16 @@ describe('paths/download/index', () => {
 
       await requestHandler(mockReq, mockRes, mockNext);
 
-      expect(getSearchFeatureIdsStub).to.have.been.calledOnce;
-      expect(getSearchFeatureIdsStub.firstCall.args[1]).to.equal(20);
+      expect(getCountStub).to.have.been.calledOnce;
+      expect(getCountStub.firstCall.args[1]).to.equal(20);
     });
 
     it('should use getDBConnection when authenticated', async () => {
       const dbConnectionObj = getMockDBConnection();
 
       const getDBConnectionStub = sinon.stub(db, 'getDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(1);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'uuid-1' });
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
       sinon.stub(DownloadService.prototype, 'linkDownloadToNewTeam').resolves();
 
@@ -184,8 +158,8 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       const getAPIUserDBConnectionStub = sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(1);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'uuid-1' });
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
@@ -206,7 +180,7 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').rejects(new Error('Search failed'));
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').rejects(new Error('Search failed'));
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
 
@@ -231,8 +205,8 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').rejects(new Error('Download creation failed'));
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
+      sinon.stub(DownloadService.prototype, 'createDownload').rejects(new Error('Download creation failed'));
 
       const publishStub = sinon.stub(publisher, 'publishProcessDownloadJob');
 
@@ -258,8 +232,8 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection();
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2, 3]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(3);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'uuid-1' });
       const publishStub = sinon
         .stub(publisher, 'publishProcessDownloadJob')
         .resolves({ status: 'published', jobId: 'job-1' });
@@ -283,8 +257,8 @@ describe('paths/download/index', () => {
       const dbConnectionObj = getMockDBConnection({ rollback: rollbackStub, release: releaseStub });
 
       sinon.stub(db, 'getAPIUserDBConnection').returns(dbConnectionObj);
-      sinon.stub(SearchFeatureService.prototype, 'getSearchFeatureIds').resolves([1, 2]);
-      sinon.stub(DownloadService.prototype, 'createDownloadRequest').resolves({ download_id: 'uuid-1' } as any);
+      sinon.stub(SearchFeatureService.prototype, 'getSearchFeaturesCount').resolves(2);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'uuid-1' });
       sinon.stub(publisher, 'publishProcessDownloadJob').rejects(new Error('pg-boss unavailable'));
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -43,7 +43,7 @@ GET.apiDoc = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  required: ['download_id', 'download_status', 'create_date', 'feature_count'],
+                  required: ['download_id', 'download_status', 'create_date'],
                   properties: {
                     download_id: {
                       type: 'string',
@@ -55,9 +55,6 @@ GET.apiDoc = {
                     },
                     create_date: {
                       type: 'string'
-                    },
-                    feature_count: {
-                      type: 'integer'
                     },
                     started_at: {
                       type: 'string',
@@ -200,21 +197,19 @@ export function createDownload(): RequestHandler {
       const searchFeatureService = new SearchFeatureService(connection);
       const downloadService = new DownloadService(connection);
 
+      // Count-only validation — no ID materialization.
       // Security filtering happens in SQL via buildSecurityFilter:
       // - systemUserId === null → anonymous, exclude secured features
       // - systemUserId === number → authenticated, include unsecured + scope-granted
       const systemUserId = isAuthenticated ? connection.systemUserId() : null;
-      const submissionFeatureIds = await searchFeatureService.getSearchFeatureIds(filters, systemUserId);
+      const matchCount = await searchFeatureService.getSearchFeaturesCount(filters, systemUserId);
 
-      if (submissionFeatureIds.length === 0) {
+      if (matchCount === 0) {
         throw new HTTP400('No features match the filter criteria');
       }
 
-      // Create download with search filters stored for traceability
-      const downloadId = await downloadService.createDownloadRequest({
-        submissionFeatureIds,
-        filters
-      });
+      // Store filters on download — features re-derived at pipeline time via search re-run
+      const downloadId = await downloadService.createDownload({ filters });
 
       // Link download to a new team for authenticated users.
       // Anonymous downloads have no download_team rows — UUID is the credential.

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -98,8 +98,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
 
   /**
    * Get all submission feature IDs in a cart (unpaginated).
-   * Used by checkout to copy cart contents to download_feature
-   * without fetching full feature metadata.
+   * Used by checkout to validate cart is non-empty before creating download.
    *
    * @param {string} cartId - The ID of the cart
    * @return {Promise<number[]>} - Array of submission feature IDs

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -15,7 +15,7 @@ describe('DownloadRepository', () => {
   });
 
   describe('createDownload', () => {
-    it('inserts download with status, fragment_size_bytes, and filters only', async () => {
+    it('inserts download with status, fragment_size_bytes, filters, and cart_id', async () => {
       const sqlStub = sinon
         .stub()
         .resolves(mockQueryResult([{ download_id: 'aaaa0000-0000-0000-0000-000000000001' }], 1));
@@ -30,6 +30,7 @@ describe('DownloadRepository', () => {
       expect(sqlText).to.not.include('team_id');
       expect(sqlText).to.not.include('data_request_id');
       expect(sqlText).to.include('fragment_size_bytes');
+      expect(sqlText).to.include('cart_id');
     });
 
     it('serializes filters as JSONB in SQL', async () => {
@@ -60,38 +61,38 @@ describe('DownloadRepository', () => {
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlValues = sqlStub.firstCall.args[0].values;
-      const filtersValue = sqlValues[sqlValues.length - 1];
-      expect(filtersValue).to.be.null;
+      // filters is second-to-last, cart_id is last
+      expect(sqlValues[sqlValues.length - 2]).to.be.null;
     });
-  });
 
-  describe('createDownloadFeatures', () => {
-    it('inserts join table rows for each feature ID using unnest', async () => {
-      const sqlStub = sinon.stub().resolves(mockQueryResult([], 3));
+    it('passes cartId value in SQL when provided', async () => {
+      const sqlStub = sinon
+        .stub()
+        .resolves(mockQueryResult([{ download_id: 'aaaa0000-0000-0000-0000-000000000001' }], 1));
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
 
       const repo = new DownloadRepository(mockDBConnection);
-      await repo.createDownloadFeatures('aaaa0000-0000-0000-0000-000000000001', [10, 20, 30]);
+      const cartId = 'cccc0000-0000-0000-0000-000000000001';
+      await repo.createDownload({ cartId });
 
       expect(sqlStub).to.have.been.calledOnce;
-      const sqlText = sqlStub.firstCall.args[0].text;
-      expect(sqlText).to.include('unnest');
       const sqlValues = sqlStub.firstCall.args[0].values;
-      expect(sqlValues).to.include('aaaa0000-0000-0000-0000-000000000001');
-      expect(sqlValues).to.deep.include([10, 20, 30]);
+      expect(sqlValues).to.include(cartId);
     });
 
-    it('handles single feature ID', async () => {
-      const sqlStub = sinon.stub().resolves(mockQueryResult([], 1));
+    it('passes null cart_id when cartId is omitted', async () => {
+      const sqlStub = sinon
+        .stub()
+        .resolves(mockQueryResult([{ download_id: 'aaaa0000-0000-0000-0000-000000000001' }], 1));
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
 
       const repo = new DownloadRepository(mockDBConnection);
-      await repo.createDownloadFeatures('aaaa0000-0000-0000-0000-000000000001', [10]);
+      await repo.createDownload({ filters: { keyword: 'moose' } });
 
       expect(sqlStub).to.have.been.calledOnce;
       const sqlValues = sqlStub.firstCall.args[0].values;
-      expect(sqlValues).to.include('aaaa0000-0000-0000-0000-000000000001');
-      expect(sqlValues).to.deep.include([10]);
+      // cart_id is the last parameter
+      expect(sqlValues[sqlValues.length - 1]).to.be.null;
     });
   });
 
@@ -189,6 +190,23 @@ describe('DownloadRepository', () => {
       expect(result.downloads[0]).to.not.have.property('total_count');
     });
 
+    it('SQL does not reference download_feature', async () => {
+      const knexStub = sinon.stub().resolves({
+        rowCount: 0,
+        rows: []
+      } as unknown as QueryResult<any>);
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+      await repo.getDownloadsByTeamMembership(123);
+
+      expect(knexStub).to.have.been.calledOnce;
+      const builtQuery = knexStub.firstCall.args[0];
+      const sqlText = builtQuery.toString();
+      expect(sqlText).to.not.include('download_feature');
+      expect(sqlText).to.not.include('feature_count');
+    });
+
     it('returns paginated results when pagination is provided', async () => {
       const mockRows = [{ download_id: 'uuid-1', total_count: 5 }];
       const mockResponse = {
@@ -216,6 +234,153 @@ describe('DownloadRepository', () => {
 
       expect(result.downloads).to.eql([]);
       expect(result.count).to.equal(0);
+    });
+  });
+
+  describe('getDownloadSource', () => {
+    it('returns cart_id, filters, and create_user for a download', async () => {
+      const sqlStub = sinon
+        .stub()
+        .resolves(
+          mockQueryResult([{ cart_id: 'cccc0000-0000-0000-0000-000000000001', filters: null, create_user: 42 }], 1)
+        );
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const result = await repo.getDownloadSource('aaaa0000-0000-0000-0000-000000000001');
+
+      expect(result).to.deep.equal({
+        cart_id: 'cccc0000-0000-0000-0000-000000000001',
+        filters: null,
+        create_user: 42
+      });
+      expect(sqlStub).to.have.been.calledOnce;
+      const sqlText = sqlStub.firstCall.args[0].text;
+      expect(sqlText).to.include('cart_id');
+      expect(sqlText).to.include('filters');
+      expect(sqlText).to.include('create_user');
+    });
+
+    it('throws ApiExecuteSQLError when download not found', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([], 0));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+
+      try {
+        await repo.getDownloadSource('bad-id');
+        expect.fail('Expected error');
+      } catch (err: any) {
+        expect(err.message).to.equal('Download not found');
+      }
+    });
+  });
+
+  describe('getDownloadFeaturesByCartId', () => {
+    it('joins cart_submission_feature to submission_feature and feature_type', async () => {
+      const knexStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: [
+          { submission_feature_id: 1, submission_id: 10, feature_type_name: 'observation', estimated_byte_size: '500' }
+        ]
+      } as unknown as QueryResult<any>);
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const result = await repo.getDownloadFeaturesByCartId('cccc0000-0000-0000-0000-000000000001');
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.have.property('submission_feature_id');
+      expect(result[0]).to.have.property('feature_type_name');
+      expect(result[0]).to.have.property('estimated_byte_size');
+
+      const builtQuery = knexStub.firstCall.args[0];
+      const sqlText = builtQuery.toString();
+      expect(sqlText).to.include('cart_submission_feature');
+      expect(sqlText).to.include('submission_feature');
+      expect(sqlText).to.include('feature_type');
+    });
+  });
+
+  describe('getDownloadFeaturesBySearchQuery', () => {
+    it('uses whereIn with Knex subquery and calls connection.knex once', async () => {
+      const knexStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: [
+          { submission_feature_id: 1, submission_id: 10, feature_type_name: 'observation', estimated_byte_size: '500' }
+        ]
+      } as unknown as QueryResult<any>);
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      // Create a mock subquery (a Knex.QueryBuilder-like object)
+      const mockSubquery = { toString: () => 'SELECT submission_feature_id FROM ...' } as any;
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const result = await repo.getDownloadFeaturesBySearchQuery(mockSubquery);
+
+      expect(result).to.have.length(1);
+      // connection.knex should be called exactly once (the outer query, not the subquery)
+      expect(knexStub).to.have.been.calledOnce;
+    });
+  });
+
+  describe('getDownloadTotalSizeByCartId', () => {
+    it('returns aggregate row with total', async () => {
+      const knexStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: [{ total: '15000' }]
+      } as unknown as QueryResult<any>);
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const result = await repo.getDownloadTotalSizeByCartId('cccc0000-0000-0000-0000-000000000001');
+
+      expect(result).to.deep.equal({ total: '15000' });
+    });
+
+    it('returns row with null total when cart has no features', async () => {
+      const knexStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: [{ total: null }]
+      } as unknown as QueryResult<any>);
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const result = await repo.getDownloadTotalSizeByCartId('cccc0000-0000-0000-0000-000000000001');
+
+      expect(result).to.deep.equal({ total: null });
+    });
+  });
+
+  describe('getDownloadTotalSizeBySearchQuery', () => {
+    it('returns aggregate row with total', async () => {
+      const knexStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: [{ total: '25000' }]
+      } as unknown as QueryResult<any>);
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const mockSubquery = { toString: () => 'SELECT submission_feature_id FROM ...' } as any;
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const result = await repo.getDownloadTotalSizeBySearchQuery(mockSubquery);
+
+      expect(result).to.deep.equal({ total: '25000' });
+    });
+
+    it('returns row with null total when no features match', async () => {
+      const knexStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: [{ total: null }]
+      } as unknown as QueryResult<any>);
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const mockSubquery = { toString: () => 'SELECT submission_feature_id FROM ...' } as any;
+
+      const repo = new DownloadRepository(mockDBConnection);
+      const result = await repo.getDownloadTotalSizeBySearchQuery(mockSubquery);
+
+      expect(result).to.deep.equal({ total: null });
     });
   });
 
@@ -289,18 +454,6 @@ describe('DownloadRepository', () => {
       const result = await repo.isDownloadClaimedByTeam('aaaa0000-0000-0000-0000-000000000001');
 
       expect(result).to.be.false;
-    });
-  });
-
-  describe('getDownloadFeatures', () => {
-    it('returns all features linked to a download without security filtering', async () => {
-      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
-      const mockDBConnection = getMockDBConnection({ knex: async () => mockResponse });
-
-      const repo = new DownloadRepository(mockDBConnection);
-      const result = await repo.getDownloadFeatures('aaaa0000-0000-0000-0000-000000000001');
-
-      expect(result).to.eql([]);
     });
   });
 });

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -172,8 +172,8 @@ describe('DownloadRepository', () => {
   describe('getDownloadsByTeamMembership', () => {
     it('returns download records and count from knex query', async () => {
       const mockRows = [
-        { download_id: 'uuid-1', download_status: 'ready', feature_count: 5, total_count: 2 },
-        { download_id: 'uuid-2', download_status: 'pending', feature_count: 0, total_count: 2 }
+        { download_id: 'uuid-1', download_status: 'ready', total_count: 2 },
+        { download_id: 'uuid-2', download_status: 'pending', total_count: 2 }
       ];
       const mockResponse = {
         rowCount: 2,
@@ -190,7 +190,7 @@ describe('DownloadRepository', () => {
     });
 
     it('returns paginated results when pagination is provided', async () => {
-      const mockRows = [{ download_id: 'uuid-1', feature_count: 3, total_count: 5 }];
+      const mockRows = [{ download_id: 'uuid-1', total_count: 5 }];
       const mockResponse = {
         rowCount: 1,
         rows: mockRows

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -328,14 +328,14 @@ describe('DownloadRepository', () => {
     it('returns aggregate row with total', async () => {
       const knexStub = sinon.stub().resolves({
         rowCount: 1,
-        rows: [{ total: '15000' }]
+        rows: [{ total: 15000 }]
       } as unknown as QueryResult<any>);
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
       const repo = new DownloadRepository(mockDBConnection);
       const result = await repo.getDownloadTotalSizeByCartId('cccc0000-0000-0000-0000-000000000001');
 
-      expect(result).to.deep.equal({ total: '15000' });
+      expect(result).to.deep.equal({ total: 15000 });
     });
 
     it('returns row with null total when cart has no features', async () => {
@@ -356,7 +356,7 @@ describe('DownloadRepository', () => {
     it('returns aggregate row with total', async () => {
       const knexStub = sinon.stub().resolves({
         rowCount: 1,
-        rows: [{ total: '25000' }]
+        rows: [{ total: 25000 }]
       } as unknown as QueryResult<any>);
       const mockDBConnection = getMockDBConnection({ knex: knexStub });
 
@@ -365,7 +365,7 @@ describe('DownloadRepository', () => {
       const repo = new DownloadRepository(mockDBConnection);
       const result = await repo.getDownloadTotalSizeBySearchQuery(mockSubquery);
 
-      expect(result).to.deep.equal({ total: '25000' });
+      expect(result).to.deep.equal({ total: 25000 });
     });
 
     it('returns row with null total when no features match', async () => {

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -1,3 +1,4 @@
+import { Knex } from 'knex';
 import SQL from 'sql-template-strings';
 import { FRAGMENT_SIZE_THRESHOLD } from '../../constants/download';
 import { getKnex } from '../../database/db';
@@ -9,6 +10,8 @@ import {
   DownloadListRecord,
   DownloadListRow,
   DownloadRecord,
+  DownloadSource,
+  DownloadTotalSize,
   HasTeams,
   IsAuthorized
 } from '../../models/download';
@@ -35,12 +38,12 @@ export class DownloadRepository extends BaseRepository {
    * @memberof DownloadRepository
    */
   async createDownload(payload: CreateDownload): Promise<DownloadId> {
-    const { fragmentSizeBytes, filters } = payload;
+    const { fragmentSizeBytes, filters, cartId } = payload;
     const sizeBytes = fragmentSizeBytes ?? FRAGMENT_SIZE_THRESHOLD;
 
     const sql = SQL`
-      INSERT INTO download (download_status, fragment_size_bytes, filters)
-      VALUES ('pending', ${sizeBytes}, ${filters ? JSON.stringify(filters) : null}::jsonb)
+      INSERT INTO download (download_status, fragment_size_bytes, filters, cart_id)
+      VALUES ('pending', ${sizeBytes}, ${filters ? JSON.stringify(filters) : null}::jsonb, ${cartId ?? null})
       RETURNING download_id;
     `;
 
@@ -54,27 +57,6 @@ export class DownloadRepository extends BaseRepository {
     }
 
     return response.rows[0];
-  }
-
-  /**
-   * Link submission features to a download request.
-   *
-   * @param {string} downloadId - The download ID.
-   * @param {number[]} submissionFeatureIds - The submission feature IDs to include.
-   * @return {Promise<void>}
-   * @memberof DownloadRepository
-   */
-  async createDownloadFeatures(downloadId: string, submissionFeatureIds: number[]): Promise<void> {
-    if (submissionFeatureIds.length === 0) {
-      return;
-    }
-
-    const sql = SQL`
-      INSERT INTO download_feature (download_id, submission_feature_id)
-      SELECT ${downloadId}, unnest(${submissionFeatureIds}::integer[]);
-    `;
-
-    await this.connection.sql(sql);
   }
 
   /**
@@ -167,9 +149,6 @@ export class DownloadRepository extends BaseRepository {
         'd.estimated_total_size_bytes',
         'd.fragment_size_bytes',
         'd.create_date',
-        knex.raw(
-          '(SELECT COUNT(*)::int FROM download_feature df WHERE df.download_id = d.download_id) AS feature_count'
-        ),
         knex.raw('COUNT(*) OVER()::int AS total_count')
       ])
       .from('download as d')
@@ -262,18 +241,46 @@ export class DownloadRepository extends BaseRepository {
   }
 
   /**
-   * Returns all features linked to a download.
+   * Get the feature resolution source for a download.
    *
-   * Authorization is enforced at creation time via buildSecurityFilter in the
-   * search query — only authorized features are ever linked. At retrieval time
-   * we return everything that was linked, avoiding the download_team → policy_team
-   * hop that would let later team membership changes alter which features are visible.
+   * Returns cart_id and filters — exactly one should be non-null.
+   * Used by DownloadService.getDownloadFeatures to branch between
+   * cart-based (frozen snapshot) and filter-based (live re-query) paths.
    *
    * @param {string} downloadId - The download ID.
-   * @return {Promise<DownloadFeatureSummary[]>} All linked features.
+   * @return {Promise<DownloadSource>}
    * @memberof DownloadRepository
    */
-  async getDownloadFeatures(downloadId: string): Promise<DownloadFeatureSummary[]> {
+  async getDownloadSource(downloadId: string): Promise<DownloadSource> {
+    const sql = SQL`
+      SELECT cart_id, filters, create_user
+      FROM download
+      WHERE download_id = ${downloadId};
+    `;
+
+    const response = await this.connection.sql(sql, DownloadSource);
+
+    if (response.rowCount === 0) {
+      throw new ApiExecuteSQLError('Download not found', [
+        'DownloadRepository->getDownloadSource',
+        'rowCount was 0, expected 1'
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Resolve download features from cart_submission_feature.
+   *
+   * Cart downloads are frozen: checkout marks the cart as CHECKED_OUT,
+   * so cart_submission_feature rows don't change after checkout.
+   *
+   * @param {string} cartId - The cart ID (from download.cart_id).
+   * @return {Promise<DownloadFeatureSummary[]>}
+   * @memberof DownloadRepository
+   */
+  async getDownloadFeaturesByCartId(cartId: string): Promise<DownloadFeatureSummary[]> {
     const knex = getKnex();
 
     const query = knex
@@ -283,13 +290,187 @@ export class DownloadRepository extends BaseRepository {
         knex.raw('ft.name AS feature_type_name'),
         knex.raw('sf.data_byte_size AS estimated_byte_size')
       ])
-      .from('download_feature as df')
-      .innerJoin('submission_feature as sf', 'df.submission_feature_id', 'sf.submission_feature_id')
+      .from('cart_submission_feature as csf')
+      .innerJoin('submission_feature as sf', 'csf.submission_feature_id', 'sf.submission_feature_id')
       .innerJoin('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
-      .where('df.download_id', downloadId);
+      .where('csf.cart_id', cartId);
 
     const response = await this.connection.knex(query, DownloadFeatureSummary);
     return response.rows;
+  }
+
+  /**
+   * Resolve download features by joining a search subquery directly to
+   * submission_feature + feature_type — entirely in SQL, no round-trip.
+   *
+   * The search CTE (with security filtering) runs as a subquery inside
+   * WHERE IN, so PostgreSQL plans and executes it in a single statement.
+   * This avoids pulling potentially 500K+ IDs into a JS array.
+   *
+   * @param {Knex.QueryBuilder} searchSubquery - Unexecuted Knex subquery
+   *   returning submission_feature_id rows (from SearchFeatureRepository).
+   * @return {Promise<DownloadFeatureSummary[]>}
+   * @memberof DownloadRepository
+   */
+  async getDownloadFeaturesBySearchQuery(searchSubquery: Knex.QueryBuilder): Promise<DownloadFeatureSummary[]> {
+    const knex = getKnex();
+
+    const query = knex
+      .select([
+        'sf.submission_feature_id',
+        'sf.submission_id',
+        knex.raw('ft.name AS feature_type_name'),
+        knex.raw('sf.data_byte_size AS estimated_byte_size')
+      ])
+      .from('submission_feature as sf')
+      .innerJoin('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
+      .whereIn('sf.submission_feature_id', searchSubquery);
+
+    const response = await this.connection.knex(query, DownloadFeatureSummary);
+    return response.rows;
+  }
+
+  /**
+   * Get total estimated byte size for a cart-based download as a SQL aggregate.
+   *
+   * Returns SUM(data_byte_size) for all features in the cart. Never materializes
+   * feature rows in JS — returns a single row with the aggregate from the database.
+   * Callers coerce the string total to a number (BIGINT returns as string from pg).
+   *
+   * @param {string} cartId - The cart ID (from download.cart_id).
+   * @return {Promise<DownloadTotalSize>} Row with total (string or null).
+   * @memberof DownloadRepository
+   */
+  async getDownloadTotalSizeByCartId(cartId: string): Promise<DownloadTotalSize> {
+    const knex = getKnex();
+    const query = knex
+      .sum('sf.data_byte_size as total')
+      .from('cart_submission_feature as csf')
+      .innerJoin('submission_feature as sf', 'csf.submission_feature_id', 'sf.submission_feature_id')
+      .where('csf.cart_id', cartId)
+      .first();
+
+    const response = await this.connection.knex(query, DownloadTotalSize);
+    return response.rows[0];
+  }
+
+  /**
+   * Get total estimated byte size for a filter-based download as a SQL aggregate.
+   *
+   * Returns SUM(data_byte_size) for all features matching the search subquery.
+   * Never materializes feature rows in JS — returns a single row with the aggregate.
+   * Callers coerce the string total to a number (BIGINT returns as string from pg).
+   *
+   * @param {Knex.QueryBuilder} searchSubquery - Unexecuted Knex subquery
+   *   returning submission_feature_id rows (from SearchFeatureRepository).
+   * @return {Promise<DownloadTotalSize>} Row with total (string or null).
+   * @memberof DownloadRepository
+   */
+  async getDownloadTotalSizeBySearchQuery(searchSubquery: Knex.QueryBuilder): Promise<DownloadTotalSize> {
+    const knex = getKnex();
+    const query = knex
+      .sum('sf.data_byte_size as total')
+      .from('submission_feature as sf')
+      .whereIn('sf.submission_feature_id', searchSubquery)
+      .first();
+
+    const response = await this.connection.knex(query, DownloadTotalSize);
+    return response.rows[0];
+  }
+
+  /**
+   * Stream features for a cart-based download using a SQL cursor.
+   *
+   * Yields batches of DownloadFeatureSummary to avoid loading 500K+ rows
+   * into JS memory. Features are sorted by feature_type_name so bin packing
+   * keeps same types together, minimizing duplicate CSVs across fragments.
+   *
+   * Must be called within an open transaction (cursors require tx context).
+   * Follows the streamFragmentFeaturesByType pattern.
+   *
+   * @param {string} cartId - The cart ID (from download.cart_id).
+   * @param {number} [batchSize=5000] - Rows per FETCH.
+   * @yields {DownloadFeatureSummary[]} Batches of feature summaries.
+   * @memberof DownloadRepository
+   */
+  async *streamDownloadFeaturesByCartId(cartId: string, batchSize = 5000): AsyncGenerator<DownloadFeatureSummary[]> {
+    const cursorName = `dl_cart_cursor_${cartId.replace(/[^a-z0-9_]/gi, '_')}`;
+
+    await this.connection.query(
+      `DECLARE ${cursorName} CURSOR FOR
+        SELECT
+          sf.submission_feature_id,
+          sf.submission_id,
+          ft.name AS feature_type_name,
+          sf.data_byte_size AS estimated_byte_size
+        FROM cart_submission_feature csf
+        INNER JOIN submission_feature sf ON csf.submission_feature_id = sf.submission_feature_id
+        INNER JOIN feature_type ft ON sf.feature_type_id = ft.feature_type_id
+        WHERE csf.cart_id = $1
+        ORDER BY ft.name, sf.submission_feature_id`,
+      [cartId]
+    );
+
+    try {
+      while (true) {
+        const result = await this.connection.query<DownloadFeatureSummary>(`FETCH ${batchSize} FROM ${cursorName}`);
+        if (result.rows.length === 0) {
+          break;
+        }
+        yield result.rows;
+      }
+    } finally {
+      await this.connection.query(`CLOSE ${cursorName}`);
+    }
+  }
+
+  /**
+   * Stream features for a filter-based download using a SQL cursor.
+   *
+   * The search CTE (with security filtering) is embedded in the cursor
+   * declaration — features are resolved and streamed in a single SQL
+   * statement, never materializing the full ID set in JS.
+   *
+   * @param {string} downloadId - The download ID (used for cursor naming).
+   * @param {string} searchSql - Raw SQL for the search subquery (from buildSearchFeatureIdsSubquery).
+   * @param {any[]} searchBindings - Parameterized bindings for the search SQL.
+   * @param {number} [batchSize=5000] - Rows per FETCH.
+   * @yields {DownloadFeatureSummary[]} Batches of feature summaries.
+   * @memberof DownloadRepository
+   */
+  async *streamDownloadFeaturesBySearchQuery(
+    downloadId: string,
+    searchSql: string,
+    searchBindings: any[],
+    batchSize = 5000
+  ): AsyncGenerator<DownloadFeatureSummary[]> {
+    const cursorName = `dl_filter_cursor_${downloadId.replace(/[^a-z0-9_]/gi, '_')}`;
+
+    await this.connection.query(
+      `DECLARE ${cursorName} CURSOR FOR
+        SELECT
+          sf.submission_feature_id,
+          sf.submission_id,
+          ft.name AS feature_type_name,
+          sf.data_byte_size AS estimated_byte_size
+        FROM submission_feature sf
+        INNER JOIN feature_type ft ON sf.feature_type_id = ft.feature_type_id
+        WHERE sf.submission_feature_id IN (${searchSql})
+        ORDER BY ft.name, sf.submission_feature_id`,
+      searchBindings
+    );
+
+    try {
+      while (true) {
+        const result = await this.connection.query<DownloadFeatureSummary>(`FETCH ${batchSize} FROM ${cursorName}`);
+        if (result.rows.length === 0) {
+          break;
+        }
+        yield result.rows;
+      }
+    } finally {
+      await this.connection.query(`CLOSE ${cursorName}`);
+    }
   }
 
   /**

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -209,12 +209,28 @@ export class SearchFeatureRepository extends BaseRepository {
       return [];
     }
 
-    const knex = getKnex();
-    const query = this.buildSearchQuery(knex, filters, systemUserId);
-    const idsQuery = knex.from(query.as('sf_filtered')).select('submission_feature_id');
-    const response = await this.connection.knex(idsQuery);
+    const subquery = this.buildSearchFeatureIdsSubquery(filters, systemUserId);
+    const response = await this.connection.knex(subquery);
 
     return response.rows;
+  }
+
+  /**
+   * Build a Knex subquery that returns submission_feature_ids matching the
+   * given filters and security context — without executing it.
+   *
+   * Used by DownloadRepository to compose the search as a SQL subquery
+   * inside a larger query, keeping feature resolution entirely in the
+   * database (no JS array round-trip for 500K+ ID sets).
+   *
+   * @param {ISearchFeaturesFilters} filters - Search filters
+   * @param {number | null} [systemUserId] - Security context
+   * @return {Knex.QueryBuilder} Unexecuted subquery returning submission_feature_id rows
+   */
+  buildSearchFeatureIdsSubquery(filters: ISearchFeaturesFilters, systemUserId?: number | null): Knex.QueryBuilder {
+    const knex = getKnex();
+    const query = this.buildSearchQuery(knex, filters, systemUserId);
+    return knex.from(query.as('sf_filtered')).select('submission_feature_id');
   }
 
   /**

--- a/api/src/services/cart-service.test.ts
+++ b/api/src/services/cart-service.test.ts
@@ -257,7 +257,6 @@ describe('CartService', () => {
         member_count: 0
       });
       const createDownloadTeamStub = sinon.stub(DownloadService.prototype, 'createDownloadTeam').resolves();
-      const createFeaturesStub = sinon.stub(DownloadService.prototype, 'createDownloadFeatures').resolves();
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart').resolves();
       const publishStub = sinon
         .stub(publisher, 'publishProcessDownloadJob')
@@ -268,9 +267,9 @@ describe('CartService', () => {
       expect(result).to.deep.equal({ download_id: 'dl-uuid' });
       expect(getIdsStub).to.have.been.calledOnceWith('cart-1');
       expect(createDownloadStub).to.have.been.calledOnceWith({
-        fragmentSizeBytes: undefined
+        fragmentSizeBytes: undefined,
+        cartId: 'cart-1'
       });
-      expect(createFeaturesStub).to.have.been.calledOnceWith('dl-uuid', [1, 2, 3]);
       expect(createTeamStub).to.have.been.calledOnceWith({
         name: `Team for cart cart-1`,
         description: 'Team automatically created for cart checkout',
@@ -295,14 +294,14 @@ describe('CartService', () => {
         .resolves({ download_id: 'dl-uuid' });
       const createTeamStub = sinon.stub(TeamService.prototype, 'createTeam');
       const createDownloadTeamStub = sinon.stub(DownloadService.prototype, 'createDownloadTeam');
-      sinon.stub(DownloadService.prototype, 'createDownloadFeatures').resolves();
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart').resolves();
       sinon.stub(publisher, 'publishProcessDownloadJob').resolves({ status: 'published', jobId: 'job-1' });
 
       await service.checkoutCart('cart-1', null);
 
       expect(createDownloadStub).to.have.been.calledOnceWith({
-        fragmentSizeBytes: undefined
+        fragmentSizeBytes: undefined,
+        cartId: 'cart-1'
       });
       expect(updateCartStub).to.have.been.calledOnceWith('cart-1', {
         cart_status: CartStatus.CHECKED_OUT,
@@ -320,7 +319,6 @@ describe('CartService', () => {
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureIds').resolves([]);
 
       const createDownloadStub = sinon.stub(DownloadService.prototype, 'createDownload');
-      const createFeaturesStub = sinon.stub(DownloadService.prototype, 'createDownloadFeatures');
       const createTeamStub = sinon.stub(TeamService.prototype, 'createTeam');
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart');
       const publishStub = sinon.stub(publisher, 'publishProcessDownloadJob');
@@ -334,7 +332,6 @@ describe('CartService', () => {
       }
 
       expect(createDownloadStub).to.not.have.been.called;
-      expect(createFeaturesStub).to.not.have.been.called;
       expect(createTeamStub).to.not.have.been.called;
       expect(updateCartStub).to.not.have.been.called;
       expect(publishStub).to.not.have.been.called;
@@ -348,7 +345,6 @@ describe('CartService', () => {
       const createDownloadStub = sinon
         .stub(DownloadService.prototype, 'createDownload')
         .resolves({ download_id: 'dl-uuid' });
-      sinon.stub(DownloadService.prototype, 'createDownloadFeatures').resolves();
       sinon.stub(DownloadService.prototype, 'createDownloadTeam').resolves();
       sinon.stub(TeamService.prototype, 'createTeam').resolves({
         team_id: 'team-1',
@@ -362,7 +358,8 @@ describe('CartService', () => {
       await service.checkoutCart('cart-1', 7, 500 * 1024 * 1024);
 
       expect(createDownloadStub).to.have.been.calledOnceWith({
-        fragmentSizeBytes: 500 * 1024 * 1024
+        fragmentSizeBytes: 500 * 1024 * 1024,
+        cartId: 'cart-1'
       });
     });
 
@@ -372,7 +369,6 @@ describe('CartService', () => {
 
       sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureIds').resolves([1, 2]);
       sinon.stub(DownloadService.prototype, 'createDownload').rejects(new Error('DB error'));
-      const createFeaturesStub = sinon.stub(DownloadService.prototype, 'createDownloadFeatures');
       const createDownloadTeamStub = sinon.stub(DownloadService.prototype, 'createDownloadTeam');
       const updateCartStub = sinon.stub(CartRepository.prototype, 'updateCart');
       const publishStub = sinon.stub(publisher, 'publishProcessDownloadJob');
@@ -384,7 +380,6 @@ describe('CartService', () => {
         expect(err.message).to.equal('DB error');
       }
 
-      expect(createFeaturesStub).to.not.have.been.called;
       expect(createDownloadTeamStub).to.not.have.been.called;
       expect(updateCartStub).to.not.have.been.called;
       expect(publishStub).to.not.have.been.called;

--- a/api/src/services/cart-service.ts
+++ b/api/src/services/cart-service.ts
@@ -142,13 +142,12 @@ export class CartService extends DBService {
       throw new HTTP400('Cannot checkout an empty cart');
     }
 
-    // Create download record (team linking handled separately via download_team)
+    // Create download with cart_id FK — features resolved at pipeline time
+    // from cart_submission_feature via download.cart_id
     const downloadId = await this.downloadService.createDownload({
-      fragmentSizeBytes
+      fragmentSizeBytes,
+      cartId
     });
-
-    // Link features to download
-    await this.downloadService.createDownloadFeatures(downloadId.download_id, featureIds);
 
     // Create team and link to download for authenticated users.
     // Anonymous checkouts have no download_team rows — UUID is the credential.

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -3,13 +3,8 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { FRAGMENT_SIZE_THRESHOLD } from '../../constants/download';
-import {
-  DownloadFeatureData,
-  DownloadFeatureSummary,
-  DownloadRecord,
-  DownloadSizeEstimate
-} from '../../models/download';
-import { DownloadFragmentId, DownloadFragmentRecord } from '../../models/download-fragment';
+import { DownloadFeatureData, DownloadFeatureSummary, DownloadRecord, DownloadSource } from '../../models/download';
+import { DownloadFragmentRecord } from '../../models/download-fragment';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { FEATURE_PROPERTY_TYPE } from '../../models/feature-property';
 import { FeatureTypeWithProperties } from '../../models/feature-type';
@@ -18,8 +13,8 @@ import { DownloadRepository } from '../../repositories/download/download-reposit
 import { getMockDBConnection } from '../../__mocks__/db';
 import { CodeService } from '../code-service';
 import { ObjectStorageService } from '../object-storage/object-storage-service';
+import { SearchFeatureService } from '../search-feature-service';
 import { DownloadPipelineService } from './download-pipeline-service';
-import { DownloadService } from './download-service';
 
 chai.use(sinonChai);
 
@@ -101,8 +96,7 @@ describe('DownloadPipelineService', () => {
 
       sinon.stub(DownloadRepository.prototype, 'findDownloadById').resolves(createMockDownloadRecord());
       sinon.stub(DownloadFragmentRepository.prototype, 'getFragmentsByDownloadId').resolves([]);
-      const mockEstimate: DownloadSizeEstimate = { totalEstimatedBytes: 1000, features: [] };
-      const estimateStub = sinon.stub(service, 'estimateDownloadSize').resolves(mockEstimate);
+      const estimateStub = sinon.stub(service, 'estimateDownloadSize').resolves(1000);
       const planStub = sinon.stub(service, 'planFragments').resolves();
 
       await service.planDownloadIfNeeded('aaaa0000-0000-0000-0000-000000000042');
@@ -321,68 +315,113 @@ describe('DownloadPipelineService', () => {
   });
 
   describe('estimateDownloadSize', () => {
-    it('sums per-feature sizes from linked features', async () => {
+    it('returns aggregate total for cart-based downloads', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
-      const features: DownloadFeatureSummary[] = [
-        { submission_feature_id: 1, feature_type_name: 'observation', estimated_byte_size: '120', submission_id: 1 },
-        { submission_feature_id: 2, feature_type_name: 'sample', estimated_byte_size: '80', submission_id: 1 }
-      ];
-      sinon.stub(DownloadService.prototype, 'getDownloadFeatures').resolves(features);
+      const source: DownloadSource = { cart_id: 'cart-uuid', filters: null, create_user: 1 };
+      sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
+      sinon.stub(DownloadRepository.prototype, 'getDownloadTotalSizeByCartId').resolves({ total: '200' });
 
       const result = await service.estimateDownloadSize('aaaa0000-0000-0000-0000-000000000001');
 
-      expect(result.totalEstimatedBytes).to.equal(200);
-      expect(result.features).to.have.length(2);
+      expect(result).to.equal(200);
     });
 
-    it('returns zero total for empty downloads', async () => {
+    it('returns aggregate total for filter-based downloads', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
-      sinon.stub(DownloadService.prototype, 'getDownloadFeatures').resolves([]);
+      const source: DownloadSource = { cart_id: null, filters: { keyword: 'moose' }, create_user: 5 };
+      sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
+      const mockSubquery = { toSQL: () => ({ sql: 'SELECT 1', bindings: [] }) } as any;
+      sinon.stub(SearchFeatureService.prototype, 'buildSearchFeatureIdsSubquery').returns(mockSubquery);
+      sinon.stub(DownloadRepository.prototype, 'getDownloadTotalSizeBySearchQuery').resolves({ total: '5000' });
 
       const result = await service.estimateDownloadSize('aaaa0000-0000-0000-0000-000000000001');
 
-      expect(result.totalEstimatedBytes).to.equal(0);
-      expect(result.features).to.have.length(0);
+      expect(result).to.equal(5000);
+    });
+
+    it('returns zero when total is null (empty result set)', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      const source: DownloadSource = { cart_id: 'cart-uuid', filters: null, create_user: 1 };
+      sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
+      sinon.stub(DownloadRepository.prototype, 'getDownloadTotalSizeByCartId').resolves({ total: null });
+
+      const result = await service.estimateDownloadSize('aaaa0000-0000-0000-0000-000000000001');
+
+      expect(result).to.equal(0);
+    });
+
+    it('throws when download has neither cart_id nor filters', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      const source: DownloadSource = { cart_id: null, filters: null, create_user: 1 };
+      sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
+
+      try {
+        await service.estimateDownloadSize('aaaa0000-0000-0000-0000-000000000001');
+        expect.fail('Expected an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('has neither cart_id nor filters');
+      }
     });
   });
 
-  describe('planFragments', () => {
-    it('creates multiple fragments when exceeding threshold', async () => {
-      // Verifies: Bin packing splits features across fragments based on fragment_size_bytes
+  // Helper: create a mock async generator for cursor-based streaming
+  async function* mockSummaryStream(features: DownloadFeatureSummary[]): AsyncGenerator<DownloadFeatureSummary[]> {
+    if (features.length > 0) {
+      yield features;
+    }
+  }
 
-      // Step 1: Setup service with mock connection
+  describe('planFragments', () => {
+    it('creates multiple fragments when exceeding threshold (cart-based)', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
-      // Step 2: Create 3 features — two fit in one bin, third needs a new bin
+      // Stub source resolution — cart-based download
+      const source: DownloadSource = { cart_id: 'cart-uuid', filters: null, create_user: 1 };
+      sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
+      sinon.stub(DownloadRepository.prototype, 'findDownloadById').resolves(
+        createMockDownloadRecord({
+          download_id: 'aaaa0000-0000-0000-0000-000000000001',
+          fragment_size_bytes: String(FRAGMENT_SIZE_THRESHOLD)
+        })
+      );
+
+      // Features: 120MB + 120MB + 80MB — first two exceed threshold (200MB), third fits with second
+      const oneHundredTwentyMB = 120 * 1024 * 1024;
+      const eightyMB = 80 * 1024 * 1024;
       const features: DownloadFeatureSummary[] = [
         {
           submission_feature_id: 10,
           feature_type_name: 'observation',
-          estimated_byte_size: '100',
+          estimated_byte_size: String(oneHundredTwentyMB),
           submission_id: 1
         },
         {
           submission_feature_id: 20,
           feature_type_name: 'observation',
-          estimated_byte_size: '100',
+          estimated_byte_size: String(oneHundredTwentyMB),
           submission_id: 1
         },
         {
           submission_feature_id: 30,
           feature_type_name: 'observation',
-          estimated_byte_size: '100',
+          estimated_byte_size: String(eightyMB),
           submission_id: 1
         }
       ];
-      // Step 3: Stub fragment repository methods
+      sinon.stub(DownloadRepository.prototype, 'streamDownloadFeaturesByCartId').returns(mockSummaryStream(features));
+
       const createFragmentStub = sinon.stub(DownloadFragmentRepository.prototype, 'createDownloadFragment');
-      createFragmentStub.onFirstCall().resolves({ download_fragment_id: 1 } satisfies DownloadFragmentId);
-      createFragmentStub.onSecondCall().resolves({ download_fragment_id: 2 } satisfies DownloadFragmentId);
+      createFragmentStub.onFirstCall().resolves({ download_fragment_id: 1 });
+      createFragmentStub.onSecondCall().resolves({ download_fragment_id: 2 });
       const createFragmentFeaturesStub = sinon
         .stub(DownloadFragmentRepository.prototype, 'createDownloadFragmentFeatures')
         .resolves();
@@ -391,68 +430,24 @@ describe('DownloadPipelineService', () => {
         .resolves();
       sinon.stub(DownloadRepository.prototype, 'updateEstimatedTotalSize').resolves();
 
-      // Stub findDownloadById to return record with default fragment_size_bytes
-      sinon.stub(DownloadRepository.prototype, 'findDownloadById').resolves(
-        createMockDownloadRecord({
-          download_id: 'aaaa0000-0000-0000-0000-000000000001',
-          fragment_size_bytes: String(FRAGMENT_SIZE_THRESHOLD)
-        })
-      );
+      const totalBytes = oneHundredTwentyMB * 2 + eightyMB;
+      await service.planFragments('aaaa0000-0000-0000-0000-000000000001', totalBytes);
 
-      // Step 4: Call planFragments with bin packing
-      // Feature 10 = 120MB, Feature 20 = 120MB (total 240MB > 200MB threshold), Feature 30 = 80MB
-      const oneHundredTwentyMB = 120 * 1024 * 1024;
-      const eightyMB = 80 * 1024 * 1024;
-      // Override estimated_byte_size on features for bin packing test
-      features[0].estimated_byte_size = String(oneHundredTwentyMB);
-      features[1].estimated_byte_size = String(oneHundredTwentyMB);
-      features[2].estimated_byte_size = String(eightyMB);
-      const sizeEstimate: DownloadSizeEstimate = {
-        totalEstimatedBytes: oneHundredTwentyMB * 2 + eightyMB,
-        features
-      };
-      await service.planFragments('aaaa0000-0000-0000-0000-000000000001', sizeEstimate);
-
-      // Step 5: Verify 2 fragments created — first has feature 10, then flush when 10+20 > threshold
       // Fragment 0: feature 10 (120MB) — flush when adding 20 would exceed 200MB
       // Fragment 1: features 20+30 (120+80=200MB)
       expect(createFragmentStub).to.have.been.calledTwice;
-      expect(createFragmentStub.firstCall.args[1]).to.equal(0); // fragment_index 0
-      expect(createFragmentStub.secondCall.args[1]).to.equal(1); // fragment_index 1
-      expect(createFragmentFeaturesStub.firstCall.args[1]).to.deep.equal([10]); // first bin: feature 10
-      expect(createFragmentFeaturesStub.secondCall.args[1]).to.deep.equal([20, 30]); // second bin: features 20, 30
+      expect(createFragmentFeaturesStub.firstCall.args[1]).to.deep.equal([10]);
+      expect(createFragmentFeaturesStub.secondCall.args[1]).to.deep.equal([20, 30]);
       expect(updateFragmentCountsStub).to.have.been.calledOnceWith('aaaa0000-0000-0000-0000-000000000001', 2);
     });
 
     it('uses custom fragment size from download record instead of default threshold', async () => {
-      // Verifies: Bin packing reads fragment_size_bytes from the download record, not the hardcoded constant
-
-      // Step 1: Setup service with mock connection
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadPipelineService(mockDBConnection);
 
-      // Step 2: Create 3 features — with 1 GB threshold, all 3 fit in one fragment
-      const features: DownloadFeatureSummary[] = [
-        {
-          submission_feature_id: 10,
-          feature_type_name: 'observation',
-          estimated_byte_size: '100',
-          submission_id: 1
-        },
-        {
-          submission_feature_id: 20,
-          feature_type_name: 'observation',
-          estimated_byte_size: '100',
-          submission_id: 1
-        },
-        {
-          submission_feature_id: 30,
-          feature_type_name: 'observation',
-          estimated_byte_size: '100',
-          submission_id: 1
-        }
-      ];
-      // Step 3: Stub findDownloadById with custom 1 GB fragment size
+      const source: DownloadSource = { cart_id: 'cart-uuid', filters: null, create_user: 1 };
+      sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
+
       const oneGB = 1000 * 1024 * 1024;
       sinon.stub(DownloadRepository.prototype, 'findDownloadById').resolves(
         createMockDownloadRecord({
@@ -461,9 +456,32 @@ describe('DownloadPipelineService', () => {
         })
       );
 
-      // Step 4: Stub fragment repository methods
+      const threeHundredMB = 300 * 1024 * 1024;
+      const twoHundredMB = 200 * 1024 * 1024;
+      const features: DownloadFeatureSummary[] = [
+        {
+          submission_feature_id: 10,
+          feature_type_name: 'observation',
+          estimated_byte_size: String(threeHundredMB),
+          submission_id: 1
+        },
+        {
+          submission_feature_id: 20,
+          feature_type_name: 'observation',
+          estimated_byte_size: String(threeHundredMB),
+          submission_id: 1
+        },
+        {
+          submission_feature_id: 30,
+          feature_type_name: 'observation',
+          estimated_byte_size: String(twoHundredMB),
+          submission_id: 1
+        }
+      ];
+      sinon.stub(DownloadRepository.prototype, 'streamDownloadFeaturesByCartId').returns(mockSummaryStream(features));
+
       const createFragmentStub = sinon.stub(DownloadFragmentRepository.prototype, 'createDownloadFragment');
-      createFragmentStub.onFirstCall().resolves({ download_fragment_id: 1 } satisfies DownloadFragmentId);
+      createFragmentStub.onFirstCall().resolves({ download_fragment_id: 1 });
       const createFragmentFeaturesStub = sinon
         .stub(DownloadFragmentRepository.prototype, 'createDownloadFragmentFeatures')
         .resolves();
@@ -472,23 +490,12 @@ describe('DownloadPipelineService', () => {
         .resolves();
       sinon.stub(DownloadRepository.prototype, 'updateEstimatedTotalSize').resolves();
 
-      // Step 5: Call planFragments — same features as previous test (300+300+200=800MB)
-      // With default 500MB threshold, this would create 2 fragments
-      // With custom 1GB threshold, all features fit in 1 fragment
-      const threeHundredMB = 300 * 1024 * 1024;
-      const twoHundredMB = 200 * 1024 * 1024;
-      features[0].estimated_byte_size = String(threeHundredMB);
-      features[1].estimated_byte_size = String(threeHundredMB);
-      features[2].estimated_byte_size = String(twoHundredMB);
-      const sizeEstimate: DownloadSizeEstimate = {
-        totalEstimatedBytes: threeHundredMB * 2 + twoHundredMB,
-        features
-      };
-      await service.planFragments('aaaa0000-0000-0000-0000-000000000001', sizeEstimate);
+      const totalBytes = threeHundredMB * 2 + twoHundredMB;
+      await service.planFragments('aaaa0000-0000-0000-0000-000000000001', totalBytes);
 
-      // Step 6: Verify only 1 fragment created — all features fit within 1 GB threshold
+      // With 1GB threshold, all features fit in 1 fragment
       expect(createFragmentStub).to.have.been.calledOnce;
-      expect(createFragmentFeaturesStub.firstCall.args[1]).to.deep.equal([10, 20, 30]); // all features in one bin
+      expect(createFragmentFeaturesStub.firstCall.args[1]).to.deep.equal([10, 20, 30]);
       expect(updateFragmentCountsStub).to.have.been.calledOnceWith('aaaa0000-0000-0000-0000-000000000001', 1);
     });
   });

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -456,7 +456,9 @@ describe('DownloadPipelineService', () => {
       );
 
       // Mock the search subquery and toSQL extraction
-      const mockSubquery = { toSQL: () => ({ toNative: () => ({ sql: 'SELECT submission_feature_id FROM ...', bindings: [5] }) }) } as any;
+      const mockSubquery = {
+        toSQL: () => ({ toNative: () => ({ sql: 'SELECT submission_feature_id FROM ...', bindings: [5] }) })
+      } as any;
       const buildSubqueryStub = sinon
         .stub(SearchFeatureService.prototype, 'buildSearchFeatureIdsSubquery')
         .returns(mockSubquery);

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -321,7 +321,7 @@ describe('DownloadPipelineService', () => {
 
       const source: DownloadSource = { cart_id: 'cart-uuid', filters: null, create_user: 1 };
       sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
-      sinon.stub(DownloadRepository.prototype, 'getDownloadTotalSizeByCartId').resolves({ total: '200' });
+      sinon.stub(DownloadRepository.prototype, 'getDownloadTotalSizeByCartId').resolves({ total: 200 });
 
       const result = await service.estimateDownloadSize('aaaa0000-0000-0000-0000-000000000001');
 
@@ -334,9 +334,9 @@ describe('DownloadPipelineService', () => {
 
       const source: DownloadSource = { cart_id: null, filters: { keyword: 'moose' }, create_user: 5 };
       sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
-      const mockSubquery = { toSQL: () => ({ sql: 'SELECT 1', bindings: [] }) } as any;
+      const mockSubquery = { toSQL: () => ({ toNative: () => ({ sql: 'SELECT 1', bindings: [] }) }) } as any;
       sinon.stub(SearchFeatureService.prototype, 'buildSearchFeatureIdsSubquery').returns(mockSubquery);
-      sinon.stub(DownloadRepository.prototype, 'getDownloadTotalSizeBySearchQuery').resolves({ total: '5000' });
+      sinon.stub(DownloadRepository.prototype, 'getDownloadTotalSizeBySearchQuery').resolves({ total: 5000 });
 
       const result = await service.estimateDownloadSize('aaaa0000-0000-0000-0000-000000000001');
 
@@ -439,6 +439,60 @@ describe('DownloadPipelineService', () => {
       expect(createFragmentFeaturesStub.firstCall.args[1]).to.deep.equal([10]);
       expect(createFragmentFeaturesStub.secondCall.args[1]).to.deep.equal([20, 30]);
       expect(updateFragmentCountsStub).to.have.been.calledOnceWith('aaaa0000-0000-0000-0000-000000000001', 2);
+    });
+
+    it('creates fragments for filter-based downloads using search stream', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      // Stub source resolution — filter-based download
+      const source: DownloadSource = { cart_id: null, filters: { keyword: 'moose' }, create_user: 5 };
+      sinon.stub(DownloadRepository.prototype, 'getDownloadSource').resolves(source);
+      sinon.stub(DownloadRepository.prototype, 'findDownloadById').resolves(
+        createMockDownloadRecord({
+          download_id: 'aaaa0000-0000-0000-0000-000000000001',
+          fragment_size_bytes: String(FRAGMENT_SIZE_THRESHOLD)
+        })
+      );
+
+      // Mock the search subquery and toSQL extraction
+      const mockSubquery = { toSQL: () => ({ toNative: () => ({ sql: 'SELECT submission_feature_id FROM ...', bindings: [5] }) }) } as any;
+      const buildSubqueryStub = sinon
+        .stub(SearchFeatureService.prototype, 'buildSearchFeatureIdsSubquery')
+        .returns(mockSubquery);
+
+      const features: DownloadFeatureSummary[] = [
+        { submission_feature_id: 10, feature_type_name: 'observation', estimated_byte_size: '500', submission_id: 1 },
+        { submission_feature_id: 20, feature_type_name: 'observation', estimated_byte_size: '300', submission_id: 1 }
+      ];
+      const streamStub = sinon
+        .stub(DownloadRepository.prototype, 'streamDownloadFeaturesBySearchQuery')
+        .returns(mockSummaryStream(features));
+
+      // Cart stream should NOT be called
+      const cartStreamStub = sinon.stub(DownloadRepository.prototype, 'streamDownloadFeaturesByCartId');
+
+      const createFragmentStub = sinon.stub(DownloadFragmentRepository.prototype, 'createDownloadFragment');
+      createFragmentStub.onFirstCall().resolves({ download_fragment_id: 1 });
+      const createFragmentFeaturesStub = sinon
+        .stub(DownloadFragmentRepository.prototype, 'createDownloadFragmentFeatures')
+        .resolves();
+      sinon.stub(DownloadRepository.prototype, 'updateDownloadFragmentCounts').resolves();
+      sinon.stub(DownloadRepository.prototype, 'updateEstimatedTotalSize').resolves();
+
+      await service.planFragments('aaaa0000-0000-0000-0000-000000000001', 800);
+
+      // Verify filter path was taken
+      expect(buildSubqueryStub).to.have.been.calledOnceWith({ keyword: 'moose' }, 5);
+      expect(streamStub).to.have.been.calledOnce;
+      expect(streamStub.firstCall.args[0]).to.equal('aaaa0000-0000-0000-0000-000000000001');
+      expect(streamStub.firstCall.args[1]).to.equal('SELECT submission_feature_id FROM ...');
+      expect(streamStub.firstCall.args[2]).to.deep.equal([5]);
+      expect(cartStreamStub).to.not.have.been.called;
+
+      // Both features fit in one fragment (800 bytes << 200MB threshold)
+      expect(createFragmentStub).to.have.been.calledOnce;
+      expect(createFragmentFeaturesStub.firstCall.args[1]).to.deep.equal([10, 20]);
     });
 
     it('uses custom fragment size from download record instead of default threshold', async () => {

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -144,7 +144,7 @@ export class DownloadPipelineService extends DBService {
       featureStream = this.downloadRepository.streamDownloadFeaturesByCartId(source.cart_id);
     } else if (source.filters) {
       const subquery = this.searchFeatureService.buildSearchFeatureIdsSubquery(source.filters, source.create_user);
-      const { sql, bindings } = subquery.toSQL();
+      const { sql, bindings } = subquery.toSQL().toNative();
       featureStream = this.downloadRepository.streamDownloadFeaturesBySearchQuery(downloadId, sql, bindings as any[]);
     } else {
       throw new Error(`Download ${downloadId} has neither cart_id nor filters`);

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -2,7 +2,7 @@ import archiver from 'archiver';
 import { PassThrough } from 'node:stream';
 import { FRAGMENT_SIZE_THRESHOLD } from '../../constants/download';
 import { IDBConnection } from '../../database/db';
-import { DownloadSizeEstimate } from '../../models/download';
+import { DownloadFeatureSummary } from '../../models/download';
 import { DownloadFragmentRecord } from '../../models/download-fragment';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { DownloadFragmentRepository } from '../../repositories/download/download-fragment-repository';
@@ -18,6 +18,7 @@ import { getLogger } from '../../utils/logger';
 import { CodeService } from '../code-service';
 import { DBService } from '../db-service';
 import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
+import { SearchFeatureService } from '../search-feature-service';
 import { DownloadService } from './download-service';
 
 const defaultLog = getLogger('services/download-pipeline-service');
@@ -51,12 +52,14 @@ export class DownloadPipelineService extends DBService {
   downloadRepository: DownloadRepository;
   fragmentRepository: DownloadFragmentRepository;
   downloadService: DownloadService;
+  searchFeatureService: SearchFeatureService;
 
   constructor(connection: IDBConnection) {
     super(connection);
     this.downloadRepository = new DownloadRepository(connection);
     this.fragmentRepository = new DownloadFragmentRepository(connection);
     this.downloadService = new DownloadService(connection);
+    this.searchFeatureService = new SearchFeatureService(connection);
   }
 
   /**
@@ -87,44 +90,67 @@ export class DownloadPipelineService extends DBService {
   }
 
   /**
-   * Estimate the total download size and plan fragmentation.
+   * Get the total estimated download size — SQL aggregate only.
    *
-   * Uses pre-computed data_byte_size which includes JSONB size + CSV overhead + artifact file size.
+   * Returns SUM(data_byte_size) without materializing feature rows.
+   * Branches on cart_id vs filters (same source resolution as getDownloadFeatures).
    *
    * @param {string} downloadId - The download ID.
-   * @return {Promise<DownloadSizeEstimate>}
+   * @return {Promise<number>} Total estimated bytes.
    * @memberof DownloadPipelineService
    */
-  async estimateDownloadSize(downloadId: string): Promise<DownloadSizeEstimate> {
-    const features = await this.downloadService.getDownloadFeatures(downloadId);
-    const totalEstimatedBytes = features.reduce((sum, f) => sum + Number(f.estimated_byte_size), 0);
+  async estimateDownloadSize(downloadId: string): Promise<number> {
+    const source = await this.downloadRepository.getDownloadSource(downloadId);
 
-    return { totalEstimatedBytes, features };
+    if (source.cart_id) {
+      const row = await this.downloadRepository.getDownloadTotalSizeByCartId(source.cart_id);
+      return Number(row.total ?? 0);
+    }
+
+    if (source.filters) {
+      const searchSubquery = this.searchFeatureService.buildSearchFeatureIdsSubquery(
+        source.filters,
+        source.create_user
+      );
+      const row = await this.downloadRepository.getDownloadTotalSizeBySearchQuery(searchSubquery);
+      return Number(row.total ?? 0);
+    }
+
+    throw new Error(`Download ${downloadId} has neither cart_id nor filters`);
   }
 
   /**
-   * Plan fragments for a download based on size estimation.
+   * Plan fragments for a download using cursor-based streaming.
    *
-   * Uses greedy bin packing driven by the download record's `fragment_size_bytes`.
-   * When total bytes fit within one bin, a single fragment is naturally created.
-   * Oversized files get their own dedicated fragment.
+   * Opens a DECLARE CURSOR over features sorted by feature_type_name,
+   * FETCHes in batches of 5000, and assigns to bins on the fly.
+   * Never holds more than one batch in memory.
+   *
+   * Follows the streamFragmentFeaturesByType pattern (download-fragment-repository.ts:136).
    *
    * @param {string} downloadId - The download ID.
-   * @param {DownloadSizeEstimate} sizeEstimate - The size estimation result.
+   * @param {number} totalEstimatedBytes - Total estimated size from estimateDownloadSize.
    * @return {Promise<void>}
    * @memberof DownloadPipelineService
    */
-  async planFragments(downloadId: string, sizeEstimate: DownloadSizeEstimate): Promise<void> {
-    // Sort by feature type so same types stay together during bin packing.
-    // This minimizes duplicate CSVs across fragments (e.g. one species_observation.csv
-    // instead of the same CSV appearing in multiple parts).
-    const features = [...sizeEstimate.features].sort((a, b) => a.feature_type_name.localeCompare(b.feature_type_name));
-
-    // Read configurable fragment size from the download record
+  async planFragments(downloadId: string, totalEstimatedBytes: number): Promise<void> {
     const download = await this.downloadRepository.findDownloadById(downloadId);
     const fragmentThreshold = Number(download?.fragment_size_bytes ?? FRAGMENT_SIZE_THRESHOLD);
+    const source = await this.downloadRepository.getDownloadSource(downloadId);
 
-    // Greedy bin packing using fragment_size_bytes as the bin capacity
+    // Open the appropriate cursor based on feature source
+    let featureStream: AsyncGenerator<DownloadFeatureSummary[]>;
+    if (source.cart_id) {
+      featureStream = this.downloadRepository.streamDownloadFeaturesByCartId(source.cart_id);
+    } else if (source.filters) {
+      const subquery = this.searchFeatureService.buildSearchFeatureIdsSubquery(source.filters, source.create_user);
+      const { sql, bindings } = subquery.toSQL();
+      featureStream = this.downloadRepository.streamDownloadFeaturesBySearchQuery(downloadId, sql, bindings as any[]);
+    } else {
+      throw new Error(`Download ${downloadId} has neither cart_id nor filters`);
+    }
+
+    // Greedy bin packing over the cursor stream
     let fragmentIndex = 0;
     let currentBinSize = 0;
     let currentBinFeatures: number[] = [];
@@ -145,40 +171,43 @@ export class DownloadPipelineService extends DBService {
       currentBinFeatures = [];
     };
 
-    for (const feature of features) {
-      const featureSize = Number(feature.estimated_byte_size);
+    // Cursor already ORDER BY ft.name, sf.submission_feature_id
+    // — same types stay together, no JS sort needed
+    for await (const batch of featureStream) {
+      for (const feature of batch) {
+        const featureSize = Number(feature.estimated_byte_size);
 
-      // Oversized file: give it its own dedicated fragment
-      if (featureSize > fragmentThreshold) {
-        await flushFragment();
-        const fragment = await this.fragmentRepository.createDownloadFragment(
-          downloadId,
-          fragmentIndex,
-          featureSize,
-          1
-        );
-        await this.fragmentRepository.createDownloadFragmentFeatures(fragment.download_fragment_id, [
-          feature.submission_feature_id
-        ]);
-        fragmentIndex++;
-        continue;
+        // Oversized file: give it its own dedicated fragment
+        if (featureSize > fragmentThreshold) {
+          await flushFragment();
+          const fragment = await this.fragmentRepository.createDownloadFragment(
+            downloadId,
+            fragmentIndex,
+            featureSize,
+            1
+          );
+          await this.fragmentRepository.createDownloadFragmentFeatures(fragment.download_fragment_id, [
+            feature.submission_feature_id
+          ]);
+          fragmentIndex++;
+          continue;
+        }
+
+        // Would exceed threshold? Flush current bin first
+        if (currentBinSize + featureSize > fragmentThreshold && currentBinFeatures.length > 0) {
+          await flushFragment();
+        }
+
+        currentBinFeatures.push(feature.submission_feature_id);
+        currentBinSize += featureSize;
       }
-
-      // Would exceed threshold? Flush current bin first
-      if (currentBinSize + featureSize > fragmentThreshold && currentBinFeatures.length > 0) {
-        await flushFragment();
-      }
-
-      currentBinFeatures.push(feature.submission_feature_id);
-      currentBinSize += featureSize;
     }
 
     // Flush remaining features
     await flushFragment();
 
     await this.downloadRepository.updateDownloadFragmentCounts(downloadId, fragmentIndex, 0);
-
-    await this.downloadRepository.updateEstimatedTotalSize(downloadId, sizeEstimate.totalEstimatedBytes);
+    await this.downloadRepository.updateEstimatedTotalSize(downloadId, totalEstimatedBytes);
   }
 
   /**
@@ -206,8 +235,8 @@ export class DownloadPipelineService extends DBService {
       return;
     }
 
-    const sizeEstimate = await this.estimateDownloadSize(downloadId);
-    await this.planFragments(downloadId, sizeEstimate);
+    const totalBytes = await this.estimateDownloadSize(downloadId);
+    await this.planFragments(downloadId, totalBytes);
   }
 
   /**

--- a/api/src/services/download/download-service.test.ts
+++ b/api/src/services/download/download-service.test.ts
@@ -50,7 +50,7 @@ describe('DownloadService', () => {
       expect(result).to.deep.equal({ downloads: [], count: 0 });
     });
 
-    it('passes through DownloadListRecord fields including create_date and feature_count', async () => {
+    it('passes through DownloadListRecord fields including create_date', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadService(mockDBConnection);
 
@@ -66,8 +66,7 @@ describe('DownloadService', () => {
           completed_fragments: 1,
           estimated_total_size_bytes: '1000',
           fragment_size_bytes: '524288000',
-          create_date: '2025-01-01T00:00:00Z',
-          feature_count: 5
+          create_date: '2025-01-01T00:00:00Z'
         }
       ];
 
@@ -79,7 +78,6 @@ describe('DownloadService', () => {
 
       expect(result.downloads).to.have.length(1);
       expect(result.downloads[0]).to.have.property('create_date', '2025-01-01T00:00:00Z');
-      expect(result.downloads[0]).to.have.property('feature_count', 5);
       expect(result.count).to.equal(1);
     });
   });

--- a/api/src/services/download/download-service.test.ts
+++ b/api/src/services/download/download-service.test.ts
@@ -4,11 +4,12 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { FRAGMENT_SIZE_THRESHOLD, SIGNED_URL_EXPIRY_FRAGMENT } from '../../constants/download';
 import { HTTP403, HTTP404, HTTP409 } from '../../errors/http-error';
-import { DownloadId, DownloadRecord } from '../../models/download';
+import { DownloadRecord } from '../../models/download';
 import { DownloadFragmentRecord } from '../../models/download-fragment';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { DownloadFragmentRepository } from '../../repositories/download/download-fragment-repository';
 import { DownloadRepository } from '../../repositories/download/download-repository';
+import { SearchFeatureRepository } from '../../repositories/search-feature-repository';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { TeamService } from '../access-policy/team-service';
 import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
@@ -121,73 +122,6 @@ describe('DownloadService', () => {
       await service.createDownloadTeam('dl-uuid', 'team-uuid');
 
       expect(stub).to.have.been.calledOnceWith('dl-uuid', 'team-uuid');
-    });
-  });
-
-  describe('createDownloadRequest', () => {
-    it('creates download without user or team fields (team linking is caller responsibility)', async () => {
-      const mockDBConnection = getMockDBConnection();
-      const service = new DownloadService(mockDBConnection);
-
-      const createDownloadStub = sinon
-        .stub(DownloadRepository.prototype, 'createDownload')
-        .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
-      sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
-
-      await service.createDownloadRequest({ submissionFeatureIds: [10, 20] });
-
-      expect(createDownloadStub).to.have.been.calledOnce;
-      const opts = createDownloadStub.firstCall.args[0];
-      expect(opts).to.not.have.property('systemUserId');
-      expect(opts).to.not.have.property('teamId');
-      expect(opts).to.not.have.property('dataRequestId');
-    });
-
-    it('passes filters to createDownload', async () => {
-      const mockDBConnection = getMockDBConnection();
-      const service = new DownloadService(mockDBConnection);
-
-      const createDownloadStub = sinon
-        .stub(DownloadRepository.prototype, 'createDownload')
-        .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
-      sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
-
-      const filters = { keyword: 'elk' };
-      await service.createDownloadRequest({ submissionFeatureIds: [10, 20], filters });
-
-      expect(createDownloadStub).to.have.been.calledOnce;
-      expect(createDownloadStub.firstCall.args[0]).to.have.deep.property('filters', { keyword: 'elk' });
-    });
-
-    it('omitting filters passes undefined', async () => {
-      const mockDBConnection = getMockDBConnection();
-      const service = new DownloadService(mockDBConnection);
-
-      const createDownloadStub = sinon
-        .stub(DownloadRepository.prototype, 'createDownload')
-        .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
-      sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
-
-      await service.createDownloadRequest({ submissionFeatureIds: [10, 20] });
-
-      expect(createDownloadStub).to.have.been.calledOnce;
-      expect(createDownloadStub.firstCall.args[0].filters).to.be.undefined;
-    });
-
-    it('creates download features after download record', async () => {
-      const mockDBConnection = getMockDBConnection();
-      const service = new DownloadService(mockDBConnection);
-
-      sinon
-        .stub(DownloadRepository.prototype, 'createDownload')
-        .resolves({ download_id: 'aaaa0000-0000-0000-0000-000000000001' } satisfies DownloadId);
-      const createFeaturesStub = sinon.stub(DownloadRepository.prototype, 'createDownloadFeatures').resolves();
-
-      await service.createDownloadRequest({ submissionFeatureIds: [10, 20], filters: { keyword: 'elk' } });
-
-      expect(createFeaturesStub).to.have.been.calledOnce;
-      expect(createFeaturesStub.firstCall.args[0]).to.equal('aaaa0000-0000-0000-0000-000000000001');
-      expect(createFeaturesStub.firstCall.args[1]).to.deep.equal([10, 20]);
     });
   });
 
@@ -445,7 +379,7 @@ describe('DownloadService', () => {
   });
 
   describe('getDownloadFeatures', () => {
-    it('delegates to repository', async () => {
+    it('resolves features from cart when cart_id is set', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadService(mockDBConnection);
 
@@ -454,24 +388,61 @@ describe('DownloadService', () => {
         { submission_feature_id: 2, submission_id: 100, feature_type_name: 'observation', estimated_byte_size: '300' }
       ];
 
-      sinon.stub(DownloadRepository.prototype, 'getDownloadFeatures').resolves(features);
+      sinon
+        .stub(DownloadRepository.prototype, 'getDownloadSource')
+        .resolves({ cart_id: 'cart-uuid', filters: null, create_user: 1 });
+      const cartStub = sinon.stub(DownloadRepository.prototype, 'getDownloadFeaturesByCartId').resolves(features);
+      const searchStub = sinon.stub(DownloadRepository.prototype, 'getDownloadFeaturesBySearchQuery');
 
       const result = await service.getDownloadFeatures('dl-1');
 
       expect(result).to.have.length(2);
-      expect(result[0].submission_feature_id).to.equal(1);
-      expect(result[1].submission_feature_id).to.equal(2);
+      expect(cartStub).to.have.been.calledOnceWith('cart-uuid');
+      expect(searchStub).to.not.have.been.called;
     });
 
-    it('returns empty when no features linked', async () => {
+    it('resolves features from search query when filters are set', async () => {
       const mockDBConnection = getMockDBConnection();
       const service = new DownloadService(mockDBConnection);
 
-      sinon.stub(DownloadRepository.prototype, 'getDownloadFeatures').resolves([]);
+      const features = [
+        { submission_feature_id: 3, submission_id: 200, feature_type_name: 'observation', estimated_byte_size: '100' }
+      ];
+
+      sinon
+        .stub(DownloadRepository.prototype, 'getDownloadSource')
+        .resolves({ cart_id: null, filters: { keyword: 'moose' }, create_user: 5 });
+      const mockSubquery = {} as any;
+      const buildStub = sinon
+        .stub(SearchFeatureRepository.prototype, 'buildSearchFeatureIdsSubquery')
+        .returns(mockSubquery);
+      const searchStub = sinon
+        .stub(DownloadRepository.prototype, 'getDownloadFeaturesBySearchQuery')
+        .resolves(features);
+      const cartStub = sinon.stub(DownloadRepository.prototype, 'getDownloadFeaturesByCartId');
 
       const result = await service.getDownloadFeatures('dl-1');
 
-      expect(result).to.deep.equal([]);
+      expect(result).to.have.length(1);
+      expect(buildStub).to.have.been.calledOnceWith({ keyword: 'moose' }, 5);
+      expect(searchStub).to.have.been.calledOnceWith(mockSubquery);
+      expect(cartStub).to.not.have.been.called;
+    });
+
+    it('throws when download has neither cart_id nor filters', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadService(mockDBConnection);
+
+      sinon
+        .stub(DownloadRepository.prototype, 'getDownloadSource')
+        .resolves({ cart_id: null, filters: null, create_user: 1 });
+
+      try {
+        await service.getDownloadFeatures('dl-1');
+        expect.fail('Expected an error');
+      } catch (error) {
+        expect((error as Error).message).to.include('has neither cart_id nor filters');
+      }
     });
   });
 });

--- a/api/src/services/download/download-service.ts
+++ b/api/src/services/download/download-service.ts
@@ -3,7 +3,6 @@ import { IDBConnection } from '../../database/db';
 import { HTTP403, HTTP404, HTTP409, HTTP500 } from '../../errors/http-error';
 import {
   CreateDownload,
-  CreateDownloadRequest,
   DownloadFeatureSummary,
   DownloadId,
   DownloadListRecord,
@@ -17,6 +16,7 @@ import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { TeamService } from '../access-policy/team-service';
 import { DBService } from '../db-service';
 import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
+import { SearchFeatureService } from '../search-feature-service';
 
 /**
  * Request-time service for downloads.
@@ -36,12 +36,14 @@ export class DownloadService extends DBService {
   downloadRepository: DownloadRepository;
   fragmentRepository: DownloadFragmentRepository;
   teamService: TeamService;
+  searchFeatureService: SearchFeatureService;
 
   constructor(connection: IDBConnection) {
     super(connection);
     this.downloadRepository = new DownloadRepository(connection);
     this.fragmentRepository = new DownloadFragmentRepository(connection);
     this.teamService = new TeamService(connection);
+    this.searchFeatureService = new SearchFeatureService(connection);
   }
 
   /**
@@ -53,45 +55,6 @@ export class DownloadService extends DBService {
    */
   async createDownload(payload: CreateDownload): Promise<DownloadId> {
     return this.downloadRepository.createDownload(payload);
-  }
-
-  /**
-   * Link submission features to a download record.
-   *
-   * @param {string} downloadId - The download ID.
-   * @param {number[]} submissionFeatureIds - The submission feature IDs to include.
-   * @return {Promise<void>}
-   * @memberof DownloadService
-   */
-  async createDownloadFeatures(downloadId: string, submissionFeatureIds: number[]): Promise<void> {
-    return this.downloadRepository.createDownloadFeatures(downloadId, submissionFeatureIds);
-  }
-
-  /**
-   * Create a new download request from search filters.
-   *
-   * Creates a download record and links the specified submission features.
-   * Caller must validate that submissionFeatureIds is non-empty.
-   *
-   * Team linking is handled separately by the caller via linkDownloadToNewTeam.
-   * Anonymous downloads have no team rows (UUID is the credential).
-   *
-   * @param {CreateDownloadRequest} payload
-   * @return {Promise<DownloadId>} The created download record ID.
-   * @memberof DownloadService
-   */
-  async createDownloadRequest(payload: CreateDownloadRequest): Promise<DownloadId> {
-    const { submissionFeatureIds, fragmentSizeMb, filters } = payload;
-    const fragmentSizeBytes = fragmentSizeMb ? fragmentSizeMb * 1024 * 1024 : undefined;
-
-    const downloadId = await this.downloadRepository.createDownload({
-      fragmentSizeBytes,
-      filters
-    });
-
-    await this.downloadRepository.createDownloadFeatures(downloadId.download_id, submissionFeatureIds);
-
-    return downloadId;
   }
 
   /**
@@ -133,20 +96,41 @@ export class DownloadService extends DBService {
   }
 
   /**
-   * Returns all features linked to a download.
+   * Resolve all features included in a download.
    *
-   * Authorization is enforced once at creation time via buildSecurityFilter in
-   * the search query — only authorized features are ever linked to the download.
-   * Re-checking at retrieval time caused a bug: the download_team → policy_team
-   * hop meant adding a user to the download team could change which features
-   * were visible.
+   * Branches based on the download's feature source:
+   * - **Cart-based** (cart_id set): features resolved from cart_submission_feature.
+   *   Cart downloads are frozen — checkout marks the cart as CHECKED_OUT, so
+   *   cart_submission_feature rows don't change post-checkout.
+   * - **Filter-based** (filters set): re-runs the search query at pipeline time,
+   *   intentionally picking up newly ingested data matching the filters.
+   *   The creator's security scope is recovered from `create_user` (set
+   *   automatically by `tr_audit_trigger` on INSERT). The search CTE runs as
+   *   a subquery inside the summary JOIN, keeping feature resolution in SQL
+   *   and avoiding a 500K+ ID round-trip through JS.
    *
    * @param {string} downloadId - The download ID.
-   * @return {Promise<DownloadFeatureSummary[]>} All linked features.
+   * @return {Promise<DownloadFeatureSummary[]>} All features for this download.
    * @memberof DownloadService
    */
   async getDownloadFeatures(downloadId: string): Promise<DownloadFeatureSummary[]> {
-    return this.downloadRepository.getDownloadFeatures(downloadId);
+    const source = await this.downloadRepository.getDownloadSource(downloadId);
+
+    if (source.cart_id) {
+      return this.downloadRepository.getDownloadFeaturesByCartId(source.cart_id);
+    }
+
+    if (source.filters) {
+      const searchSubquery = this.searchFeatureService.buildSearchFeatureIdsSubquery(
+        source.filters,
+        source.create_user
+      );
+
+      return this.downloadRepository.getDownloadFeaturesBySearchQuery(searchSubquery);
+    }
+
+    // CHECK constraint prevents this, but guard defensively
+    throw new Error(`Download ${downloadId} has neither cart_id nor filters`);
   }
 
   /**

--- a/api/src/services/search-feature-service.ts
+++ b/api/src/services/search-feature-service.ts
@@ -1,4 +1,5 @@
 import { FeatureCollection } from 'geojson';
+import { Knex } from 'knex';
 import { IDBConnection } from '../database/db';
 import { SearchFeatureRepository } from '../repositories/search-feature-repository';
 import { SubmissionRepository } from '../repositories/submission-repository';
@@ -76,6 +77,19 @@ export class SearchFeatureService extends DBService {
     defaultLog.debug({ label: 'getSearchFeatureIds', filters });
     const rows = await this.searchFeatureRepository.searchFeatureIdsByFilters(filters, systemUserId);
     return rows.map((row) => row.submission_feature_id);
+  }
+
+  /**
+   * Build a Knex subquery returning matching submission_feature_ids
+   * without executing it. Used by DownloadService to compose
+   * the search as a SQL subquery (no JS round-trip for large sets).
+   *
+   * @param {ISearchFeaturesFilters} filters - Search filters
+   * @param {number | null} [systemUserId] - Security context
+   * @return {Knex.QueryBuilder} Unexecuted subquery returning submission_feature_id rows
+   */
+  buildSearchFeatureIdsSubquery(filters: ISearchFeaturesFilters, systemUserId?: number | null): Knex.QueryBuilder {
+    return this.searchFeatureRepository.buildSearchFeatureIdsSubquery(filters, systemUserId);
   }
 
   /**

--- a/database/src/migrations/20260401184728_deprecate_download_feature.ts
+++ b/database/src/migrations/20260401184728_deprecate_download_feature.ts
@@ -1,0 +1,91 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- SIMSBIOHUB-950: Add cart_id FK to download, drop download_feature
+    --------------------------------------------------------------------------------
+
+    -- Add cart_id FK to download (nullable — filter-based downloads have no cart)
+    ALTER TABLE download ADD COLUMN cart_id UUID;
+    ALTER TABLE download ADD CONSTRAINT download_cart_fk
+      FOREIGN KEY (cart_id) REFERENCES cart(cart_id);
+    CREATE INDEX download_cart_idx ON download(cart_id);
+
+    COMMENT ON COLUMN download.cart_id IS 'FK to cart table. Set for cart-based downloads, NULL for filter-based. Used to resolve features at pipeline time via cart_submission_feature.';
+
+    -- Every download must have a feature source: either cart_id or filters
+    ALTER TABLE download ADD CONSTRAINT download_feature_source_check
+      CHECK (cart_id IS NOT NULL OR filters IS NOT NULL);
+
+    --------------------------------------------------------------------------------
+    -- DROP download_feature (0 rows — clean drop, no data migration needed)
+    --------------------------------------------------------------------------------
+
+    DROP TRIGGER IF EXISTS journal_download_feature ON download_feature;
+    DROP TRIGGER IF EXISTS audit_download_feature ON download_feature;
+    DROP INDEX IF EXISTS download_feature_idx2;
+    DROP INDEX IF EXISTS download_feature_idx1;
+    DROP TABLE IF EXISTS download_feature;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Recreate download_feature
+    --------------------------------------------------------------------------------
+
+    CREATE TABLE download_feature (
+      download_feature_id       INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+      download_id               UUID NOT NULL,
+      submission_feature_id     INTEGER NOT NULL,
+      create_date               TIMESTAMPTZ(6) NOT NULL DEFAULT now(),
+      create_user               INTEGER NOT NULL,
+      update_date               TIMESTAMPTZ(6),
+      update_user               INTEGER,
+      revision_count            INTEGER NOT NULL DEFAULT 0,
+      CONSTRAINT download_feature_pk PRIMARY KEY (download_feature_id),
+      CONSTRAINT download_feature_fk1 FOREIGN KEY (download_id) REFERENCES download(download_id) ON DELETE CASCADE,
+      CONSTRAINT download_feature_fk2 FOREIGN KEY (submission_feature_id) REFERENCES submission_feature(submission_feature_id)
+    );
+
+    CREATE INDEX download_feature_idx1 ON download_feature(download_id);
+    CREATE INDEX download_feature_idx2 ON download_feature(submission_feature_id);
+
+    COMMENT ON TABLE download_feature IS 'Join table linking download requests to selected submission features.';
+    COMMENT ON COLUMN download_feature.download_feature_id IS 'System generated surrogate primary key identifier.';
+    COMMENT ON COLUMN download_feature.download_id IS 'Foreign key to the download table.';
+    COMMENT ON COLUMN download_feature.submission_feature_id IS 'Foreign key to the submission_feature table.';
+    COMMENT ON COLUMN download_feature.create_date IS 'The datetime the record was created.';
+    COMMENT ON COLUMN download_feature.create_user IS 'The id of the user who created the record.';
+    COMMENT ON COLUMN download_feature.update_date IS 'The datetime the record was last updated.';
+    COMMENT ON COLUMN download_feature.update_user IS 'The id of the user who last updated the record.';
+    COMMENT ON COLUMN download_feature.revision_count IS 'Revision count used for concurrency control.';
+
+    --------------------------------------------------------------------------------
+    -- AUDIT / JOURNAL TRIGGERS
+    --------------------------------------------------------------------------------
+
+    CREATE TRIGGER audit_download_feature
+      BEFORE INSERT OR UPDATE OR DELETE ON download_feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_audit_trigger();
+
+    CREATE TRIGGER journal_download_feature
+      AFTER INSERT OR UPDATE OR DELETE ON download_feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_journal_trigger();
+
+    --------------------------------------------------------------------------------
+    -- Remove cart_id and CHECK constraint from download
+    --------------------------------------------------------------------------------
+
+    ALTER TABLE download DROP CONSTRAINT IF EXISTS download_feature_source_check;
+    DROP INDEX IF EXISTS download_cart_idx;
+    ALTER TABLE download DROP CONSTRAINT IF EXISTS download_cart_fk;
+    ALTER TABLE download DROP COLUMN IF EXISTS cart_id;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-950](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-950)

## Description of Changes

We do not want to store the set of features to be included in a download. Instead, we will calculate the features at runtime using the download criteria

Acceptance Criteria
1. Drop `download_feature` table

2. Fix any breaking changes.

## Testing Notes

 Prerequisites                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                      
  - Queue worker running (make queue)                                                                                                                                                                                                                                                                
                                                                                                                                                                                 
  Cart Checkout Path                                                                                                                                                             
                                                                                                                                                                                 
  1. Search for features and add them to a cart                                                                                                                                  
  2. Check out the cart (POST /api/cart/{cartId}/checkout)                                                                                                                       
  3. Wait for the queue to process the download                                                                                                                                  
  4. Download the ZIP and verify it contains exactly the features that were in the cart                                                                                          
                                                                                                                                                                                 
  Filter Download Path                                                                                                                                                           
                                                                                                                                                                                 
  1. Create a filter-based download (POST /api/download with search filters)                                                                                                  
  2. Wait for the queue to process the download
  3. Download the ZIP and verify it contains features matching the filters    
