### PR TITLE
SIMSBIOHUB-992: Fix all references to `submission_feature_property_timestamp.value`

### DIFF
--- a/api/src/__integration__/db/download-parquet-pipeline.integration.ts
+++ b/api/src/__integration__/db/download-parquet-pipeline.integration.ts
@@ -19,6 +19,7 @@ import sinon from 'sinon';
 import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, getKnex, IDBConnection, initDBPool } from '../../database/db';
 import { ApiConflictError } from '../../errors/api-error';
+import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../../models/datetime-column';
 import { ParquetFeatureData } from '../../models/download';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { BaseFeatureRow, DownloadRepository } from '../../repositories/download/download-repository';
@@ -63,6 +64,13 @@ function assembleFeatureData(
       const propName = prop.feature_property_name;
       if (JSONB_FALLBACK_TYPES.has(prop.feature_property_type_name)) {
         data[propName] = baseRow.data?.properties?.[propName] ?? null;
+      } else if (prop.feature_property_type_name === 'datetime') {
+        // Mirror production hydrator: datetime properties are projected as two
+        // synthetic rows (`<prop>_date`, `<prop>_time`); write both keys.
+        const dateKey = `${propName}${DATETIME_DATE_SUFFIX}`;
+        const timeKey = `${propName}${DATETIME_TIME_SUFFIX}`;
+        data[dateKey] = typedProps[dateKey] ?? null;
+        data[timeKey] = typedProps[timeKey] ?? null;
       } else if (propName in typedProps) {
         data[propName] = typedProps[propName];
       } else {
@@ -177,8 +185,16 @@ describe('Download Parquet pipeline (integration)', function () {
          VALUES ($1, $2, ST_GeomFromGeoJSON($3), $4)`,
         [submissionFeatureId, featureTypePropertyId, value as string, systemUserId]
       );
+    } else if (tableName === 'submission_feature_property_timestamp') {
+      const ts = value as { date_value: string | null; time_value: string | null };
+      await connection.query(
+        `INSERT INTO submission_feature_property_timestamp
+           (submission_feature_id, feature_type_property_id, date_value, time_value, create_user)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [submissionFeatureId, featureTypePropertyId, ts.date_value, ts.time_value, systemUserId]
+      );
     } else {
-      // string, number, boolean, timestamp — all use a `value` column
+      // string, number, boolean — all use a `value` column
       await connection.query(
         `INSERT INTO ${tableName} (submission_feature_id, feature_type_property_id, value, create_user)
          VALUES ($1, $2, $3, $4)`,
@@ -455,12 +471,10 @@ describe('Download Parquet pipeline (integration)', function () {
 
       // Insert typed property rows for capture
       await insertTypedPropertyRow('submission_feature_property_string', captureFeatureId, 62, 'Test comment value');
-      await insertTypedPropertyRow(
-        'submission_feature_property_timestamp',
-        captureFeatureId,
-        51,
-        '2024-06-15T10:30:00Z'
-      );
+      await insertTypedPropertyRow('submission_feature_property_timestamp', captureFeatureId, 51, {
+        date_value: '2024-06-15',
+        time_value: '10:30:00'
+      });
 
       // Insert typed property row for measurement
       await insertTypedPropertyRow('submission_feature_property_number', measurementFeatureId, 29, 42.5);
@@ -475,7 +489,8 @@ describe('Download Parquet pipeline (integration)', function () {
       const captureRows = await streamAndHydrate(captureCartId, 'capture', captureProperties);
       expect(captureRows).to.have.length(1);
       expect(captureRows[0].data.comment).to.equal('Test comment value');
-      expect(captureRows[0].data.timestamp).to.not.be.null;
+      expect(captureRows[0].data.timestamp_date).to.equal('2024-06-15');
+      expect(captureRows[0].data.timestamp_time).to.equal('10:30:00');
 
       // Stream and hydrate measurement
       const measurementCartId = await createCartWithFeatures([measurementFeatureId]);
@@ -487,6 +502,45 @@ describe('Download Parquet pipeline (integration)', function () {
       expect(measurementRows).to.have.length(1);
       // NUMERIC comes back as JS number due to custom parser
       expect(Number(measurementRows[0].data.measurement_value)).to.equal(42.5);
+    });
+
+    it('hydrates a date-only timestamp into <prop>_date with <prop>_time null', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const captureFeatureId = await createTestFeature(connection, submissionId, 'capture', { comment: 'date-only' });
+      await insertTypedPropertyRow('submission_feature_property_timestamp', captureFeatureId, 51, {
+        date_value: '2024-06-15',
+        time_value: null
+      });
+
+      const cartId = await createCartWithFeatures([captureFeatureId]);
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'timestamp', feature_property_type_name: 'datetime' }
+      ];
+      const rows = await streamAndHydrate(cartId, 'capture', properties);
+
+      expect(rows).to.have.length(1);
+      expect(rows[0].data.timestamp_date).to.equal('2024-06-15');
+      // timestamp_time may be null (set by hydrator) or undefined (key never written) — accept both
+      expect(rows[0].data.timestamp_time ?? null).to.be.null;
+    });
+
+    it('hydrates a time-only timestamp into <prop>_time with <prop>_date null', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const captureFeatureId = await createTestFeature(connection, submissionId, 'capture', { comment: 'time-only' });
+      await insertTypedPropertyRow('submission_feature_property_timestamp', captureFeatureId, 51, {
+        date_value: null,
+        time_value: '10:30:00'
+      });
+
+      const cartId = await createCartWithFeatures([captureFeatureId]);
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'timestamp', feature_property_type_name: 'datetime' }
+      ];
+      const rows = await streamAndHydrate(cartId, 'capture', properties);
+
+      expect(rows).to.have.length(1);
+      expect(rows[0].data.timestamp_date ?? null).to.be.null;
+      expect(rows[0].data.timestamp_time).to.equal('10:30:00');
     });
 
     it('should resolve code property to contributor_codeset_code.label', async () => {
@@ -626,7 +680,9 @@ describe('Download Parquet pipeline (integration)', function () {
       const rows = await streamAndHydrate(cartId, 'capture', properties);
       expect(rows).to.have.length(1);
       expect(rows[0].data.comment).to.equal('Partial data');
-      expect(rows[0].data.timestamp).to.be.null;
+      // datetime expands to two keys; both null when no typed row exists
+      expect(rows[0].data.timestamp_date).to.be.null;
+      expect(rows[0].data.timestamp_time).to.be.null;
     });
 
     it('should fall back to JSONB for array properties', async () => {

--- a/api/src/__integration__/system/ingest-to-export.integration.ts
+++ b/api/src/__integration__/system/ingest-to-export.integration.ts
@@ -102,9 +102,16 @@ describe('Ingest → Download → Export (system integration)', function () {
         (${submissionFeatureId}, ${dopId}, ${data.dop}, ${systemUserId}),
         (${submissionFeatureId}, ${elevationId}, ${data.elevation}, ${systemUserId});
     `);
+    // The timestamp table stores partial-component datetimes — split the ISO
+    // string into date + time at the call site (the boundary that has the
+    // intent context). The repo doesn't coerce; the DB CHECK enforces
+    // at-least-one-non-null.
+    const dateValue = data.timestamp.slice(0, 10);
+    const timeValue = data.timestamp.slice(11, 19);
     await connection.sql(SQL`
-      INSERT INTO submission_feature_property_timestamp (submission_feature_id, feature_type_property_id, value, create_user)
-      VALUES (${submissionFeatureId}, ${timestampId}, ${data.timestamp}, ${systemUserId});
+      INSERT INTO submission_feature_property_timestamp
+        (submission_feature_id, feature_type_property_id, date_value, time_value, create_user)
+      VALUES (${submissionFeatureId}, ${timestampId}, ${dateValue}::date, ${timeValue}::time, ${systemUserId});
     `);
     // Geometry uses ST_GeomFromGeoJSON; pass the inner Feature.geometry, not the FeatureCollection wrapper.
     const innerGeom = (data.geometry as any)?.features?.[0]?.geometry ?? data.geometry;
@@ -199,7 +206,10 @@ describe('Ingest → Download → Export (system integration)', function () {
     // System columns lead so consumers can join cross-file (uuid, parent_uuid)
     // and trace back to the platform UI (submission_feature_id).
     expect(header).to.include.members(['submission_feature_id', 'uuid', 'parent_uuid']);
-    expect(header).to.include.members(['dop', 'elevation', 'timestamp', 'geometry']);
+    // `datetime` properties expand into two output columns (`<prop>_date`,
+    // `<prop>_time`) so partial-component values remain first-class for
+    // columnar predicate pushdown.
+    expect(header).to.include.members(['dop', 'elevation', 'timestamp_date', 'timestamp_time', 'geometry']);
 
     const row = lines[1].split(',');
     const col = (name: string): string => row[header.indexOf(name)];
@@ -213,7 +223,10 @@ describe('Ingest → Download → Export (system integration)', function () {
 
     expect(col('dop'), 'dop should round-trip the ingested number').to.equal('4.2');
     expect(col('elevation'), 'elevation should round-trip the ingested number').to.equal('1234.5');
-    expect(col('timestamp'), 'timestamp should round-trip the ingested ISO string').to.contain('2026-04-24T12:34:56');
+    expect(col('timestamp_date'), 'timestamp_date should round-trip the ingested date component').to.equal(
+      '2026-04-24'
+    );
+    expect(col('timestamp_time'), 'timestamp_time should round-trip the ingested time component').to.equal('12:34:56');
     // Geometry is emitted as a single WKT column (per Phase 5 of plan-review-fixes).
     expect(col('geometry'), 'geometry should be a Point WKT').to.match(/^POINT\(-123\.1234\s+49\.5678\)$/);
   });

--- a/api/src/models/datetime-column.test.ts
+++ b/api/src/models/datetime-column.test.ts
@@ -33,11 +33,7 @@ describe('datetime-column', () => {
         { feature_property_name: 'observation_date', feature_property_type_name: 'string' }
       ];
 
-      expect(() => assertNoDatetimeColumnCollisions(properties))
-        .to.throw(Error)
-        .with.property('message')
-        .that.matches(/observation/)
-        .and.matches(/observation_date/);
+      expect(() => assertNoDatetimeColumnCollisions(properties)).to.throw(/observation_date/);
     });
 
     it('should throw when a datetime expansion collides with a sibling _time property', () => {

--- a/api/src/models/datetime-column.test.ts
+++ b/api/src/models/datetime-column.test.ts
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { assertNoDatetimeColumnCollisions } from './datetime-column';
+
+describe('datetime-column', () => {
+  describe('assertNoDatetimeColumnCollisions', () => {
+    it('should not throw for a clean property list', () => {
+      const properties = [
+        { feature_property_name: 'name', feature_property_type_name: 'string' },
+        { feature_property_name: 'observation', feature_property_type_name: 'datetime' },
+        { feature_property_name: 'count', feature_property_type_name: 'number' }
+      ];
+
+      expect(() => assertNoDatetimeColumnCollisions(properties)).to.not.throw();
+    });
+
+    it('should not throw for a datetime property whose name itself ends in _date', () => {
+      // A datetime property named `start_date` expands to `start_date_date` /
+      // `start_date_time`. Neither matches `start_date` itself, so there's no
+      // self-collision. Live data has `start_date` and `end_date` — must not flag.
+      const properties = [
+        { feature_property_name: 'start_date', feature_property_type_name: 'datetime' },
+        { feature_property_name: 'end_date', feature_property_type_name: 'datetime' }
+      ];
+
+      expect(() => assertNoDatetimeColumnCollisions(properties)).to.not.throw();
+    });
+
+    it('should throw when a datetime expansion collides with a sibling _date property', () => {
+      const properties = [
+        { feature_property_name: 'observation', feature_property_type_name: 'datetime' },
+        { feature_property_name: 'observation_date', feature_property_type_name: 'string' }
+      ];
+
+      expect(() => assertNoDatetimeColumnCollisions(properties))
+        .to.throw(Error)
+        .with.property('message')
+        .that.matches(/observation/)
+        .and.matches(/observation_date/);
+    });
+
+    it('should throw when a datetime expansion collides with a sibling _time property', () => {
+      const properties = [
+        { feature_property_name: 'observation', feature_property_type_name: 'datetime' },
+        { feature_property_name: 'observation_time', feature_property_type_name: 'number' }
+      ];
+
+      expect(() => assertNoDatetimeColumnCollisions(properties)).to.throw(/observation_time/);
+    });
+
+    it('should throw when two datetime properties collide via expansion', () => {
+      // datetime `obs` → expands to `obs_date` / `obs_time`. datetime `obs_date`
+      // is a real property whose name matches the first's expansion. Last-write-
+      // wins in the SQL UNION would corrupt both.
+      const properties = [
+        { feature_property_name: 'obs', feature_property_type_name: 'datetime' },
+        { feature_property_name: 'obs_date', feature_property_type_name: 'datetime' }
+      ];
+
+      expect(() => assertNoDatetimeColumnCollisions(properties)).to.throw(/obs_date/);
+    });
+
+    it('should not throw for an empty property list', () => {
+      expect(() => assertNoDatetimeColumnCollisions([])).to.not.throw();
+    });
+
+    it('should not throw for a list with only non-datetime properties', () => {
+      // Even with `_date` / `_time` suffixed names, no expansion happens without
+      // a datetime property — so no collision is possible.
+      const properties = [
+        { feature_property_name: 'sample_date', feature_property_type_name: 'string' },
+        { feature_property_name: 'sample_time', feature_property_type_name: 'string' }
+      ];
+
+      expect(() => assertNoDatetimeColumnCollisions(properties)).to.not.throw();
+    });
+  });
+});

--- a/api/src/models/datetime-column.ts
+++ b/api/src/models/datetime-column.ts
@@ -13,3 +13,45 @@
  */
 export const DATETIME_DATE_SUFFIX = '_date';
 export const DATETIME_TIME_SUFFIX = '_time';
+
+/**
+ * Throw if any datetime property's expanded synthetic columns
+ * (`<name>_date`, `<name>_time`) collide with another property's name in the
+ * same feature_type schema.
+ *
+ * Example collision: a feature_type with datetime `observation` AND string
+ * `observation_date`. The synthetic key `observation_date` would shadow the
+ * real string property — last-write-wins in the SQL UNION ALL projection,
+ * the hydrator's key map, and the Parquet/CSV schema field assignment. The
+ * shadowing is silent and corrupts the export.
+ *
+ * Called at schema-build time so a misconfigured feature_type fails loud
+ * before any row is hydrated. Live data is collision-free at the time this
+ * check was added; the validator is forward-looking — any future
+ * configuration that introduces the conflict is rejected here rather than
+ * surfacing as garbled cells.
+ *
+ * @throws Error naming both colliding property names.
+ */
+export function assertNoDatetimeColumnCollisions(
+  properties: ReadonlyArray<{ feature_property_name: string; feature_property_type_name: string }>
+): void {
+  const allNames = new Set(properties.map((p) => p.feature_property_name));
+
+  for (const prop of properties) {
+    if (prop.feature_property_type_name !== 'datetime') {
+      continue;
+    }
+
+    for (const suffix of [DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX]) {
+      const expanded = `${prop.feature_property_name}${suffix}`;
+      if (allNames.has(expanded)) {
+        throw new Error(
+          `datetime property '${prop.feature_property_name}' expands to synthetic column ` +
+            `'${expanded}', which collides with another property of the same name in the ` +
+            `same feature_type. Rename one of the two properties.`
+        );
+      }
+    }
+  }
+}

--- a/api/src/models/datetime-column.ts
+++ b/api/src/models/datetime-column.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared suffix constants for `datetime` feature properties expanded into two
+ * output columns. Used by:
+ *   - the SQL projection in `download-repository.ts` `fetchTypedPropertyRows`
+ *     `datetime` branch (synthetic row `name` values), and
+ *   - the column-expansion helper in `parquet-utils.ts` (Parquet schema +
+ *     row writer + CSV writer).
+ *
+ * Both sites must produce the same column names for the same input property
+ * or hydrated data lands under one key while the writer reads from another,
+ * silently nulling the cell. Importing from a single source eliminates that
+ * regression class.
+ */
+export const DATETIME_DATE_SUFFIX = '_date';
+export const DATETIME_TIME_SUFFIX = '_time';

--- a/api/src/models/submission-feature-property-timestamp.ts
+++ b/api/src/models/submission-feature-property-timestamp.ts
@@ -1,10 +1,22 @@
 import { z } from 'zod';
 
+/**
+ * Zod schema for `submission_feature_property_timestamp` rows.
+ *
+ * The table stores partial-component datetime values: a row may have a date, a time, or both. The
+ * DB CHECK constraint guarantees at least one of `date_value` / `time_value` is non-null. Both
+ * fields are nullable in the model so partial-component rows pass through without coercion;
+ * callers that need a complete `Date` must handle null components.
+ *
+ * Postgres returns `DATE` as `'YYYY-MM-DD'` and `TIME WITHOUT TIME ZONE` as `'HH:MM:SS'` strings
+ * (no special pg parser is installed for these types in `db.ts`).
+ */
 export const SubmissionFeaturePropertyTimestampSchema = z.object({
   submission_feature_property_timestamp_id: z.number().int(),
   submission_feature_id: z.number().int(),
   feature_type_property_id: z.number().int(),
-  value: z.string()
+  date_value: z.string().nullable(),
+  time_value: z.string().nullable()
 });
 
 export type SubmissionFeaturePropertyTimestamp = z.infer<typeof SubmissionFeaturePropertyTimestampSchema>;
@@ -12,5 +24,6 @@ export type SubmissionFeaturePropertyTimestamp = z.infer<typeof SubmissionFeatur
 export interface CreateSubmissionFeaturePropertyTimestamp {
   submission_feature_id: number;
   feature_type_property_id: number;
-  value: string;
+  date_value: string | null;
+  time_value: string | null;
 }

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -804,6 +804,31 @@ describe('DownloadRepository', () => {
       expect(taxonQuery).to.not.be.undefined;
     });
 
+    it('expands datetime into UNION ALL of _date and _time arms over the timestamp table', async () => {
+      const queryStub = sinon.stub();
+      queryStub.resolves({ rows: [] });
+
+      const mockDBConnection = getMockDBConnection({ query: queryStub });
+      const repo = new DownloadRepository(mockDBConnection);
+
+      await repo.fetchTypedPropertyRows([1], ['datetime']);
+
+      const datetimeQuery = queryStub
+        .getCalls()
+        .map((c) => String(c.args[0]))
+        .find((sql) => sql.includes('submission_feature_property_timestamp'));
+      expect(datetimeQuery, 'expected datetime branch query').to.not.be.undefined;
+      // The split read projection: each component is filtered to non-null and aliased
+      // with the suffixed name. Two arms joined by UNION ALL preserve partial-component data.
+      expect(datetimeQuery).to.include('date_value');
+      expect(datetimeQuery).to.include('time_value');
+      expect(datetimeQuery).to.include('_date');
+      expect(datetimeQuery).to.include('_time');
+      expect(datetimeQuery).to.include('UNION ALL');
+      // The old `p.value` reference must be gone — the timestamp table no longer has that column.
+      expect(/\bp\.value\b/.test(datetimeQuery!), 'datetime SQL must not reference p.value').to.be.false;
+    });
+
     it('uses ST_AsGeoJSON for spatial properties', async () => {
       const queryStub = sinon.stub();
       const geoJson = { type: 'Point', coordinates: [-123.5, 48.4] };

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { DOWNLOAD_FEATURE_BATCH_SIZE } from '../../constants/download';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError, ApiNotFoundError } from '../../errors/api-error';
+import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../../models/datetime-column';
 import {
   CreateDownload,
   DownloadArtifactInfo,
@@ -822,11 +823,35 @@ export class DownloadRepository extends BaseRepository {
                 INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id
                 INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
                 WHERE p.submission_feature_id = ANY($1)`,
-      datetime: `SELECT p.submission_feature_id, fp.name, p.value
+      // `datetime` emits up to two synthetic rows per source row, with the
+      // property name suffixed `_date` / `_time`. A row with both components
+      // populated produces two rows; a partial-component row produces one.
+      // The Parquet schema/writer and CSV writer expand each `datetime`
+      // property into matching `<prop>_date` / `<prop>_time` columns, so
+      // `assembleFeatureData` merges these synthetic rows under the same
+      // suffixed keys without special-casing.
+      //
+      // Two columns rather than one combined `TIMESTAMP_MILLIS` because
+      // Parquet/CSV are query substrates: partial components must remain
+      // first-class for predicate pushdown (DuckDB filters by date-of or
+      // time-of without parsing a string). The DB schema split into
+      // `date_value` / `time_value` was driven by the same first-class-
+      // partials rule on the read side.
+      //
+      // Suffix constants live in `models/datetime-column.ts` and are shared
+      // with `parquet-utils.ts`. The two sites must produce identical column
+      // names — drift silently nulls cells.
+      datetime: `SELECT p.submission_feature_id, fp.name || '${DATETIME_DATE_SUFFIX}' AS name, to_char(p.date_value, 'YYYY-MM-DD') AS value
                  FROM submission_feature_property_timestamp p
                  INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id
                  INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
-                 WHERE p.submission_feature_id = ANY($1)`,
+                 WHERE p.submission_feature_id = ANY($1) AND p.date_value IS NOT NULL
+                 UNION ALL
+                 SELECT p.submission_feature_id, fp.name || '${DATETIME_TIME_SUFFIX}' AS name, to_char(p.time_value, 'HH24:MI:SS') AS value
+                 FROM submission_feature_property_timestamp p
+                 INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id
+                 INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
+                 WHERE p.submission_feature_id = ANY($1) AND p.time_value IS NOT NULL`,
       code: `SELECT p.submission_feature_id, fp.name, ccc.label AS value
              FROM submission_feature_property_code p
              INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id

--- a/api/src/repositories/submission-feature-property-timestamp-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-timestamp-repository.test.ts
@@ -15,7 +15,8 @@ describe('SubmissionFeaturePropertyTimestampRepository', () => {
     submission_feature_property_timestamp_id: 1,
     submission_feature_id: 10,
     feature_type_property_id: 20,
-    value: '2026-01-01T00:00:00.000Z'
+    date_value: '2026-01-01',
+    time_value: '00:00:00'
   };
 
   describe('insert', () => {
@@ -26,7 +27,8 @@ describe('SubmissionFeaturePropertyTimestampRepository', () => {
       const result = await repository.insertSubmissionFeaturePropertyTimestamp({
         submission_feature_id: 10,
         feature_type_property_id: 20,
-        value: '2026-01-01T00:00:00.000Z'
+        date_value: '2026-01-01',
+        time_value: '00:00:00'
       });
 
       expect(result).to.eql(mockRow);
@@ -40,7 +42,8 @@ describe('SubmissionFeaturePropertyTimestampRepository', () => {
         await repository.insertSubmissionFeaturePropertyTimestamp({
           submission_feature_id: 10,
           feature_type_property_id: 20,
-          value: '2026-01-01T00:00:00.000Z'
+          date_value: '2026-01-01',
+          time_value: '00:00:00'
         });
         expect.fail();
       } catch (error) {

--- a/api/src/repositories/submission-feature-property-timestamp-repository.ts
+++ b/api/src/repositories/submission-feature-property-timestamp-repository.ts
@@ -11,6 +11,10 @@ export class SubmissionFeaturePropertyTimestampRepository extends BaseRepository
   /**
    * Insert a submission_feature_property_timestamp row.
    *
+   * Caller is responsible for splitting any JS `Date` / `dayjs` value into the two component
+   * fields before calling. The DB CHECK constraint enforces "at least one component non-null" —
+   * if both are null the SQL surfaces the error; the repository does not pre-check.
+   *
    * @param {CreateSubmissionFeaturePropertyTimestamp} payload
    * @return {Promise<SubmissionFeaturePropertyTimestamp>}
    * @memberof SubmissionFeaturePropertyTimestampRepository
@@ -25,7 +29,8 @@ export class SubmissionFeaturePropertyTimestampRepository extends BaseRepository
         'submission_feature_property_timestamp_id',
         'submission_feature_id',
         'feature_type_property_id',
-        'value'
+        'date_value',
+        'time_value'
       ]);
 
     const response = await this.connection.knex(query, SubmissionFeaturePropertyTimestampSchema);
@@ -56,7 +61,8 @@ export class SubmissionFeaturePropertyTimestampRepository extends BaseRepository
         'submission_feature_property_timestamp_id',
         'submission_feature_id',
         'feature_type_property_id',
-        'value'
+        'date_value',
+        'time_value'
       ])
       .where('submission_feature_property_timestamp_id', submissionFeaturePropertyTimestampId);
 
@@ -95,7 +101,8 @@ export class SubmissionFeaturePropertyTimestampRepository extends BaseRepository
         'submission_feature_property_timestamp_id',
         'submission_feature_id',
         'feature_type_property_id',
-        'value'
+        'date_value',
+        'time_value'
       ])
       .where('submission_feature_id', submissionFeatureId);
 
@@ -120,7 +127,8 @@ export class SubmissionFeaturePropertyTimestampRepository extends BaseRepository
         'submission_feature_property_timestamp_id',
         'submission_feature_id',
         'feature_type_property_id',
-        'value'
+        'date_value',
+        'time_value'
       ])
       .where('feature_type_property_id', featureTypePropertyId);
 

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -3,6 +3,7 @@ import { PassThrough } from 'node:stream';
 import { IDBConnection } from '../../database/db';
 import { ApiConflictError } from '../../errors/api-error';
 import { ArtifactStatusEnum } from '../../models/artifact';
+import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../../models/datetime-column';
 import { DownloadRecord, DownloadSource, ParquetFeatureData } from '../../models/download';
 import { DownloadStatusEnum } from '../../models/download-status';
 import { BaseFeatureRow, DownloadRepository } from '../../repositories/download/download-repository';
@@ -320,6 +321,18 @@ export class DownloadPipelineService extends DBService {
         if (JSONB_FALLBACK_TYPES.has(prop.feature_property_type_name)) {
           // Array/object/artifact_key: fall back to JSONB data.properties
           data[propName] = baseRow.data?.properties?.[propName] ?? null;
+        } else if (prop.feature_property_type_name === 'datetime') {
+          // `datetime` properties are projected as two synthetic rows by
+          // `fetchTypedPropertyRows` with suffixed `name` values
+          // (`<prop>_date`, `<prop>_time`). The hydrator mirrors that
+          // expansion: each datetime property writes two `data` keys, one or
+          // both of which may be null for partial-component rows. Suffix
+          // constants live in `models/datetime-column.ts`; the SQL projection
+          // uses the same constants — drift silently nulls cells.
+          const dateKey = `${propName}${DATETIME_DATE_SUFFIX}`;
+          const timeKey = `${propName}${DATETIME_TIME_SUFFIX}`;
+          data[dateKey] = typedProps[dateKey] ?? null;
+          data[timeKey] = typedProps[timeKey] ?? null;
         } else if (propName in typedProps) {
           data[propName] = typedProps[propName];
         } else {

--- a/api/src/services/submission-feature-property-timestamp-service.test.ts
+++ b/api/src/services/submission-feature-property-timestamp-service.test.ts
@@ -75,17 +75,4 @@ describe('SubmissionFeaturePropertyTimestampService', () => {
     expect(stub).to.have.been.calledOnceWith(20);
     expect(result).to.eql([mockRow]);
   });
-  it('propagates repository errors', async () => {
-    const service = new SubmissionFeaturePropertyTimestampService(getMockDBConnection());
-    sinon
-      .stub(SubmissionFeaturePropertyTimestampRepository.prototype, 'insertSubmissionFeaturePropertyTimestamp')
-      .rejects(new Error('DB error'));
-
-    try {
-      await service.createSubmissionFeaturePropertyTimestamp(createPayload);
-      expect.fail('Expected error to be thrown');
-    } catch (error) {
-      expect((error as Error).message).to.equal('DB error');
-    }
-  });
 });

--- a/api/src/services/submission-feature-property-timestamp-service.test.ts
+++ b/api/src/services/submission-feature-property-timestamp-service.test.ts
@@ -20,13 +20,15 @@ describe('SubmissionFeaturePropertyTimestampService', () => {
     submission_feature_property_timestamp_id: 1,
     submission_feature_id: 10,
     feature_type_property_id: 20,
-    value: '2026-01-01T00:00:00.000Z'
+    date_value: '2026-01-01',
+    time_value: '00:00:00'
   };
 
   const createPayload: CreateSubmissionFeaturePropertyTimestamp = {
     submission_feature_id: 10,
     feature_type_property_id: 20,
-    value: '2026-01-01T00:00:00.000Z'
+    date_value: '2026-01-01',
+    time_value: '00:00:00'
   };
   it('delegates create', async () => {
     const service = new SubmissionFeaturePropertyTimestampService(getMockDBConnection());

--- a/api/src/utils/csv-utils.test.ts
+++ b/api/src/utils/csv-utils.test.ts
@@ -279,6 +279,17 @@ describe('csv-utils', () => {
       expect(result).to.deep.equal(['observed_at_date', 'observed_at_time']);
       expect(result).to.not.include('observed_at');
     });
+
+    it('should throw when a datetime expansion collides with a sibling property name', () => {
+      // Schema-build is the gate for collision detection; downstream consumers
+      // (flattener) trust the validated list.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observation', feature_property_type_name: 'datetime' },
+        { feature_property_name: 'observation_time', feature_property_type_name: 'number' }
+      ];
+
+      expect(() => buildSchemaHeaders(properties)).to.throw(/observation_time/);
+    });
   });
 
   describe('buildCombinedHeaders', () => {
@@ -481,6 +492,37 @@ describe('csv-utils', () => {
         observed_at_date: '',
         observed_at_time: '13:45:00'
       });
+    });
+
+    it('should format Date and millisecond inputs from a Parquet round-trip back to canonical strings', () => {
+      // parquetjs returns Date (UTC midnight) for native DATE columns and ms-since-midnight
+      // numbers for TIME_MILLIS columns. Both must normalize back to the SQL projection's
+      // canonical strings — without this branch the generic toStringOrEmpty path would
+      // JSON-stringify the Date and render the raw ms count.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observed_at', feature_property_type_name: 'datetime' }
+      ];
+      // 13:45:00 → (13*3600 + 45*60) * 1000 = 49_500_000.
+      const data = { observed_at_date: new Date('2024-06-15T00:00:00Z'), observed_at_time: 49_500_000 };
+
+      const result = flattenFeatureBySchema(data, properties, 100);
+
+      expect(result).to.deep.equal({
+        observed_at_date: '2024-06-15',
+        observed_at_time: '13:45:00'
+      });
+    });
+
+    it('should zero-pad single-digit components when formatting a TIME_MILLIS millisecond input', () => {
+      // 04:05:06 → (4*3600 + 5*60 + 6) * 1000 = 14_706_000.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observed_at', feature_property_type_name: 'datetime' }
+      ];
+      const data = { observed_at_date: null, observed_at_time: 14_706_000 };
+
+      const result = flattenFeatureBySchema(data, properties, 100);
+
+      expect(result.observed_at_time).to.equal('04:05:06');
     });
 
     it('should flatten arrays with semicolons', () => {

--- a/api/src/utils/csv-utils.test.ts
+++ b/api/src/utils/csv-utils.test.ts
@@ -268,6 +268,17 @@ describe('csv-utils', () => {
 
       expect(buildSchemaHeaders(properties)).to.deep.equal(['description', 'geometry', 'centroid', 'name']);
     });
+
+    it('should expand a datetime property into two suffixed columns (no bare column)', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observed_at', feature_property_type_name: 'datetime' }
+      ];
+
+      const result = buildSchemaHeaders(properties);
+
+      expect(result).to.deep.equal(['observed_at_date', 'observed_at_time']);
+      expect(result).to.not.include('observed_at');
+    });
   });
 
   describe('buildCombinedHeaders', () => {
@@ -283,12 +294,14 @@ describe('csv-utils', () => {
 
       const result = buildCombinedHeaders(parentProperties, childProperties, ['dataset_name', 'dataset_id']);
 
+      // datetime expands into two suffixed columns; the bare `timestamp` is gone.
       expect(result).to.deep.equal([
         'dataset_name',
         'dataset_id',
         'device_key',
         'animal_identifier',
-        'timestamp',
+        'timestamp_date',
+        'timestamp_time',
         'geometry'
       ]);
     });
@@ -313,7 +326,7 @@ describe('csv-utils', () => {
 
       const result = buildCombinedHeaders(parentProperties, childProperties);
 
-      expect(result).to.deep.equal(['device_key', 'timestamp']);
+      expect(result).to.deep.equal(['device_key', 'timestamp_date', 'timestamp_time']);
     });
 
     it('should return only child headers when no parent and no system headers', () => {
@@ -338,14 +351,16 @@ describe('csv-utils', () => {
         { feature_property_name: 'temperature', feature_property_type_name: 'number' }
       ];
       const parentData = { device_key: 'TAG-001', animal_identifier: 'M12345' };
-      const childData = { timestamp: '2024-01-01T12:00:00Z', temperature: 22.5 };
+      // datetime arrives hydrated as two suffixed keys, not a combined ISO string.
+      const childData = { timestamp_date: '2024-01-01', timestamp_time: '12:00:00', temperature: 22.5 };
 
       const result = flattenFeatureWithParent(childData, childProperties, parentData, parentProperties, 100);
 
       expect(result).to.deep.equal({
         device_key: 'TAG-001',
         animal_identifier: 'M12345',
-        timestamp: '2024-01-01T12:00:00Z',
+        timestamp_date: '2024-01-01',
+        timestamp_time: '12:00:00',
         temperature: '22.5'
       });
     });
@@ -406,15 +421,65 @@ describe('csv-utils', () => {
         { feature_property_name: 'timestamp', feature_property_type_name: 'datetime' },
         { feature_property_name: 'active', feature_property_type_name: 'boolean' }
       ];
-      const data = { name: 'Bear', count: 5, timestamp: '2024-01-01T00:00:00Z', active: true };
+      // datetime is hydrated as two suffixed keys; the flattener pulls each cell directly.
+      const data = {
+        name: 'Bear',
+        count: 5,
+        timestamp_date: '2024-01-01',
+        timestamp_time: '00:00:00',
+        active: true
+      };
 
       const result = flattenFeatureBySchema(data, properties, 100);
 
       expect(result).to.deep.equal({
         name: 'Bear',
         count: '5',
-        timestamp: '2024-01-01T00:00:00Z',
+        timestamp_date: '2024-01-01',
+        timestamp_time: '00:00:00',
         active: 'true'
+      });
+    });
+
+    it('should emit two cells (date + time) for a datetime property with both components set', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observed_at', feature_property_type_name: 'datetime' }
+      ];
+      const data = { observed_at_date: '2024-06-15', observed_at_time: '13:45:00' };
+
+      const result = flattenFeatureBySchema(data, properties, 100);
+
+      expect(result).to.deep.equal({
+        observed_at_date: '2024-06-15',
+        observed_at_time: '13:45:00'
+      });
+    });
+
+    it('should emit empty string for the missing component of a date-only datetime', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observed_at', feature_property_type_name: 'datetime' }
+      ];
+      const data = { observed_at_date: '2024-06-15', observed_at_time: null };
+
+      const result = flattenFeatureBySchema(data, properties, 100);
+
+      expect(result).to.deep.equal({
+        observed_at_date: '2024-06-15',
+        observed_at_time: ''
+      });
+    });
+
+    it('should emit empty string for the missing component of a time-only datetime', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observed_at', feature_property_type_name: 'datetime' }
+      ];
+      const data = { observed_at_date: null, observed_at_time: '13:45:00' };
+
+      const result = flattenFeatureBySchema(data, properties, 100);
+
+      expect(result).to.deep.equal({
+        observed_at_date: '',
+        observed_at_time: '13:45:00'
       });
     });
 

--- a/api/src/utils/csv-utils.ts
+++ b/api/src/utils/csv-utils.ts
@@ -41,8 +41,10 @@ export function buildSchemaHeaders(properties: CsvPropertyDefinition[]): string[
     if (prop.feature_property_type_name === 'artifact_key') {
       headers.push('filePath');
     } else if (prop.feature_property_type_name === 'datetime') {
-      headers.push(`${prop.feature_property_name}${DATETIME_DATE_SUFFIX}`);
-      headers.push(`${prop.feature_property_name}${DATETIME_TIME_SUFFIX}`);
+      headers.push(
+        `${prop.feature_property_name}${DATETIME_DATE_SUFFIX}`,
+        `${prop.feature_property_name}${DATETIME_TIME_SUFFIX}`
+      );
     } else {
       headers.push(prop.feature_property_name);
     }
@@ -197,7 +199,7 @@ function formatDatetimeDateCell(value: unknown): string {
   if (value instanceof Date) {
     return value.toISOString().slice(0, 10);
   }
-  return String(value);
+  return typeof value === 'string' ? value : '';
 }
 
 /**
@@ -222,7 +224,7 @@ function formatDatetimeTimeCell(value: unknown): string {
     const ss = totalSeconds % 60;
     return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
   }
-  return String(value);
+  return typeof value === 'string' ? value : '';
 }
 
 /**

--- a/api/src/utils/csv-utils.ts
+++ b/api/src/utils/csv-utils.ts
@@ -6,6 +6,7 @@
 import wkx from 'wkx';
 
 import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../models/datetime-column';
+import { parquetDateToString, parquetTimeMillisToString } from './parquet-utils';
 
 export interface CsvPropertyDefinition {
   feature_property_name: string;
@@ -135,10 +136,18 @@ export function flattenFeatureBySchema(
 
   for (const prop of properties) {
     if (prop.feature_property_type_name === 'datetime') {
+      // The CSV is written from rows the Parquet reader returns. parquetjs reads
+      // `DATE` columns as JS `Date` objects (UTC midnight on the stored day) and
+      // `TIME_MILLIS` columns as raw millisecond integers. Both must be
+      // formatted back into the canonical `'YYYY-MM-DD'` / `'HH:MM:SS'` strings
+      // the SQL projection produced — otherwise the generic `toStringOrEmpty`
+      // path would JSON-stringify the Date (`'"2026-04-24T00:00:00.000Z"'`)
+      // and render the raw ms count for time. Strings still pass through
+      // unchanged for callers that haven't gone through Parquet.
       const dateKey = `${prop.feature_property_name}${DATETIME_DATE_SUFFIX}`;
       const timeKey = `${prop.feature_property_name}${DATETIME_TIME_SUFFIX}`;
-      result[dateKey] = toStringOrEmpty(data[dateKey]);
-      result[timeKey] = toStringOrEmpty(data[timeKey]);
+      result[dateKey] = formatDatetimeDateCell(data[dateKey]);
+      result[timeKey] = formatDatetimeTimeCell(data[timeKey]);
       continue;
     }
 
@@ -164,6 +173,38 @@ export function flattenFeatureBySchema(
   }
 
   return result;
+}
+
+/**
+ * Format a `<prop>_date` cell value for CSV output. parquetjs hands back a
+ * `Date` (UTC midnight) for native `DATE` columns; the SQL projection emits a
+ * `'YYYY-MM-DD'` string when CSV is fed directly without a Parquet round-trip.
+ * Either form normalizes to the canonical date string. Null/undefined → empty.
+ */
+function formatDatetimeDateCell(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return parquetDateToString(value);
+  }
+  return String(value as string);
+}
+
+/**
+ * Format a `<prop>_time` cell value for CSV output. parquetjs hands back a
+ * raw millisecond integer for native `TIME_MILLIS` columns; the SQL projection
+ * emits a `'HH:MM:SS'` string when CSV is fed directly. Either form normalizes
+ * to the canonical time string. Null/undefined → empty.
+ */
+function formatDatetimeTimeCell(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+  if (typeof value === 'number') {
+    return parquetTimeMillisToString(value);
+  }
+  return String(value as string);
 }
 
 /**

--- a/api/src/utils/csv-utils.ts
+++ b/api/src/utils/csv-utils.ts
@@ -5,8 +5,11 @@
  */
 import wkx from 'wkx';
 
-import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../models/datetime-column';
-import { parquetDateToString, parquetTimeMillisToString } from './parquet-utils';
+import {
+  assertNoDatetimeColumnCollisions,
+  DATETIME_DATE_SUFFIX,
+  DATETIME_TIME_SUFFIX
+} from '../models/datetime-column';
 
 export interface CsvPropertyDefinition {
   feature_property_name: string;
@@ -30,6 +33,8 @@ export interface CsvPropertyDefinition {
  * @returns {string[]} Ordered header names.
  */
 export function buildSchemaHeaders(properties: CsvPropertyDefinition[]): string[] {
+  assertNoDatetimeColumnCollisions(properties);
+
   const headers: string[] = [];
 
   for (const prop of properties) {
@@ -180,15 +185,19 @@ export function flattenFeatureBySchema(
  * `Date` (UTC midnight) for native `DATE` columns; the SQL projection emits a
  * `'YYYY-MM-DD'` string when CSV is fed directly without a Parquet round-trip.
  * Either form normalizes to the canonical date string. Null/undefined → empty.
+ *
+ * The Date branch matches the original SQL projection's
+ * `to_char(date_value, 'YYYY-MM-DD')` output exactly — without it, the
+ * generic `toStringOrEmpty` path would JSON-stringify the Date (`'"2026-04-24T00:00:00.000Z"'`).
  */
 function formatDatetimeDateCell(value: unknown): string {
   if (value == null) {
     return '';
   }
   if (value instanceof Date) {
-    return parquetDateToString(value);
+    return value.toISOString().slice(0, 10);
   }
-  return String(value as string);
+  return String(value);
 }
 
 /**
@@ -196,15 +205,24 @@ function formatDatetimeDateCell(value: unknown): string {
  * raw millisecond integer for native `TIME_MILLIS` columns; the SQL projection
  * emits a `'HH:MM:SS'` string when CSV is fed directly. Either form normalizes
  * to the canonical time string. Null/undefined → empty.
+ *
+ * The number branch matches the original SQL projection's
+ * `to_char(time_value, 'HH24:MI:SS')` output exactly — without it, the
+ * generic `toStringOrEmpty` path would render the raw integer count
+ * (e.g. `'45296000'`).
  */
 function formatDatetimeTimeCell(value: unknown): string {
   if (value == null) {
     return '';
   }
   if (typeof value === 'number') {
-    return parquetTimeMillisToString(value);
+    const totalSeconds = Math.floor(value / 1000);
+    const hh = Math.floor(totalSeconds / 3600);
+    const mm = Math.floor((totalSeconds % 3600) / 60);
+    const ss = totalSeconds % 60;
+    return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
   }
-  return String(value as string);
+  return String(value);
 }
 
 /**

--- a/api/src/utils/csv-utils.ts
+++ b/api/src/utils/csv-utils.ts
@@ -5,6 +5,8 @@
  */
 import wkx from 'wkx';
 
+import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../models/datetime-column';
+
 export interface CsvPropertyDefinition {
   feature_property_name: string;
   feature_property_type_name: string;
@@ -17,6 +19,12 @@ export interface CsvPropertyDefinition {
  * the cell value is WKT (decoded from the Parquet WKB buffer at flatten
  * time). artifact_key properties map to a single `filePath` column.
  *
+ * `datetime` properties emit two columns (`<prop>_date`, `<prop>_time`) so
+ * partial-component data (date-only, time-only, or both) round-trips
+ * losslessly and remains queryable as native columnar predicates. The
+ * suffix convention is shared with the SQL projection and the Parquet
+ * column expansion — all three sites must agree on the names.
+ *
  * @param {CsvPropertyDefinition[]} properties - Schema property definitions.
  * @returns {string[]} Ordered header names.
  */
@@ -26,6 +34,9 @@ export function buildSchemaHeaders(properties: CsvPropertyDefinition[]): string[
   for (const prop of properties) {
     if (prop.feature_property_type_name === 'artifact_key') {
       headers.push('filePath');
+    } else if (prop.feature_property_type_name === 'datetime') {
+      headers.push(`${prop.feature_property_name}${DATETIME_DATE_SUFFIX}`);
+      headers.push(`${prop.feature_property_name}${DATETIME_TIME_SUFFIX}`);
     } else {
       headers.push(prop.feature_property_name);
     }
@@ -96,7 +107,11 @@ export function flattenFeatureWithParent(
  * Flatten a feature's JSONB data using schema-defined property types.
  *
  * Type-aware rules:
- * - string, number, datetime, boolean → String(value)
+ * - string, number, boolean → String(value)
+ * - datetime → expands to two cells (`<prop>_date`, `<prop>_time`); each
+ *   pulled directly from the matching key on `data`. Partial-component data
+ *   round-trips losslessly: a null component produces an empty cell while
+ *   the other carries its ISO string. See {@link buildSchemaHeaders}.
  * - spatial → decode WKB Buffer (as produced by the Parquet writer) → single
  *   column under the property's own name, value is WKT
  * - array → delegate to flattenArray()
@@ -119,6 +134,14 @@ export function flattenFeatureBySchema(
   const result: Record<string, string> = {};
 
   for (const prop of properties) {
+    if (prop.feature_property_type_name === 'datetime') {
+      const dateKey = `${prop.feature_property_name}${DATETIME_DATE_SUFFIX}`;
+      const timeKey = `${prop.feature_property_name}${DATETIME_TIME_SUFFIX}`;
+      result[dateKey] = toStringOrEmpty(data[dateKey]);
+      result[timeKey] = toStringOrEmpty(data[timeKey]);
+      continue;
+    }
+
     const value = data[prop.feature_property_name];
 
     switch (prop.feature_property_type_name) {

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -12,8 +12,6 @@ import {
   extractGeoJsonGeometry,
   featureToRow,
   geoJsonToWkb,
-  parquetDateToString,
-  parquetTimeMillisToString,
   propertyTypeToParquetType,
   timeStringToMillis
 } from './parquet-utils';
@@ -135,36 +133,13 @@ describe('parquet-utils', () => {
       // 23:59:59 → 86_399_000; INT32 ceiling is ~2.14e9 so we have plenty of headroom.
       expect(timeStringToMillis('23:59:59')).to.equal(86_399_000);
     });
-  });
 
-  describe('parquetDateToString', () => {
-    it('should round-trip dateStringToParquet output back to the original string', () => {
-      const original = '2024-06-15';
-      expect(parquetDateToString(dateStringToParquet(original))).to.equal(original);
-    });
-
-    it('should format a UTC midnight Date as YYYY-MM-DD', () => {
-      expect(parquetDateToString(new Date('2026-04-24T00:00:00Z'))).to.equal('2026-04-24');
-    });
-  });
-
-  describe('parquetTimeMillisToString', () => {
-    it('should round-trip timeStringToMillis output back to the original string', () => {
-      const original = '13:45:00';
-      expect(parquetTimeMillisToString(timeStringToMillis(original))).to.equal(original);
-    });
-
-    it('should format midnight as 00:00:00', () => {
-      expect(parquetTimeMillisToString(0)).to.equal('00:00:00');
-    });
-
-    it('should format the last second of the day as 23:59:59', () => {
-      expect(parquetTimeMillisToString(86_399_000)).to.equal('23:59:59');
-    });
-
-    it('should zero-pad single-digit components', () => {
-      // 04:05:06 → (4*3600 + 5*60 + 6) * 1000 = 14_706_000
-      expect(parquetTimeMillisToString(14_706_000)).to.equal('04:05:06');
+    it('should clamp Postgres end-of-day 24:00:00 to 86_399_999', () => {
+      // Postgres `time` accepts '24:00:00' as ISO 8601 nominal end-of-day, but
+      // Parquet TIME_MILLIS doesn't define 86_400_000 and downstream readers
+      // disagree on how to handle it. The clamp keeps the cell in the de facto
+      // 0..86_399_999 range at a 1 ms cost, preferable to wrapping to 00:00:00.
+      expect(timeStringToMillis('24:00:00')).to.equal(86_399_999);
     });
   });
 
@@ -263,6 +238,17 @@ describe('parquet-utils', () => {
       expect(sfid.primitiveType).to.equal('INT64');
       // optional=false in @dsnp/parquetjs surfaces as REQUIRED on the schema field.
       expect(sfid.repetitionType).to.equal('REQUIRED');
+    });
+
+    it('should throw when a datetime expansion collides with a sibling property name', () => {
+      // Schema-build is the gate for collision detection; downstream consumers
+      // (hydrator, writer) trust the validated list.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observation', feature_property_type_name: 'datetime' },
+        { feature_property_name: 'observation_date', feature_property_type_name: 'string' }
+      ];
+
+      expect(() => buildParquetSchema(properties)).to.throw(/observation_date/);
     });
   });
 

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -12,6 +12,8 @@ import {
   extractGeoJsonGeometry,
   featureToRow,
   geoJsonToWkb,
+  parquetDateToString,
+  parquetTimeMillisToString,
   propertyTypeToParquetType,
   timeStringToMillis
 } from './parquet-utils';
@@ -132,6 +134,37 @@ describe('parquet-utils', () => {
     it('should produce a value within INT32 range for the last second of the day', () => {
       // 23:59:59 → 86_399_000; INT32 ceiling is ~2.14e9 so we have plenty of headroom.
       expect(timeStringToMillis('23:59:59')).to.equal(86_399_000);
+    });
+  });
+
+  describe('parquetDateToString', () => {
+    it('should round-trip dateStringToParquet output back to the original string', () => {
+      const original = '2024-06-15';
+      expect(parquetDateToString(dateStringToParquet(original))).to.equal(original);
+    });
+
+    it('should format a UTC midnight Date as YYYY-MM-DD', () => {
+      expect(parquetDateToString(new Date('2026-04-24T00:00:00Z'))).to.equal('2026-04-24');
+    });
+  });
+
+  describe('parquetTimeMillisToString', () => {
+    it('should round-trip timeStringToMillis output back to the original string', () => {
+      const original = '13:45:00';
+      expect(parquetTimeMillisToString(timeStringToMillis(original))).to.equal(original);
+    });
+
+    it('should format midnight as 00:00:00', () => {
+      expect(parquetTimeMillisToString(0)).to.equal('00:00:00');
+    });
+
+    it('should format the last second of the day as 23:59:59', () => {
+      expect(parquetTimeMillisToString(86_399_000)).to.equal('23:59:59');
+    });
+
+    it('should zero-pad single-digit components', () => {
+      // 04:05:06 → (4*3600 + 5*60 + 6) * 1000 = 14_706_000
+      expect(parquetTimeMillisToString(14_706_000)).to.equal('04:05:06');
     });
   });
 
@@ -301,10 +334,7 @@ describe('parquet-utils', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'created', feature_property_type_name: 'datetime' }
       ];
-      const row = featureToRow(
-        makeFeature({ created_date: '2024-06-15', created_time: '13:45:00' }),
-        properties
-      );
+      const row = featureToRow(makeFeature({ created_date: '2024-06-15', created_time: '13:45:00' }), properties);
 
       // DATE column: a Date instance at UTC midnight (the writer encodes
       // `getTime() / 86_400_000` to days-since-epoch INT32).

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -30,13 +30,13 @@ describe('parquet-utils', () => {
       expect(propertyTypeToParquetType('boolean')).to.equal('BOOLEAN');
     });
 
-    it('should default datetime to UTF8 because expansion is handled upstream', () => {
-      // `datetime` is intentionally absent from the propertyTypeToParquetType
-      // switch — expandPropertyToColumns short-circuits and emits two columns
-      // (DATE + TIME_MILLIS) before this function is consulted. Direct callers
-      // hitting 'datetime' fall through to the default UTF8, which is wrong;
-      // the test pins the behavior so the absence is intentional, not a bug.
-      expect(propertyTypeToParquetType('datetime')).to.equal('UTF8');
+    it('should throw for datetime because the helper must be used (DATE + TIME_MILLIS expansion)', () => {
+      // `datetime` cannot map to a single Parquet primitive — `expandPropertyToColumns`
+      // splits it into two columns (DATE + TIME_MILLIS) before the writer asks for a
+      // type. Reaching this case means a caller bypassed the helper; failing loud
+      // points the bug at the caller instead of letting UTF8 silently land in the
+      // Parquet footer.
+      expect(() => propertyTypeToParquetType('datetime')).to.throw(/datetime/);
     });
 
     it('should map code to UTF8 (resolved label is a string)', () => {

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -7,10 +7,13 @@ import { CsvPropertyDefinition } from './csv-utils';
 import {
   buildGeoParquetMetadata,
   buildParquetSchema,
+  dateStringToParquet,
+  expandPropertyToColumns,
   extractGeoJsonGeometry,
   featureToRow,
   geoJsonToWkb,
-  propertyTypeToParquetType
+  propertyTypeToParquetType,
+  timeStringToMillis
 } from './parquet-utils';
 
 describe('parquet-utils', () => {
@@ -27,8 +30,13 @@ describe('parquet-utils', () => {
       expect(propertyTypeToParquetType('boolean')).to.equal('BOOLEAN');
     });
 
-    it('should map datetime to TIMESTAMP_MILLIS', () => {
-      expect(propertyTypeToParquetType('datetime')).to.equal('TIMESTAMP_MILLIS');
+    it('should default datetime to UTF8 because expansion is handled upstream', () => {
+      // `datetime` is intentionally absent from the propertyTypeToParquetType
+      // switch — expandPropertyToColumns short-circuits and emits two columns
+      // (DATE + TIME_MILLIS) before this function is consulted. Direct callers
+      // hitting 'datetime' fall through to the default UTF8, which is wrong;
+      // the test pins the behavior so the absence is intentional, not a bug.
+      expect(propertyTypeToParquetType('datetime')).to.equal('UTF8');
     });
 
     it('should map code to UTF8 (resolved label is a string)', () => {
@@ -57,6 +65,73 @@ describe('parquet-utils', () => {
 
     it('should default unknown types to UTF8', () => {
       expect(propertyTypeToParquetType('unknown_type')).to.equal('UTF8');
+    });
+  });
+
+  describe('expandPropertyToColumns', () => {
+    it('should return one spec for a string property', () => {
+      const result = expandPropertyToColumns({
+        feature_property_name: 'site_name',
+        feature_property_type_name: 'string'
+      });
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.deep.equal({ name: 'site_name', parquetType: 'UTF8' });
+    });
+
+    it('should return one spec for a number property', () => {
+      const result = expandPropertyToColumns({
+        feature_property_name: 'count',
+        feature_property_type_name: 'number'
+      });
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.deep.equal({ name: 'count', parquetType: 'DOUBLE' });
+    });
+
+    it('should expand a datetime property into native DATE and TIME_MILLIS specs', () => {
+      const result = expandPropertyToColumns({
+        feature_property_name: 'observed_at',
+        feature_property_type_name: 'datetime'
+      });
+
+      expect(result).to.have.length(2);
+      expect(result[0]).to.deep.equal({ name: 'observed_at_date', parquetType: 'DATE' });
+      expect(result[1]).to.deep.equal({ name: 'observed_at_time', parquetType: 'TIME_MILLIS' });
+    });
+
+    it('should preserve property name for spatial', () => {
+      const result = expandPropertyToColumns({
+        feature_property_name: 'geometry',
+        feature_property_type_name: 'spatial'
+      });
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.deep.equal({ name: 'geometry', parquetType: 'BYTE_ARRAY' });
+    });
+  });
+
+  describe('dateStringToParquet', () => {
+    it('should convert YYYY-MM-DD to a Date at UTC midnight', () => {
+      const d = dateStringToParquet('2024-06-15');
+      expect(d).to.be.instanceOf(Date);
+      expect(d.toISOString()).to.equal('2024-06-15T00:00:00.000Z');
+    });
+  });
+
+  describe('timeStringToMillis', () => {
+    it('should convert HH:MM:SS to milliseconds-since-midnight', () => {
+      // 13:45:00 → (13*3600 + 45*60 + 0) * 1000 = 49_500_000.
+      expect(timeStringToMillis('13:45:00')).to.equal(49_500_000);
+    });
+
+    it('should produce 0 for midnight', () => {
+      expect(timeStringToMillis('00:00:00')).to.equal(0);
+    });
+
+    it('should produce a value within INT32 range for the last second of the day', () => {
+      // 23:59:59 → 86_399_000; INT32 ceiling is ~2.14e9 so we have plenty of headroom.
+      expect(timeStringToMillis('23:59:59')).to.equal(86_399_000);
     });
   });
 
@@ -120,12 +195,31 @@ describe('parquet-utils', () => {
       expect(schema.fields['title']).to.exist;
       expect(schema.fields['value']).to.exist;
       expect(schema.fields['active']).to.exist;
-      expect(schema.fields['created']).to.exist;
+      // datetime expands into two native columns (DATE + TIME_MILLIS); the bare `created` field is gone.
+      expect(schema.fields['created']).to.not.exist;
+      expect(schema.fields['created_date']).to.exist;
+      expect(schema.fields['created_time']).to.exist;
       expect(schema.fields['status']).to.exist;
       expect(schema.fields['species']).to.exist;
       expect(schema.fields['tags']).to.exist;
       expect(schema.fields['meta']).to.exist;
       expect(schema.fields['file']).to.exist;
+    });
+
+    it('should expand a datetime property into native DATE and TIME_MILLIS columns', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'observed_at', feature_property_type_name: 'datetime' }
+      ];
+      const schema = buildParquetSchema(properties);
+
+      expect(schema.fields['observed_at']).to.not.exist;
+      expect(schema.fields['observed_at_date']).to.exist;
+      expect(schema.fields['observed_at_time']).to.exist;
+      // DATE → INT32 days-since-epoch; TIME_MILLIS → INT32 ms-since-midnight.
+      expect(schema.fields['observed_at_date'].primitiveType).to.equal('INT32');
+      expect(schema.fields['observed_at_date'].originalType).to.equal('DATE');
+      expect(schema.fields['observed_at_time'].primitiveType).to.equal('INT32');
+      expect(schema.fields['observed_at_time'].originalType).to.equal('TIME_MILLIS');
     });
 
     it('should always include submission_feature_id as a NOT NULL INT64 column', () => {
@@ -203,27 +297,45 @@ describe('parquet-utils', () => {
       expect(row['active']).to.equal(true);
     });
 
-    it('should convert datetime strings to Date for parquet TIMESTAMP_MILLIS encoding', () => {
-      // pg returns TIMESTAMP / TIMESTAMPTZ as strings (db.ts type parsers). parquetjs
-      // needs Date instances — its TIMESTAMP_MILLIS writer falls back to parseInt()
-      // on strings and eats only the leading year digits.
+    it('should convert the two datetime cells to native primitives for the Parquet writer', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'created', feature_property_type_name: 'datetime' }
       ];
-      const row = featureToRow(makeFeature({ created: '2024-01-01T00:00:00Z' }), properties);
+      const row = featureToRow(
+        makeFeature({ created_date: '2024-06-15', created_time: '13:45:00' }),
+        properties
+      );
 
-      expect(row['created']).to.be.instanceOf(Date);
-      expect((row['created'] as Date).getTime()).to.equal(new Date('2024-01-01T00:00:00Z').getTime());
+      // DATE column: a Date instance at UTC midnight (the writer encodes
+      // `getTime() / 86_400_000` to days-since-epoch INT32).
+      expect(row['created_date']).to.be.instanceOf(Date);
+      expect((row['created_date'] as Date).toISOString()).to.equal('2024-06-15T00:00:00.000Z');
+      // TIME_MILLIS column: ms-since-midnight INT32.
+      // 13:45:00 → (13*3600 + 45*60) * 1000 = 49_500_000.
+      expect(row['created_time']).to.equal(49_500_000);
+      // The bare property name must not appear — Parquet schema expects only the suffixed pair.
+      expect(row).to.not.have.property('created');
     });
 
-    it('should pass datetime Date instances through unchanged', () => {
+    it('should write null for the missing component of a date-only datetime', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'created', feature_property_type_name: 'datetime' }
       ];
-      const date = new Date('2024-06-15T12:30:00Z');
-      const row = featureToRow(makeFeature({ created: date }), properties);
+      const row = featureToRow(makeFeature({ created_date: '2024-06-15' }), properties);
 
-      expect(row['created']).to.equal(date);
+      expect(row['created_date']).to.be.instanceOf(Date);
+      expect((row['created_date'] as Date).toISOString()).to.equal('2024-06-15T00:00:00.000Z');
+      expect(row['created_time']).to.be.null;
+    });
+
+    it('should write null for the missing component of a time-only datetime', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'created', feature_property_type_name: 'datetime' }
+      ];
+      const row = featureToRow(makeFeature({ created_time: '13:45:00' }), properties);
+
+      expect(row['created_date']).to.be.null;
+      expect(row['created_time']).to.equal(49_500_000);
     });
 
     it('should pass through code values directly (pre-resolved label)', () => {

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -9,7 +9,11 @@
  */
 import { ParquetSchema, type FieldDefinition, type SchemaDefinition } from '@dsnp/parquetjs';
 
-import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../models/datetime-column';
+import {
+  assertNoDatetimeColumnCollisions,
+  DATETIME_DATE_SUFFIX,
+  DATETIME_TIME_SUFFIX
+} from '../models/datetime-column';
 import { ParquetFeatureData } from '../models/download';
 import type { CsvPropertyDefinition } from './csv-utils';
 
@@ -93,51 +97,24 @@ export function dateStringToParquet(s: string): Date {
 
 /**
  * Convert a `'HH:MM:SS'` string to milliseconds-since-midnight for
- * `@dsnp/parquetjs`'s TIME_MILLIS writer (INT32, range 0–86_400_000).
+ * `@dsnp/parquetjs`'s TIME_MILLIS writer (INT32, valid range 0–86_399_999).
+ *
+ * Postgres `time without time zone` accepts the literal `'24:00:00'` as ISO
+ * 8601 nominal end-of-day. The Parquet TIME_MILLIS spec doesn't define a
+ * value at exactly 86_400_000 ms, and downstream readers (DuckDB, Arrow,
+ * pandas) handle the boundary inconsistently — accept, clip, or throw.
+ * We clamp at `86_399_999` so the cell stays in the de facto valid range.
+ * The 1 ms loss preserves "near end of day" semantics rather than wrapping
+ * to `00:00:00`, and the source Postgres value is unaffected.
  *
  * @param s 24-hour time string in `'HH:MM:SS'` format, exactly as the SQL
  *   projection emits via `to_char(time_value, 'HH24:MI:SS')`.
- * @returns Milliseconds since midnight.
+ * @returns Milliseconds since midnight, clamped to `86_399_999`.
  */
 export function timeStringToMillis(s: string): number {
   const [hh, mm, ss] = s.split(':').map(Number);
-  return (hh * 3600 + mm * 60 + ss) * 1000;
-}
-
-/**
- * Convert a `Date` (as returned by `@dsnp/parquetjs` reading a DATE column —
- * UTC midnight on the stored day) back to a canonical `'YYYY-MM-DD'` string.
- *
- * Used by the CSV flattener so the read-back of a Parquet `<prop>_date` column
- * matches the original SQL projection's `to_char(date_value, 'YYYY-MM-DD')`
- * output exactly. Without this, the flattener would JSON-stringify the Date
- * (producing a quoted ISO-with-`Z` blob).
- *
- * @param d Date at UTC midnight (parquetjs `fromPrimitive_DATE` always sets it).
- * @returns ISO date string in `'YYYY-MM-DD'` format.
- */
-export function parquetDateToString(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
-
-/**
- * Convert milliseconds-since-midnight (as returned by `@dsnp/parquetjs` reading
- * a TIME_MILLIS column) back to a canonical `'HH:MM:SS'` string.
- *
- * Used by the CSV flattener so the read-back of a Parquet `<prop>_time` column
- * matches the original SQL projection's `to_char(time_value, 'HH24:MI:SS')`
- * output exactly. Without this, the flattener would render the raw integer
- * count (e.g. `'45296000'`).
- *
- * @param ms Milliseconds since midnight (range 0–86_399_999).
- * @returns 24-hour time string in `'HH:MM:SS'` format.
- */
-export function parquetTimeMillisToString(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const hh = Math.floor(totalSeconds / 3600);
-  const mm = Math.floor((totalSeconds % 3600) / 60);
-  const ss = totalSeconds % 60;
-  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+  const ms = (hh * 3600 + mm * 60 + ss) * 1000;
+  return Math.min(ms, 86_399_999);
 }
 
 /**
@@ -205,6 +182,8 @@ export function propertyTypeToParquetType(typeName: string): FieldDefinition['ty
  * @returns A ParquetSchema instance ready for writer construction.
  */
 export function buildParquetSchema(properties: CsvPropertyDefinition[]): ParquetSchema {
+  assertNoDatetimeColumnCollisions(properties);
+
   const fields: SchemaDefinition = {};
 
   // Every Parquet file includes the feature UUID for cross-file joins

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -11,7 +11,7 @@ import { ParquetSchema, type FieldDefinition, type SchemaDefinition } from '@dsn
 
 import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../models/datetime-column';
 import { ParquetFeatureData } from '../models/download';
-import { CsvPropertyDefinition } from './csv-utils';
+import type { CsvPropertyDefinition } from './csv-utils';
 
 /**
  * Output column spec produced by expanding a single feature property definition.
@@ -28,7 +28,8 @@ export interface FeatureColumnSpec {
  * Expand a feature property definition into one or more output column specs.
  *
  * Most property types map 1:1 to a single output column. `datetime` is the
- * exception: it expands into `<name><_date>` and `<name><_time>` UTF8 columns
+ * exception: it expands into `<name>_date` (Parquet `DATE` — INT32 days-since-
+ * epoch) and `<name>_time` (Parquet `TIME_MILLIS` — INT32 ms-since-midnight)
  * so partial-component values (date-only, time-only, or both) round-trip
  * losslessly and remain filterable as native columnar predicates in DuckDB,
  * pandas, and GIS tools.
@@ -38,18 +39,17 @@ export interface FeatureColumnSpec {
  * query plans and discarding partial-component data that the underlying DB
  * stores as first-class (the `submission_feature_property_timestamp` table
  * holds nullable `date_value` / `time_value` columns with a CHECK that at
- * least one is set).
- *
- * UTF8 over native Parquet `DATE` / `TIME_MILLIS` logical types because the
- * canonical ISO strings (`YYYY-MM-DD`, `HH:MM:SS`) are predicate-friendly
- * (DuckDB `CAST(... AS DATE)` or string compare on ISO order) and avoid
- * @dsnp/parquetjs logical-type writer-support uncertainty. A future upgrade
- * lands here only.
+ * least one is set). UTF8 strings would force per-row CAST in DuckDB and
+ * break per-row-group min/max predicate pushdown — choosing native logical
+ * types preserves both. CSV remains UTF8 because CSV is untyped at the
+ * format level.
  *
  * The `_date` / `_time` suffixes are imported from `models/datetime-column`
  * and shared with the SQL projection in `download-repository.ts`. The two
  * sites must produce identical names for the same input property — a drift
- * silently nulls cells.
+ * silently nulls cells. Conversion from the SQL projection's ISO strings to
+ * the writer's expected primitives happens in `featureToRow` via
+ * `dateStringToParquet` and `timeStringToMillis`.
  *
  * @param prop - Feature property definition (name + type).
  * @returns Array of column specs. Single-element for non-datetime types;
@@ -102,6 +102,42 @@ export function dateStringToParquet(s: string): Date {
 export function timeStringToMillis(s: string): number {
   const [hh, mm, ss] = s.split(':').map(Number);
   return (hh * 3600 + mm * 60 + ss) * 1000;
+}
+
+/**
+ * Convert a `Date` (as returned by `@dsnp/parquetjs` reading a DATE column —
+ * UTC midnight on the stored day) back to a canonical `'YYYY-MM-DD'` string.
+ *
+ * Used by the CSV flattener so the read-back of a Parquet `<prop>_date` column
+ * matches the original SQL projection's `to_char(date_value, 'YYYY-MM-DD')`
+ * output exactly. Without this, the flattener would JSON-stringify the Date
+ * (producing a quoted ISO-with-`Z` blob).
+ *
+ * @param d Date at UTC midnight (parquetjs `fromPrimitive_DATE` always sets it).
+ * @returns ISO date string in `'YYYY-MM-DD'` format.
+ */
+export function parquetDateToString(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Convert milliseconds-since-midnight (as returned by `@dsnp/parquetjs` reading
+ * a TIME_MILLIS column) back to a canonical `'HH:MM:SS'` string.
+ *
+ * Used by the CSV flattener so the read-back of a Parquet `<prop>_time` column
+ * matches the original SQL projection's `to_char(time_value, 'HH24:MI:SS')`
+ * output exactly. Without this, the flattener would render the raw integer
+ * count (e.g. `'45296000'`).
+ *
+ * @param ms Milliseconds since midnight (range 0–86_399_999).
+ * @returns 24-hour time string in `'HH:MM:SS'` format.
+ */
+export function parquetTimeMillisToString(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hh = Math.floor(totalSeconds / 3600);
+  const mm = Math.floor((totalSeconds % 3600) / 60);
+  const ss = totalSeconds % 60;
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
 }
 
 /**

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -139,10 +139,15 @@ export function propertyTypeToParquetType(typeName: string): FieldDefinition['ty
       return 'DOUBLE';
     case 'boolean':
       return 'BOOLEAN';
-    // `datetime` is intentionally absent: it is handled upstream by
-    // `expandPropertyToColumns`, which returns two columns (DATE + TIME_MILLIS)
-    // rather than a single primitive. Any direct caller passing 'datetime' here
-    // gets the default UTF8 fallback, which is wrong — go through the helper.
+    case 'datetime':
+      // `datetime` cannot map to a single primitive — it splits into two columns
+      // (DATE + TIME_MILLIS) via `expandPropertyToColumns`. Reaching this case is
+      // a programming error: a caller bypassed the helper and asked for a single
+      // type. Fail loudly so the wrong column shape doesn't quietly land in the
+      // Parquet footer as UTF8.
+      throw new Error(
+        `propertyTypeToParquetType: 'datetime' has no single Parquet type — use expandPropertyToColumns to get DATE + TIME_MILLIS`
+      );
     case 'code':
       // Code properties arrive pre-resolved: the cursor JOIN resolves FK -> display label
       return 'UTF8';

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -9,8 +9,100 @@
  */
 import { ParquetSchema, type FieldDefinition, type SchemaDefinition } from '@dsnp/parquetjs';
 
+import { DATETIME_DATE_SUFFIX, DATETIME_TIME_SUFFIX } from '../models/datetime-column';
 import { ParquetFeatureData } from '../models/download';
 import { CsvPropertyDefinition } from './csv-utils';
+
+/**
+ * Output column spec produced by expanding a single feature property definition.
+ *
+ * Most property types map 1:1 (one property -> one column). `datetime`
+ * expands to two — see {@link expandPropertyToColumns}.
+ */
+export interface FeatureColumnSpec {
+  name: string;
+  parquetType: FieldDefinition['type'];
+}
+
+/**
+ * Expand a feature property definition into one or more output column specs.
+ *
+ * Most property types map 1:1 to a single output column. `datetime` is the
+ * exception: it expands into `<name><_date>` and `<name><_time>` UTF8 columns
+ * so partial-component values (date-only, time-only, or both) round-trip
+ * losslessly and remain filterable as native columnar predicates in DuckDB,
+ * pandas, and GIS tools.
+ *
+ * Parquet/CSV are themselves query substrates: a single combined ISO string
+ * would force every consumer to parse before filtering, defeating columnar
+ * query plans and discarding partial-component data that the underlying DB
+ * stores as first-class (the `submission_feature_property_timestamp` table
+ * holds nullable `date_value` / `time_value` columns with a CHECK that at
+ * least one is set).
+ *
+ * UTF8 over native Parquet `DATE` / `TIME_MILLIS` logical types because the
+ * canonical ISO strings (`YYYY-MM-DD`, `HH:MM:SS`) are predicate-friendly
+ * (DuckDB `CAST(... AS DATE)` or string compare on ISO order) and avoid
+ * @dsnp/parquetjs logical-type writer-support uncertainty. A future upgrade
+ * lands here only.
+ *
+ * The `_date` / `_time` suffixes are imported from `models/datetime-column`
+ * and shared with the SQL projection in `download-repository.ts`. The two
+ * sites must produce identical names for the same input property — a drift
+ * silently nulls cells.
+ *
+ * @param prop - Feature property definition (name + type).
+ * @returns Array of column specs. Single-element for non-datetime types;
+ *   two-element (`<name>_date`, `<name>_time`) for datetime.
+ */
+export function expandPropertyToColumns(prop: CsvPropertyDefinition): FeatureColumnSpec[] {
+  if (prop.feature_property_type_name === 'datetime') {
+    // Native Parquet logical types — DATE (INT32 days-since-epoch) and TIME_MILLIS
+    // (INT32 ms-since-midnight). DuckDB / pandas / arrow read these as native
+    // `date` / `time` columns with predicate pushdown via per-row-group min/max
+    // statistics. UTF8 strings would force consumers to CAST per row and break
+    // statistics-driven row-group skipping (the whole point of Parquet as a
+    // query substrate). Conversion from the SQL projection's ISO strings happens
+    // in `featureToRow` via `dateStringToParquet` / `timeStringToMillis`.
+    return [
+      { name: `${prop.feature_property_name}${DATETIME_DATE_SUFFIX}`, parquetType: 'DATE' },
+      { name: `${prop.feature_property_name}${DATETIME_TIME_SUFFIX}`, parquetType: 'TIME_MILLIS' }
+    ];
+  }
+  return [
+    {
+      name: prop.feature_property_name,
+      parquetType: propertyTypeToParquetType(prop.feature_property_type_name)
+    }
+  ];
+}
+
+/**
+ * Convert a `'YYYY-MM-DD'` string to a `Date` instance for `@dsnp/parquetjs`'s
+ * DATE writer. The library accepts a `Date` and converts internally to days-
+ * since-epoch (`getTime() / 86_400_000`). Constructed at UTC midnight so the
+ * conversion is deterministic regardless of host timezone.
+ *
+ * @param s ISO date string in `'YYYY-MM-DD'` format, exactly as the SQL
+ *   projection emits via `to_char(date_value, 'YYYY-MM-DD')`.
+ * @returns A `Date` at the corresponding UTC midnight.
+ */
+export function dateStringToParquet(s: string): Date {
+  return new Date(`${s}T00:00:00Z`);
+}
+
+/**
+ * Convert a `'HH:MM:SS'` string to milliseconds-since-midnight for
+ * `@dsnp/parquetjs`'s TIME_MILLIS writer (INT32, range 0–86_400_000).
+ *
+ * @param s 24-hour time string in `'HH:MM:SS'` format, exactly as the SQL
+ *   projection emits via `to_char(time_value, 'HH24:MI:SS')`.
+ * @returns Milliseconds since midnight.
+ */
+export function timeStringToMillis(s: string): number {
+  const [hh, mm, ss] = s.split(':').map(Number);
+  return (hh * 3600 + mm * 60 + ss) * 1000;
+}
 
 /**
  * Maps a feature property type name to a Parquet field type.
@@ -34,8 +126,10 @@ export function propertyTypeToParquetType(typeName: string): FieldDefinition['ty
       return 'DOUBLE';
     case 'boolean':
       return 'BOOLEAN';
-    case 'datetime':
-      return 'TIMESTAMP_MILLIS';
+    // `datetime` is intentionally absent: it is handled upstream by
+    // `expandPropertyToColumns`, which returns two columns (DATE + TIME_MILLIS)
+    // rather than a single primitive. Any direct caller passing 'datetime' here
+    // gets the default UTF8 fallback, which is wrong — go through the helper.
     case 'code':
       // Code properties arrive pre-resolved: the cursor JOIN resolves FK -> display label
       return 'UTF8';
@@ -94,10 +188,9 @@ export function buildParquetSchema(properties: CsvPropertyDefinition[]): Parquet
   fields['submission_feature_id'] = { type: 'INT64', optional: false };
 
   for (const prop of properties) {
-    fields[prop.feature_property_name] = {
-      type: propertyTypeToParquetType(prop.feature_property_type_name),
-      optional: true
-    };
+    for (const col of expandPropertyToColumns(prop)) {
+      fields[col.name] = { type: col.parquetType, optional: true };
+    }
   }
 
   return new ParquetSchema(fields);
@@ -128,6 +221,22 @@ export function featureToRow(
   row['submission_feature_id'] = feature.submission_feature_id;
 
   for (const prop of properties) {
+    if (prop.feature_property_type_name === 'datetime') {
+      // `datetime` expands into two native Parquet columns: DATE (INT32 days-
+      // since-epoch) and TIME_MILLIS (INT32 ms-since-midnight). The hydrator
+      // wrote canonical ISO strings under `<prop>_date` / `<prop>_time` keys
+      // (one or both may be null per the DB CHECK); convert each non-null
+      // string to the writer's expected primitive. See `expandPropertyToColumns`
+      // for why this is two columns rather than one combined timestamp.
+      const dateKey = `${prop.feature_property_name}${DATETIME_DATE_SUFFIX}`;
+      const timeKey = `${prop.feature_property_name}${DATETIME_TIME_SUFFIX}`;
+      const dateStr = feature.data[dateKey];
+      const timeStr = feature.data[timeKey];
+      row[dateKey] = typeof dateStr === 'string' ? dateStringToParquet(dateStr) : null;
+      row[timeKey] = typeof timeStr === 'string' ? timeStringToMillis(timeStr) : null;
+      continue;
+    }
+
     const value = feature.data[prop.feature_property_name];
 
     if (value == null) {
@@ -146,14 +255,6 @@ export function featureToRow(
         break;
       case 'object':
         row[prop.feature_property_name] = JSON.stringify(value);
-        break;
-      case 'datetime':
-        // db.ts installs a global pg type parser that returns TIMESTAMP / TIMESTAMPTZ
-        // as raw strings rather than Date objects. @dsnp/parquetjs's
-        // toPrimitive_TIMESTAMP_MILLIS hits its `string` branch and calls parseInt,
-        // which eats only the leading year digits (e.g. "2024-01-01..." → 2024 ms).
-        // Converting to a Date here lets the writer use its Date branch (getTime()).
-        row[prop.feature_property_name] = value instanceof Date ? value : new Date(value as string);
         break;
       default:
         // string, number, boolean, code, taxon, artifact_key — pass through directly

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -258,32 +258,25 @@ export function featureToRow(
     }
 
     const value = feature.data[prop.feature_property_name];
-
-    if (value == null) {
-      row[prop.feature_property_name] = null;
-      continue;
-    }
-
-    switch (prop.feature_property_type_name) {
-      case 'spatial': {
-        const geometry = extractGeoJsonGeometry(value);
-        row[prop.feature_property_name] = geometry ? geoJsonToWkb(geometry) : null;
-        break;
-      }
-      case 'array':
-        row[prop.feature_property_name] = JSON.stringify(value);
-        break;
-      case 'object':
-        row[prop.feature_property_name] = JSON.stringify(value);
-        break;
-      default:
-        // string, number, boolean, code, taxon, artifact_key — pass through directly
-        row[prop.feature_property_name] = value;
-        break;
-    }
+    row[prop.feature_property_name] = value == null ? null : encodePropertyValue(prop, value);
   }
 
   return row;
+}
+
+function encodePropertyValue(prop: CsvPropertyDefinition, value: unknown): unknown {
+  switch (prop.feature_property_type_name) {
+    case 'spatial': {
+      const geometry = extractGeoJsonGeometry(value);
+      return geometry ? geoJsonToWkb(geometry) : null;
+    }
+    case 'array':
+    case 'object':
+      return JSON.stringify(value);
+    default:
+      // string, number, boolean, code, taxon, artifact_key — pass through directly
+      return value;
+  }
 }
 
 /**


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-992](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-992)

## Description of Changes

The download flow is broken because there are some more `submission_feature_property_timestamp.value` references, but that value got split into `date_value` and `time_value`. 

**Acceptance Criteria**
1. Change references to explicit date/time

Javascript Date/dayjs objects must be split into separate date and time values when queried against the submission_feature_property_timestamp table
All references to the singular `values` should be updated to use date_value/time_value
Queries for "time_value" with a null date_value should ignore date
eg. Find all records between 1pm and 5pm, irrespective of the date
Queries for "date_value" with a null time_value should ignore time

## Testing Notes

Automated coverage:

```bash
make test                     # unit tests
make test-db                  # DB integration
make test-sys                 # system integration
```

Manual smoke (download flow):

1. `make web && make minio && make queue` — start the stack.
2. With default seed data, search **telemetry** (`timestamp`), add to cart, check out, wait for **Ready**.
3. **Export CSV** from the download card; wait for `download_export` to reach `ready`.
4. Open the resulting CSV — datetime columns should render as separate date / time values (no empty cells, no `[object Object]`, no `undefined`).
