### PR TITLE
SIMSBIOHUB-973:  Queue publishers should throw on failure

### DIFF
--- a/api/src/__integration__/db/cart-checkout.integration.ts
+++ b/api/src/__integration__/db/cart-checkout.integration.ts
@@ -3,11 +3,14 @@
 // works correctly against the real database.
 //
 // Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
+// pg-boss is not running in the make test-db environment, so CartService.dependencies.publishProcessDownloadJob
+// is stubbed in beforeEach to resolve without attempting a real enqueue.
 //
 // Run: make test-db
 // Requires: make web (database must be running with seed data)
 
 import { expect } from 'chai';
+import sinon from 'sinon';
 import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
 import { HTTP400 } from '../../errors/http-error';
@@ -31,11 +34,18 @@ describe('Cart checkout (integration)', function () {
     await connection.open();
     cartService = new CartService(connection);
     downloadService = new DownloadService(connection);
+
+    // pg-boss is not running in the make test-db environment; stub the publisher so
+    // CartService.checkoutCart can complete without attempting a real enqueue.
+    sinon
+      .stub(CartService.dependencies, 'publishProcessDownloadJob')
+      .resolves({ status: 'published', jobId: 'stub-job-id' });
   });
 
   afterEach(async () => {
     await connection.rollback();
     connection.release();
+    sinon.restore();
   });
 
   /**

--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -1,9 +1,12 @@
 // Integration test for security scope pipeline — verifies scope creation, anchor computation,
 // team scope grants, orphan cleanup, and search access filtering against the real database.
 //
-// Tests use repository methods directly for scope setup (bypassing pg-boss which is not
-// running in the make test-db environment). SecurityScopeService.cleanupScopesForDeletedStatements
-// is safe to call directly as it only uses repository methods internally.
+// Tests use repository methods directly for scope setup. Service methods that internally
+// publish pg-boss jobs (e.g. cleanupScopesForDeletedStatements → publishComputeScopeAnchorsJob)
+// are called directly, but the publisher is stubbed in beforeEach because pg-boss is not
+// running in the make test-db environment. Anchor recomputation is simulated by calling
+// the phase methods (deleteStaleAnchorBatch / computeAnchorBatch) directly via
+// refreshAnchorsViaService.
 //
 // Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
 //
@@ -11,6 +14,7 @@
 // Requires: make web (database must be running with seed data)
 
 import { expect } from 'chai';
+import sinon from 'sinon';
 import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
 import { SecurityScopeRepository } from '../../repositories/authorization/security-scope-repository';
@@ -48,11 +52,19 @@ describe('Security scope search (integration)', function () {
     scopeRepo = new SecurityScopeRepository(connection);
     scopeService = new SecurityScopeService(connection);
     searchRepo = new SearchFeatureRepository(connection);
+
+    // pg-boss is not running in the make test-db environment; stub the publisher so
+    // service methods that enqueue anchor-computation jobs can proceed. Anchor recomputation
+    // is simulated by calling phase methods directly via refreshAnchorsViaService.
+    sinon
+      .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+      .resolves({ status: 'published', jobId: 'stub-job-id' });
   });
 
   afterEach(async () => {
     await connection.rollback();
     connection.release();
+    sinon.restore();
   });
 
   // ── Helpers ──────────────────────────────────────────────────────────

--- a/api/src/paths/cart/{cartId}/checkout/index.test.ts
+++ b/api/src/paths/cart/{cartId}/checkout/index.test.ts
@@ -7,7 +7,11 @@ import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks
 import * as db from '../../../../database/db';
 import { ApiError } from '../../../../errors/api-error';
 import { DownloadId } from '../../../../models/download';
+import { CartRepository } from '../../../../repositories/cart-repository';
+import { TeamService } from '../../../../services/access-policy/team-service';
 import { CartService } from '../../../../services/cart-service';
+import { CartSubmissionFeatureService } from '../../../../services/cart-submission-feature-service';
+import { DownloadService } from '../../../../services/download/download-service';
 
 chai.use(sinonChai);
 
@@ -137,6 +141,42 @@ describe('cart/{cartId}/checkout', () => {
         expect.fail('Expected handler to throw');
       } catch (error) {
         expect((error as ApiError).message).to.equal('Checkout failed');
+        expect(mockDBConnection.rollback).to.have.been.calledOnce;
+        expect(mockDBConnection.release).to.have.been.calledOnce;
+      }
+    });
+
+    it('rolls back and releases when publishProcessDownloadJob throws', async () => {
+      const mockDBConnection = getMockDBConnection({
+        commit: sinon.stub(),
+        rollback: sinon.stub(),
+        release: sinon.stub(),
+        systemUserId: sinon.stub().returns(42)
+      });
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+      sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureIds').resolves([1, 2, 3]);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'dl-uuid-1' });
+      sinon.stub(TeamService.prototype, 'createTeam').resolves({
+        team_id: 'team-1',
+        name: 'team',
+        description: 'description',
+        member_count: 0
+      });
+      sinon.stub(DownloadService.prototype, 'createDownloadTeam').resolves();
+      sinon.stub(CartRepository.prototype, 'updateCart').resolves();
+      sinon.stub(CartService.dependencies, 'publishProcessDownloadJob').rejects(new Error('pg-boss unavailable'));
+
+      const requestHandler = checkoutCart();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params.cartId = 'cart-uuid-5678';
+      mockReq.keycloak_token = { sub: 'user-id' };
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail('Expected handler to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
         expect(mockDBConnection.rollback).to.have.been.calledOnce;
         expect(mockDBConnection.release).to.have.been.calledOnce;
       }

--- a/api/src/queue/jobs/process-submission-features-job.test.ts
+++ b/api/src/queue/jobs/process-submission-features-job.test.ts
@@ -84,27 +84,22 @@ describe('process-submission-features-job', () => {
       expect(publishStub.calledBefore(toIngestedStub)).to.be.true;
     });
 
-    it('rethrows when enqueue returns error and does not mark upload ingested', async () => {
+    it('finalizes upload as ingested when indexing publish throws (warn-and-commit)', async () => {
       sinon.stub(SubmissionIngestionService.prototype, 'ingestSubmissionUpload').resolves({ valid: true, errors: [] });
       sinon
         .stub(processSubmissionFeaturesJobDependencies, 'publishIndexSubmissionFeaturesJob')
-        .resolves({ status: 'error', message: 'pg-boss unavailable' });
+        .rejects(new Error('pg-boss unavailable'));
 
-      try {
-        await processSubmissionFeaturesJobHandler([createMockJob()]);
-        expect.fail('expected an error');
-      } catch (error) {
-        expect((error as Error).message).to.contain('Index submission publish failed');
-      }
+      await processSubmissionFeaturesJobHandler([createMockJob()]);
 
       const toIngestedStub = SubmissionUploadService.prototype.transitionSubmissionUploadToIngested as sinon.SinonStub;
       const updateValidationStub = SubmissionValidationService.prototype
         .updateSubmissionValidationStatus as sinon.SinonStub;
       const deleteFeaturesStub = SubmissionFeatureIngestionService.prototype
         .deleteFeaturesBySubmissionUploadId as sinon.SinonStub;
-      expect(toIngestedStub.called).to.be.false;
-      expect(updateValidationStub.calledWith('test-job-id', 'completed')).to.be.false;
-      expect(deleteFeaturesStub.calledWith('test-sub-upload-id')).to.be.true;
+      expect(toIngestedStub.calledWith('test-sub-upload-id')).to.be.true;
+      expect(updateValidationStub.calledWith('test-job-id', 'completed')).to.be.true;
+      expect(deleteFeaturesStub.called).to.be.false;
     });
 
     it('marks upload invalid when ingestion returns deterministic validation errors', async () => {

--- a/api/src/queue/jobs/process-submission-features-job.ts
+++ b/api/src/queue/jobs/process-submission-features-job.ts
@@ -258,13 +258,13 @@ async function finalizeProcessSubmissionFeaturesStage(
 }
 
 /**
- * Publish downstream index work.
+ * Publish downstream index work, warn-and-commit on failure.
  *
- * This step is intentionally isolated in its own transaction boundary:
- * - If enqueue fails, the process job throws and is retried by pg-boss.
- * - Because earlier phases are already committed, retries resume from persisted state.
- *
- * Index publish is required for successful process-stage completion.
+ * Indexing is best-effort: the just-completed ingestion/validation status updates are durable
+ * work and finalize regardless of whether the downstream indexing job enqueues. Throwing here
+ * would unwind real completed work and trigger pg-boss retry of the whole ingestion stage,
+ * which is undesirable. On enqueue failure we log a warning and let the orchestrator continue
+ * to its finalize phase.
  *
  * @param {number} submissionId Submission scope.
  * @param {string} submissionUploadId Submission upload scope.
@@ -277,34 +277,33 @@ async function executeIndexSubmissionFeaturesPublish(
   jobId: string
 ): Promise<void> {
   await withConnection(async (connection) => {
-    // Enqueue downstream indexing and treat enqueue failures as retryable job failures.
     const publishStart = Date.now();
-    const indexResult = await processSubmissionFeaturesJobDependencies.publishIndexSubmissionFeaturesJob(connection, {
-      submissionId
-    });
 
-    if (indexResult.status === 'error') {
-      defaultLog.error({
+    try {
+      const indexResult = await processSubmissionFeaturesJobDependencies.publishIndexSubmissionFeaturesJob(connection, {
+        submissionId
+      });
+
+      defaultLog.info({
         label: 'executeIndexSubmissionFeaturesPublish',
-        message: 'Index submission publish failed',
+        message: 'Index submission publish completed',
         jobId,
         submissionUploadId,
         submissionId,
         elapsedMs: Date.now() - publishStart,
         indexResult
       });
-      throw new Error(`Index submission publish failed: ${indexResult.message}`);
+    } catch (error) {
+      defaultLog.warn({
+        label: 'executeIndexSubmissionFeaturesPublish',
+        message: 'Index submission publish failed; finalizing ingestion status anyway',
+        jobId,
+        submissionUploadId,
+        submissionId,
+        elapsedMs: Date.now() - publishStart,
+        error: toErrorMetadata(error)
+      });
     }
-
-    defaultLog.info({
-      label: 'executeIndexSubmissionFeaturesPublish',
-      message: 'Index submission publish completed',
-      jobId,
-      submissionUploadId,
-      submissionId,
-      elapsedMs: Date.now() - publishStart,
-      indexResult
-    });
   });
 }
 

--- a/api/src/queue/publisher.test.ts
+++ b/api/src/queue/publisher.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import { getMockDBConnection } from '../__mocks__/db';
+import { ApiNotFoundError } from '../errors/api-error';
 import type { DownloadRecord } from '../models/download';
 import type { SubmissionUpload } from '../models/submission-upload';
 import type { SubmissionValidationRecord } from '../models/submission-validation';
@@ -166,16 +167,18 @@ describe('publisher', () => {
       expect(options.db.executeSql).to.be.a('function');
     });
 
-    it('returns error status when pg-boss throws', async () => {
+    it('throws when pg-boss throws', async () => {
       const mockConnection = getMockDBConnection();
 
       sinon.stub(SubmissionValidationService.prototype, 'getSubmissionValidationBySubmissionUploadId').resolves(null);
       sinon.stub(publisherDependencies, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
-
-      expect(result.status).to.equal('error');
-      expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
+      try {
+        await publishProcessSubmissionFeaturesJob(mockConnection, defaultSubmissionUpload);
+        expect.fail('expected publisher to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss not initialized');
+      }
     });
 
     it('returns blocked status when validation record exists with non-failed status', async () => {
@@ -346,15 +349,17 @@ describe('publisher', () => {
       );
     });
 
-    it('returns error status when pg-boss throws', async () => {
+    it('throws when pg-boss throws', async () => {
       sinon.stub(publisherDependencies, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishMalwareScanJob(getMockDBConnection(), {
-        artifactSecurityId: 'artifact-security-000'
-      });
-
-      expect(result.status).to.equal('error');
-      expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
+      try {
+        await publishMalwareScanJob(getMockDBConnection(), {
+          artifactSecurityId: 'artifact-security-000'
+        });
+        expect.fail('expected publisher to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss not initialized');
+      }
     });
   });
 
@@ -449,16 +454,16 @@ describe('publisher', () => {
       );
     });
 
-    it('returns error status when pg-boss throws', async () => {
+    it('throws when pg-boss throws', async () => {
       const mockConnection = getMockDBConnection();
       sinon.stub(publisherDependencies, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishIndexSubmissionFeaturesJob(mockConnection, {
-        submissionId: 777
-      });
-
-      expect(result.status).to.equal('error');
-      expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
+      try {
+        await publishIndexSubmissionFeaturesJob(mockConnection, { submissionId: 777 });
+        expect.fail('expected publisher to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss not initialized');
+      }
     });
   });
 
@@ -537,15 +542,19 @@ describe('publisher', () => {
       );
     });
 
-    it('returns error when download not found', async () => {
+    it('throws ApiNotFoundError when download not found', async () => {
       const mockConnection = getMockDBConnection();
       sinon.stub(DownloadService.prototype, 'findDownloadById').resolves(null);
 
       const data = { downloadId: 'aaaa0000-0000-0000-0000-000000000999' };
-      const result = await publishProcessDownloadJob(mockConnection, data);
 
-      expect(result.status).to.equal('error');
-      expect((result as { status: 'error'; message: string }).message).to.equal('Download not found');
+      try {
+        await publishProcessDownloadJob(mockConnection, data);
+        expect.fail('expected ApiNotFoundError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+        expect((error as ApiNotFoundError).message).to.equal('Download not found');
+      }
     });
 
     it('uses singletonKey based on downloadId to prevent duplicates', async () => {
@@ -586,18 +595,20 @@ describe('publisher', () => {
       );
     });
 
-    it('returns error status when pg-boss throws', async () => {
+    it('throws when pg-boss throws', async () => {
       const mockConnection = getMockDBConnection();
 
       sinon.stub(DownloadService.prototype, 'findDownloadById').resolves(createMockDownload());
       sinon.stub(publisherDependencies, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishProcessDownloadJob(mockConnection, {
-        downloadId: 'aaaa0000-0000-0000-0000-000000000001'
-      });
-
-      expect(result.status).to.equal('error');
-      expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
+      try {
+        await publishProcessDownloadJob(mockConnection, {
+          downloadId: 'aaaa0000-0000-0000-0000-000000000001'
+        });
+        expect.fail('expected publisher to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss not initialized');
+      }
     });
   });
 
@@ -684,14 +695,16 @@ describe('publisher', () => {
       );
     });
 
-    it('returns error status when pg-boss throws', async () => {
+    it('throws when pg-boss throws', async () => {
       const mockConnection = getMockDBConnection();
       sinon.stub(publisherDependencies, 'getPgBoss').throws(new Error('pg-boss not initialized'));
 
-      const result = await publishComputeScopeAnchorsJob(mockConnection, { securityScopeId: 'scope-uuid-1' });
-
-      expect(result.status).to.equal('error');
-      expect((result as { status: 'error'; message: string }).message).to.equal('pg-boss not initialized');
+      try {
+        await publishComputeScopeAnchorsJob(mockConnection, { securityScopeId: 'scope-uuid-1' });
+        expect.fail('expected publisher to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss not initialized');
+      }
     });
   });
 });

--- a/api/src/queue/publisher.ts
+++ b/api/src/queue/publisher.ts
@@ -1,4 +1,5 @@
 import { IDBConnection } from '../database/db';
+import { ApiNotFoundError } from '../errors/api-error';
 import { DownloadStatusEnum } from '../models/download-status';
 import { SubmissionUpload } from '../models/submission-upload';
 import { DownloadService } from '../services/download/download-service';
@@ -58,8 +59,7 @@ export interface IPublishOptions {
 export type PublishJobResult =
   | { status: 'published'; jobId: string }
   | { status: 'blocked'; message: string; existingStatus: string }
-  | { status: 'duplicate'; message: string }
-  | { status: 'error'; message: string };
+  | { status: 'duplicate'; message: string };
 
 /**
  * Options for process submission features jobs.
@@ -114,7 +114,9 @@ const PROCESS_DOWNLOAD_OPTIONS: IPublishOptions = {
  * @param {IDBConnection} connection Database connection for submission validation tracking
  * @param {SubmissionUpload} submissionUpload Pre-resolved bridge record
  * @param {IPublishOptions} [options={}] Job options
- * @return {*}  {Promise<PublishJobResult>} Result indicating success, blocked, duplicate, or error
+ * @return {*}  {Promise<PublishJobResult>} Result indicating success, blocked, or duplicate
+ * @throws Rethrows any error from pg-boss (`boss.createQueue` / `boss.send`) after logging it;
+ *         callers' surrounding transaction rolls back automatically.
  */
 export const publishProcessSubmissionFeaturesJob = async (
   connection: IDBConnection,
@@ -203,16 +205,13 @@ export const publishProcessSubmissionFeaturesJob = async (
       return { status: 'duplicate', message: 'Job already exists for this submission' };
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
     defaultLog.error({
       label: 'publishProcessSubmissionFeaturesJob',
       message: 'Failed to publish job',
       submissionUploadId,
       error
     });
-
-    return { status: 'error', message: errorMessage };
+    throw error;
   }
 };
 
@@ -224,7 +223,9 @@ export const publishProcessSubmissionFeaturesJob = async (
  * @param {IDBConnection} connection Database connection for submission validation tracking
  * @param {IMalwareScanJobData} data Job data containing artifactSecurityId
  * @param {IPublishOptions} [options={}] Job options
- * @return {*}  {Promise<PublishJobResult>} Result indicating success, duplicate, or error
+ * @return {*}  {Promise<PublishJobResult>} Result indicating success or duplicate
+ * @throws Rethrows any error from pg-boss (`boss.createQueue` / `boss.send`) after logging it;
+ *         callers' surrounding transaction rolls back automatically.
  */
 export const publishMalwareScanJob = async (
   connection: IDBConnection,
@@ -270,16 +271,13 @@ export const publishMalwareScanJob = async (
 
     return { status: 'duplicate', message: 'Job already exists for this artifact security record' };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
     defaultLog.error({
       label: 'publishMalwareScanJob',
       message: 'Failed to publish job',
       artifactSecurityId: data.artifactSecurityId,
       error
     });
-
-    return { status: 'error', message: errorMessage };
+    throw error;
   }
 };
 
@@ -292,7 +290,10 @@ export const publishMalwareScanJob = async (
  * @param {IDBConnection} connection Database connection for download record updates
  * @param {IProcessDownloadJobData} data Job data containing downloadId
  * @param {IPublishOptions} [options={}] Job options
- * @return {*}  {Promise<PublishJobResult>} Result indicating success, duplicate, or error
+ * @return {*}  {Promise<PublishJobResult>} Result indicating success or duplicate
+ * @throws {ApiNotFoundError} When the download row does not exist.
+ * @throws Rethrows any error from pg-boss (`boss.createQueue` / `boss.send`) after logging it;
+ *         callers' surrounding transaction rolls back automatically.
  */
 export const publishProcessDownloadJob = async (
   connection: IDBConnection,
@@ -306,7 +307,7 @@ export const publishProcessDownloadJob = async (
     const download = await downloadService.findDownloadById(data.downloadId);
 
     if (!download) {
-      return { status: 'error', message: 'Download not found' };
+      throw new ApiNotFoundError('Download not found', ['publishProcessDownloadJob', { downloadId: data.downloadId }]);
     }
 
     // Check if download is already being processed or completed
@@ -361,16 +362,13 @@ export const publishProcessDownloadJob = async (
 
     return { status: 'duplicate', message: 'Job already exists for this download' };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
     defaultLog.error({
       label: 'publishProcessDownloadJob',
       message: 'Failed to publish job',
       downloadId: data.downloadId,
       error
     });
-
-    return { status: 'error', message: errorMessage };
+    throw error;
   }
 };
 
@@ -395,7 +393,9 @@ const INDEX_SUBMISSION_FEATURES_OPTIONS: IPublishOptions = {
  * @param {IDBConnection} connection Database connection for transactional job insert
  * @param {IIndexSubmissionFeaturesJobData} data Job data containing submissionId
  * @param {IPublishOptions} [options={}] Job options
- * @return {*}  {Promise<PublishJobResult>} Result indicating success, duplicate, or error
+ * @return {*}  {Promise<PublishJobResult>} Result indicating success or duplicate
+ * @throws Rethrows any error from pg-boss (`boss.createQueue` / `boss.send`) after logging it;
+ *         callers' surrounding transaction rolls back automatically.
  */
 export const publishIndexSubmissionFeaturesJob = async (
   connection: IDBConnection,
@@ -435,16 +435,13 @@ export const publishIndexSubmissionFeaturesJob = async (
 
     return { status: 'duplicate', message: 'Job already exists for this submission' };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
     defaultLog.error({
       label: 'publishIndexSubmissionFeaturesJob',
       message: 'Failed to publish job',
       submissionId: data.submissionId,
       error
     });
-
-    return { status: 'error', message: errorMessage };
+    throw error;
   }
 };
 
@@ -470,7 +467,9 @@ const COMPUTE_SCOPE_ANCHORS_OPTIONS: IPublishOptions = {
  * @param {IDBConnection} connection Database connection for transactional job insert
  * @param {IComputeScopeAnchorsJobData} data Job data containing securityScopeId
  * @param {IPublishOptions} [options={}] Job options
- * @return {*}  {Promise<PublishJobResult>} Result indicating success, duplicate, or error
+ * @return {*}  {Promise<PublishJobResult>} Result indicating success or duplicate
+ * @throws Rethrows any error from pg-boss (`boss.createQueue` / `boss.send`) after logging it;
+ *         callers' surrounding transaction rolls back automatically.
  */
 export const publishComputeScopeAnchorsJob = async (
   connection: IDBConnection,
@@ -512,15 +511,12 @@ export const publishComputeScopeAnchorsJob = async (
 
     return { status: 'duplicate', message: 'Job already exists for this security scope' };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
     defaultLog.error({
       label: 'publishComputeScopeAnchorsJob',
       message: 'Failed to publish job',
       securityScopeId: data.securityScopeId,
       error
     });
-
-    return { status: 'error', message: errorMessage };
+    throw error;
   }
 };

--- a/api/src/services/access-policy/security-scope-service.test.ts
+++ b/api/src/services/access-policy/security-scope-service.test.ts
@@ -83,6 +83,39 @@ describe('SecurityScopeService', () => {
       expect(mappingStub).to.have.been.calledOnce;
       expect(mappingStub).to.have.been.calledWith(policyStatementId, securityScopeId);
     });
+
+    it('throws when publishComputeScopeAnchorsJob throws (new scope branch)', async () => {
+      const newScope: SecurityScope = { security_scope_id: securityScopeId, scope_hash: scopeHash };
+      sinon.stub(SecurityScopeRepository.prototype, 'insertSecurityScope').resolves(newScope);
+      sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
+      sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .rejects(new Error('pg-boss unavailable'));
+
+      try {
+        await service.createScopeForPolicyStatement(policyStatementId, urn);
+        expect.fail('expected createScopeForPolicyStatement to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
+    });
+
+    it('throws when publishComputeScopeAnchorsJob throws (existing scope branch)', async () => {
+      const existingScope: SecurityScope = { security_scope_id: securityScopeId, scope_hash: scopeHash };
+      sinon.stub(SecurityScopeRepository.prototype, 'insertSecurityScope').resolves(null);
+      sinon.stub(SecurityScopeRepository.prototype, 'getSecurityScopeByScopeHash').resolves(existingScope);
+      sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
+      sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .rejects(new Error('pg-boss unavailable'));
+
+      try {
+        await service.createScopeForPolicyStatement(policyStatementId, urn);
+        expect.fail('expected createScopeForPolicyStatement to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
+    });
   });
 
   describe('cleanupScopesForDeletedStatements', () => {
@@ -155,6 +188,28 @@ describe('SecurityScopeService', () => {
       expect(orphanStub).not.to.have.been.called;
       expect(publishStub).not.to.have.been.called;
     });
+
+    it('throws when publishComputeScopeAnchorsJob throws (cleanup loop)', async () => {
+      sinon
+        .stub(SecurityScopeRepository.prototype, 'findScopeIdsForStatements')
+        .resolves([{ security_scope_id: 'scope-1' }]);
+      sinon.stub(SecurityScopeRepository.prototype, 'deletePolicyStatementScopes').resolves();
+      sinon.stub(SecurityScopeRepository.prototype, 'deleteTeamSecurityScopes').resolves();
+      sinon.stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesFromPolicyChain').resolves();
+      sinon
+        .stub(SecurityScopeRepository.prototype, 'findOrphanedScopeIds')
+        .resolves([{ security_scope_id: 'scope-1' }]);
+      sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .rejects(new Error('pg-boss unavailable'));
+
+      try {
+        await service.cleanupScopesForDeletedStatements(['ps-1'], ['team-1']);
+        expect.fail('expected cleanupScopesForDeletedStatements to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
+    });
   });
 
   describe('rebuildTeamSecurityScopes', () => {
@@ -209,6 +264,22 @@ describe('SecurityScopeService', () => {
 
       expect(findStub).to.have.been.calledOnceWith(999);
       expect(publishStub).not.to.have.been.called;
+    });
+
+    it('throws when publishComputeScopeAnchorsJob throws (trigger loop)', async () => {
+      sinon
+        .stub(SecurityScopeRepository.prototype, 'findScopeIdsMatchingSubmission')
+        .resolves([{ security_scope_id: 'scope-1' }]);
+      sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .rejects(new Error('pg-boss unavailable'));
+
+      try {
+        await service.triggerAnchorComputationForSubmission(1);
+        expect.fail('expected triggerAnchorComputationForSubmission to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
     });
   });
 

--- a/api/src/services/cart-service.test.ts
+++ b/api/src/services/cart-service.test.ts
@@ -390,6 +390,30 @@ describe('CartService', () => {
       expect(updateCartStub).to.not.have.been.called;
       expect(publishStub).to.not.have.been.called;
     });
+
+    it('throws when publishProcessDownloadJob throws', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new CartService(mockDBConnection);
+
+      sinon.stub(CartSubmissionFeatureService.prototype, 'getCartSubmissionFeatureIds').resolves([1, 2, 3]);
+      sinon.stub(DownloadService.prototype, 'createDownload').resolves({ download_id: 'dl-uuid-1' });
+      sinon.stub(TeamService.prototype, 'createTeam').resolves({
+        team_id: 'team-1',
+        name: 'team',
+        description: 'description',
+        member_count: 0
+      });
+      sinon.stub(DownloadService.prototype, 'createDownloadTeam').resolves();
+      sinon.stub(CartRepository.prototype, 'updateCart').resolves();
+      sinon.stub(CartService.dependencies, 'publishProcessDownloadJob').rejects(new Error('pg-boss unavailable'));
+
+      try {
+        await service.checkoutCart('cart-1', 42);
+        expect.fail('expected checkoutCart to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
+    });
   });
 
   describe('updateCart', () => {

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -561,5 +561,25 @@ describe('ArtifactSecurityService', () => {
         expect((err as Error).message).to.equal('Failed to get submission upload record');
       }
     });
+
+    it('throws when publishProcessSubmissionFeaturesJob throws', async () => {
+      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
+        submission_upload_id: 'su-1',
+        submission_id: 999,
+        upload_id: 'upload-1',
+        status: 'pending',
+        ticket_id: '22222222-2222-2222-2222-222222222222'
+      });
+      sinon
+        .stub(ArtifactSecurityService.dependencies, 'publishProcessSubmissionFeaturesJob')
+        .rejects(new Error('pg-boss unavailable'));
+
+      try {
+        await service.publishNextPipelineStep(mockUploadArchive);
+        expect.fail('expected publishNextPipelineStep to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
+    });
   });
 });

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -465,6 +465,86 @@ describe('ArtifactSecurityService', () => {
         });
       }
     });
+
+    it('does not commit CLEAN security, unblock archive, or promote S3 when clean-scan publish throws', async () => {
+      // Verifies the orphan-prevention ordering in `executeScan`:
+      // publish must run BEFORE the CLEAN security write, the archive unblock, and the S3 promote.
+      // If publish throws, none of those irreversible writes must happen — so the scan can be retried
+      // from a fresh PENDING state. The outer catch still commits the FAILED scan row for audit.
+
+      const mockUploadArchive: UploadArchive = {
+        upload_archive_id: 'archive-1',
+        upload_id: 'upload-1',
+        artifact_id: 'artifact-1',
+        archive_status: ProcessStatusStatusEnum.BLOCKED
+      };
+
+      sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
+      sinon.stub(ArtifactService.prototype, 'getArtifact').resolves(mockArtifact);
+      sinon
+        .stub(ArtifactSecurityScanService.prototype, 'insertArtifactSecurityScan')
+        .resolves({ artifact_security_scan_id: 'scan-1' });
+
+      // scanArtifactObject internals — clean scan outcome.
+      sinon.stub(ObjectStorageService.prototype, 'getFileStream').resolves(Readable.from('test-data'));
+      sinon.stub(ArtifactSecurityService.dependencies, 'getClamAvScanner').resolves({
+        scanStream: sinon.stub().resolves({ isInfected: false })
+      } as any);
+
+      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
+        submission_upload_id: 'su-1',
+        submission_id: 123,
+        upload_id: 'upload-1',
+        status: 'pending',
+        ticket_id: '11111111-1111-1111-1111-111111111111'
+      });
+
+      sinon
+        .stub(ArtifactSecurityService.dependencies, 'publishProcessSubmissionFeaturesJob')
+        .rejects(new Error('pg-boss unavailable'));
+
+      // Spies on the writes that must NOT happen when publish throws.
+      const updateArtifactSecurityStub = sinon
+        .stub(ArtifactSecurityRepository.prototype, 'updateArtifactSecurity')
+        .resolves(mockSecurityRecord);
+      const promoteFromSecurityStub = sinon
+        .stub(ObjectStorageService.prototype, 'promoteFromSecurity')
+        .resolves({ key: 'test.tar' });
+      const updateUploadArchiveStub = sinon
+        .stub(UploadArchiveService.prototype, 'updateUploadArchive')
+        .resolves({ upload_archive_id: 'archive-1' });
+
+      // Spy on the scan-row FAILED update that MUST happen (outer catch).
+      const updateScanStub = sinon
+        .stub(ArtifactSecurityScanService.prototype, 'updateArtifactSecurityScan')
+        .resolves({ artifact_security_scan_id: 'scan-1' });
+
+      try {
+        await service.executeScan('security-1');
+        expect.fail('expected executeScan to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+
+        // The reorder's whole point: CLEAN was never committed.
+        expect(
+          updateArtifactSecurityStub.neverCalledWith(
+            sinon.match.any,
+            sinon.match({ security: SecurityStatusEnum.CLEAN })
+          )
+        ).to.be.true;
+
+        // S3 promote never happened.
+        expect(promoteFromSecurityStub.called).to.be.false;
+
+        // Archive stayed BLOCKED.
+        expect(updateUploadArchiveStub.called).to.be.false;
+
+        // Outer catch still committed the audit trail.
+        expect(updateScanStub.calledWith(sinon.match.any, sinon.match({ scan_status: ProcessStatusStatusEnum.FAILED })))
+          .to.be.true;
+      }
+    });
   });
 
   describe('handleCleanScanResult', () => {
@@ -475,10 +555,10 @@ describe('ArtifactSecurityService', () => {
       archive_status: ProcessStatusStatusEnum.BLOCKED
     };
 
-    it('should promote file and unblock archive, returning the upload archive record', async () => {
-      // Verifies: handleCleanScanResult promotes file, updates archive status, and returns the archive
+    it('should promote file and unblock archive', async () => {
+      // Verifies: handleCleanScanResult promotes file and updates archive status.
+      // Caller is responsible for looking up the archive; this method receives it pre-resolved.
 
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
       const promoteStub = sinon
         .stub(ObjectStorageService.prototype, 'promoteFromSecurity')
         .resolves({ key: 'test.tar' });
@@ -486,29 +566,11 @@ describe('ArtifactSecurityService', () => {
         upload_archive_id: 'archive-1'
       });
 
-      const result = await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
+      await service.handleCleanScanResult(mockUploadArchive, 'uploads/test.tar');
 
       expect(promoteStub.calledOnceWith('uploads/test.tar')).to.be.true;
       expect(updateArchiveStub.calledOnceWith('archive-1', { archive_status: ProcessStatusStatusEnum.PENDING })).to.be
         .true;
-      expect(result).to.eql(mockUploadArchive);
-    });
-
-    it('should propagate error when upload_archive lookup throws', async () => {
-      // Verifies: missing upload_archive is data corruption — error propagates, no S3 promote
-
-      sinon
-        .stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId')
-        .rejects(new Error('Failed to get upload archive record'));
-      const promoteStub = sinon.stub(ObjectStorageService.prototype, 'promoteFromSecurity');
-
-      try {
-        await service.handleCleanScanResult('artifact-1', 'uploads/test.tar');
-        expect.fail('Expected error not thrown');
-      } catch (err) {
-        expect((err as Error).message).to.equal('Failed to get upload archive record');
-        expect(promoteStub.called).to.be.false;
-      }
     });
   });
 

--- a/api/src/services/upload/artifact-security-service.ts
+++ b/api/src/services/upload/artifact-security-service.ts
@@ -86,28 +86,30 @@ export class ArtifactSecurityService extends DBService {
   }
 
   /**
-   * Handle post-scan actions for a clean artifact.
+   * Perform the irreversible post-clean-scan writes: promote the S3 object from the security bucket to the main
+   * bucket, and unblock the upload_archive so extraction can proceed.
    *
-   * Promotes the object from quarantine to main storage and unblocks the corresponding upload archive.
+   * **Ordering contract.** This method must only be called AFTER `publishNextPipelineStep` has successfully
+   * enqueued the downstream submission-processing job. Running it earlier creates an orphan: a CLEAN/promoted
+   * artifact with no downstream pipeline step to consume it. See `executeScan` for the full ordering.
    *
-   * @param {string} artifactId - Artifact identifier.
-   * @param {string} objectKey - S3 object key for the artifact.
-   * @returns {Promise<UploadArchive>} Updated upload archive record after unblocking.
+   * Known residual: if this method itself throws between the CLEAN-security commit and its two writes
+   * (e.g. S3 outage between `promoteFromSecurity` and `updateUploadArchive`), a narrower orphan direction
+   * is possible (security=CLEAN but archive=BLOCKED). Fixing that tail requires a transactional outbox or
+   * similar structural change.
+   *
+   * @param {UploadArchive} uploadArchive - The already-looked-up archive record for the artifact.
+   * @param {string} objectKey - S3 object key to promote from security to main bucket.
+   * @returns {Promise<void>}
    */
-  async handleCleanScanResult(artifactId: string, objectKey: string): Promise<UploadArchive> {
-    const uploadArchiveService = new UploadArchiveService(this.connection);
-    const uploadArchive = await uploadArchiveService.getUploadArchiveByArtifactId(artifactId);
-
-    // 1. Copy file from security bucket to main bucket
+  async handleCleanScanResult(uploadArchive: UploadArchive, objectKey: string): Promise<void> {
     const storageService = new ObjectStorageService();
     await storageService.promoteFromSecurity(objectKey);
 
-    // 2. Unblock the upload_archive for extraction
+    const uploadArchiveService = new UploadArchiveService(this.connection);
     await uploadArchiveService.updateUploadArchive(uploadArchive.upload_archive_id, {
       archive_status: ProcessStatusStatusEnum.PENDING
     });
-
-    return uploadArchive;
   }
 
   /**
@@ -183,15 +185,35 @@ export class ArtifactSecurityService extends DBService {
         results: sanitizeJsonbValue(scanOutcome.results)
       });
 
-      // 5. Update artifact security status
-      await this.updateArtifactSecurity(artifactSecurityId, {
-        security: scanOutcome.securityStatus
-      });
-
-      // 6. Handle post-scan actions for clean files
+      // 5. Handle post-scan actions by scan outcome.
       if (scanOutcome.securityStatus === SecurityStatusEnum.CLEAN) {
-        const uploadArchive = await this.handleCleanScanResult(artifact.artifact_id, artifact.object_key);
+        // Publish BEFORE committing any point-of-no-return write
+        // (security = CLEAN, archive unblock, S3 promote).
+        //
+        // If `publishProcessSubmissionFeaturesJob` throws here — e.g. pg-boss's DB is
+        // unavailable — the caller's transaction rolls back with nothing CLEAN persisted,
+        // the archive stays BLOCKED, and the S3 object stays in the security bucket.
+        // pg-boss retries the whole scan on a fresh connection; `getArtifactSecurity`
+        // still reads `security = PENDING`, so `executeScan` re-runs the full flow and
+        // converges. Without this ordering, a queue outage at this step leaves a clean
+        // artifact with no downstream submission-processing job.
+        const uploadArchiveService = new UploadArchiveService(this.connection);
+        const uploadArchive = await uploadArchiveService.getUploadArchiveByArtifactId(artifact.artifact_id);
+
         await this.publishNextPipelineStep(uploadArchive);
+
+        // Point-of-no-return: publish succeeded; now commit the CLEAN state and
+        // the irreversible S3 + archive writes.
+        await this.updateArtifactSecurity(artifactSecurityId, {
+          security: SecurityStatusEnum.CLEAN
+        });
+        await this.handleCleanScanResult(uploadArchive, artifact.object_key);
+      } else {
+        // INFECTED / ERROR / SKIPPED: no publish, no S3 promote, no archive unblock.
+        // Write the security status directly — no orphan risk on this branch.
+        await this.updateArtifactSecurity(artifactSecurityId, {
+          security: scanOutcome.securityStatus
+        });
       }
 
       return {

--- a/api/src/services/upload/upload-ingestion-service.test.ts
+++ b/api/src/services/upload/upload-ingestion-service.test.ts
@@ -498,5 +498,37 @@ describe('UploadIngestionService', () => {
         expect(publishStub.called).to.be.false;
       }
     });
+
+    describe('when publishMalwareScanJob throws', () => {
+      beforeEach(() => {
+        // Parent beforeEach pre-stubs publishMalwareScanJob to resolve;
+        // restore that stub and re-stub to reject so the publisher throws.
+        (UploadIngestionService.dependencies.publishMalwareScanJob as sinon.SinonStub).restore();
+        sinon
+          .stub(UploadIngestionService.dependencies, 'publishMalwareScanJob')
+          .rejects(new Error('pg-boss unavailable'));
+      });
+
+      it('throws when publishMalwareScanJob throws', async () => {
+        sinon.stub(UploadService.prototype, 'getUpload').resolves(mockUpload);
+        sinon.stub(UploadService.prototype, 'updateUpload').resolves({ upload_id: 'upload-456' });
+        sinon.stub(ArtifactService.prototype, 'updateArtifactsByUploadId').resolves();
+        sinon.stub(ArtifactSecurityService.prototype, 'insertArtifactSecurityByUploadId').resolves(mockSecurityRecords);
+        sinon.stub(UploadArchiveService.prototype, 'updateUploadArchivesByUploadId').resolves(mockUploadArchiveRecords);
+
+        const s3ClientStub = { send: sinon.stub().resolves({ ETag: 'etag' }) };
+        sinon
+          .stub(UploadIngestionService.dependencies, 'getSecurityS3Client')
+          .returns(s3ClientStub as unknown as S3Client);
+        sinon.stub(UploadIngestionService.dependencies, 'getSecurityObjectStoreBucketName').returns('security-bucket');
+
+        try {
+          await service.completeArchiveUpload(mockParams);
+          expect.fail('expected completeArchiveUpload to throw');
+        } catch (error) {
+          expect((error as Error).message).to.equal('pg-boss unavailable');
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-973](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-973)

## Description of Changes

**Acceptance criteria**

1. Publishers in `api/src/queue/publisher.ts` throw (do not swallow) when `boss.send` rejects; the existing structured error log is emitted before the rethrow.
2. PublishJobResult` is narrowed to `published | duplicate`; the `error` variant is removed from the type and from every call site.
4. Caller `services/upload/upload-ingestion-service.ts:232` is `await`ed.
5. Publisher unit tests assert that each publisher throws when `boss.send` rejects (prior `{ status: 'error' }` expectations flipped). Existing `published` / `duplicate` assertions still pass.
6. Each of the seven production call sites has an integration or route test asserting the DB row is not committed when its publisher throws, following the pattern at `api/src/paths/download/index.test.ts:260`.

## Testing Notes

- API internal changes
- Run all tests.
