### PR TITLE
SIMSBIOHUB-991: Fix Mock Telemetry Seed After Timestamp Column Split

### DIFF
--- a/database/src/seeds/04_mock_test_data.ts
+++ b/database/src/seeds/04_mock_test_data.ts
@@ -736,13 +736,13 @@ export const insertTelemetryRecord = async (
   );
 
   await knex.raw(
-    `INSERT INTO submission_feature_property_timestamp (submission_feature_id, feature_type_property_id, value, create_user)
-     SELECT sf.submission_feature_id, ftp.feature_type_property_id, ?::timestamptz, 1
+    `INSERT INTO submission_feature_property_timestamp (submission_feature_id, feature_type_property_id, date_value, time_value, create_user)
+     SELECT sf.submission_feature_id, ftp.feature_type_property_id, ?::timestamptz::date, ?::timestamptz::time, 1
      FROM submission_feature sf
      JOIN feature_type_property ftp ON ftp.feature_type_id = sf.feature_type_id AND ftp.record_end_date IS NULL
      JOIN feature_property fp ON fp.feature_property_id = ftp.feature_property_id AND fp.record_end_date IS NULL
      WHERE sf.submission_feature_id = ? AND sf.record_end_date IS NULL AND fp.name = 'timestamp';`,
-    [telemetryData.timestamp, submission_feature_id]
+    [telemetryData.timestamp, telemetryData.timestamp, submission_feature_id]
   );
 
   // Geometry: use the shared helper which targets `fp.name = 'geometry'`.


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-991](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-991)

## Description of Changes

`make web` fails on clean `dev` because seed `04_mock_test_data.ts` inserts into the dropped `submission_feature_property_timestamp.value` column.
 

**Acceptance Criteria**
 
`make clean && make web` succeeds 

