### PR TITLE
SIMSBIOHUB-975: Bug Fix: Preserve Original Error when Thrown

### DIFF
--- a/api/src/errors/base-error.test.ts
+++ b/api/src/errors/base-error.test.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { ApiError, ApiNotFoundError } from './api-error';
+import { BaseError } from './base-error';
+
+class TestBaseError extends BaseError {
+  constructor(message: string, errors?: (string | object)[], stack?: string) {
+    super('Test Error', message, errors, stack);
+  }
+}
+
+describe('BaseError', () => {
+  it('preserves prototype chain for subclasses', () => {
+    const err = new TestBaseError('boom');
+
+    expect(err).to.be.instanceOf(Error);
+    expect(err).to.be.instanceOf(BaseError);
+    expect(err).to.be.instanceOf(TestBaseError);
+  });
+
+  it('preserves prototype chain for ApiError subclasses', () => {
+    const err = new ApiNotFoundError('Cart not found');
+
+    expect(err).to.be.instanceOf(Error);
+    expect(err).to.be.instanceOf(ApiError);
+    expect(err).to.be.instanceOf(ApiNotFoundError);
+  });
+
+  it('normalizes nested Error values in errors array', () => {
+    const nested = new Error('nested failure');
+    const err = new TestBaseError('boom', [nested, 'extra']);
+
+    expect(err.errors).to.deep.equal([{ name: 'Error', message: 'nested failure' }, 'extra']);
+  });
+
+  it('uses the provided stack when supplied', () => {
+    const customStack = 'custom-stack-line';
+    const err = new TestBaseError('boom', [], customStack);
+
+    expect(err.stack).to.equal(customStack);
+  });
+});

--- a/api/src/errors/base-error.ts
+++ b/api/src/errors/base-error.ts
@@ -4,6 +4,8 @@ export class BaseError extends Error {
   constructor(name: string, message: string, errors?: (string | object)[], stack?: string) {
     super(message);
 
+    Object.setPrototypeOf(this, new.target.prototype);
+
     this.name = name;
 
     for (const error of errors ?? []) {
@@ -19,7 +21,7 @@ export class BaseError extends Error {
     if (stack) {
       this.stack = stack;
     } else {
-      Error.captureStackTrace(this);
+      Error.captureStackTrace(this, new.target);
     }
   }
 }


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-975

## Description of Changes
Regression where “cart not found” responses were returned as `500` instead of `404`.
Repository/business logic still threw the correct not-found error.
Root cause was custom error type identity loss after the TypeScript/toolchain upgrade.
Error mapping depended on type checks; failed checks caused fallback to generic `500 Unexpected Error`.
Fix was applied in the shared base error class to preserve custom error identity and proper stack behavior.
Result: not-found errors now map correctly to `404` again.
Verified with targeted error-mapping and cart repository tests.