### PR TITLE
SIMSBIOHUB-1008: Fix issue with helm env var parsing

### DIFF
--- a/api/src/constants/download.ts
+++ b/api/src/constants/download.ts
@@ -1,3 +1,5 @@
+import { getNumberEnv } from '../utils/env-utils';
+
 export const SIGNED_URL_EXPIRY_DOWNLOAD = 432000; // 5 days
 
 /**
@@ -12,4 +14,4 @@ export const DEFAULT_MAX_PART_SIZE_BYTES = '524288000';
  * Tunable via env var so ops can adjust memory pressure vs throughput without
  * a code change. Larger = fewer round trips but higher peak heap per batch.
  */
-export const DOWNLOAD_FEATURE_BATCH_SIZE = Number(process.env.DOWNLOAD_FEATURE_BATCH_SIZE ?? 5000);
+export const DOWNLOAD_FEATURE_BATCH_SIZE = getNumberEnv('DOWNLOAD_FEATURE_BATCH_SIZE', 5000);

--- a/api/src/constants/ingestion.ts
+++ b/api/src/constants/ingestion.ts
@@ -1,19 +1,21 @@
+import { getNumberEnv } from '../utils/env-utils';
+
 /**
  * Feature records buffered per batch while streaming submission archives.
  */
-export const INGESTION_FEATURE_BATCH_SIZE = Number(process.env.INGESTION_FEATURE_BATCH_SIZE ?? 10000);
+export const INGESTION_FEATURE_BATCH_SIZE = getNumberEnv('INGESTION_FEATURE_BATCH_SIZE', 10000);
 
 /**
  * Contributor codes inserted per DB write batch.
  */
-export const INGESTION_CONTRIBUTOR_CODE_BATCH_SIZE = Number(process.env.INGESTION_CONTRIBUTOR_CODE_BATCH_SIZE ?? 10000);
+export const INGESTION_CONTRIBUTOR_CODE_BATCH_SIZE = getNumberEnv('INGESTION_CONTRIBUTOR_CODE_BATCH_SIZE', 10000);
 
 /**
  * Approximate media bytes buffered before a media ingest flush.
  */
-export const INGESTION_MEDIA_BATCH_BYTES = Number(process.env.INGESTION_MEDIA_BATCH_BYTES ?? 50 * 1024 * 1024);
+export const INGESTION_MEDIA_BATCH_BYTES = getNumberEnv('INGESTION_MEDIA_BATCH_BYTES', 50 * 1024 * 1024);
 
 /**
  * Media files buffered before a media ingest flush.
  */
-export const INGESTION_MEDIA_BATCH_FILES = Number(process.env.INGESTION_MEDIA_BATCH_FILES ?? 10000);
+export const INGESTION_MEDIA_BATCH_FILES = getNumberEnv('INGESTION_MEDIA_BATCH_FILES', 10000);

--- a/api/src/constants/security.ts
+++ b/api/src/constants/security.ts
@@ -1,4 +1,6 @@
+import { getNumberEnv } from '../utils/env-utils';
+
 /**
  * Anchor rows processed per keyset page in security-scope anchor maintenance.
  */
-export const SECURITY_SCOPE_ANCHOR_BATCH_SIZE = Number(process.env.SECURITY_SCOPE_ANCHOR_BATCH_SIZE ?? 5000);
+export const SECURITY_SCOPE_ANCHOR_BATCH_SIZE = getNumberEnv('SECURITY_SCOPE_ANCHOR_BATCH_SIZE', 5000);

--- a/api/src/constants/upload.ts
+++ b/api/src/constants/upload.ts
@@ -1,3 +1,5 @@
+import { getNumberEnv } from '../utils/env-utils';
+
 /**
  * Multipart upload sizing and presign configuration.
  *
@@ -40,9 +42,7 @@ export const S3_MULTIPART_MAX_PARTS = 10000;
  * (fewer requests/round-trips), but can exceed it when constrained by S3 limits.
  * Backward compatible fallback to legacy `UPLOAD_TARGET_PARTS`.
  */
-export const UPLOAD_TARGET_PART_COUNT = Number(
-  process.env.UPLOAD_TARGET_PART_COUNT ?? process.env.UPLOAD_TARGET_PARTS ?? 10
-);
+export const UPLOAD_TARGET_PART_COUNT = getNumberEnv(['UPLOAD_TARGET_PART_COUNT', 'UPLOAD_TARGET_PARTS'], 10);
 
 /**
  * Application-level soft cap for part size during multipart planning.
@@ -52,8 +52,9 @@ export const UPLOAD_TARGET_PART_COUNT = Number(
  * larger parts to satisfy `S3_MULTIPART_MAX_PARTS` on very large uploads.
  * Backward compatible fallback to legacy `UPLOAD_DESIRED_MAX_PART_SIZE_BYTES`.
  */
-export const UPLOAD_PART_SIZE_CAP_BYTES = Number(
-  process.env.UPLOAD_PART_SIZE_CAP_BYTES ?? process.env.UPLOAD_DESIRED_MAX_PART_SIZE_BYTES ?? 100 * 1024 * 1024
+export const UPLOAD_PART_SIZE_CAP_BYTES = getNumberEnv(
+  ['UPLOAD_PART_SIZE_CAP_BYTES', 'UPLOAD_DESIRED_MAX_PART_SIZE_BYTES'],
+  100 * 1024 * 1024
 ); // prefer max ~100 MiB part size unless S3 max-part-count requires larger
 
 /**
@@ -62,8 +63,9 @@ export const UPLOAD_PART_SIZE_CAP_BYTES = Number(
  * For uploads at or below this size, planner can remain near minimum part size.
  * Above this threshold, part size increases stepwise to avoid too many tiny parts.
  */
-export const UPLOAD_PART_SIZE_SCALE_START_BYTES = Number(
-  process.env.UPLOAD_PART_SIZE_SCALE_START_BYTES ?? process.env.UPLOAD_SCALE_START_BYTES ?? 20 * 1024 * 1024
+export const UPLOAD_PART_SIZE_SCALE_START_BYTES = getNumberEnv(
+  ['UPLOAD_PART_SIZE_SCALE_START_BYTES', 'UPLOAD_SCALE_START_BYTES'],
+  20 * 1024 * 1024
 );
 
 /**
@@ -73,8 +75,9 @@ export const UPLOAD_PART_SIZE_SCALE_START_BYTES = Number(
  * - every additional 10 MiB of object size after `UPLOAD_PART_SIZE_SCALE_START_BYTES`
  *   advances one ramp step.
  */
-export const UPLOAD_PART_SIZE_SCALE_STEP_BYTES = Number(
-  process.env.UPLOAD_PART_SIZE_SCALE_STEP_BYTES ?? process.env.UPLOAD_SCALE_STEP_BYTES ?? 10 * 1024 * 1024
+export const UPLOAD_PART_SIZE_SCALE_STEP_BYTES = getNumberEnv(
+  ['UPLOAD_PART_SIZE_SCALE_STEP_BYTES', 'UPLOAD_SCALE_STEP_BYTES'],
+  10 * 1024 * 1024
 );
 
 /**
@@ -85,10 +88,9 @@ export const UPLOAD_PART_SIZE_SCALE_STEP_BYTES = Number(
  *   `UPLOAD_PART_SIZE_CAP_BYTES` (or overridden by S3 hard constraints).
  * Backward compatible fallback to legacy `UPLOAD_SCALE_STEP_PART_SIZE_BYTES`.
  */
-export const UPLOAD_PART_SIZE_SCALE_STEP_INCREMENT_BYTES = Number(
-  process.env.UPLOAD_PART_SIZE_SCALE_STEP_INCREMENT_BYTES ??
-    process.env.UPLOAD_SCALE_STEP_PART_SIZE_BYTES ??
-    1024 * 1024
+export const UPLOAD_PART_SIZE_SCALE_STEP_INCREMENT_BYTES = getNumberEnv(
+  ['UPLOAD_PART_SIZE_SCALE_STEP_INCREMENT_BYTES', 'UPLOAD_SCALE_STEP_PART_SIZE_BYTES'],
+  1024 * 1024
 ); // +1 MiB per step
 
 /**
@@ -97,14 +99,14 @@ export const UPLOAD_PART_SIZE_SCALE_STEP_INCREMENT_BYTES = Number(
  * Batching reduces request payload size and avoids very large single presign responses
  * when uploads contain many parts.
  */
-export const UPLOAD_PRESIGNED_URL_BATCH_SIZE = Number(process.env.UPLOAD_PRESIGNED_URL_BATCH_SIZE ?? 200);
+export const UPLOAD_PRESIGNED_URL_BATCH_SIZE = getNumberEnv('UPLOAD_PRESIGNED_URL_BATCH_SIZE', 200);
 
 /**
  * Expiry window (seconds) for generated presigned part URLs.
  *
  * Must be long enough for clients to upload all planned parts under normal conditions.
  */
-export const UPLOAD_PRESIGNED_URL_EXPIRY_SECONDS = Number(process.env.UPLOAD_PRESIGNED_URL_EXPIRY_SECONDS ?? 3600);
+export const UPLOAD_PRESIGNED_URL_EXPIRY_SECONDS = getNumberEnv('UPLOAD_PRESIGNED_URL_EXPIRY_SECONDS', 3600);
 
 /**
  * Approximate in-memory byte threshold for pending feature batch flush.
@@ -113,7 +115,7 @@ export const UPLOAD_PRESIGNED_URL_EXPIRY_SECONDS = Number(process.env.UPLOAD_PRE
  * is not sufficient. Parser computes an estimated per-feature byte contribution and
  * flushes when this threshold is reached.
  */
-export const UPLOAD_FEATURE_BATCH_MAX_BYTES = Number(process.env.UPLOAD_FEATURE_BATCH_MAX_BYTES ?? 8 * 1024 * 1024);
+export const UPLOAD_FEATURE_BATCH_MAX_BYTES = getNumberEnv('UPLOAD_FEATURE_BATCH_MAX_BYTES', 8 * 1024 * 1024);
 
 /**
  * Maximum concurrent media uploads from `files/*` entries while streaming one archive.
@@ -121,8 +123,9 @@ export const UPLOAD_FEATURE_BATCH_MAX_BYTES = Number(process.env.UPLOAD_FEATURE_
  * Higher values can improve throughput but increase memory/socket pressure.
  * Backward compatible fallback to legacy `SUBMISSION_ARCHIVE_MEDIA_CONCURRENCY`.
  */
-export const UPLOAD_ARCHIVE_MEDIA_CONCURRENCY = Number(
-  process.env.UPLOAD_ARCHIVE_MEDIA_CONCURRENCY ?? process.env.SUBMISSION_ARCHIVE_MEDIA_CONCURRENCY ?? 1
+export const UPLOAD_ARCHIVE_MEDIA_CONCURRENCY = getNumberEnv(
+  ['UPLOAD_ARCHIVE_MEDIA_CONCURRENCY', 'SUBMISSION_ARCHIVE_MEDIA_CONCURRENCY'],
+  1
 );
 
 /**
@@ -131,7 +134,7 @@ export const UPLOAD_ARCHIVE_MEDIA_CONCURRENCY = Number(
  * Keep this at 1 for memory-constrained workers (1 GiB / 1 vCPU) so a worker
  * processes one upload job at a time.
  */
-export const UPLOAD_JOB_BATCH_SIZE = Number(process.env.UPLOAD_JOB_BATCH_SIZE ?? 1);
+export const UPLOAD_JOB_BATCH_SIZE = getNumberEnv('UPLOAD_JOB_BATCH_SIZE', 1);
 
 /**
  * Hard size limit for a single JSON archive entry (`features/*.json` or `codes/*.json`).
@@ -139,6 +142,4 @@ export const UPLOAD_JOB_BATCH_SIZE = Number(process.env.UPLOAD_JOB_BATCH_SIZE ??
  * Prevents unbounded buffering/parse of unexpectedly large JSON files and fails fast
  * with `IngestionValidationError` when exceeded.
  */
-export const UPLOAD_ARCHIVE_JSON_FILE_MAX_BYTES = Number(
-  process.env.UPLOAD_ARCHIVE_JSON_FILE_MAX_BYTES ?? 32 * 1024 * 1024
-); // 32 MiB
+export const UPLOAD_ARCHIVE_JSON_FILE_MAX_BYTES = getNumberEnv('UPLOAD_ARCHIVE_JSON_FILE_MAX_BYTES', 32 * 1024 * 1024); // 32 MiB

--- a/api/src/utils/env-utils.ts
+++ b/api/src/utils/env-utils.ts
@@ -1,0 +1,46 @@
+/**
+ * Returns a normalized env value, or undefined when the value should be treated as missing.
+ */
+export const getOptionalEnv = (key: string): string | undefined => {
+  const value = process.env[key];
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  if (!normalized || normalized === 'undefined' || normalized === 'null') {
+    return undefined;
+  }
+
+  return normalized;
+};
+
+/**
+ * Returns the first finite numeric env value from the provided keys.
+ *
+ * Missing, empty, and non-numeric values are ignored.
+ */
+export const getOptionalNumberEnv = (keys: string | string[]): number | undefined => {
+  const normalizedKeys = Array.isArray(keys) ? keys : [keys];
+
+  for (const key of normalizedKeys) {
+    const value = getOptionalEnv(key);
+    if (value === undefined) {
+      continue;
+    }
+
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Returns the first finite numeric env value from the provided keys, or a default.
+ */
+export const getNumberEnv = (keys: string | string[], defaultValue: number): number => {
+  return getOptionalNumberEnv(keys) ?? defaultValue;
+};

--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -18,23 +18,10 @@ import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import NodeClam from 'clamscan';
 import { Readable } from 'stream';
+import { getOptionalEnv } from './env-utils';
 import { getLogger } from './logger';
 
 const defaultLog = getLogger('/api/src/utils/file-utils');
-
-const getOptionalEnv = (key: string): string | undefined => {
-  const value = process.env[key];
-  if (!value) {
-    return undefined;
-  }
-
-  const normalized = value.trim();
-  if (!normalized || normalized === 'undefined' || normalized === 'null') {
-    return undefined;
-  }
-
-  return normalized;
-};
 
 export interface IDatasetS3FileKey {
   datasetUUID: string;

--- a/infrastructure/queue/templates/deployment.yaml
+++ b/infrastructure/queue/templates/deployment.yaml
@@ -183,39 +183,49 @@ spec:
             - name: LOG_FILE_MAX_FILES
               value: {{ .Values.app.logging.fileMaxFiles | quote }}
             # Ingestion pipeline
+            {{- if .Values.app.ingestion.featureBatchSize }}
             - name: INGESTION_FEATURE_BATCH_SIZE
               value: {{ .Values.app.ingestion.featureBatchSize | quote }}
-            {{ if .Values.app.ingestion.contributorCodeBatchSize }}
+            {{- end }}
+            {{- if .Values.app.ingestion.contributorCodeBatchSize }}
             - name: INGESTION_CONTRIBUTOR_CODE_BATCH_SIZE
               value: {{ .Values.app.ingestion.contributorCodeBatchSize | quote }}
-            {{ end }}
-            {{ if .Values.app.ingestion.mediaBatchBytes }}
+            {{- end }}
+            {{- if .Values.app.ingestion.mediaBatchBytes }}
             - name: INGESTION_MEDIA_BATCH_BYTES
               value: {{ .Values.app.ingestion.mediaBatchBytes | quote }}
-            {{ end }}
-            {{ if .Values.app.ingestion.mediaBatchFiles }}
+            {{- end }}
+            {{- if .Values.app.ingestion.mediaBatchFiles }}
             - name: INGESTION_MEDIA_BATCH_FILES
               value: {{ .Values.app.ingestion.mediaBatchFiles | quote }}
-            {{ end }}
+            {{- end }}
             # Security scope
+            {{- if .Values.app.security.scopeAnchorBatchSize }}
             - name: SECURITY_SCOPE_ANCHOR_BATCH_SIZE
               value: {{ .Values.app.security.scopeAnchorBatchSize | quote }}
+            {{- end }}
             # Upload pipeline (archive ingestion)
+            {{- if .Values.app.uploadIngestion.featureBatchMaxBytes }}
             - name: UPLOAD_FEATURE_BATCH_MAX_BYTES
               value: {{ .Values.app.uploadIngestion.featureBatchMaxBytes | quote }}
-            {{ if .Values.app.uploadIngestion.mediaConcurrency }}
+            {{- end }}
+            {{- if .Values.app.uploadIngestion.mediaConcurrency }}
             - name: UPLOAD_ARCHIVE_MEDIA_CONCURRENCY
               value: {{ .Values.app.uploadIngestion.mediaConcurrency | quote }}
-            {{ end }}
-            {{ if .Values.app.uploadIngestion.jobBatchSize }}
+            {{- end }}
+            {{- if .Values.app.uploadIngestion.jobBatchSize }}
             - name: UPLOAD_JOB_BATCH_SIZE
               value: {{ .Values.app.uploadIngestion.jobBatchSize | quote }}
-            {{ end }}
+            {{- end }}
+            {{- if .Values.app.uploadIngestion.jsonFileMaxBytes }}
             - name: UPLOAD_ARCHIVE_JSON_FILE_MAX_BYTES
               value: {{ .Values.app.uploadIngestion.jsonFileMaxBytes | quote }}
+            {{- end }}
             # Download pipeline
+            {{- if .Values.app.download.featureBatchSize }}
             - name: DOWNLOAD_FEATURE_BATCH_SIZE
               value: {{ .Values.app.download.featureBatchSize | quote }}
+            {{- end }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.image }}:{{ include "app.imageTag" . }}"
           imagePullPolicy: Always
           resources:

--- a/infrastructure/queue/values.yaml
+++ b/infrastructure/queue/values.yaml
@@ -61,9 +61,9 @@ app:
   # Ingestion pipeline — queue memory and DB-write tuning knobs
   ingestion:
     featureBatchSize: "10000" # INGESTION_FEATURE_BATCH_SIZE: features buffered per archive ingest batch
-    contributorCodeBatchSize: "" # INGESTION_CONTRIBUTOR_CODE_BATCH_SIZE: contributor codes per DB insert batch
-    mediaBatchBytes: "" # INGESTION_MEDIA_BATCH_BYTES: max buffered media bytes before flush
-    mediaBatchFiles: "" # INGESTION_MEDIA_BATCH_FILES: max buffered media files before flush
+    contributorCodeBatchSize: null # INGESTION_CONTRIBUTOR_CODE_BATCH_SIZE: contributor codes per DB insert batch (optional, omitted when unset)
+    mediaBatchBytes: null # INGESTION_MEDIA_BATCH_BYTES: max buffered media bytes before flush (optional, omitted when unset)
+    mediaBatchFiles: null # INGESTION_MEDIA_BATCH_FILES: max buffered media files before flush (optional, omitted when unset)
 
   # Security scope anchor maintenance
   security:
@@ -72,8 +72,8 @@ app:
   # Upload pipeline — archive ingest controls (queue-consumed)
   uploadIngestion:
     featureBatchMaxBytes: "52428800" # UPLOAD_FEATURE_BATCH_MAX_BYTES: heap bound for feature batch buffering
-    mediaConcurrency: "" # UPLOAD_ARCHIVE_MEDIA_CONCURRENCY: concurrent media uploads while streaming one archive
-    jobBatchSize: "" # UPLOAD_JOB_BATCH_SIZE: jobs fetched per worker polling cycle
+    mediaConcurrency: null # UPLOAD_ARCHIVE_MEDIA_CONCURRENCY: concurrent media uploads while streaming one archive (optional, omitted when unset)
+    jobBatchSize: null # UPLOAD_JOB_BATCH_SIZE: jobs fetched per worker polling cycle (optional, omitted when unset)
     jsonFileMaxBytes: "104857600" # UPLOAD_ARCHIVE_JSON_FILE_MAX_BYTES: max bytes per features/codes JSON entry
 
   # Download pipeline — memory-impacting tuning knobs (DOWNLOAD_* prefix)


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1008](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1008)

## Description of Changes

- Updated `infrastructure/queue/templates/deployment.yaml` so optional Helm-migrated env vars are only rendered when values are provided.
- Updated `infrastructure/queue/values.yaml` to use `null` for optional queue tuning env values, so they are omitted when unset.
- Added shared env parsing helpers in `api/src/utils/env-utils.ts` to normalize empty/placeholder env values and safely parse numeric envs.
- Refactored numeric constants in `api/src/constants/{ingestion,upload,download,security}.ts` to use shared helper parsing, preventing empty-string env values from causing invalid numeric behavior.
- Reused the shared `getOptionalEnv` helper in `api/src/utils/file-utils.ts` to keep env normalization logic consistent.

## Testing Notes

- Ran `npm run typecheck` in `api` (pass).
- Ran `npm run lint` in `api` (pass).
- Ran `helm template queue ./infrastructure/queue -f ./infrastructure/queue/values.yaml --show-only templates/deployment.yaml` (pass).
- Verified optional queue env vars are omitted when unset, while default-backed required vars still render.