### PR TITLE
SIMSBIOHUB-985: Restrict security scopes to access-orientied policies

### DIFF
--- a/api/src/__integration__/db/policy-status-flip.integration.ts
+++ b/api/src/__integration__/db/policy-status-flip.integration.ts
@@ -106,6 +106,16 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     return result.rows[0].count;
   }
 
+  // Run the full lazy-materialization sequence for one (team, policy) pair:
+  // materialize the policy-wide statement scopes, then grant team access if
+  // there were any ALLOW statements to materialize.
+  async function materializeAndGrant(teamId: string, policyId: string): Promise<void> {
+    const materialized = await scopeService.materializePolicyStatementScopes(policyId);
+    if (materialized) {
+      await scopeService.grantTeamAccessForPolicy(teamId, policyId);
+    }
+  }
+
   // URNs use real feature_type names — `tr_policy_statement_urn_validation` rejects
   // unknown types. Tests use type-wildcard URNs (urn:*:<type>:*) so no real submission
   // is needed; transaction rollback handles isolation between tests.
@@ -144,9 +154,9 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     await insertTeamPolicy(teamId, policyC);
 
     // Materialize the starting state (all three policies grant their scopes).
-    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyA);
-    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyB);
-    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyC);
+    await materializeAndGrant(teamId, policyA);
+    await materializeAndGrant(teamId, policyB);
+    await materializeAndGrant(teamId, policyC);
     // URN_A dedupes to one security_scope row → team has 2 distinct scopes.
     expect(await countTeamScopes(teamId)).to.equal(2);
 
@@ -166,7 +176,7 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     const teamId = await createTeam(connection, 'deny-only-team');
     await insertTeamPolicy(teamId, policyId);
 
-    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
+    await materializeAndGrant(teamId, policyId);
 
     expect(await countTeamScopes(teamId)).to.equal(0);
     expect(await countPolicyStatementScopes(policyId)).to.equal(0);
@@ -180,7 +190,7 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     const teamId = await createTeam(connection, 'mixed-ended-team');
     await insertTeamPolicy(teamId, policyId);
 
-    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
+    await materializeAndGrant(teamId, policyId);
 
     expect(await countPolicyStatementScopes(policyId)).to.equal(1);
     expect(await countTeamScopes(teamId)).to.equal(1);

--- a/api/src/__integration__/db/policy-status-flip.integration.ts
+++ b/api/src/__integration__/db/policy-status-flip.integration.ts
@@ -1,0 +1,193 @@
+// Integration test for SIMSBIOHUB-985 — verifies that team_security_scope rows
+// are materialized only when (a) a team_policy links a team to an (b) approved
+// policy with (c) ≥1 ALLOW statement, and that downgrades / DENY-only / ended
+// statements all correctly produce zero rows or remove existing rows.
+//
+// Status-flip orchestration runs through PolicyService.updatePolicy; team_policy
+// delete runs through TeamPolicyService.deleteTeamPolicy. The DB is the source
+// of truth for assertions — we read row counts directly, not via stubs.
+//
+// pg-boss is not running in `make test-db`; the anchor-publish dependency is
+// stubbed so the materialize path can proceed without enqueueing jobs.
+//
+// Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
+//
+// Run: make test-db
+// Requires: make web (database must be running with seed data)
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import SQL from 'sql-template-strings';
+import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { PolicyService } from '../../services/access-policy/policy-service';
+import { SecurityScopeService } from '../../services/access-policy/security-scope-service';
+import { createTeam } from '../helpers/test-rbac-helpers';
+
+describe('Policy status flip + lazy scope materialization (integration)', function () {
+  this.timeout(15000);
+
+  let connection: IDBConnection;
+  let policyService: PolicyService;
+  let scopeService: SecurityScopeService;
+
+  before(() => {
+    initDBPool(defaultPoolConfig);
+  });
+
+  beforeEach(async () => {
+    connection = getAPIUserDBConnection();
+    await connection.open();
+    policyService = new PolicyService(connection);
+    scopeService = new SecurityScopeService(connection);
+
+    sinon
+      .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+      .resolves({ status: 'published', jobId: 'stub-job-id' });
+  });
+
+  afterEach(async () => {
+    await connection.rollback();
+    connection.release();
+    sinon.restore();
+  });
+
+  // ── Helpers ──────────────────────────────────────────────────────────
+
+  async function insertPolicy(name: string, status: 'requested' | 'reviewed' | 'approved' | 'denied'): Promise<string> {
+    const systemUserId = connection.systemUserId();
+    const result = await connection.sql(SQL`
+      INSERT INTO policy (name, status, create_user)
+      VALUES (${name}, ${status}, ${systemUserId})
+      RETURNING policy_id;
+    `);
+    return result.rows[0].policy_id;
+  }
+
+  async function insertStatement(policyId: string, urn: string, effect: 'allow' | 'deny'): Promise<string> {
+    const systemUserId = connection.systemUserId();
+    const result = await connection.sql(SQL`
+      INSERT INTO policy_statement (policy_id, effect, submission_feature_urn, create_user)
+      VALUES (${policyId}, ${effect}, ${urn}, ${systemUserId})
+      RETURNING policy_statement_id;
+    `);
+    return result.rows[0].policy_statement_id;
+  }
+
+  async function insertTeamPolicy(teamId: string, policyId: string): Promise<string> {
+    const systemUserId = connection.systemUserId();
+    const result = await connection.sql(SQL`
+      INSERT INTO team_policy (team_id, policy_id, create_user)
+      VALUES (${teamId}, ${policyId}, ${systemUserId})
+      RETURNING team_policy_id;
+    `);
+    return result.rows[0].team_policy_id;
+  }
+
+  async function softEndStatement(statementId: string): Promise<void> {
+    await connection.sql(SQL`
+      UPDATE policy_statement SET record_end_date = now()
+      WHERE policy_statement_id = ${statementId};
+    `);
+  }
+
+  async function countTeamScopes(teamId: string): Promise<number> {
+    const result = await connection.sql(SQL`
+      SELECT count(*)::integer AS count FROM team_security_scope WHERE team_id = ${teamId};
+    `);
+    return result.rows[0].count;
+  }
+
+  async function countPolicyStatementScopes(policyId: string): Promise<number> {
+    const result = await connection.sql(SQL`
+      SELECT count(*)::integer AS count FROM policy_statement_scope pss
+      JOIN policy_statement ps ON ps.policy_statement_id = pss.policy_statement_id
+      WHERE ps.policy_id = ${policyId};
+    `);
+    return result.rows[0].count;
+  }
+
+  // Unique URN suffix per test so concurrent runs / seeded scopes don't collide.
+  let _seq = 0;
+  const uniqueUrn = (label: string) => `urn:99999:test_${label}_${Date.now()}_${++_seq}:*`;
+
+  // ── Tests ───────────────────────────────────────────────────────────
+
+  it('materializes team_security_scope when status transitions requested → reviewed → approved', async () => {
+    const policyId = await insertPolicy('flip-up', 'requested');
+    await insertStatement(policyId, uniqueUrn('flip_up'), 'allow');
+    const teamId = await createTeam(connection, 'flip-up-team');
+    await insertTeamPolicy(teamId, policyId);
+
+    expect(await countTeamScopes(teamId)).to.equal(0);
+
+    await policyService.updatePolicy(policyId, { status: 'reviewed' });
+    expect(await countTeamScopes(teamId)).to.equal(0);
+
+    await policyService.updatePolicy(policyId, { status: 'approved' });
+    expect(await countTeamScopes(teamId)).to.equal(1);
+    expect(await countPolicyStatementScopes(policyId)).to.equal(1);
+  });
+
+  it("removes only the downgraded policy's team_security_scope rows on approved → reviewed, preserving shared-scope grants from other live policies", async () => {
+    const sharedUrn = uniqueUrn('shared');
+    const policyA = await insertPolicy('shared-A', 'approved');
+    await insertStatement(policyA, sharedUrn, 'allow');
+    const policyB = await insertPolicy('shared-B', 'approved');
+    await insertStatement(policyB, sharedUrn, 'allow');
+    const policyC = await insertPolicy('exclusive-C', 'approved');
+    await insertStatement(policyC, uniqueUrn('exclusive'), 'allow');
+
+    const teamId = await createTeam(connection, 'shared-team');
+    await insertTeamPolicy(teamId, policyA);
+    await insertTeamPolicy(teamId, policyB);
+    await insertTeamPolicy(teamId, policyC);
+
+    // Materialize the starting state (all three policies grant their scopes).
+    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyA);
+    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyB);
+    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyC);
+    // sharedUrn dedupes to one security_scope row → team has 2 distinct scopes.
+    expect(await countTeamScopes(teamId)).to.equal(2);
+
+    // Downgrade A — B still justifies the shared scope; C still justifies its exclusive scope.
+    await policyService.updatePolicy(policyA, { status: 'reviewed' });
+    expect(await countTeamScopes(teamId)).to.equal(2);
+
+    // Downgrade B — the shared scope is no longer justified anywhere on this team;
+    // C's exclusive scope remains.
+    await policyService.updatePolicy(policyB, { status: 'reviewed' });
+    expect(await countTeamScopes(teamId)).to.equal(1);
+  });
+
+  it('produces zero team_security_scope rows for an approved policy with DENY-only statements', async () => {
+    const policyId = await insertPolicy('deny-only', 'approved');
+    await insertStatement(policyId, uniqueUrn('deny_only'), 'deny');
+    const teamId = await createTeam(connection, 'deny-only-team');
+    await insertTeamPolicy(teamId, policyId);
+
+    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
+
+    expect(await countTeamScopes(teamId)).to.equal(0);
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+  });
+
+  it('excludes statements with record_end_date IS NOT NULL from materialization', async () => {
+    const policyId = await insertPolicy('mixed-ended', 'approved');
+    const liveStmt = await insertStatement(policyId, uniqueUrn('live'), 'allow');
+    const endedStmt = await insertStatement(policyId, uniqueUrn('ended'), 'allow');
+    await softEndStatement(endedStmt);
+    const teamId = await createTeam(connection, 'mixed-ended-team');
+    await insertTeamPolicy(teamId, policyId);
+
+    await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
+
+    expect(await countPolicyStatementScopes(policyId)).to.equal(1);
+    expect(await countTeamScopes(teamId)).to.equal(1);
+
+    const linked = await connection.sql(SQL`
+      SELECT policy_statement_id FROM policy_statement_scope
+      WHERE policy_statement_id IN (${liveStmt}, ${endedStmt});
+    `);
+    expect(linked.rows.map((r: { policy_statement_id: string }) => r.policy_statement_id)).to.deep.equal([liveStmt]);
+  });
+});

--- a/api/src/__integration__/db/policy-status-flip.integration.ts
+++ b/api/src/__integration__/db/policy-status-flip.integration.ts
@@ -57,7 +57,7 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     const systemUserId = connection.systemUserId();
     const result = await connection.sql(SQL`
       INSERT INTO policy (name, status, create_user)
-      VALUES (${name}, ${status}, ${systemUserId})
+      VALUES (${name}, ${status}::policy_status, ${systemUserId})
       RETURNING policy_id;
     `);
     return result.rows[0].policy_id;
@@ -67,7 +67,7 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     const systemUserId = connection.systemUserId();
     const result = await connection.sql(SQL`
       INSERT INTO policy_statement (policy_id, effect, submission_feature_urn, create_user)
-      VALUES (${policyId}, ${effect}, ${urn}, ${systemUserId})
+      VALUES (${policyId}, ${effect}::policy_effect, ${urn}, ${systemUserId})
       RETURNING policy_statement_id;
     `);
     return result.rows[0].policy_statement_id;
@@ -106,15 +106,17 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     return result.rows[0].count;
   }
 
-  // Unique URN suffix per test so concurrent runs / seeded scopes don't collide.
-  let _seq = 0;
-  const uniqueUrn = (label: string) => `urn:99999:test_${label}_${Date.now()}_${++_seq}:*`;
+  // URNs use real feature_type names — `tr_policy_statement_urn_validation` rejects
+  // unknown types. Tests use type-wildcard URNs (urn:*:<type>:*) so no real submission
+  // is needed; transaction rollback handles isolation between tests.
+  const URN_A = 'urn:*:dataset:*';
+  const URN_B = 'urn:*:marking:*';
 
   // ── Tests ───────────────────────────────────────────────────────────
 
   it('materializes team_security_scope when status transitions requested → reviewed → approved', async () => {
     const policyId = await insertPolicy('flip-up', 'requested');
-    await insertStatement(policyId, uniqueUrn('flip_up'), 'allow');
+    await insertStatement(policyId, URN_A, 'allow');
     const teamId = await createTeam(connection, 'flip-up-team');
     await insertTeamPolicy(teamId, policyId);
 
@@ -129,13 +131,12 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
   });
 
   it("removes only the downgraded policy's team_security_scope rows on approved → reviewed, preserving shared-scope grants from other live policies", async () => {
-    const sharedUrn = uniqueUrn('shared');
     const policyA = await insertPolicy('shared-A', 'approved');
-    await insertStatement(policyA, sharedUrn, 'allow');
+    await insertStatement(policyA, URN_A, 'allow');
     const policyB = await insertPolicy('shared-B', 'approved');
-    await insertStatement(policyB, sharedUrn, 'allow');
+    await insertStatement(policyB, URN_A, 'allow');
     const policyC = await insertPolicy('exclusive-C', 'approved');
-    await insertStatement(policyC, uniqueUrn('exclusive'), 'allow');
+    await insertStatement(policyC, URN_B, 'allow');
 
     const teamId = await createTeam(connection, 'shared-team');
     await insertTeamPolicy(teamId, policyA);
@@ -146,7 +147,7 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
     await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyA);
     await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyB);
     await scopeService.materializeStatementScopesAndTeamAccess(teamId, policyC);
-    // sharedUrn dedupes to one security_scope row → team has 2 distinct scopes.
+    // URN_A dedupes to one security_scope row → team has 2 distinct scopes.
     expect(await countTeamScopes(teamId)).to.equal(2);
 
     // Downgrade A — B still justifies the shared scope; C still justifies its exclusive scope.
@@ -161,7 +162,7 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
 
   it('produces zero team_security_scope rows for an approved policy with DENY-only statements', async () => {
     const policyId = await insertPolicy('deny-only', 'approved');
-    await insertStatement(policyId, uniqueUrn('deny_only'), 'deny');
+    await insertStatement(policyId, URN_A, 'deny');
     const teamId = await createTeam(connection, 'deny-only-team');
     await insertTeamPolicy(teamId, policyId);
 
@@ -173,8 +174,8 @@ describe('Policy status flip + lazy scope materialization (integration)', functi
 
   it('excludes statements with record_end_date IS NOT NULL from materialization', async () => {
     const policyId = await insertPolicy('mixed-ended', 'approved');
-    const liveStmt = await insertStatement(policyId, uniqueUrn('live'), 'allow');
-    const endedStmt = await insertStatement(policyId, uniqueUrn('ended'), 'allow');
+    const liveStmt = await insertStatement(policyId, URN_A, 'allow');
+    const endedStmt = await insertStatement(policyId, URN_B, 'allow');
     await softEndStatement(endedStmt);
     const teamId = await createTeam(connection, 'mixed-ended-team');
     await insertTeamPolicy(teamId, policyId);

--- a/api/src/__integration__/db/policy-status-orchestration.integration.ts
+++ b/api/src/__integration__/db/policy-status-orchestration.integration.ts
@@ -1,0 +1,783 @@
+// Integration tests for the team-link invariant on the security-scope cache.
+//
+// Every `team_security_scope` and `policy_statement_scope` row must walk back
+// to a live `team_policy` ⨝ `policy(status='approved')` ⨝ `policy_statement(effect='ALLOW')`.
+// Statement creation alone never produces cache rows — the cache materializes
+// lazily on `team_policy` create or on the status flip into `approved`, and is
+// rebuilt on `team_policy` delete or on the flip away from `approved`.
+//
+// These tests exercise the real service stack so the production orchestration
+// (PolicyService, TeamPolicyService, DataRequestService, DownloadPolicyService,
+// SecurityScopeService) runs against a real database. The pg-boss publisher is
+// stubbed because pg-boss is not running under `make test-db`; the stub also
+// makes invocation count assertable so we can pin which paths publish anchor
+// jobs and which intentionally do not.
+//
+// Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
+//
+// Run: make test-db
+// Requires: make web (database must be running with seed data)
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import SQL from 'sql-template-strings';
+import { z } from 'zod';
+import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { PolicyEffect } from '../../models/policy-statement';
+import { SecurityScopeRepository } from '../../repositories/authorization/security-scope-repository';
+import { PolicyService } from '../../services/access-policy/policy-service';
+import { SecurityScopeService } from '../../services/access-policy/security-scope-service';
+import { TeamPolicyService } from '../../services/access-policy/team-policy-service';
+import { DataRequestService } from '../../services/data-request-service';
+import { DownloadPolicyService } from '../../services/download/download-policy-service';
+import { addTeamMember, createPolicy, createPolicyStatement, createTeam } from '../helpers/test-rbac-helpers';
+import { getOrCreateIntegrationTicketId } from '../helpers/test-submission-helpers';
+
+// ── Typed row schemas for raw SELECTs ────────────────────────────────────
+
+const SecurityScopeIdRow = z.object({ security_scope_id: z.string().uuid() });
+
+const CountRow = z.object({ count: z.number() });
+
+// Used by the global invariant query (I11). Every cache row this returns is an
+// orphan — a row whose policy chain is missing or whose policy/statement gates
+// no longer satisfy the access invariant.
+const OrphanRow = z.object({
+  team_id: z.string().uuid().nullable(),
+  security_scope_id: z.string().uuid(),
+  policy_statement_id: z.string().uuid().nullable()
+});
+
+describe('Policy status orchestration (integration)', function () {
+  this.timeout(15000);
+
+  let connection: IDBConnection;
+  let publisherStub: sinon.SinonStub;
+
+  before(() => {
+    initDBPool(defaultPoolConfig);
+  });
+
+  beforeEach(async () => {
+    // `connection.open()` begins the implicit transaction; afterEach's
+    // `connection.rollback()` discards every write made during the test.
+    connection = getAPIUserDBConnection();
+    await connection.open();
+
+    // pg-boss is not running under `make test-db`. The stub lets the production
+    // orchestration proceed and exposes invocation counts so we can pin which
+    // code paths publish anchor jobs and which paths must stay silent.
+    publisherStub = sinon
+      .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+      .resolves({ status: 'published', jobId: 'stub-job-id' });
+  });
+
+  afterEach(async () => {
+    await connection.rollback();
+    connection.release();
+    sinon.restore();
+  });
+
+  // ── Cache-state inspection helpers ───────────────────────────────────
+
+  /** Count `team_security_scope` rows for one (team, policy)'s scopes. */
+  async function countTeamScopesForPolicy(teamId: string, policyId: string): Promise<number> {
+    const result = await connection.sql(
+      SQL`
+        SELECT count(*)::integer AS count
+        FROM team_security_scope tss
+        JOIN policy_statement_scope pss USING (security_scope_id)
+        JOIN policy_statement ps USING (policy_statement_id)
+        WHERE tss.team_id = ${teamId}
+          AND ps.policy_id = ${policyId};
+      `,
+      CountRow
+    );
+    return result.rows[0].count;
+  }
+
+  /** Count `policy_statement_scope` rows that belong to a policy's statements. */
+  async function countPolicyStatementScopes(policyId: string): Promise<number> {
+    const result = await connection.sql(
+      SQL`
+        SELECT count(*)::integer AS count
+        FROM policy_statement_scope pss
+        JOIN policy_statement ps USING (policy_statement_id)
+        WHERE ps.policy_id = ${policyId};
+      `,
+      CountRow
+    );
+    return result.rows[0].count;
+  }
+
+  /** All `security_scope_id`s currently mapped to a policy's statements. */
+  async function getScopeIdsForPolicy(policyId: string): Promise<string[]> {
+    const result = await connection.sql(
+      SQL`
+        SELECT DISTINCT pss.security_scope_id
+        FROM policy_statement_scope pss
+        JOIN policy_statement ps USING (policy_statement_id)
+        WHERE ps.policy_id = ${policyId}
+        ORDER BY pss.security_scope_id;
+      `,
+      SecurityScopeIdRow
+    );
+    return result.rows.map((r) => r.security_scope_id);
+  }
+
+  /** All `security_scope_id`s a team can reach via its team_security_scope rows. */
+  async function getTeamSecurityScopeIds(teamId: string): Promise<string[]> {
+    const result = await connection.sql(
+      SQL`
+        SELECT security_scope_id FROM team_security_scope
+        WHERE team_id = ${teamId}
+        ORDER BY security_scope_id;
+      `,
+      SecurityScopeIdRow
+    );
+    return result.rows.map((r) => r.security_scope_id);
+  }
+
+  /** True if a security_scope row exists for this URN's hash. */
+  async function hasSecurityScopeRowForStatement(policyStatementId: string): Promise<boolean> {
+    const result = await connection.sql(
+      SQL`
+        SELECT count(*)::integer AS count FROM policy_statement_scope
+        WHERE policy_statement_id = ${policyStatementId};
+      `,
+      CountRow
+    );
+    return result.rows[0].count > 0;
+  }
+
+  /** Pull a ticket ID for the data-request flow (creates one if missing). */
+  async function ensureTicketId(): Promise<string> {
+    // The data-request flow only needs a valid ticket FK target. Submission /
+    // upload identifiers are placeholders — the helper hashes them into the
+    // ticket description and reuses an existing match if one exists.
+    return getOrCreateIntegrationTicketId(
+      connection,
+      0,
+      '00000000-0000-0000-0000-000000000000',
+      connection.systemUserId()
+    );
+  }
+
+  // ── I1: TeamPolicyService.createTeamPolicy lazily materializes ───────
+
+  it('I1: createTeamPolicy on approved policy + ALLOW statement materializes one scope, one mapping, one team grant; publisher called once', async () => {
+    const policyId = await createPolicy(connection, 'I1-approved-allow');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamId = await createTeam(connection, 'I1 Team');
+    await addTeamMember(connection, teamId, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyId });
+
+    // One security_scope, one policy_statement_scope mapping, one team grant.
+    expect(await countPolicyStatementScopes(policyId)).to.equal(1);
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(1);
+
+    const scopeIds = await getScopeIdsForPolicy(policyId);
+    expect(scopeIds).to.have.length(1);
+
+    // The anchor-computation job for the materialized scope is published exactly once.
+    expect(publisherStub.callCount).to.equal(1);
+    expect(publisherStub.firstCall.args[1]).to.deep.equal({ securityScopeId: scopeIds[0] });
+
+    // Sanity: cache row points at the same scope_id that the statement was mapped to.
+    const teamScopeIds = await getTeamSecurityScopeIds(teamId);
+    expect(teamScopeIds).to.deep.equal(scopeIds);
+  });
+
+  // ── I2: PolicyService.updatePolicy(→ approved) populates the cache ───
+
+  it('I2: flipping a policy from reviewed → approved with linked team_policies materializes the cache for each linked team', async () => {
+    const policyId = await createPolicy(connection, 'I2-reviewed', 'reviewed');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamId = await createTeam(connection, 'I2 Team');
+    await addTeamMember(connection, teamId, connection.systemUserId());
+
+    // Link the team before approval — the cache must stay empty until the flip.
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyId });
+
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(0);
+    expect(publisherStub.callCount).to.equal(0);
+
+    const policyService = new PolicyService(connection);
+    await policyService.updatePolicy(policyId, { status: 'approved' });
+
+    expect(await countPolicyStatementScopes(policyId)).to.equal(1);
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(1);
+
+    const scopeIds = await getScopeIdsForPolicy(policyId);
+    expect(scopeIds).to.have.length(1);
+
+    expect(publisherStub.callCount).to.equal(1);
+    expect(publisherStub.firstCall.args[1]).to.deep.equal({ securityScopeId: scopeIds[0] });
+  });
+
+  // ── I3: PolicyService.updatePolicy(approved → reviewed) ungrants all teams ─
+
+  it('I3: flipping a policy out of approved removes every linked team’s team_security_scope rows; shared scope + mapping rows stay', async () => {
+    const policyId = await createPolicy(connection, 'I3-approved');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamA = await createTeam(connection, 'I3 Team A');
+    const teamB = await createTeam(connection, 'I3 Team B');
+    await addTeamMember(connection, teamA, connection.systemUserId());
+    await addTeamMember(connection, teamB, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamA, policy_id: policyId });
+    await teamPolicyService.createTeamPolicy({ team_id: teamB, policy_id: policyId });
+
+    // Both teams should be in the cache before the flip.
+    expect(await countTeamScopesForPolicy(teamA, policyId)).to.equal(1);
+    expect(await countTeamScopesForPolicy(teamB, policyId)).to.equal(1);
+
+    const publishCountBeforeFlip = publisherStub.callCount;
+
+    const policyService = new PolicyService(connection);
+    await policyService.updatePolicy(policyId, { status: 'reviewed' });
+
+    // Both teams are ungranted for this policy's scopes.
+    expect(await countTeamScopesForPolicy(teamA, policyId)).to.equal(0);
+    expect(await countTeamScopesForPolicy(teamB, policyId)).to.equal(0);
+
+    // Shared scope row and policy_statement_scope mapping survive the downgrade —
+    // the rebuild only touches per-team grants, not the global cache rows.
+    expect(await countPolicyStatementScopes(policyId)).to.equal(1);
+
+    // The reverse path rebuilds teams from the policy chain; it does not publish
+    // new anchor jobs because no new scopes are being materialized.
+    expect(publisherStub.callCount).to.equal(publishCountBeforeFlip);
+  });
+
+  // ── I3b: downgrade preserves access still justified by another live policy ─
+
+  it('I3b: downgrading one of two approved policies justifying the same scope leaves the team’s access intact via the other policy', async () => {
+    // A team can reach the same scope through two different approved policies
+    // (different statements, identical URN → identical scope_hash → shared
+    // `security_scope` row, two `policy_statement_scope` rows pointing at it).
+    // Downgrading one of the policies must NOT drop the team's `team_security_scope`
+    // row, because the other policy still justifies it. This is the multi-policy
+    // form of Edge Case #3 — the rebuild must walk the full live policy chain,
+    // not just remove rows attributed to the downgraded policy.
+    const sharedUrn = 'urn:*:dataset:*';
+
+    const policyA = await createPolicy(connection, 'I3b-policy-A');
+    const statementA = await createPolicyStatement(connection, policyA, sharedUrn);
+
+    const policyB = await createPolicy(connection, 'I3b-policy-B');
+    const statementB = await createPolicyStatement(connection, policyB, sharedUrn);
+
+    const teamId = await createTeam(connection, 'I3b Team');
+    await addTeamMember(connection, teamId, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyA });
+    await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyB });
+
+    // Pre-flip state: one shared scope, two mappings (one per statement), one team grant.
+    const scopeIdsForA = await getScopeIdsForPolicy(policyA);
+    const scopeIdsForB = await getScopeIdsForPolicy(policyB);
+    expect(scopeIdsForA).to.have.lengthOf(1);
+    expect(scopeIdsForB).to.deep.equal(scopeIdsForA);
+    expect(await getTeamSecurityScopeIds(teamId)).to.deep.equal(scopeIdsForA);
+
+    const publishCountBeforeFlip = publisherStub.callCount;
+
+    const policyService = new PolicyService(connection);
+    await policyService.updatePolicy(policyA, { status: 'reviewed' });
+
+    // Team access to the shared scope must survive the downgrade — Policy B still
+    // justifies it. The team_security_scope row that previously walked back to
+    // Policy A's statement now walks back to Policy B's.
+    expect(await getTeamSecurityScopeIds(teamId)).to.deep.equal(scopeIdsForA);
+
+    // Both `policy_statement_scope` mapping rows persist — rebuild operates per
+    // team and never deletes scope mappings.
+    expect(await hasSecurityScopeRowForStatement(statementA)).to.equal(true);
+    expect(await hasSecurityScopeRowForStatement(statementB)).to.equal(true);
+
+    // Rebuild path publishes no new anchor jobs.
+    expect(publisherStub.callCount).to.equal(publishCountBeforeFlip);
+  });
+
+  // ── I4: DataRequestService.createDataRequestForTicket stays scope-free ───
+
+  it('I4: creating a data-request (status=requested, DENY policy) creates no scope, mapping, or team grant rows; publisher silent', async () => {
+    const ticketId = await ensureTicketId();
+    const dataRequestService = new DataRequestService(connection);
+
+    const created = await dataRequestService.createDataRequestForTicket(ticketId, {
+      requested_by: connection.systemUserId(),
+      reason: 'I4 anti-regression',
+      system_user_ids: [connection.systemUserId()]
+    });
+
+    // Pull the auto-created policy via its data_request row.
+    const policyId = created.policy_id;
+
+    // Nothing about a requested DENY policy should hit the cache.
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+
+    const teamGrants = await connection.sql(
+      SQL`
+        SELECT count(*)::integer AS count
+        FROM team_security_scope tss
+        JOIN team_policy tp USING (team_id)
+        WHERE tp.policy_id = ${policyId};
+      `,
+      CountRow
+    );
+    expect(teamGrants.rows[0].count).to.equal(0);
+
+    // A security_scope row keyed by this policy's statement URN must not exist.
+    const stmtScope = await connection.sql(
+      SQL`
+        SELECT count(*)::integer AS count
+        FROM security_scope ss
+        JOIN policy_statement_scope pss USING (security_scope_id)
+        JOIN policy_statement ps USING (policy_statement_id)
+        WHERE ps.policy_id = ${policyId};
+      `,
+      CountRow
+    );
+    expect(stmtScope.rows[0].count).to.equal(0);
+
+    expect(publisherStub.callCount).to.equal(0);
+  });
+
+  // ── I5: data-request approval lifecycle end-to-end ───────────────────
+
+  it('I5: after a data-request is created, swapping in an ALLOW statement and flipping requested → reviewed → approved materializes the cache only on approval', async () => {
+    const ticketId = await ensureTicketId();
+    const dataRequestService = new DataRequestService(connection);
+    const policyService = new PolicyService(connection);
+
+    const created = await dataRequestService.createDataRequestForTicket(ticketId, {
+      requested_by: connection.systemUserId(),
+      reason: 'I5 approval lifecycle',
+      system_user_ids: [connection.systemUserId()]
+    });
+    const policyId = created.policy_id;
+
+    // Pre-state: data-request flow leaves the cache empty (re-asserts I4 invariant).
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+    expect(publisherStub.callCount).to.equal(0);
+
+    // Reviewer swaps the deny-all statement for an ALLOW grant. The Knex
+    // `update` call rejects empty payloads, so we pass `description` as a
+    // no-op metadata change to satisfy the layer below.
+    await policyService.updatePolicyWithStatements(policyId, { description: 'I5 review notes' }, [
+      { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:dataset:*' }
+    ]);
+
+    // Still requested → still no cache rows, still no publishes.
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+    expect(publisherStub.callCount).to.equal(0);
+
+    // First lifecycle step: requested → reviewed.
+    await policyService.updatePolicy(policyId, { status: 'reviewed' });
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+    expect(publisherStub.callCount).to.equal(0);
+
+    // Second lifecycle step: reviewed → approved. Now the team_policy linked
+    // by createDataRequestForTicket triggers fan-out materialization.
+    await policyService.updatePolicy(policyId, { status: 'approved' });
+
+    expect(await countPolicyStatementScopes(policyId)).to.equal(1);
+
+    const teamGrantsAfterApproval = await connection.sql(
+      SQL`
+        SELECT count(*)::integer AS count
+        FROM team_security_scope tss
+        JOIN team_policy tp USING (team_id)
+        WHERE tp.policy_id = ${policyId};
+      `,
+      CountRow
+    );
+    expect(teamGrantsAfterApproval.rows[0].count).to.equal(1);
+
+    // One publish per materialized scope; the policy has exactly one ALLOW statement.
+    expect(publisherStub.callCount).to.equal(1);
+  });
+
+  // ── I6: DownloadPolicyService stays compliant ────────────────────────
+
+  it('I6: createDownloadPolicy creates the policy + statements but no scope, mapping, or team grant rows; publisher silent', async () => {
+    const downloadPolicyService = new DownloadPolicyService(connection);
+
+    const { policy_id } = await downloadPolicyService.createDownloadPolicy({
+      name: 'I6 Download Policy',
+      description: 'audit: download policies stay scope-free',
+      featureTypes: ['dataset'],
+      expressionId: null
+    });
+
+    expect(await countPolicyStatementScopes(policy_id)).to.equal(0);
+
+    const teamGrants = await connection.sql(
+      SQL`
+        SELECT count(*)::integer AS count
+        FROM team_security_scope tss
+        JOIN team_policy tp USING (team_id)
+        WHERE tp.policy_id = ${policy_id};
+      `,
+      CountRow
+    );
+    expect(teamGrants.rows[0].count).to.equal(0);
+
+    expect(publisherStub.callCount).to.equal(0);
+  });
+
+  // ── I7: deleteTeamPolicy preserves shared scope rows ────────────────
+
+  it('I7: deleting one team’s team_policy ungrants that team without disturbing other teams’ access or the shared scope rows', async () => {
+    const policyId = await createPolicy(connection, 'I7-shared-approved');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamA = await createTeam(connection, 'I7 Team A');
+    const teamB = await createTeam(connection, 'I7 Team B');
+    await addTeamMember(connection, teamA, connection.systemUserId());
+    await addTeamMember(connection, teamB, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    const teamPolicyA = await teamPolicyService.createTeamPolicy({ team_id: teamA, policy_id: policyId });
+    await teamPolicyService.createTeamPolicy({ team_id: teamB, policy_id: policyId });
+
+    const scopeIdsBefore = await getScopeIdsForPolicy(policyId);
+    expect(scopeIdsBefore).to.have.length(1);
+    expect(await countTeamScopesForPolicy(teamA, policyId)).to.equal(1);
+    expect(await countTeamScopesForPolicy(teamB, policyId)).to.equal(1);
+
+    await teamPolicyService.deleteTeamPolicy(teamPolicyA.team_policy_id);
+
+    // A loses its grant; B is untouched.
+    expect(await countTeamScopesForPolicy(teamA, policyId)).to.equal(0);
+    expect(await countTeamScopesForPolicy(teamB, policyId)).to.equal(1);
+
+    // Shared scope + mapping rows survive — B still references them.
+    expect(await countPolicyStatementScopes(policyId)).to.equal(1);
+    const scopeIdsAfter = await getScopeIdsForPolicy(policyId);
+    expect(scopeIdsAfter).to.deep.equal(scopeIdsBefore);
+  });
+
+  // ── I8: updatePolicyWithStatements rederives scope for active consumers ───
+
+  it('I8: replacing a policy’s statement on an approved policy with active team_policy links cleans up the old scope mapping, materializes the new scope, and switches the team grant', async () => {
+    const policyId = await createPolicy(connection, 'I8-active-consumers');
+    const oldStmtId = await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamId = await createTeam(connection, 'I8 Team');
+    await addTeamMember(connection, teamId, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyId });
+
+    const oldScopeIds = await getScopeIdsForPolicy(policyId);
+    expect(oldScopeIds).to.have.length(1);
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(1);
+
+    const callsAfterSetup = publisherStub.callCount;
+
+    const policyService = new PolicyService(connection);
+    await policyService.updatePolicyWithStatements(policyId, { description: 'I8 swapped statements' }, [
+      { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:sample_site:*' }
+    ]);
+
+    // Old statement's mapping is gone; the urn1 security_scope row may stay
+    // around (other policies could share it) but it has no active reference
+    // from this policy any more.
+    expect(await hasSecurityScopeRowForStatement(oldStmtId)).to.equal(false);
+
+    // New statement now drives the policy's only active mapping.
+    const newScopeIds = await getScopeIdsForPolicy(policyId);
+    expect(newScopeIds).to.have.length(1);
+    expect(newScopeIds[0]).to.not.equal(oldScopeIds[0]);
+
+    // The team's grant switches to the new scope.
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(1);
+    const teamScopeIds = await getTeamSecurityScopeIds(teamId);
+    expect(teamScopeIds).to.include(newScopeIds[0]);
+    expect(teamScopeIds).to.not.include(oldScopeIds[0]);
+
+    // Publisher fires at least once for the new scope. Orphan-cleanup may also
+    // republish the old scope_id; pin only the must-have so the test is stable
+    // against future internal-publish ordering tweaks.
+    const newPublishes = publisherStub.getCalls().slice(callsAfterSetup);
+    const publishedScopeIds = newPublishes.map((call) => call.args[1].securityScopeId);
+    expect(publishedScopeIds).to.include(newScopeIds[0]);
+  });
+
+  // ── I9: update-without-consumers stays lazy ─────────────────────────
+
+  it('I9: updatePolicyWithStatements on a policy with no team_policy links produces zero scope rows before and after; publisher silent', async () => {
+    const policyId = await createPolicy(connection, 'I9-no-consumers');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    // Pre-state: no team_policy linkage → no cache rows yet.
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+
+    const policyService = new PolicyService(connection);
+    await policyService.updatePolicyWithStatements(policyId, { description: 'I9 swapped statements' }, [
+      { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:sample_site:*' }
+    ]);
+
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+    expect(publisherStub.callCount).to.equal(0);
+  });
+
+  // ── I10: DENY-only approved policy still grants no scope rows ──────
+
+  it('I10: createTeamPolicy on an approved policy with only DENY statements produces no scope, mapping, or team grant rows; publisher silent', async () => {
+    const policyId = await createPolicy(connection, 'I10-deny-only');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*', PolicyEffect.DENY);
+
+    const teamId = await createTeam(connection, 'I10 Team');
+    await addTeamMember(connection, teamId, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyId });
+
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(0);
+    expect(publisherStub.callCount).to.equal(0);
+  });
+
+  // ── I10b: requested-status policy still grants no scope rows ───────
+
+  it('I10b: createTeamPolicy on a requested-status policy (even with ALLOW statements) produces no team grant rows; publisher silent', async () => {
+    // Closes the API-contract gap: a not-yet-approved policy must not leak
+    // access through the team_policy create path even if its statements
+    // would otherwise qualify.
+    const policyId = await createPolicy(connection, 'I10b-requested-allow', 'requested');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamId = await createTeam(connection, 'I10b Team');
+    await addTeamMember(connection, teamId, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyId });
+
+    expect(await countPolicyStatementScopes(policyId)).to.equal(0);
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(0);
+    expect(publisherStub.callCount).to.equal(0);
+  });
+
+  // ── I11: global invariant — no orphan cache rows after multi-scenario run ─
+
+  it('I11: after running I1 + I2 + I7 + I8 sequentially, every team_security_scope and policy_statement_scope row walks back to an approved policy with an ALLOW statement', async () => {
+    // -- I1: createTeamPolicy on an approved+ALLOW policy ---------------
+    const i1PolicyId = await createPolicy(connection, 'I11-I1');
+    await createPolicyStatement(connection, i1PolicyId, 'urn:*:dataset:*');
+    const i1TeamId = await createTeam(connection, 'I11 Team I1');
+    await addTeamMember(connection, i1TeamId, connection.systemUserId());
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: i1TeamId, policy_id: i1PolicyId });
+
+    // -- I2: reviewed → approved flip with linked team_policy -----------
+    const i2PolicyId = await createPolicy(connection, 'I11-I2', 'reviewed');
+    await createPolicyStatement(connection, i2PolicyId, 'urn:*:sample_site:*');
+    const i2TeamId = await createTeam(connection, 'I11 Team I2');
+    await addTeamMember(connection, i2TeamId, connection.systemUserId());
+    await teamPolicyService.createTeamPolicy({ team_id: i2TeamId, policy_id: i2PolicyId });
+    const policyService = new PolicyService(connection);
+    await policyService.updatePolicy(i2PolicyId, { status: 'approved' });
+
+    // -- I7: deleteTeamPolicy ungrants A, keeps B + shared scope rows --
+    const i7PolicyId = await createPolicy(connection, 'I11-I7');
+    await createPolicyStatement(connection, i7PolicyId, 'urn:*:animal:*');
+    const i7TeamA = await createTeam(connection, 'I11 Team I7 A');
+    const i7TeamB = await createTeam(connection, 'I11 Team I7 B');
+    await addTeamMember(connection, i7TeamA, connection.systemUserId());
+    await addTeamMember(connection, i7TeamB, connection.systemUserId());
+    const teamPolicyA = await teamPolicyService.createTeamPolicy({ team_id: i7TeamA, policy_id: i7PolicyId });
+    await teamPolicyService.createTeamPolicy({ team_id: i7TeamB, policy_id: i7PolicyId });
+    await teamPolicyService.deleteTeamPolicy(teamPolicyA.team_policy_id);
+
+    // -- I8: replace ALLOW statement on a live approved policy ---------
+    const i8PolicyId = await createPolicy(connection, 'I11-I8');
+    await createPolicyStatement(connection, i8PolicyId, 'urn:*:capture:*');
+    const i8TeamId = await createTeam(connection, 'I11 Team I8');
+    await addTeamMember(connection, i8TeamId, connection.systemUserId());
+    await teamPolicyService.createTeamPolicy({ team_id: i8TeamId, policy_id: i8PolicyId });
+    await policyService.updatePolicyWithStatements(i8PolicyId, { description: 'I11 I8 step' }, [
+      { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:mortality:*' }
+    ]);
+
+    // Walk every team_security_scope row this test produced back through the
+    // policy chain. Any row that cannot reach `team_policy ⨝
+    // policy(status='approved') ⨝ policy_statement(effect='ALLOW')` (all live,
+    // all record_end_date IS NULL) is an orphan — the team-link invariant has
+    // been violated. The query scopes to the four (team, policy) pairs created
+    // here so pre-existing seed-level orphans cannot mask a real regression.
+    const testTeamIds = [i1TeamId, i2TeamId, i7TeamA, i7TeamB, i8TeamId];
+    const testPolicyIds = [i1PolicyId, i2PolicyId, i7PolicyId, i8PolicyId];
+
+    const teamOrphans = await connection.sql(
+      SQL`
+        SELECT tss.team_id, tss.security_scope_id, NULL::uuid AS policy_statement_id
+        FROM team_security_scope tss
+        WHERE tss.team_id = ANY(${testTeamIds}::uuid[])
+          AND NOT EXISTS (
+            SELECT 1
+            FROM policy_statement_scope pss
+            JOIN policy_statement ps
+              ON ps.policy_statement_id = pss.policy_statement_id
+              AND ps.effect = 'allow'
+              AND ps.record_end_date IS NULL
+            JOIN policy p
+              ON p.policy_id = ps.policy_id
+              AND p.status = 'approved'
+              AND p.record_end_date IS NULL
+            JOIN team_policy tp
+              ON tp.policy_id = p.policy_id
+              AND tp.team_id = tss.team_id
+              AND tp.record_end_date IS NULL
+            WHERE pss.security_scope_id = tss.security_scope_id
+          );
+      `,
+      OrphanRow
+    );
+    expect(
+      teamOrphans.rowCount,
+      `unexpected team_security_scope orphans: ${JSON.stringify(teamOrphans.rows)}`
+    ).to.equal(0);
+
+    // Same walk for policy_statement_scope — only rows whose statement is ALLOW
+    // and whose policy is approved (both live) are allowed to exist. Scoped to
+    // the policies created in this test.
+    const statementOrphans = await connection.sql(
+      SQL`
+        SELECT NULL::uuid AS team_id, pss.security_scope_id, pss.policy_statement_id
+        FROM policy_statement_scope pss
+        JOIN policy_statement filter_ps ON filter_ps.policy_statement_id = pss.policy_statement_id
+        WHERE filter_ps.policy_id = ANY(${testPolicyIds}::uuid[])
+          AND NOT EXISTS (
+            SELECT 1
+            FROM policy_statement ps
+            JOIN policy p
+              ON p.policy_id = ps.policy_id
+              AND p.status = 'approved'
+              AND p.record_end_date IS NULL
+            WHERE ps.policy_statement_id = pss.policy_statement_id
+              AND ps.effect = 'allow'
+              AND ps.record_end_date IS NULL
+          );
+      `,
+      OrphanRow
+    );
+    expect(
+      statementOrphans.rowCount,
+      `unexpected policy_statement_scope orphans: ${JSON.stringify(statementOrphans.rows)}`
+    ).to.equal(0);
+
+    // Spot-check the scenarios actually produced live cache rows where
+    // expected — guards against a future change that silently leaves the
+    // cache empty (which would also produce zero orphans).
+    expect(await countTeamScopesForPolicy(i1TeamId, i1PolicyId)).to.equal(1);
+    expect(await countTeamScopesForPolicy(i2TeamId, i2PolicyId)).to.equal(1);
+    expect(await countTeamScopesForPolicy(i7TeamA, i7PolicyId)).to.equal(0);
+    expect(await countTeamScopesForPolicy(i7TeamB, i7PolicyId)).to.equal(1);
+    expect(await countTeamScopesForPolicy(i8TeamId, i8PolicyId)).to.equal(1);
+  });
+
+  // ── I12: publisher fires only for access-impacting changes ──────────
+
+  it('I12: (a) a second team_policy on an approved policy publishes once; (b) metadata-only updatePolicy does not publish', async () => {
+    const policyId = await createPolicy(connection, 'I12-approved');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamA = await createTeam(connection, 'I12 Team A');
+    const teamB = await createTeam(connection, 'I12 Team B');
+    await addTeamMember(connection, teamA, connection.systemUserId());
+    await addTeamMember(connection, teamB, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    await teamPolicyService.createTeamPolicy({ team_id: teamA, policy_id: policyId });
+
+    const setupCalls = publisherStub.callCount;
+    expect(setupCalls).to.equal(1);
+
+    const scopeIds = await getScopeIdsForPolicy(policyId);
+    expect(scopeIds).to.have.length(1);
+
+    // (a) Granting a second team materializes one anchor-publish for the
+    // shared scope. Even though the scope_id already exists, the materialize
+    // path re-publishes so anchor recompute covers any cleaned-up rows.
+    await teamPolicyService.createTeamPolicy({ team_id: teamB, policy_id: policyId });
+
+    expect(publisherStub.callCount - setupCalls).to.equal(1);
+    expect(publisherStub.lastCall.args[1]).to.deep.equal({ securityScopeId: scopeIds[0] });
+
+    // (b) A metadata-only updatePolicy (no status, no statement set change)
+    // must not publish. The orchestration short-circuits at the
+    // `status === undefined` branch.
+    const callsBeforeRename = publisherStub.callCount;
+    const policyService = new PolicyService(connection);
+    await policyService.updatePolicy(policyId, { name: 'I12-renamed' });
+    expect(publisherStub.callCount).to.equal(callsBeforeRename);
+  });
+
+  // ── I12c: status-flip to approved with zero linked teams is a clean no-op ─
+
+  it('I12c: flipping an unlinked policy to approved succeeds and produces zero cache rows, zero publishes', async () => {
+    // API Contract #3: an admin can approve a policy that is not (yet) linked
+    // to any team. The status write must succeed, but the cache orchestration
+    // has nothing to fan out — no `team_security_scope` rows appear and the
+    // publisher stays silent.
+    const policyId = await createPolicy(connection, 'I12c-no-teams', 'reviewed');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const publishCountBeforeFlip = publisherStub.callCount;
+
+    const policyService = new PolicyService(connection);
+    const updated = await policyService.updatePolicy(policyId, { status: 'approved' });
+
+    expect(updated.status).to.equal('approved');
+    expect(await getScopeIdsForPolicy(policyId)).to.have.lengthOf(0);
+    expect(publisherStub.callCount).to.equal(publishCountBeforeFlip);
+  });
+
+  // ── I13: SQL-layer defense against a stale caller after soft-delete ──
+
+  it('I13: calling insertTeamSecurityScopesForPolicy after the team_policy link is soft-deleted inserts zero rows (SQL filter is the safety net)', async () => {
+    // Defense-in-depth check. The orchestrator decides when to call
+    // `insertTeamSecurityScopesForPolicy`; a misbehaving or stale caller
+    // holding a `(teamId, policyId)` pair past a `team_policy` soft-delete
+    // must not be able to re-create cache rows. The `JOIN team_policy tp
+    // … WHERE tp.record_end_date IS NULL` clause is the only thing
+    // catching that case at the SQL layer.
+    const policyId = await createPolicy(connection, 'I13-stale-caller');
+    await createPolicyStatement(connection, policyId, 'urn:*:dataset:*');
+
+    const teamId = await createTeam(connection, 'I13 Team');
+    await addTeamMember(connection, teamId, connection.systemUserId());
+
+    const teamPolicyService = new TeamPolicyService(connection);
+    const teamPolicy = await teamPolicyService.createTeamPolicy({ team_id: teamId, policy_id: policyId });
+
+    // Sanity: link is live, cache row exists.
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(1);
+
+    // Soft-delete the link. `deleteTeamPolicy` also runs the rebuild path,
+    // so the cache row is gone after this call.
+    await teamPolicyService.deleteTeamPolicy(teamPolicy.team_policy_id);
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(0);
+
+    // Simulate a stale orchestrator: same `(teamId, policyId)` pair, but the
+    // link beneath it has been soft-deleted. The repository call must be a
+    // no-op — the SQL filter drops the row before the INSERT sees it.
+    const securityScopeRepository = new SecurityScopeRepository(connection);
+    await securityScopeRepository.insertTeamSecurityScopesForPolicy(teamId, policyId);
+
+    expect(await countTeamScopesForPolicy(teamId, policyId)).to.equal(0);
+  });
+});

--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -1537,6 +1537,10 @@ describe('Security scope search (integration)', function () {
     // Seed data may include policy_statements with wildcard URNs (urn_submission_id = '*')
     // that match any submission. Tests use a baseline snapshot to isolate assertions
     // to scopes created within the test.
+    //
+    // A live team_policy link is required for the gate (SIMSBIOHUB-985 invariant) —
+    // each test wires one so the URN-matching predicates are what's actually being
+    // exercised. Tests that target the gate itself live in the next describe block.
 
     it('should match a submission-scoped URN (urn:{subId}:*:*)', async () => {
       const submissionId = await createTestSubmission(connection);
@@ -1545,6 +1549,8 @@ describe('Security scope search (integration)', function () {
       const policyId = await createPolicy(connection, 'sub-scope-match');
       const stmtId = await createPolicyStatement(connection, policyId, `urn:${submissionId}:*:*`);
       const scopeId = await setupScopeChain(scopeRepo, stmtId, `urn:${submissionId}:*:*`);
+      const teamId = await createTeam(connection, 'sub-scope-team');
+      await createTeamPolicy(connection, teamId, policyId);
 
       const result = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
       const scopeIds = result.map((r) => r.security_scope_id);
@@ -1560,6 +1566,8 @@ describe('Security scope search (integration)', function () {
       const policyId = await createPolicy(connection, 'wildcard-match');
       const stmtId = await createPolicyStatement(connection, policyId, 'urn:*:*:*');
       const scopeId = await setupScopeChain(scopeRepo, stmtId, 'urn:*:*:*');
+      const teamId = await createTeam(connection, 'wildcard-team');
+      await createTeamPolicy(connection, teamId, policyId);
 
       const result = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
       const scopeIds = result.map((r) => r.security_scope_id);
@@ -1574,6 +1582,8 @@ describe('Security scope search (integration)', function () {
       const policyId = await createPolicy(connection, 'type-wildcard-match');
       const stmtId = await createPolicyStatement(connection, policyId, 'urn:*:telemetry:*');
       const scopeId = await setupScopeChain(scopeRepo, stmtId, 'urn:*:telemetry:*');
+      const teamId = await createTeam(connection, 'type-wildcard-team');
+      await createTeamPolicy(connection, teamId, policyId);
 
       const result = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
       const scopeIds = result.map((r) => r.security_scope_id);
@@ -1590,6 +1600,8 @@ describe('Security scope search (integration)', function () {
       const policyId = await createPolicy(connection, 'no-match');
       const stmtId = await createPolicyStatement(connection, policyId, `urn:${sub1}:*:*`);
       const scopeId = await setupScopeChain(scopeRepo, stmtId, `urn:${sub1}:*:*`);
+      const teamId = await createTeam(connection, 'no-match-team');
+      await createTeamPolicy(connection, teamId, policyId);
 
       const result = await scopeRepo.findScopeIdsMatchingSubmission(sub2);
       const scopeIds = result.map((r) => r.security_scope_id);
@@ -1607,11 +1619,15 @@ describe('Security scope search (integration)', function () {
       const policyA = await createPolicy(connection, 'specific-match');
       const stmtA = await createPolicyStatement(connection, policyA, `urn:${submissionId}:*:*`);
       const scopeIdA = await setupScopeChain(scopeRepo, stmtA, `urn:${submissionId}:*:*`);
+      const teamA = await createTeam(connection, 'specific-team');
+      await createTeamPolicy(connection, teamA, policyA);
 
       // Wildcard scope (different hash → different scope row)
       const policyB = await createPolicy(connection, 'wildcard-also-match');
       const stmtB = await createPolicyStatement(connection, policyB, 'urn:*:*:*');
       const scopeIdB = await setupScopeChain(scopeRepo, stmtB, 'urn:*:*:*');
+      const teamB = await createTeam(connection, 'wildcard-also-team');
+      await createTeamPolicy(connection, teamB, policyB);
 
       const result = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
       const scopeIds = result.map((r) => r.security_scope_id);
@@ -1628,6 +1644,8 @@ describe('Security scope search (integration)', function () {
       const policyId = await createPolicy(connection, 'soft-deleted-match');
       const stmtId = await createPolicyStatement(connection, policyId, `urn:${submissionId}:*:*`);
       const scopeId = await setupScopeChain(scopeRepo, stmtId, `urn:${submissionId}:*:*`);
+      const teamId = await createTeam(connection, 'soft-deleted-team');
+      await createTeamPolicy(connection, teamId, policyId);
 
       await softDeleteStatement(stmtId);
 
@@ -1648,10 +1666,14 @@ describe('Security scope search (integration)', function () {
       const policyA = await createPolicy(connection, 'dedup-A');
       const stmtA = await createPolicyStatement(connection, policyA, urn);
       const scopeIdA = await setupScopeChain(scopeRepo, stmtA, urn);
+      const teamA = await createTeam(connection, 'dedup-team-A');
+      await createTeamPolicy(connection, teamA, policyA);
 
       const policyB = await createPolicy(connection, 'dedup-B');
       const stmtB = await createPolicyStatement(connection, policyB, urn);
       const scopeIdB = await setupScopeChain(scopeRepo, stmtB, urn);
+      const teamB = await createTeam(connection, 'dedup-team-B');
+      await createTeamPolicy(connection, teamB, policyB);
 
       // Same scope_hash → same scope row
       expect(scopeIdA).to.equal(scopeIdB);
@@ -1660,6 +1682,68 @@ describe('Security scope search (integration)', function () {
 
       // DISTINCT in the query → only 1 new scope despite 2 statements
       expect(result).to.have.lengthOf(baseline.length + 1);
+    });
+  });
+
+  // ── findScopeIdsMatchingSubmission → team_policy gate (SIMSBIOHUB-985) ──
+
+  describe('findScopeIdsMatchingSubmission → team_policy gate', () => {
+    // Edge case #9 from spec.md: anchor recomputation must not fire for scopes
+    // outside the team-link set. The repository gates on a live team_policy so
+    // orphaned scopes (no team granted) don't drive wasted anchor-compute jobs.
+
+    it('should not return scopes for an approved policy with no team_policy', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const baseline = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
+
+      const policyId = await createPolicy(connection, 'no-team-policy');
+      const stmtId = await createPolicyStatement(connection, policyId, `urn:${submissionId}:*:*`);
+      const scopeId = await setupScopeChain(scopeRepo, stmtId, `urn:${submissionId}:*:*`);
+
+      const result = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
+      const scopeIds = result.map((r) => r.security_scope_id);
+
+      expect(scopeIds).to.not.include(scopeId);
+      expect(result).to.have.lengthOf(baseline.length);
+    });
+
+    it('should drop a scope from the result after its last team_policy is soft-deleted', async () => {
+      const submissionId = await createTestSubmission(connection);
+
+      const policyId = await createPolicy(connection, 'orphan-on-delete');
+      const stmtId = await createPolicyStatement(connection, policyId, `urn:${submissionId}:*:*`);
+      const scopeId = await setupScopeChain(scopeRepo, stmtId, `urn:${submissionId}:*:*`);
+      const teamId = await createTeam(connection, 'orphan-on-delete-team');
+      const teamPolicyId = await createTeamPolicy(connection, teamId, policyId);
+
+      // While the team_policy is live, the scope appears
+      const before = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
+      expect(before.map((r) => r.security_scope_id)).to.include(scopeId);
+
+      // After the only team_policy is soft-deleted, the scope is gated out
+      await softDeleteTeamPolicy(teamPolicyId);
+      const after = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
+      expect(after.map((r) => r.security_scope_id)).to.not.include(scopeId);
+    });
+
+    it('should keep a shared scope while any team_policy still references its policy', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const urn = `urn:${submissionId}:*:*`;
+
+      const policyId = await createPolicy(connection, 'shared-team-policies');
+      const stmtId = await createPolicyStatement(connection, policyId, urn);
+      const scopeId = await setupScopeChain(scopeRepo, stmtId, urn);
+
+      const teamA = await createTeam(connection, 'shared-A');
+      const teamB = await createTeam(connection, 'shared-B');
+      const tpA = await createTeamPolicy(connection, teamA, policyId);
+      await createTeamPolicy(connection, teamB, policyId);
+
+      // Drop only one of the two links — the other still justifies the scope
+      await softDeleteTeamPolicy(tpA);
+
+      const result = await scopeRepo.findScopeIdsMatchingSubmission(submissionId);
+      expect(result.map((r) => r.security_scope_id)).to.include(scopeId);
     });
   });
 

--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -1458,7 +1458,7 @@ describe('Security scope search (integration)', function () {
       // security_scope row (scope_hash match) but its anchors were deleted
       // during the orphan cleanup from the first change.
       //
-      // setupScopeChain mirrors createScopeForPolicyStatement: it checks
+      // setupScopeChain mirrors materializeScopeForPolicyStatement: it checks
       // insertSecurityScope (ON CONFLICT DO NOTHING) — if null, reuses the
       // existing scope WITHOUT recomputing anchors.
       //

--- a/api/src/__integration__/helpers/test-rbac-helpers.ts
+++ b/api/src/__integration__/helpers/test-rbac-helpers.ts
@@ -7,6 +7,8 @@
  */
 import SQL from 'sql-template-strings';
 import { IDBConnection } from '../../database/db';
+import { PolicyStatus } from '../../models/policy';
+import { PolicyEffect } from '../../models/policy-statement';
 import { SecurityScopeRepository } from '../../repositories/authorization/security-scope-repository';
 import { computeScopeHash } from '../../utils/scope-hash';
 
@@ -40,11 +42,24 @@ export async function addTeamMember(connection: IDBConnection, teamId: string, s
   `);
 }
 
-export async function createPolicy(connection: IDBConnection, name: string): Promise<string> {
+/**
+ * Insert a policy row. Defaults to `status='approved'` so existing callers that
+ * only need a working access-policy do not have to thread the status through;
+ * tests exercising the request → reviewed → approved lifecycle override it.
+ *
+ * The `status` parameter is cast to `biohub.policy_status` in SQL because pg
+ * binds string parameters as `text`; without the explicit cast Postgres
+ * rejects the INSERT (no implicit text → policy_status coercion).
+ */
+export async function createPolicy(
+  connection: IDBConnection,
+  name: string,
+  status: PolicyStatus = 'approved'
+): Promise<string> {
   const systemUserId = connection.systemUserId();
   const result = await connection.sql(SQL`
     INSERT INTO policy (name, status, create_user)
-    VALUES (${name}, 'approved', ${systemUserId})
+    VALUES (${name}, ${status}::biohub.policy_status, ${systemUserId})
     RETURNING policy_id;
   `);
   return result.rows[0].policy_id;
@@ -53,12 +68,24 @@ export async function createPolicy(connection: IDBConnection, name: string): Pro
 /**
  * Create a policy statement with the given URN.
  * The DB trigger auto-decomposes the URN into indexed columns.
+ *
+ * Defaults to `effect='allow'` so existing callers that grant access keep
+ * their original shape; tests for DENY-only policies override the effect.
+ *
+ * The `effect` parameter is cast to `biohub.policy_effect` in SQL because pg
+ * binds string parameters as `text`; without the explicit cast Postgres
+ * rejects the INSERT (no implicit text → policy_effect coercion).
  */
-export async function createPolicyStatement(connection: IDBConnection, policyId: string, urn: string): Promise<string> {
+export async function createPolicyStatement(
+  connection: IDBConnection,
+  policyId: string,
+  urn: string,
+  effect: PolicyEffect = PolicyEffect.ALLOW
+): Promise<string> {
   const systemUserId = connection.systemUserId();
   const result = await connection.sql(SQL`
     INSERT INTO policy_statement (policy_id, effect, submission_feature_urn, create_user)
-    VALUES (${policyId}, 'allow', ${urn}, ${systemUserId})
+    VALUES (${policyId}, ${effect}::biohub.policy_effect, ${urn}, ${systemUserId})
     RETURNING policy_statement_id;
   `);
   return result.rows[0].policy_statement_id;

--- a/api/src/models/policy-statement.ts
+++ b/api/src/models/policy-statement.ts
@@ -16,6 +16,17 @@ export const PolicyStatement = z.object({
 
 export type PolicyStatement = z.infer<typeof PolicyStatement>;
 
+/**
+ * Picked shape for queries that return only the statement identity and its URN target.
+ * Used by the security-scope materialization path — the scope cache only needs to know
+ * which statement is being materialized and which feature URN it grants access to.
+ */
+export const PolicyStatementUrn = PolicyStatement.pick({
+  policy_statement_id: true,
+  submission_feature_urn: true
+});
+export type PolicyStatementUrn = z.infer<typeof PolicyStatementUrn>;
+
 export interface CreatePolicyStatement {
   policy_id: string;
   effect: PolicyEffect;

--- a/api/src/repositories/authorization/security-scope-repository.test.ts
+++ b/api/src/repositories/authorization/security-scope-repository.test.ts
@@ -367,7 +367,7 @@ describe('SecurityScopeRepository', () => {
       expect(result).to.eql([]);
     });
 
-    it('filters to ALLOW statements on approved active policies', async () => {
+    it('filters to ALLOW statements on approved active policies with a live team_policy', async () => {
       const sqlStub = sinon.stub().resolves(mockQueryResult([]));
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
       const repository = new SecurityScopeRepository(mockDBConnection);
@@ -379,6 +379,8 @@ describe('SecurityScopeRepository', () => {
       expect(sqlText).to.include('ps.effect =');
       expect(sqlText).to.include("p.status = 'approved'");
       expect(sqlText).to.include('p.record_end_date is null');
+      expect(sqlText).to.include('join team_policy tp');
+      expect(sqlText).to.include('tp.record_end_date is null');
       expect(sqlValues).to.include('allow');
     });
   });

--- a/api/src/repositories/authorization/security-scope-repository.test.ts
+++ b/api/src/repositories/authorization/security-scope-repository.test.ts
@@ -386,7 +386,7 @@ describe('SecurityScopeRepository', () => {
   });
 
   describe('team scope derivation guards', () => {
-    it('insertTeamSecurityScopesForPolicy only grants from ALLOW approved active policy and active team', async () => {
+    it('insertTeamSecurityScopesForPolicy requires a live team_policy link and an ALLOW approved active policy + active team', async () => {
       const sqlStub = sinon.stub().resolves(mockQueryResult([]));
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
       const repository = new SecurityScopeRepository(mockDBConnection);
@@ -395,6 +395,8 @@ describe('SecurityScopeRepository', () => {
 
       const sqlText = sqlStub.firstCall.args[0].text.toLowerCase();
       const sqlValues = sqlStub.firstCall.args[0].values;
+      expect(sqlText).to.include('from team_policy tp');
+      expect(sqlText).to.include('tp.record_end_date is null');
       expect(sqlText).to.include('ps.effect =');
       expect(sqlText).to.include("p.status = 'approved'");
       expect(sqlText).to.include('p.record_end_date is null');

--- a/api/src/repositories/authorization/security-scope-repository.ts
+++ b/api/src/repositories/authorization/security-scope-repository.ts
@@ -2,7 +2,7 @@ import SQL from 'sql-template-strings';
 import { SECURITY_SCOPE_ANCHOR_BATCH_SIZE } from '../../constants/security';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
-import { PolicyEffect } from '../../models/policy-statement';
+import { PolicyEffect, PolicyStatementUrn } from '../../models/policy-statement';
 import { SecurityScope, SecurityScopeId } from '../../models/security-scope';
 import { AnchorBatchResult, SecurityScopeUrn } from '../../services/access-policy/security-scope-service.interface';
 import { BaseRepository } from '../base-repository';
@@ -552,6 +552,39 @@ export class SecurityScopeRepository extends BaseRepository {
     `;
 
     await this.connection.sql(sqlStatement);
+  }
+
+  /**
+   * Return the active ALLOW statements for an approved policy.
+   *
+   * The scope cache materializes lazily — when a team gains standing access through
+   * a `team_policy` link or when a policy's status flips to `approved`. Only ALLOW
+   * statements on an approved policy contribute access; DENY statements record
+   * filters but do not produce visible cache rows. Both gates (`policy.status` and
+   * `policy_statement.effect`) are enforced here so the service layer can stay thin.
+   *
+   * Returns an empty array when the policy is not approved, has no active ALLOW
+   * statements, or does not exist — callers treat `[]` as a no-op signal.
+   *
+   * @param policyId UUID of the policy
+   * @returns Array of `{ policy_statement_id, submission_feature_urn }` for active ALLOW statements
+   */
+  async getActiveAllowStatementsForApprovedPolicy(policyId: string): Promise<PolicyStatementUrn[]> {
+    const sqlStatement = SQL`
+      SELECT ps.policy_statement_id, ps.submission_feature_urn
+      FROM policy p
+      JOIN policy_statement ps
+        ON ps.policy_id = p.policy_id
+        AND ps.effect = ${PolicyEffect.ALLOW}
+        AND ps.record_end_date IS NULL
+      WHERE p.policy_id = ${policyId}
+        AND p.status = 'approved'
+        AND p.record_end_date IS NULL;
+    `;
+
+    const response = await this.connection.sql(sqlStatement, PolicyStatementUrn);
+
+    return response.rows;
   }
 
   /**

--- a/api/src/repositories/authorization/security-scope-repository.ts
+++ b/api/src/repositories/authorization/security-scope-repository.ts
@@ -593,6 +593,11 @@ export class SecurityScopeRepository extends BaseRepository {
    * Used when new security rules are applied to features in a submission —
    * finds scopes that may need new anchors computed for the affected submission.
    *
+   * A live `team_policy` link is required: a scope without one grants access to
+   * no team, so anchor recomputation for it is wasted work. Gating here keeps
+   * anchor-compute jobs scoped to the access cache only — the invariant captured
+   * in SIMSBIOHUB-985.
+   *
    * @param submissionId The submission ID to match against scope URNs
    * @returns Array of SecurityScopeId rows for matching scopes
    */
@@ -602,6 +607,7 @@ export class SecurityScopeRepository extends BaseRepository {
       FROM policy_statement ps
       JOIN policy_statement_scope pss ON pss.policy_statement_id = ps.policy_statement_id
       JOIN policy p ON p.policy_id = ps.policy_id
+      JOIN team_policy tp ON tp.policy_id = p.policy_id AND tp.record_end_date IS NULL
       WHERE ps.record_end_date IS NULL
         AND ps.effect = ${PolicyEffect.ALLOW}
         AND p.record_end_date IS NULL

--- a/api/src/repositories/authorization/security-scope-repository.ts
+++ b/api/src/repositories/authorization/security-scope-repository.ts
@@ -476,8 +476,12 @@ export class SecurityScopeRepository extends BaseRepository {
   /**
    * Insert team_security_scope rows for a team's scopes derived from a specific policy.
    *
-   * Walks the policy → policy_statement → policy_statement_scope chain to find
-   * all scopes granted by the policy, then inserts team_security_scope rows.
+   * The team-link invariant — cache rows exist iff a live `team_policy` ties the
+   * team to an approved policy with at least one ALLOW statement — is enforced
+   * in this SQL via the `team_policy` join. A stale caller that holds onto a
+   * `(teamId, policyId)` pair after the link has been soft-deleted cannot
+   * recreate cache rows; the join filters them out.
+   *
    * ON CONFLICT DO NOTHING makes this safe for idempotent calls — a team may
    * already have access to the same scope through a different policy.
    *
@@ -487,19 +491,24 @@ export class SecurityScopeRepository extends BaseRepository {
   async insertTeamSecurityScopesForPolicy(teamId: string, policyId: string): Promise<void> {
     const sqlStatement = SQL`
       INSERT INTO team_security_scope (team_id, security_scope_id)
-      SELECT ${teamId}, pss.security_scope_id
-      FROM policy p
+      SELECT tp.team_id, pss.security_scope_id
+      FROM team_policy tp
+      JOIN policy p
+        ON p.policy_id = tp.policy_id
+        AND p.status = 'approved'
+        AND p.record_end_date IS NULL
       JOIN policy_statement ps
         ON ps.policy_id = p.policy_id
         AND ps.effect = ${PolicyEffect.ALLOW}
         AND ps.record_end_date IS NULL
-      JOIN policy_statement_scope pss ON pss.policy_statement_id = ps.policy_statement_id
+      JOIN policy_statement_scope pss
+        ON pss.policy_statement_id = ps.policy_statement_id
       JOIN team t
-        ON t.team_id = ${teamId}
+        ON t.team_id = tp.team_id
         AND t.record_end_date IS NULL
-      WHERE p.policy_id = ${policyId}
-        AND p.status = 'approved'
-        AND p.record_end_date IS NULL
+      WHERE tp.team_id = ${teamId}
+        AND tp.policy_id = ${policyId}
+        AND tp.record_end_date IS NULL
       ON CONFLICT (team_id, security_scope_id) DO NOTHING;
     `;
 
@@ -569,7 +578,7 @@ export class SecurityScopeRepository extends BaseRepository {
    * @param policyId UUID of the policy
    * @returns Array of `{ policy_statement_id, submission_feature_urn }` for active ALLOW statements
    */
-  async getActiveAllowStatementsForApprovedPolicy(policyId: string): Promise<PolicyStatementUrn[]> {
+  async findActiveAllowStatementsForApprovedPolicy(policyId: string): Promise<PolicyStatementUrn[]> {
     const sqlStatement = SQL`
       SELECT ps.policy_statement_id, ps.submission_feature_urn
       FROM policy p

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -106,6 +106,198 @@ describe('PolicyService', () => {
       expect(stub).to.have.been.calledWith('1', { name: 'Updated', description: 'Updated desc' });
       expect(result).to.eql(updatedPolicy);
     });
+
+    // C1: reviewed → approved + 2 team_policies → materialize fires once per team; rebuild not called.
+    it('materializes the access cache once per linked team on transition into approved', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'reviewed' };
+      const updatedPolicy: Policy = { ...currentPolicy, status: 'approved' };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      const updateStub = sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
+        { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
+      ]);
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      const result = await policyService.updatePolicy('1', { status: 'approved' } as UpdatePolicy);
+
+      expect(updateStub).to.have.been.calledOnceWith('1', { status: 'approved' });
+      expect(materializeStub).to.have.been.calledTwice;
+      expect(materializeStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(materializeStub.secondCall).to.have.been.calledWith('team-2', '1');
+      expect(rebuildStub).to.not.have.been.called;
+      expect(result).to.eql(updatedPolicy);
+    });
+
+    // C2: approved → reviewed + 2 team_policies → rebuild fires once per team; materialize not called.
+    it('rebuilds the access cache once per linked team on transition out of approved (→ reviewed)', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'approved' };
+      const updatedPolicy: Policy = { ...currentPolicy, status: 'reviewed' };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
+        { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
+      ]);
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      await policyService.updatePolicy('1', { status: 'reviewed' } as UpdatePolicy);
+
+      expect(rebuildStub).to.have.been.calledTwice;
+      expect(rebuildStub.firstCall).to.have.been.calledWith('team-1');
+      expect(rebuildStub.secondCall).to.have.been.calledWith('team-2');
+      expect(materializeStub).to.not.have.been.called;
+    });
+
+    // C3: approved → denied + 1 team_policy → rebuild fires once; materialize not called.
+    it('rebuilds the access cache once per linked team on transition out of approved (→ denied)', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'approved' };
+      const updatedPolicy: Policy = { ...currentPolicy, status: 'denied' };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      sinon
+        .stub(TeamPolicyRepository.prototype, 'getTeamPolicies')
+        .resolves([{ team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' }]);
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      await policyService.updatePolicy('1', { status: 'denied' } as UpdatePolicy);
+
+      expect(rebuildStub).to.have.been.calledOnceWith('team-1');
+      expect(materializeStub).to.not.have.been.called;
+    });
+
+    // C4: requested → reviewed + 1 team_policy → neither orchestration branch fires; getTeamPolicies still called.
+    it('skips both orchestration branches when transitioning between non-approved statuses', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'requested' };
+      const updatedPolicy: Policy = { ...currentPolicy, status: 'reviewed' };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      const getTeamPoliciesStub = sinon
+        .stub(TeamPolicyRepository.prototype, 'getTeamPolicies')
+        .resolves([{ team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' }]);
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      await policyService.updatePolicy('1', { status: 'reviewed' } as UpdatePolicy);
+
+      expect(getTeamPoliciesStub).to.have.been.calledOnceWith({ policyIds: ['1'] });
+      expect(materializeStub).to.not.have.been.called;
+      expect(rebuildStub).to.not.have.been.called;
+    });
+
+    // C5: same-status update approved → approved short-circuits before fetching team policies.
+    it('short-circuits same-status updates without fetching team policies or touching the cache', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'approved' };
+      const updatedPolicy: Policy = { ...currentPolicy, name: 'Renamed' };
+
+      const getPolicyStub = sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      const updateStub = sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      const getTeamPoliciesStub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies');
+      const materializeStub = sinon.stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess');
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes');
+
+      await policyService.updatePolicy('1', { name: 'Renamed', status: 'approved' } as UpdatePolicy);
+
+      expect(getPolicyStub).to.have.been.calledOnce;
+      expect(updateStub).to.have.been.calledOnce;
+      expect(getTeamPoliciesStub).to.not.have.been.called;
+      expect(materializeStub).to.not.have.been.called;
+      expect(rebuildStub).to.not.have.been.called;
+    });
+
+    // C6: payload without status — bypasses workflow validation entirely.
+    it('bypasses workflow validation and orchestration when status is not in the payload', async () => {
+      const updatedPolicy: Policy = {
+        policy_id: '1',
+        name: 'Renamed',
+        description: 'desc',
+        status: 'requested'
+      };
+      const getPolicyStub = sinon.stub(PolicyRepository.prototype, 'getPolicy');
+      const updateStub = sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      const getTeamPoliciesStub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies');
+      const materializeStub = sinon.stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess');
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes');
+
+      await policyService.updatePolicy('1', { name: 'Renamed' } as UpdatePolicy);
+
+      expect(updateStub).to.have.been.calledOnceWith('1', { name: 'Renamed' });
+      expect(getPolicyStub).to.not.have.been.called;
+      expect(getTeamPoliciesStub).to.not.have.been.called;
+      expect(materializeStub).to.not.have.been.called;
+      expect(rebuildStub).to.not.have.been.called;
+    });
+
+    // C7: reviewed → approved + zero linked team_policies → neither materialize nor rebuild fires.
+    it('skips orchestration when no team policies are linked to the policy', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'reviewed' };
+      const updatedPolicy: Policy = { ...currentPolicy, status: 'approved' };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      const updateStub = sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      await policyService.updatePolicy('1', { status: 'approved' } as UpdatePolicy);
+
+      expect(updateStub).to.have.been.calledOnce;
+      expect(materializeStub).to.not.have.been.called;
+      expect(rebuildStub).to.not.have.been.called;
+    });
+
+    // C8: requested → approved is blocked by assertCanApproveRequest. No repo write, no team-policy fetch.
+    it('throws HTTP400 and does not write or fetch team policies when approving directly from requested', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'requested' };
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      const updateStub = sinon.stub(PolicyRepository.prototype, 'updatePolicy');
+      const getTeamPoliciesStub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies');
+
+      try {
+        await policyService.updatePolicy('1', { status: 'approved' } as UpdatePolicy);
+        expect.fail('expected updatePolicy to throw');
+      } catch (err: any) {
+        expect(err.message).to.equal(`Cannot approve request while policy is 'requested'`);
+      }
+
+      expect(updateStub).to.not.have.been.called;
+      expect(getTeamPoliciesStub).to.not.have.been.called;
+    });
+
+    // C9: denied → approved is blocked by assertValidStatusTransition (denied only transitions to reviewed).
+    it('throws HTTP400 and does not write or fetch team policies when approving from denied', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'denied' };
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      const updateStub = sinon.stub(PolicyRepository.prototype, 'updatePolicy');
+      const getTeamPoliciesStub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies');
+
+      try {
+        await policyService.updatePolicy('1', { status: 'approved' } as UpdatePolicy);
+        expect.fail('expected updatePolicy to throw');
+      } catch (err: any) {
+        expect(err.message).to.equal('Invalid policy status transition: denied -> approved');
+      }
+
+      expect(updateStub).to.not.have.been.called;
+      expect(getTeamPoliciesStub).to.not.have.been.called;
+    });
   });
 
   describe('deletePolicy', () => {
@@ -279,82 +471,9 @@ describe('PolicyService', () => {
   });
 
   describe('createPolicyWithStatements', () => {
-    it('should create policy, statements, and scopes for each statement', async () => {
+    // A1: New policy with 2 ALLOW statements — scope materialization NOT called; statements + conditions inserted.
+    it('does not call materializeScopeForPolicyStatement; persists statements and conditions', async () => {
       const mockPolicy: Policy = { policy_id: '1', name: 'New Policy', description: 'Desc', status: 'requested' };
-      const mockStatement: PolicyStatement = {
-        policy_statement_id: 's1',
-        policy_id: '1',
-        effect: PolicyEffect.ALLOW,
-        submission_feature_urn: 'urn:*:telemetry:*'
-      };
-      const mockCondition: PolicyStatementCondition = {
-        policy_statement_condition_id: 'c1',
-        policy_statement_id: 's1',
-        operator: PolicyConditionOperator.STRING_EQUALS,
-        key: 'region',
-        value: 'north'
-      };
-
-      const insertPolicyStub = sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
-      const insertStatementStub = sinon
-        .stub(PolicyStatementRepository.prototype, 'insertPolicyStatement')
-        .resolves(mockStatement);
-      const insertConditionStub = sinon
-        .stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition')
-        .resolves(mockCondition);
-      const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
-        .resolves('scope-1');
-
-      const result = await policyService.createPolicyWithStatements(
-        { name: 'New Policy', description: 'Desc', status: 'requested' } as CreatePolicy,
-        [
-          {
-            effect: PolicyEffect.ALLOW,
-            submission_feature_urn: 'urn:*:telemetry:*',
-            conditions: [{ operator: PolicyConditionOperator.STRING_EQUALS, key: 'region', value: 'north' }]
-          }
-        ]
-      );
-
-      expect(insertPolicyStub).to.have.been.calledWith({
-        name: 'New Policy',
-        description: 'Desc',
-        status: 'requested'
-      });
-      expect(insertStatementStub).to.have.been.calledOnce;
-      expect(insertConditionStub).to.have.been.calledOnce;
-      expect(createScopeStub).to.have.been.calledOnce;
-      expect(createScopeStub).to.have.been.calledWith('s1', 'urn:*:telemetry:*');
-      expect(result).to.eql({
-        ...mockPolicy,
-        statements: [{ ...mockStatement, conditions: [mockCondition] }]
-      });
-    });
-
-    it('should not call materializeScopeForPolicyStatement when no statements provided', async () => {
-      const mockPolicy: Policy = {
-        policy_id: '1',
-        name: 'Empty Policy',
-        description: 'No statements',
-        status: 'requested'
-      };
-      sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
-      const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
-        .resolves('scope-1');
-
-      const result = await policyService.createPolicyWithStatements(
-        { name: 'Empty Policy', description: 'No statements', status: 'requested' } as CreatePolicy,
-        []
-      );
-
-      expect(createScopeStub).to.not.have.been.called;
-      expect(result).to.eql({ ...mockPolicy, statements: [] });
-    });
-
-    it('should create scopes for multiple statements', async () => {
-      const mockPolicy: Policy = { policy_id: '1', name: 'Multi Policy', description: 'Desc', status: 'requested' };
       const mockStatement1: PolicyStatement = {
         policy_statement_id: 's1',
         policy_id: '1',
@@ -367,27 +486,63 @@ describe('PolicyService', () => {
         effect: PolicyEffect.ALLOW,
         submission_feature_urn: 'urn:10:*:*'
       };
+      const mockCondition: PolicyStatementCondition = {
+        policy_statement_condition_id: 'c1',
+        policy_statement_id: 's1',
+        operator: PolicyConditionOperator.STRING_EQUALS,
+        key: 'region',
+        value: 'north'
+      };
 
-      sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
+      const insertPolicyStub = sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
       const insertStatementStub = sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement');
       insertStatementStub.onCall(0).resolves(mockStatement1);
       insertStatementStub.onCall(1).resolves(mockStatement2);
-      sinon.stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition');
-      const createScopeStub = sinon
+      const insertConditionStub = sinon
+        .stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition')
+        .resolves(mockCondition);
+      const materializeStub = sinon
         .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
-      await policyService.createPolicyWithStatements({ name: 'Multi Policy', description: 'Desc' } as CreatePolicy, [
-        { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' },
-        { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:10:*:*' }
-      ]);
+      const result = await policyService.createPolicyWithStatements(
+        { name: 'New Policy', description: 'Desc', status: 'requested' } as CreatePolicy,
+        [
+          {
+            effect: PolicyEffect.ALLOW,
+            submission_feature_urn: 'urn:*:telemetry:*',
+            conditions: [{ operator: PolicyConditionOperator.STRING_EQUALS, key: 'region', value: 'north' }]
+          },
+          {
+            effect: PolicyEffect.ALLOW,
+            submission_feature_urn: 'urn:10:*:*'
+          }
+        ]
+      );
 
-      expect(createScopeStub).to.have.been.calledTwice;
-      expect(createScopeStub.firstCall).to.have.been.calledWith('s1', 'urn:*:telemetry:*');
-      expect(createScopeStub.secondCall).to.have.been.calledWith('s2', 'urn:10:*:*');
+      expect(insertPolicyStub).to.have.been.calledWith({
+        name: 'New Policy',
+        description: 'Desc',
+        status: 'requested'
+      });
+      expect(insertStatementStub).to.have.been.calledTwice;
+      expect(insertConditionStub).to.have.been.calledOnce;
+      expect(materializeStub).to.not.have.been.called;
+      expect(materializeTeamAccessStub).to.not.have.been.called;
+      expect(result).to.eql({
+        ...mockPolicy,
+        statements: [
+          { ...mockStatement1, conditions: [mockCondition] },
+          { ...mockStatement2, conditions: [] }
+        ]
+      });
     });
 
-    it('should persist optional statement expressions', async () => {
+    // A2: Statement with expression — expression persisted; scope materialization NOT called.
+    it('persists statement expressions without materializing scopes', async () => {
       const mockPolicy: Policy = { policy_id: '1', name: 'Expression Policy', description: null, status: 'requested' };
       const mockStatement: PolicyStatement = {
         policy_statement_id: 's1',
@@ -412,7 +567,9 @@ describe('PolicyService', () => {
       sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves(mockStatement);
       sinon.stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition');
-      sinon.stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement').resolves('scope-1');
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
+        .resolves('scope-1');
       const writeExpressionTreeStub = sinon
         .stub(ExpressionTreeService.prototype, 'writeExpressionTree')
         .resolves({ expression_id: 'expr-1' });
@@ -433,13 +590,49 @@ describe('PolicyService', () => {
 
       expect(writeExpressionTreeStub).to.have.been.calledOnceWith(expression);
       expect(replaceExpressionStub).to.have.been.calledOnceWith('s1', 'expr-1');
+      expect(materializeStub).to.not.have.been.called;
       expect(result.statements[0]).to.include({ ...mockStatement });
       expect(result.statements[0].expression).to.eql(expression);
+    });
+
+    // A3: Empty statements list — no statement, condition, scope, or expression work.
+    it('skips statement, condition, scope, and expression work for an empty statement list', async () => {
+      const mockPolicy: Policy = {
+        policy_id: '1',
+        name: 'Empty Policy',
+        description: 'No statements',
+        status: 'requested'
+      };
+      sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
+      const insertStatementStub = sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves();
+      const insertConditionStub = sinon
+        .stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition')
+        .resolves();
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
+        .resolves('scope-1');
+      const writeExpressionTreeStub = sinon.stub(ExpressionTreeService.prototype, 'writeExpressionTree').resolves();
+      const replaceExpressionStub = sinon
+        .stub(PolicyStatementExpressionService.prototype, 'replacePolicyStatementExpression')
+        .resolves();
+
+      const result = await policyService.createPolicyWithStatements(
+        { name: 'Empty Policy', description: 'No statements', status: 'requested' } as CreatePolicy,
+        []
+      );
+
+      expect(insertStatementStub).to.not.have.been.called;
+      expect(insertConditionStub).to.not.have.been.called;
+      expect(materializeStub).to.not.have.been.called;
+      expect(writeExpressionTreeStub).to.not.have.been.called;
+      expect(replaceExpressionStub).to.not.have.been.called;
+      expect(result).to.eql({ ...mockPolicy, statements: [] });
     });
   });
 
   describe('updatePolicyWithStatements', () => {
-    it('should clean up old scope mappings, create new scopes, and rebuild affected teams', async () => {
+    // B1: Existing stmt + new stmt + zero linked team_policies — scope materialization NOT called; cleanup runs on old IDs.
+    it('cleans up old statement scope mappings without materializing scopes (no linked teams)', async () => {
       const mockPolicy: Policy = {
         policy_id: '1',
         name: 'Updated Policy',
@@ -463,21 +656,16 @@ describe('PolicyService', () => {
 
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves(existingStatements);
-      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
-        {
-          team_policy_id: 'tp1',
-          team_id: 'team-1',
-          policy_id: '1',
-          team_name: 'Team 1',
-          policy_name: 'Policy 1'
-        }
-      ]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
       sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
       sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves(newStatement);
-      const createScopeStub = sinon
+      const materializeStub = sinon
         .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
       const cleanupStub = sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
       const result = await policyService.updatePolicyWithStatements(
         '1',
@@ -485,42 +673,174 @@ describe('PolicyService', () => {
         [{ effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }]
       );
 
-      expect(createScopeStub).to.have.been.calledOnce;
-      expect(createScopeStub).to.have.been.calledWith('new-s1', 'urn:*:telemetry:*');
-      expect(cleanupStub).to.have.been.calledOnce;
-      expect(cleanupStub).to.have.been.calledWith(['old-s1'], ['team-1']);
+      expect(materializeStub).to.not.have.been.called;
+      expect(cleanupStub).to.have.been.calledOnceWith(['old-s1'], []);
+      expect(materializeTeamAccessStub).to.not.have.been.called;
       expect(result).to.eql({
         ...mockPolicy,
         statements: [{ ...newStatement, conditions: [] }]
       });
     });
 
-    it('should clean up old scope mappings and skip scope creation when updating with empty statements', async () => {
-      const mockPolicy: Policy = { policy_id: '1', name: 'Policy', description: 'Desc', status: 'requested' };
+    // B2: Approved policy + 3 linked team_policies — team-access materialization runs once per team.
+    it('runs team-access materialization once per linked team when the policy is approved', async () => {
+      const mockPolicy: Policy = {
+        policy_id: '1',
+        name: 'Approved Policy',
+        description: 'desc',
+        status: 'approved'
+      };
+      const newStatement: PolicyStatement = {
+        policy_statement_id: 'new-s1',
+        policy_id: '1',
+        effect: PolicyEffect.ALLOW,
+        submission_feature_urn: 'urn:*:telemetry:*'
+      };
+
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
+        { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' },
+        { team_policy_id: 'tp3', team_id: 'team-3', policy_id: '1', team_name: 'C', policy_name: 'P' }
+      ]);
+      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves(newStatement);
+      sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
+        .resolves('scope-1');
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+
+      await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }
+      ]);
+
+      expect(materializeStub).to.not.have.been.called;
+      expect(materializeTeamAccessStub).to.have.been.calledThrice;
+      expect(materializeTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(materializeTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
+      expect(materializeTeamAccessStub.thirdCall).to.have.been.calledWith('team-3', '1');
+    });
+
+    // B3: Approved + 0 linked teams — no team-access materialization.
+    it('skips team-access materialization when the approved policy has no linked teams', async () => {
+      const mockPolicy: Policy = {
+        policy_id: '1',
+        name: 'Approved Policy',
+        description: 'desc',
+        status: 'approved'
+      };
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+
+      await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, []);
+
+      expect(materializeTeamAccessStub).to.not.have.been.called;
+    });
+
+    // B4: Non-approved (reviewed) + 2 linked teams — no team-access materialization (status gate).
+    it('skips team-access materialization when the policy is not approved', async () => {
+      const mockPolicy: Policy = {
+        policy_id: '1',
+        name: 'Reviewed Policy',
+        description: 'desc',
+        status: 'reviewed'
+      };
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
+        { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
+      ]);
+      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+
+      await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, []);
+
+      expect(materializeTeamAccessStub).to.not.have.been.called;
+    });
+
+    // B5: Ordering — delete old statements, then create new ones, then cleanup, then per-team materialization.
+    it('orders delete-old statements before createStatements before cleanup before team-access materialization', async () => {
+      const mockPolicy: Policy = {
+        policy_id: '1',
+        name: 'Approved Policy',
+        description: 'desc',
+        status: 'approved'
+      };
       const existingStatements: PolicyStatement[] = [
-        { policy_statement_id: 's1', policy_id: '1', effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:*:*' },
-        { policy_statement_id: 's2', policy_id: '1', effect: PolicyEffect.DENY, submission_feature_urn: 'urn:*:*:*' }
+        {
+          policy_statement_id: 'old-s1',
+          policy_id: '1',
+          effect: PolicyEffect.ALLOW,
+          submission_feature_urn: 'urn:old:*:*'
+        }
       ];
+      const newStatement: PolicyStatement = {
+        policy_statement_id: 'new-s1',
+        policy_id: '1',
+        effect: PolicyEffect.ALLOW,
+        submission_feature_urn: 'urn:*:telemetry:*'
+      };
 
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves(existingStatements);
-      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
-      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
-      const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
-        .resolves('scope-1');
+      sinon
+        .stub(TeamPolicyRepository.prototype, 'getTeamPolicies')
+        .resolves([{ team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' }]);
+      const deleteStub = sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      const insertStmtStub = sinon
+        .stub(PolicyStatementRepository.prototype, 'insertPolicyStatement')
+        .resolves(newStatement);
       const cleanupStub = sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
-      const result = await policyService.updatePolicyWithStatements(
-        '1',
-        { name: 'Policy', description: 'Desc' } as UpdatePolicy,
-        []
-      );
+      await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }
+      ]);
 
-      expect(createScopeStub).to.not.have.been.called;
-      expect(cleanupStub).to.have.been.calledOnce;
-      expect(cleanupStub).to.have.been.calledWith(['s1', 's2'], []);
-      expect(result).to.eql({ ...mockPolicy, statements: [] });
+      expect(deleteStub).to.have.been.calledBefore(insertStmtStub);
+      expect(insertStmtStub).to.have.been.calledBefore(cleanupStub);
+      expect(cleanupStub).to.have.been.calledBefore(materializeTeamAccessStub);
+    });
+
+    // B6: Approved + linked teams + empty replacement statement list — team-access materialization still fires once per team.
+    // This is the deliberate-revocation path: the cache rebuilds against an empty ALLOW set.
+    it('fires team-access materialization once per team when an approved policy is updated with no statements', async () => {
+      const mockPolicy: Policy = {
+        policy_id: '1',
+        name: 'Approved Policy',
+        description: 'desc',
+        status: 'approved'
+      };
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
+        { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
+      ]);
+      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+
+      await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, []);
+
+      expect(materializeTeamAccessStub).to.have.been.calledTwice;
+      expect(materializeTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(materializeTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
     });
   });
 });

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -107,7 +107,8 @@ describe('PolicyService', () => {
       expect(result).to.eql(updatedPolicy);
     });
 
-    // C1: reviewed → approved + 2 team_policies → materialize fires once per team; rebuild not called.
+    // C1: reviewed → approved + 2 team_policies → policy-wide materialization fires
+    // once; per-team grant fires once per team; rebuild not called.
     it('materializes the access cache once per linked team on transition into approved', async () => {
       const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'reviewed' };
       const updatedPolicy: Policy = { ...currentPolicy, status: 'approved' };
@@ -118,19 +119,44 @@ describe('PolicyService', () => {
         { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
         { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
       ]);
-      const materializeStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
       const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
 
       const result = await policyService.updatePolicy('1', { status: 'approved' } as UpdatePolicy);
 
       expect(updateStub).to.have.been.calledOnceWith('1', { status: 'approved' });
-      expect(materializeStub).to.have.been.calledTwice;
-      expect(materializeStub.firstCall).to.have.been.calledWith('team-1', '1');
-      expect(materializeStub.secondCall).to.have.been.calledWith('team-2', '1');
+      // Policy-wide statement-scope materialization runs once, not per team.
+      expect(materializePolicyStub).to.have.been.calledOnceWith('1');
+      expect(grantTeamAccessStub).to.have.been.calledTwice;
+      expect(grantTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(grantTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
       expect(rebuildStub).to.not.have.been.called;
       expect(result).to.eql(updatedPolicy);
+    });
+
+    // C1b: reviewed → approved but policy has no active ALLOW statements →
+    // policy-wide materialization short-circuits; no per-team grant fires.
+    it('skips per-team grants when transition into approved finds no ALLOW statements', async () => {
+      const currentPolicy: Policy = { policy_id: '1', name: 'P', description: null, status: 'reviewed' };
+      const updatedPolicy: Policy = { ...currentPolicy, status: 'approved' };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(currentPolicy);
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(updatedPolicy);
+      sinon
+        .stub(TeamPolicyRepository.prototype, 'getTeamPolicies')
+        .resolves([{ team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' }]);
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(false);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
+
+      await policyService.updatePolicy('1', { status: 'approved' } as UpdatePolicy);
+
+      expect(materializePolicyStub).to.have.been.calledOnce;
+      expect(grantTeamAccessStub).to.not.have.been.called;
     });
 
     // C2: approved → reviewed + 2 team_policies → rebuild fires once per team; materialize not called.
@@ -345,19 +371,34 @@ describe('PolicyService', () => {
       expect(rebuildStub).to.not.have.been.called;
     });
 
-    it('materializes per linked team when transitioning into approved', async () => {
+    it('materializes statement scopes once and grants per team when transitioning into approved', async () => {
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(linkedTeamPolicies);
-      const materializeStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
       const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes');
 
       await invoke('reviewed', 'approved');
 
-      expect(materializeStub).to.have.been.calledTwice;
-      expect(materializeStub.firstCall).to.have.been.calledWith('team-1', policyId);
-      expect(materializeStub.secondCall).to.have.been.calledWith('team-2', policyId);
+      expect(materializePolicyStub).to.have.been.calledOnceWith(policyId);
+      expect(grantTeamAccessStub).to.have.been.calledTwice;
+      expect(grantTeamAccessStub.firstCall).to.have.been.calledWith('team-1', policyId);
+      expect(grantTeamAccessStub.secondCall).to.have.been.calledWith('team-2', policyId);
       expect(rebuildStub).to.not.have.been.called;
+    });
+
+    it('skips the team-grant loop when policy-wide materialization short-circuits on approved', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(linkedTeamPolicies);
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(false);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
+
+      await invoke('reviewed', 'approved');
+
+      expect(materializePolicyStub).to.have.been.calledOnceWith(policyId);
+      expect(grantTeamAccessStub).to.not.have.been.called;
     });
 
     it('rebuilds per linked team when transitioning out of approved (→ reviewed)', async () => {
@@ -811,19 +852,21 @@ describe('PolicyService', () => {
       const materializeStub = sinon
         .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
-      const materializeTeamAccessStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, [
         { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }
       ]);
 
       expect(materializeStub).to.not.have.been.called;
-      expect(materializeTeamAccessStub).to.have.been.calledThrice;
-      expect(materializeTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
-      expect(materializeTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
-      expect(materializeTeamAccessStub.thirdCall).to.have.been.calledWith('team-3', '1');
+      expect(materializePolicyStub).to.have.been.calledOnceWith('1');
+      expect(grantTeamAccessStub).to.have.been.calledThrice;
+      expect(grantTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(grantTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
+      expect(grantTeamAccessStub.thirdCall).to.have.been.calledWith('team-3', '1');
     });
 
     // B3: Approved + 0 linked teams — no team-access materialization.
@@ -907,9 +950,10 @@ describe('PolicyService', () => {
         .stub(PolicyStatementRepository.prototype, 'insertPolicyStatement')
         .resolves(newStatement);
       const cleanupStub = sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
-      const materializeTeamAccessStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, [
         { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }
@@ -917,12 +961,14 @@ describe('PolicyService', () => {
 
       expect(deleteStub).to.have.been.calledBefore(insertStmtStub);
       expect(insertStmtStub).to.have.been.calledBefore(cleanupStub);
-      expect(cleanupStub).to.have.been.calledBefore(materializeTeamAccessStub);
+      expect(cleanupStub).to.have.been.calledBefore(materializePolicyStub);
     });
 
-    // B6: Approved + linked teams + empty replacement statement list — team-access materialization still fires once per team.
-    // This is the deliberate-revocation path: the cache rebuilds against an empty ALLOW set.
-    it('fires team-access materialization once per team when an approved policy is updated with no statements', async () => {
+    // B6: Approved + linked teams + empty replacement statement list — the tail
+    // block still runs policy-wide materialization and grants once per team.
+    // This is the deliberate-revocation path: the cache rebuilds against the
+    // (now empty) ALLOW set.
+    it('fires policy-wide materialization once and per-team grant when an approved policy is updated with no statements', async () => {
       const mockPolicy: Policy = {
         policy_id: '1',
         name: 'Approved Policy',
@@ -937,23 +983,25 @@ describe('PolicyService', () => {
         { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
       ]);
       sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
-      const materializeTeamAccessStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       await policyService.updatePolicyWithStatements('1', {} as UpdatePolicy, []);
 
-      expect(materializeTeamAccessStub).to.have.been.calledTwice;
-      expect(materializeTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
-      expect(materializeTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
+      expect(materializePolicyStub).to.have.been.calledOnceWith('1');
+      expect(grantTeamAccessStub).to.have.been.calledTwice;
+      expect(grantTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(grantTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
     });
 
     // B7: Combined { status: 'approved', statements } on a reviewed policy with linked teams.
-    // The shared `applyCacheFanOutForTransition` fans out materialize once per team for
-    // the reviewed → approved transition. The same-status tail block at the end of
-    // `updatePolicyWithStatements` is skipped because previousStatus !== nextStatus,
-    // so anchor-publish jobs are not doubled.
-    it('combined approval + statement replacement fires team-access materialization exactly once per team', async () => {
+    // The shared `applyCacheFanOutForTransition` runs policy-wide materialization
+    // once and grants per team for the reviewed → approved transition. The
+    // same-status tail block at the end of `updatePolicyWithStatements` is skipped
+    // because previousStatus !== nextStatus, so anchor-publish jobs are not doubled.
+    it('combined approval + statement replacement runs policy-wide materialization once and per-team grants', async () => {
       const reviewedPolicy: Policy = {
         policy_id: '1',
         name: 'Reviewing',
@@ -986,17 +1034,19 @@ describe('PolicyService', () => {
       sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
       sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves(newStatement);
       sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
-      const materializeTeamAccessStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       await policyService.updatePolicyWithStatements('1', { status: 'approved' } as UpdatePolicy, [
         { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }
       ]);
 
-      expect(materializeTeamAccessStub).to.have.been.calledTwice;
-      expect(materializeTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
-      expect(materializeTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
+      expect(materializePolicyStub).to.have.been.calledOnceWith('1');
+      expect(grantTeamAccessStub).to.have.been.calledTwice;
+      expect(grantTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(grantTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
       expect(getPolicyStub).to.have.been.calledOnce;
     });
 
@@ -1092,13 +1142,15 @@ describe('PolicyService', () => {
         .resolves([{ team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' }]);
       sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
       sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
-      const materializeTeamAccessStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializePolicyStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantTeamAccessStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       await policyService.updatePolicyWithStatements('1', { status: 'approved' } as UpdatePolicy, []);
 
-      expect(materializeTeamAccessStub).to.have.been.calledOnceWith('team-1', '1');
+      expect(materializePolicyStub).to.have.been.calledOnceWith('1');
+      expect(grantTeamAccessStub).to.have.been.calledOnceWith('team-1', '1');
     });
   });
 });

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -303,7 +303,7 @@ describe('PolicyService', () => {
         .stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition')
         .resolves(mockCondition);
       const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'createScopeForPolicyStatement')
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
 
       const result = await policyService.createPolicyWithStatements(
@@ -332,7 +332,7 @@ describe('PolicyService', () => {
       });
     });
 
-    it('should not call createScopeForPolicyStatement when no statements provided', async () => {
+    it('should not call materializeScopeForPolicyStatement when no statements provided', async () => {
       const mockPolicy: Policy = {
         policy_id: '1',
         name: 'Empty Policy',
@@ -341,7 +341,7 @@ describe('PolicyService', () => {
       };
       sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
       const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'createScopeForPolicyStatement')
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
 
       const result = await policyService.createPolicyWithStatements(
@@ -374,7 +374,7 @@ describe('PolicyService', () => {
       insertStatementStub.onCall(1).resolves(mockStatement2);
       sinon.stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition');
       const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'createScopeForPolicyStatement')
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
 
       await policyService.createPolicyWithStatements({ name: 'Multi Policy', description: 'Desc' } as CreatePolicy, [
@@ -412,7 +412,7 @@ describe('PolicyService', () => {
       sinon.stub(PolicyRepository.prototype, 'insertPolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves(mockStatement);
       sinon.stub(PolicyStatementConditionRepository.prototype, 'insertPolicyStatementCondition');
-      sinon.stub(SecurityScopeService.prototype, 'createScopeForPolicyStatement').resolves('scope-1');
+      sinon.stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement').resolves('scope-1');
       const writeExpressionTreeStub = sinon
         .stub(ExpressionTreeService.prototype, 'writeExpressionTree')
         .resolves({ expression_id: 'expr-1' });
@@ -475,7 +475,7 @@ describe('PolicyService', () => {
       sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
       sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves(newStatement);
       const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'createScopeForPolicyStatement')
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
       const cleanupStub = sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
 
@@ -507,7 +507,7 @@ describe('PolicyService', () => {
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
       sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
       const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'createScopeForPolicyStatement')
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
       const cleanupStub = sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
 

--- a/api/src/services/access-policy/policy-service.test.ts
+++ b/api/src/services/access-policy/policy-service.test.ts
@@ -300,6 +300,105 @@ describe('PolicyService', () => {
     });
   });
 
+  // Direct tests of the private `applyCacheFanOutForTransition` helper. Public-method
+  // tests (`updatePolicy` C-tests, `updatePolicyWithStatements` B-tests) exercise the
+  // helper transitively, but this block pins its contract independent of any caller
+  // so a future caller cannot accidentally bypass an invariant the helper enforces
+  // (e.g. the same-status no-op).
+  describe('applyCacheFanOutForTransition', () => {
+    const policyId = 'policy-1';
+    const linkedTeamPolicies = [
+      { team_policy_id: 'tp1', team_id: 'team-1', policy_id: policyId, team_name: 'A', policy_name: 'P' },
+      { team_policy_id: 'tp2', team_id: 'team-2', policy_id: policyId, team_name: 'B', policy_name: 'P' }
+    ];
+
+    // The helper is intentionally private; tests access it via an `any` cast to
+    // pin the contract without exposing the surface to production callers.
+    const invoke = (from: 'requested' | 'reviewed' | 'approved' | 'denied', to: typeof from) =>
+      (
+        policyService as unknown as {
+          applyCacheFanOutForTransition: (id: string, from: string, to: string) => Promise<void>;
+        }
+      ).applyCacheFanOutForTransition(policyId, from, to);
+
+    it('returns early without fetching team policies when from === to', async () => {
+      const getTeamPoliciesStub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies');
+      const materializeStub = sinon.stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess');
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes');
+
+      await invoke('approved', 'approved');
+
+      expect(getTeamPoliciesStub).to.not.have.been.called;
+      expect(materializeStub).to.not.have.been.called;
+      expect(rebuildStub).to.not.have.been.called;
+    });
+
+    it('fetches team policies but skips fan-out when no team_policy links exist', async () => {
+      const getTeamPoliciesStub = sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
+      const materializeStub = sinon.stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess');
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes');
+
+      await invoke('reviewed', 'approved');
+
+      expect(getTeamPoliciesStub).to.have.been.calledOnceWith({ policyIds: [policyId] });
+      expect(materializeStub).to.not.have.been.called;
+      expect(rebuildStub).to.not.have.been.called;
+    });
+
+    it('materializes per linked team when transitioning into approved', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(linkedTeamPolicies);
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes');
+
+      await invoke('reviewed', 'approved');
+
+      expect(materializeStub).to.have.been.calledTwice;
+      expect(materializeStub.firstCall).to.have.been.calledWith('team-1', policyId);
+      expect(materializeStub.secondCall).to.have.been.calledWith('team-2', policyId);
+      expect(rebuildStub).to.not.have.been.called;
+    });
+
+    it('rebuilds per linked team when transitioning out of approved (→ reviewed)', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(linkedTeamPolicies);
+      const materializeStub = sinon.stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess');
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      await invoke('approved', 'reviewed');
+
+      expect(rebuildStub).to.have.been.calledTwice;
+      expect(rebuildStub.firstCall).to.have.been.calledWith('team-1');
+      expect(rebuildStub.secondCall).to.have.been.calledWith('team-2');
+      expect(materializeStub).to.not.have.been.called;
+    });
+
+    it('rebuilds per linked team when transitioning out of approved (→ denied)', async () => {
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves(linkedTeamPolicies);
+      const materializeStub = sinon.stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess');
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      await invoke('approved', 'denied');
+
+      expect(rebuildStub).to.have.been.calledTwice;
+      expect(materializeStub).to.not.have.been.called;
+    });
+
+    it('fetches team policies but fires neither branch for transitions not involving approved', async () => {
+      const getTeamPoliciesStub = sinon
+        .stub(TeamPolicyRepository.prototype, 'getTeamPolicies')
+        .resolves(linkedTeamPolicies);
+      const materializeStub = sinon.stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess');
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes');
+
+      await invoke('requested', 'reviewed');
+
+      expect(getTeamPoliciesStub).to.have.been.calledOnce;
+      expect(materializeStub).to.not.have.been.called;
+      expect(rebuildStub).to.not.have.been.called;
+    });
+  });
+
   describe('deletePolicy', () => {
     it('should fetch teams and statements before soft-delete, then clean up scope mappings', async () => {
       const mockStatements: PolicyStatement[] = [
@@ -654,6 +753,7 @@ describe('PolicyService', () => {
         submission_feature_urn: 'urn:*:telemetry:*'
       };
 
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(mockPolicy);
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves(existingStatements);
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
@@ -697,6 +797,7 @@ describe('PolicyService', () => {
         submission_feature_urn: 'urn:*:telemetry:*'
       };
 
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(mockPolicy);
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
@@ -733,6 +834,7 @@ describe('PolicyService', () => {
         description: 'desc',
         status: 'approved'
       };
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(mockPolicy);
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([]);
@@ -754,6 +856,7 @@ describe('PolicyService', () => {
         description: 'desc',
         status: 'reviewed'
       };
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(mockPolicy);
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
@@ -793,6 +896,7 @@ describe('PolicyService', () => {
         submission_feature_urn: 'urn:*:telemetry:*'
       };
 
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(mockPolicy);
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves(existingStatements);
       sinon
@@ -825,6 +929,7 @@ describe('PolicyService', () => {
         description: 'desc',
         status: 'approved'
       };
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(mockPolicy);
       sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(mockPolicy);
       sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
       sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
@@ -841,6 +946,159 @@ describe('PolicyService', () => {
       expect(materializeTeamAccessStub).to.have.been.calledTwice;
       expect(materializeTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
       expect(materializeTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
+    });
+
+    // B7: Combined { status: 'approved', statements } on a reviewed policy with linked teams.
+    // The shared `applyCacheFanOutForTransition` fans out materialize once per team for
+    // the reviewed → approved transition. The same-status tail block at the end of
+    // `updatePolicyWithStatements` is skipped because previousStatus !== nextStatus,
+    // so anchor-publish jobs are not doubled.
+    it('combined approval + statement replacement fires team-access materialization exactly once per team', async () => {
+      const reviewedPolicy: Policy = {
+        policy_id: '1',
+        name: 'Reviewing',
+        description: 'desc',
+        status: 'reviewed'
+      };
+      const approvedPolicy: Policy = {
+        policy_id: '1',
+        name: 'Approved',
+        description: 'desc',
+        status: 'approved'
+      };
+      const newStatement: PolicyStatement = {
+        policy_statement_id: 'new-s1',
+        policy_id: '1',
+        effect: PolicyEffect.ALLOW,
+        submission_feature_urn: 'urn:*:telemetry:*'
+      };
+
+      // `getPolicy` is called once to capture the previous status. The transition
+      // validator runs against that snapshot; the repository's `updatePolicy` below
+      // is a plain row write with no orchestration of its own.
+      const getPolicyStub = sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(reviewedPolicy);
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(approvedPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
+        { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
+      ]);
+      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement').resolves(newStatement);
+      sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+
+      await policyService.updatePolicyWithStatements('1', { status: 'approved' } as UpdatePolicy, [
+        { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }
+      ]);
+
+      expect(materializeTeamAccessStub).to.have.been.calledTwice;
+      expect(materializeTeamAccessStub.firstCall).to.have.been.calledWith('team-1', '1');
+      expect(materializeTeamAccessStub.secondCall).to.have.been.calledWith('team-2', '1');
+      expect(getPolicyStub).to.have.been.calledOnce;
+    });
+
+    // B8: Combined { status: 'reviewed', statements } downgrade on an approved policy.
+    // The shared `applyCacheFanOutForTransition` fans out rebuild once per team for
+    // the approved → reviewed transition. The same-status tail block is skipped
+    // because previousStatus !== nextStatus.
+    it('combined downgrade + statement replacement issues per-team rebuilds and skips the tail materialize', async () => {
+      const approvedPolicy: Policy = {
+        policy_id: '1',
+        name: 'Approved',
+        description: 'desc',
+        status: 'approved'
+      };
+      const reviewedPolicy: Policy = {
+        policy_id: '1',
+        name: 'Reviewed',
+        description: 'desc',
+        status: 'reviewed'
+      };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(approvedPolicy);
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(reviewedPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'getTeamPolicies').resolves([
+        { team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' },
+        { team_policy_id: 'tp2', team_id: 'team-2', policy_id: '1', team_name: 'B', policy_name: 'P' }
+      ]);
+      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+      const rebuildStub = sinon.stub(SecurityScopeService.prototype, 'rebuildTeamSecurityScopes').resolves();
+
+      await policyService.updatePolicyWithStatements('1', { status: 'reviewed' } as UpdatePolicy, []);
+
+      expect(materializeTeamAccessStub).to.not.have.been.called;
+      expect(rebuildStub).to.have.been.calledTwice;
+      expect(rebuildStub.firstCall).to.have.been.calledWith('team-1');
+      expect(rebuildStub.secondCall).to.have.been.calledWith('team-2');
+    });
+
+    // B9: Invalid status transition is rejected before any statement mutation happens.
+    // The fail-fast guard exists so a rejected transition cannot leave the statement
+    // set replaced and the policy row unchanged.
+    it('rejects an invalid status transition before deleting old statements or writing new ones', async () => {
+      const deniedPolicy: Policy = {
+        policy_id: '1',
+        name: 'Denied',
+        description: 'desc',
+        status: 'denied'
+      };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(deniedPolicy);
+      const updateStub = sinon.stub(PolicyRepository.prototype, 'updatePolicy');
+      const deleteStmtStub = sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement');
+      const insertStmtStub = sinon.stub(PolicyStatementRepository.prototype, 'insertPolicyStatement');
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+
+      try {
+        await policyService.updatePolicyWithStatements('1', { status: 'approved' } as UpdatePolicy, [
+          { effect: PolicyEffect.ALLOW, submission_feature_urn: 'urn:*:telemetry:*' }
+        ]);
+        expect.fail('expected updatePolicyWithStatements to throw for invalid transition');
+      } catch (error) {
+        expect((error as Error).message).to.match(/Invalid policy status transition: denied -> approved/);
+      }
+
+      expect(updateStub).to.not.have.been.called;
+      expect(deleteStmtStub).to.not.have.been.called;
+      expect(insertStmtStub).to.not.have.been.called;
+    });
+
+    // B10: Same-status combined update on an approved policy. The shared
+    // `applyCacheFanOutForTransition` is a no-op on same-status calls, so the tail
+    // block at the end of `updatePolicyWithStatements` is the only path that
+    // re-derives the cache. Without it, a statement swap would leave the team
+    // pointing at the deleted statements' scope mappings.
+    it('fires the tail materialize when the combined update is same-status approved + statements', async () => {
+      const approvedPolicy: Policy = {
+        policy_id: '1',
+        name: 'Approved',
+        description: 'desc',
+        status: 'approved'
+      };
+
+      sinon.stub(PolicyRepository.prototype, 'getPolicy').resolves(approvedPolicy);
+      sinon.stub(PolicyRepository.prototype, 'updatePolicy').resolves(approvedPolicy);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([]);
+      sinon
+        .stub(TeamPolicyRepository.prototype, 'getTeamPolicies')
+        .resolves([{ team_policy_id: 'tp1', team_id: 'team-1', policy_id: '1', team_name: 'A', policy_name: 'P' }]);
+      sinon.stub(PolicyStatementRepository.prototype, 'deletePolicyStatement').resolves();
+      sinon.stub(SecurityScopeService.prototype, 'cleanupScopesForDeletedStatements').resolves();
+      const materializeTeamAccessStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
+
+      await policyService.updatePolicyWithStatements('1', { status: 'approved' } as UpdatePolicy, []);
+
+      expect(materializeTeamAccessStub).to.have.been.calledOnceWith('team-1', '1');
     });
   });
 });

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -168,8 +168,16 @@ export class PolicyService extends DBService {
     }
 
     if (to === 'approved') {
+      // Materialize the shared statement-scope rows once for this policy, then
+      // grant access per team. The statement-scope work depends only on the
+      // policy, so splitting these avoids re-running the policy-wide INSERTs
+      // and re-publishing anchor jobs for every team in the fan-out.
+      const materialized = await this.securityScopeService.materializePolicyStatementScopes(policyId);
+      if (!materialized) {
+        return;
+      }
       for (const teamPolicy of teamPolicies) {
-        await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamPolicy.team_id, policyId);
+        await this.securityScopeService.grantTeamAccessForPolicy(teamPolicy.team_id, policyId);
       }
     } else if (from === 'approved') {
       for (const teamPolicy of teamPolicies) {
@@ -323,8 +331,9 @@ export class PolicyService extends DBService {
    * Statement creation no longer materializes security scopes. The access-cache
    * (`security_scope`, `policy_statement_scope`, `team_security_scope`) is only
    * populated when a `team_policy` link exists and the policy is approved — that
-   * fan-out lives in `SecurityScopeService.materializeStatementScopesAndTeamAccess`
-   * and fires from `TeamPolicyService.createTeamPolicy` and from policy approval.
+   * fan-out lives in `SecurityScopeService.materializePolicyStatementScopes` +
+   * `grantTeamAccessForPolicy` and fires from `TeamPolicyService.createTeamPolicy`
+   * and from policy approval.
    *
    * @param {CreatePolicy} policyData - Policy payload.
    * @param {CreatePolicyStatementPayload[]} statements - Statement payloads.
@@ -407,8 +416,12 @@ export class PolicyService extends DBService {
     // helper is a no-op on same-status calls, and the new mappings do not
     // exist in `team_security_scope` until we materialize.
     if (previousStatus === nextStatus && nextStatus === 'approved' && affectedTeamIds.length > 0) {
-      for (const teamId of affectedTeamIds) {
-        await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
+      // Materialize the policy-wide scope mappings once, then grant per team.
+      const materialized = await this.securityScopeService.materializePolicyStatementScopes(policyId);
+      if (materialized) {
+        for (const teamId of affectedTeamIds) {
+          await this.securityScopeService.grantTeamAccessForPolicy(teamId, policyId);
+        }
       }
     }
 

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -88,7 +88,19 @@ export class PolicyService extends DBService {
   }
 
   /**
-   * Update policy fields and validate lifecycle transitions when status changes.
+   * Update policy fields, validate lifecycle transitions, and keep the access
+   * cache in sync with the resulting status.
+   *
+   * The access cache (`security_scope`, `policy_statement_scope`,
+   * `team_security_scope`) must mirror the policy's approval state: an
+   * approved policy with linked `team_policies` must have rows; a non-approved
+   * policy must not. The reverse direction is load-bearing — without rebuilding
+   * each linked team when a policy leaves `approved`, the cache would silently
+   * keep granting access through a downgraded or denied policy.
+   *
+   * Validation runs before any cache writes so a rejected status change cannot
+   * mutate the cache. Teams are processed sequentially to pin grant ordering
+   * and keep the connection-use window bounded.
    *
    * @param {string} policyId - Policy UUID.
    * @param {UpdatePolicy} policyData - Partial policy update payload.
@@ -114,7 +126,31 @@ export class PolicyService extends DBService {
 
     // Enforce lifecycle transition matrix for all status changes.
     this.assertValidStatusTransition(currentPolicy.status, policyData.status);
-    return this.policyRepository.updatePolicy(policyId, policyData);
+
+    const updated = await this.policyRepository.updatePolicy(policyId, policyData);
+
+    // Orchestrate the access cache for any linked team_policies. Validation must
+    // succeed before this point so a rejected status write cannot mutate the cache.
+    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policyId] });
+    if (teamPolicies.length === 0) {
+      return updated;
+    }
+
+    if (policyData.status === 'approved') {
+      // Transition into approved — populate the cache for each linked team.
+      for (const teamPolicy of teamPolicies) {
+        await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamPolicy.team_id, policyId);
+      }
+    } else if (currentPolicy.status === 'approved') {
+      // Transition out of approved — rebuild each linked team from the remaining
+      // policy chain. Without the reverse direction, a downgraded policy would
+      // silently keep granting access.
+      for (const teamPolicy of teamPolicies) {
+        await this.securityScopeService.rebuildTeamSecurityScopes(teamPolicy.team_id);
+      }
+    }
+
+    return updated;
   }
 
   /**
@@ -248,7 +284,13 @@ export class PolicyService extends DBService {
   }
 
   /**
-   * Create a policy and its associated statements/conditions/scopes.
+   * Create a policy and its associated statements and conditions.
+   *
+   * Statement creation no longer materializes security scopes. The access-cache
+   * (`security_scope`, `policy_statement_scope`, `team_security_scope`) is only
+   * populated when a `team_policy` link exists and the policy is approved — that
+   * fan-out lives in `SecurityScopeService.materializeStatementScopesAndTeamAccess`
+   * and fires from `TeamPolicyService.createTeamPolicy` and from policy approval.
    *
    * @param {CreatePolicy} policyData - Policy payload.
    * @param {CreatePolicyStatementPayload[]} statements - Statement payloads.
@@ -260,12 +302,19 @@ export class PolicyService extends DBService {
     statements: CreatePolicyStatementPayload[]
   ): Promise<PolicyWithStatements> {
     const policy = await this.policyRepository.insertPolicy(policyData);
-    const createdStatements = await this.createStatementsWithScopes(policy.policy_id, statements);
+    const createdStatements = await this.createStatements(policy.policy_id, statements);
     return { ...policy, statements: createdStatements };
   }
 
   /**
-   * Update a policy and fully replace its statements/conditions/scopes.
+   * Update a policy and fully replace its statements and conditions.
+   *
+   * After the statement set is replaced, re-derive the access cache for each
+   * live `team_policy` so the cache reflects the new statement set. The grant
+   * call short-circuits inside `SecurityScopeService` when the policy is not
+   * approved, so non-approved policies skip the fan-out cleanly. Teams are
+   * processed sequentially (not via `Promise.all`) to pin grant ordering and
+   * to keep the connection-use window bounded.
    *
    * @param {string} policyId - Policy UUID.
    * @param {UpdatePolicy} policyData - Partial policy update payload.
@@ -281,7 +330,7 @@ export class PolicyService extends DBService {
     // Apply policy metadata and status changes first, including lifecycle validation.
     const policy = await this.updatePolicy(policyId, policyData);
 
-    // Capture existing statement and scope associations before replacement.
+    // Capture existing statement associations before replacement.
     const existingStatements = await this.policyStatementService.getPolicyStatements(policyId);
     const oldStatementIds = existingStatements.map((s) => s.policy_statement_id);
 
@@ -292,19 +341,27 @@ export class PolicyService extends DBService {
       existingStatements.map((stmt) => this.policyStatementService.deletePolicyStatement(stmt.policy_statement_id))
     );
 
-    // Rebuild statements and recreate security scopes from the incoming payload.
-    const createdStatements = await this.createStatementsWithScopes(policyId, statements);
+    // Rebuild statements from the incoming payload.
+    const createdStatements = await this.createStatements(policyId, statements);
 
     // Remove outdated scope mappings for teams linked to this policy.
     if (oldStatementIds.length > 0) {
       await this.securityScopeService.cleanupScopesForDeletedStatements(oldStatementIds, affectedTeamIds);
     }
 
+    // Re-derive the access cache for each live team_policy against the new
+    // statement set. Non-approved policies short-circuit inside the service.
+    if (policy.status === 'approved' && affectedTeamIds.length > 0) {
+      for (const teamId of affectedTeamIds) {
+        await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
+      }
+    }
+
     return { ...policy, statements: createdStatements };
   }
 
   /**
-   * Create policy statements, create nested conditions, and materialize security scopes.
+   * Create policy statements and their nested conditions and expressions.
    *
    * @private
    * @param {string} policyId - Policy UUID.
@@ -312,12 +369,11 @@ export class PolicyService extends DBService {
    * @return {Promise<PolicyStatementWithConditions[]>} Created statements with conditions.
    * @memberof PolicyService
    */
-  private async createStatementsWithScopes(
+  private async createStatements(
     policyId: string,
     statements: CreatePolicyStatementPayload[]
   ): Promise<PolicyStatementWithConditions[]> {
-    // Create statements and nested conditions first.
-    const createdStatements = await Promise.all(
+    return Promise.all(
       statements.map(async (stmt) => {
         const statement = await this.policyStatementService.createPolicyStatement({
           policy_id: policyId,
@@ -347,15 +403,5 @@ export class PolicyService extends DBService {
         return { ...statement, conditions, ...(stmt.expression ? { expression: stmt.expression } : {}) };
       })
     );
-
-    // Materialize scope records after statement identifiers exist.
-    for (const stmt of createdStatements) {
-      await this.securityScopeService.materializeScopeForPolicyStatement(
-        stmt.policy_statement_id,
-        stmt.submission_feature_urn
-      );
-    }
-
-    return createdStatements;
   }
 }

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -119,38 +119,94 @@ export class PolicyService extends DBService {
       return this.policyRepository.updatePolicy(policyId, policyData);
     }
 
-    // Explicit approval requests are guarded: requests must be reviewed before approval.
-    if (policyData.status === 'approved') {
-      this.assertCanApproveRequest(currentPolicy.status);
-    }
-
-    // Enforce lifecycle transition matrix for all status changes.
     this.assertValidStatusTransition(currentPolicy.status, policyData.status);
 
     const updated = await this.policyRepository.updatePolicy(policyId, policyData);
 
-    // Orchestrate the access cache for any linked team_policies. Validation must
-    // succeed before this point so a rejected status write cannot mutate the cache.
-    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policyId] });
-    if (teamPolicies.length === 0) {
-      return updated;
+    // Cache orchestration runs only after the row write succeeds — a rejected
+    // status write must not mutate the cache.
+    await this.applyCacheFanOutForTransition(policyId, currentPolicy.status, policyData.status);
+
+    return updated;
+  }
+
+  /**
+   * Apply the access-cache side effects implied by a policy status transition.
+   *
+   * The cache materializes lazily and reflects standing access only: a row
+   * exists iff a live `team_policy` links a team to an approved policy with at
+   * least one ALLOW statement. Two transitions move rows in or out:
+   *
+   *   - `* → approved` materializes scope + mapping + team-grant rows for each
+   *     linked team.
+   *   - `approved → *` rebuilds each linked team from the remaining policy
+   *     chain. Without the reverse direction, a downgraded policy would
+   *     silently keep granting access.
+   *
+   * Same-status calls and transitions that do not involve `approved` (e.g.
+   * `requested → reviewed`) are no-ops; the call shape `(policyId, from, to)`
+   * stays the same so callers do not need to branch on whether status changed.
+   *
+   * Teams are processed sequentially to pin grant ordering and keep the
+   * connection-use window bounded.
+   *
+   * @private
+   * @param {string} policyId - Policy UUID.
+   * @param {PolicyStatus} from - Status the policy held before the write.
+   * @param {PolicyStatus} to - Status the policy holds after the write.
+   * @return {Promise<void>}
+   * @memberof PolicyService
+   */
+  private async applyCacheFanOutForTransition(policyId: string, from: PolicyStatus, to: PolicyStatus): Promise<void> {
+    if (from === to) {
+      return;
     }
 
-    if (policyData.status === 'approved') {
-      // Transition into approved — populate the cache for each linked team.
+    const teamPolicies = await this.teamPolicyRepository.getTeamPolicies({ policyIds: [policyId] });
+    if (teamPolicies.length === 0) {
+      return;
+    }
+
+    if (to === 'approved') {
       for (const teamPolicy of teamPolicies) {
         await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamPolicy.team_id, policyId);
       }
-    } else if (currentPolicy.status === 'approved') {
-      // Transition out of approved — rebuild each linked team from the remaining
-      // policy chain. Without the reverse direction, a downgraded policy would
-      // silently keep granting access.
+    } else if (from === 'approved') {
       for (const teamPolicy of teamPolicies) {
         await this.securityScopeService.rebuildTeamSecurityScopes(teamPolicy.team_id);
       }
     }
+  }
 
-    return updated;
+  /**
+   * Validate lifecycle transition between two policy status values.
+   *
+   * Encodes the full transition matrix plus the additional "requested cannot
+   * jump directly to approved" guard so callers compose a single validation
+   * call. Throws `HTTP400` on invalid transitions; same-status calls should be
+   * filtered by the caller before reaching this method.
+   *
+   * @private
+   * @param {PolicyStatus} current - Current policy status.
+   * @param {PolicyStatus} next - Target policy status.
+   * @return {void}
+   * @memberof PolicyService
+   */
+  private assertValidStatusTransition(current: PolicyStatus, next: PolicyStatus): void {
+    if (next === 'approved') {
+      this.assertCanApproveRequest(current);
+    }
+
+    const validTransitions: Record<PolicyStatus, PolicyStatus[]> = {
+      requested: ['reviewed', 'denied'],
+      reviewed: ['approved', 'denied'],
+      approved: ['reviewed', 'denied'],
+      denied: ['reviewed']
+    };
+
+    if (!validTransitions[current].includes(next)) {
+      throw new HTTP400(`Invalid policy status transition: ${current} -> ${next}`);
+    }
   }
 
   /**
@@ -167,28 +223,6 @@ export class PolicyService extends DBService {
 
     if (blockedStatuses.has(current)) {
       throw new HTTP400(`Cannot approve request while policy is '${current}'`);
-    }
-  }
-
-  /**
-   * Validate lifecycle transition between two policy status values.
-   *
-   * @private
-   * @param {PolicyStatus} current - Current policy status.
-   * @param {PolicyStatus} next - Target policy status.
-   * @return {void}
-   * @memberof PolicyService
-   */
-  private assertValidStatusTransition(current: PolicyStatus, next: PolicyStatus): void {
-    const validTransitions: Record<PolicyStatus, PolicyStatus[]> = {
-      requested: ['reviewed', 'denied'],
-      reviewed: ['approved', 'denied'],
-      approved: ['reviewed', 'denied'],
-      denied: ['reviewed']
-    };
-
-    if (!validTransitions[current].includes(next)) {
-      throw new HTTP400(`Invalid policy status transition: ${current} -> ${next}`);
     }
   }
 
@@ -309,12 +343,15 @@ export class PolicyService extends DBService {
   /**
    * Update a policy and fully replace its statements and conditions.
    *
-   * After the statement set is replaced, re-derive the access cache for each
-   * live `team_policy` so the cache reflects the new statement set. The grant
-   * call short-circuits inside `SecurityScopeService` when the policy is not
-   * approved, so non-approved policies skip the fan-out cleanly. Teams are
-   * processed sequentially (not via `Promise.all`) to pin grant ordering and
-   * to keep the connection-use window bounded.
+   * Order is deliberate: status-transition validation runs first so a rejected
+   * transition cannot leave the statement set replaced and the policy row
+   * unchanged. Statements are replaced next, then stale scope mappings are
+   * cleaned up, then the policy row is written. The shared transition helper
+   * runs last so the single cache orchestration sees the new statement set.
+   *
+   * For approved policies whose status did not change, the helper is a no-op
+   * — but the statement set still changed, so the cache is re-derived here
+   * with a per-team materialize against the new mappings.
    *
    * @param {string} policyId - Policy UUID.
    * @param {UpdatePolicy} policyData - Partial policy update payload.
@@ -327,10 +364,18 @@ export class PolicyService extends DBService {
     policyData: UpdatePolicy,
     statements: CreatePolicyStatementPayload[]
   ): Promise<PolicyWithStatements> {
-    // Apply policy metadata and status changes first, including lifecycle validation.
-    const policy = await this.updatePolicy(policyId, policyData);
+    // Capture state up front so we can decide validation + final orchestration.
+    const previousPolicy = await this.policyRepository.getPolicy(policyId);
+    const previousStatus = previousPolicy.status;
+    const nextStatus = policyData.status ?? previousStatus;
 
-    // Capture existing statement associations before replacement.
+    // Validate the status transition before any mutation so a rejected
+    // transition cannot leave the statement set replaced and the row unchanged.
+    if (policyData.status !== undefined && policyData.status !== previousStatus) {
+      this.assertValidStatusTransition(previousStatus, policyData.status);
+    }
+
+    // Capture existing statement associations + linked teams before replacement.
     const existingStatements = await this.policyStatementService.getPolicyStatements(policyId);
     const oldStatementIds = existingStatements.map((s) => s.policy_statement_id);
 
@@ -349,9 +394,19 @@ export class PolicyService extends DBService {
       await this.securityScopeService.cleanupScopesForDeletedStatements(oldStatementIds, affectedTeamIds);
     }
 
-    // Re-derive the access cache for each live team_policy against the new
-    // statement set. Non-approved policies short-circuit inside the service.
-    if (policy.status === 'approved' && affectedTeamIds.length > 0) {
+    // Write the policy row directly — validation already ran above so we do
+    // not need to re-enter the public `updatePolicy` path (which would also
+    // orchestrate, doubling the fan-out). The shared transition helper below
+    // owns the cache side effect.
+    const policy = await this.policyRepository.updatePolicy(policyId, policyData);
+
+    await this.applyCacheFanOutForTransition(policyId, previousStatus, nextStatus);
+
+    // Statement-set replacement on an approved policy with linked teams must
+    // re-derive the cache even when status did not change — the transition
+    // helper is a no-op on same-status calls, and the new mappings do not
+    // exist in `team_security_scope` until we materialize.
+    if (previousStatus === nextStatus && nextStatus === 'approved' && affectedTeamIds.length > 0) {
       for (const teamId of affectedTeamIds) {
         await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
       }

--- a/api/src/services/access-policy/policy-service.ts
+++ b/api/src/services/access-policy/policy-service.ts
@@ -350,7 +350,7 @@ export class PolicyService extends DBService {
 
     // Materialize scope records after statement identifiers exist.
     for (const stmt of createdStatements) {
-      await this.securityScopeService.createScopeForPolicyStatement(
+      await this.securityScopeService.materializeScopeForPolicyStatement(
         stmt.policy_statement_id,
         stmt.submission_feature_urn
       );

--- a/api/src/services/access-policy/security-scope-service.test.ts
+++ b/api/src/services/access-policy/security-scope-service.test.ts
@@ -22,7 +22,7 @@ describe('SecurityScopeService', () => {
     sinon.restore();
   });
 
-  describe('createScopeForPolicyStatement', () => {
+  describe('materializeScopeForPolicyStatement', () => {
     const policyStatementId = '11111111-1111-1111-1111-111111111111';
     const urn = 'urn:10:telemetry:*';
     const scopeHash = 'fakehash123';
@@ -40,7 +40,7 @@ describe('SecurityScopeService', () => {
         .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
         .resolves({ status: 'published', jobId: 'job-1' });
 
-      const result = await service.createScopeForPolicyStatement(policyStatementId, urn);
+      const result = await service.materializeScopeForPolicyStatement(policyStatementId, urn);
 
       expect(SecurityScopeService.dependencies.computeScopeHash).to.have.been.calledWith(urn);
       expect(insertStub).to.have.been.calledWith(scopeHash);
@@ -60,7 +60,7 @@ describe('SecurityScopeService', () => {
         .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
         .resolves({ status: 'published', jobId: 'job-1' });
 
-      const result = await service.createScopeForPolicyStatement(policyStatementId, urn);
+      const result = await service.materializeScopeForPolicyStatement(policyStatementId, urn);
 
       expect(insertStub).to.have.been.calledWith(scopeHash);
       expect(getStub).to.have.been.calledWith(scopeHash);
@@ -78,7 +78,7 @@ describe('SecurityScopeService', () => {
         .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
         .resolves({ status: 'published', jobId: 'job-1' });
 
-      await service.createScopeForPolicyStatement(policyStatementId, urn);
+      await service.materializeScopeForPolicyStatement(policyStatementId, urn);
 
       expect(mappingStub).to.have.been.calledOnce;
       expect(mappingStub).to.have.been.calledWith(policyStatementId, securityScopeId);
@@ -93,8 +93,8 @@ describe('SecurityScopeService', () => {
         .rejects(new Error('pg-boss unavailable'));
 
       try {
-        await service.createScopeForPolicyStatement(policyStatementId, urn);
-        expect.fail('expected createScopeForPolicyStatement to throw');
+        await service.materializeScopeForPolicyStatement(policyStatementId, urn);
+        expect.fail('expected materializeScopeForPolicyStatement to throw');
       } catch (error) {
         expect((error as Error).message).to.equal('pg-boss unavailable');
       }
@@ -110,8 +110,8 @@ describe('SecurityScopeService', () => {
         .rejects(new Error('pg-boss unavailable'));
 
       try {
-        await service.createScopeForPolicyStatement(policyStatementId, urn);
-        expect.fail('expected createScopeForPolicyStatement to throw');
+        await service.materializeScopeForPolicyStatement(policyStatementId, urn);
+        expect.fail('expected materializeScopeForPolicyStatement to throw');
       } catch (error) {
         expect((error as Error).message).to.equal('pg-boss unavailable');
       }
@@ -227,13 +227,171 @@ describe('SecurityScopeService', () => {
     });
   });
 
-  describe('grantTeamScopesForPolicy', () => {
-    it('delegates to repository', async () => {
-      const stub = sinon.stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy').resolves();
+  describe('materializeStatementScopesAndTeamAccess', () => {
+    const teamId = 'team-1';
+    const policyId = 'policy-1';
+    const statementOneId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const statementTwoId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    const urnOne = 'urn:10:telemetry:*';
+    const urnTwo = 'urn:10:observation:*';
+    const scopeIdOne = '11111111-1111-1111-1111-111111111111';
+    const scopeIdTwo = '22222222-2222-2222-2222-222222222222';
 
-      await service.grantTeamScopesForPolicy('team-1', 'policy-1');
+    it('A1: materializes ALLOW statements then issues the team grant (effect gate + ordering)', async () => {
+      const getStatementsStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy')
+        .resolves([
+          { policy_statement_id: statementOneId, submission_feature_urn: urnOne },
+          { policy_statement_id: statementTwoId, submission_feature_urn: urnTwo }
+        ]);
 
-      expect(stub).to.have.been.calledOnceWith('team-1', 'policy-1');
+      const computeHashStub = sinon
+        .stub(SecurityScopeService.dependencies, 'computeScopeHash')
+        .onFirstCall()
+        .returns('hash-1')
+        .onSecondCall()
+        .returns('hash-2');
+
+      const insertScopeStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'insertSecurityScope')
+        .onFirstCall()
+        .resolves({ security_scope_id: scopeIdOne, scope_hash: 'hash-1' })
+        .onSecondCall()
+        .resolves({ security_scope_id: scopeIdTwo, scope_hash: 'hash-2' });
+
+      const insertMappingStub = sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
+
+      const publishStub = sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .resolves({ status: 'published', jobId: 'job-1' });
+
+      const insertTeamGrantStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy')
+        .resolves();
+
+      await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+
+      expect(getStatementsStub).to.have.been.calledOnceWith(policyId);
+      expect(computeHashStub).to.have.been.calledTwice;
+      expect(insertScopeStub).to.have.been.calledTwice;
+      expect(insertMappingStub).to.have.been.calledTwice;
+      expect(insertMappingStub.firstCall).to.have.been.calledWith(statementOneId, scopeIdOne);
+      expect(insertMappingStub.secondCall).to.have.been.calledWith(statementTwoId, scopeIdTwo);
+      expect(publishStub).to.have.been.calledTwice;
+      expect(insertTeamGrantStub).to.have.been.calledOnceWith(teamId, policyId);
+      // Materialize-then-grant ordering: every mapping insert precedes the team grant.
+      expect(insertMappingStub).to.have.been.calledBefore(insertTeamGrantStub);
+      expect(publishStub).to.have.been.calledBefore(insertTeamGrantStub);
+    });
+
+    it('A2: not approved → short-circuits before any materialization or team grant', async () => {
+      sinon.stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy').resolves([]);
+
+      const insertScopeStub = sinon.stub(SecurityScopeRepository.prototype, 'insertSecurityScope');
+      const insertMappingStub = sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope');
+      const publishStub = sinon.stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob');
+      const insertTeamGrantStub = sinon.stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy');
+
+      await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+
+      expect(insertScopeStub).not.to.have.been.called;
+      expect(insertMappingStub).not.to.have.been.called;
+      expect(publishStub).not.to.have.been.called;
+      expect(insertTeamGrantStub).not.to.have.been.called;
+    });
+
+    it('A3: approved with zero ALLOW statements → same observable behavior as A2 (no team grant)', async () => {
+      // The repository returns `[]` both when the policy is not approved AND when
+      // the policy is approved but has no active ALLOW statements (the SQL filters
+      // on both gates). At the service layer the two cases are indistinguishable
+      // and both short-circuit before the team-grant insert. The integration test
+      // suite covers the SQL-layer distinction.
+      sinon.stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy').resolves([]);
+
+      const insertScopeStub = sinon.stub(SecurityScopeRepository.prototype, 'insertSecurityScope');
+      const insertTeamGrantStub = sinon.stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy');
+
+      await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+
+      expect(insertScopeStub).not.to.have.been.called;
+      expect(insertTeamGrantStub).not.to.have.been.called;
+    });
+
+    it('A4: ALLOW statement URN already has a scope → existing scope reused, mapping inserted, anchor re-queued', async () => {
+      sinon
+        .stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy')
+        .resolves([{ policy_statement_id: statementOneId, submission_feature_urn: urnOne }]);
+
+      sinon.stub(SecurityScopeService.dependencies, 'computeScopeHash').returns('hash-1');
+
+      // First insert returns null (existing scope wins the conflict).
+      sinon.stub(SecurityScopeRepository.prototype, 'insertSecurityScope').resolves(null);
+      const getExistingStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'getSecurityScopeByScopeHash')
+        .resolves({ security_scope_id: scopeIdOne, scope_hash: 'hash-1' });
+
+      const insertMappingStub = sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
+      const publishStub = sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .resolves({ status: 'published', jobId: 'job-1' });
+      const insertTeamGrantStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy')
+        .resolves();
+
+      await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+
+      expect(getExistingStub).to.have.been.calledOnceWith('hash-1');
+      expect(insertMappingStub).to.have.been.calledOnceWith(statementOneId, scopeIdOne);
+      expect(publishStub).to.have.been.calledOnceWith(mockDBConnection, { securityScopeId: scopeIdOne });
+      expect(insertTeamGrantStub).to.have.been.calledOnceWith(teamId, policyId);
+    });
+
+    it('A5: called twice with the same args → both resolve (idempotency)', async () => {
+      sinon
+        .stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy')
+        .resolves([{ policy_statement_id: statementOneId, submission_feature_urn: urnOne }]);
+      sinon.stub(SecurityScopeService.dependencies, 'computeScopeHash').returns('hash-1');
+      sinon
+        .stub(SecurityScopeRepository.prototype, 'insertSecurityScope')
+        .resolves({ security_scope_id: scopeIdOne, scope_hash: 'hash-1' });
+      sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
+      sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .resolves({ status: 'published', jobId: 'job-1' });
+      sinon.stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy').resolves();
+
+      await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+      await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+    });
+
+    it('A6: publish failure on the first statement aborts before the team grant runs', async () => {
+      sinon.stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy').resolves([
+        { policy_statement_id: statementOneId, submission_feature_urn: urnOne },
+        { policy_statement_id: statementTwoId, submission_feature_urn: urnTwo }
+      ]);
+
+      sinon.stub(SecurityScopeService.dependencies, 'computeScopeHash').returns('hash-1');
+      const insertScopeStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'insertSecurityScope')
+        .resolves({ security_scope_id: scopeIdOne, scope_hash: 'hash-1' });
+      sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
+      sinon
+        .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
+        .rejects(new Error('pg-boss unavailable'));
+      const insertTeamGrantStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy')
+        .resolves();
+
+      try {
+        await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+        expect.fail('expected materializeStatementScopesAndTeamAccess to throw');
+      } catch (error) {
+        expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
+
+      // Sequential for-await — second statement never reached, team grant never runs.
+      expect(insertScopeStub).to.have.been.calledOnce;
+      expect(insertTeamGrantStub).not.to.have.been.called;
     });
   });
 

--- a/api/src/services/access-policy/security-scope-service.test.ts
+++ b/api/src/services/access-policy/security-scope-service.test.ts
@@ -239,7 +239,7 @@ describe('SecurityScopeService', () => {
 
     it('A1: materializes ALLOW statements then issues the team grant (effect gate + ordering)', async () => {
       const getStatementsStub = sinon
-        .stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy')
+        .stub(SecurityScopeRepository.prototype, 'findActiveAllowStatementsForApprovedPolicy')
         .resolves([
           { policy_statement_id: statementOneId, submission_feature_urn: urnOne },
           { policy_statement_id: statementTwoId, submission_feature_urn: urnTwo }
@@ -285,7 +285,7 @@ describe('SecurityScopeService', () => {
     });
 
     it('A2: not approved → short-circuits before any materialization or team grant', async () => {
-      sinon.stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy').resolves([]);
+      sinon.stub(SecurityScopeRepository.prototype, 'findActiveAllowStatementsForApprovedPolicy').resolves([]);
 
       const insertScopeStub = sinon.stub(SecurityScopeRepository.prototype, 'insertSecurityScope');
       const insertMappingStub = sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope');
@@ -306,7 +306,7 @@ describe('SecurityScopeService', () => {
       // on both gates). At the service layer the two cases are indistinguishable
       // and both short-circuit before the team-grant insert. The integration test
       // suite covers the SQL-layer distinction.
-      sinon.stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy').resolves([]);
+      sinon.stub(SecurityScopeRepository.prototype, 'findActiveAllowStatementsForApprovedPolicy').resolves([]);
 
       const insertScopeStub = sinon.stub(SecurityScopeRepository.prototype, 'insertSecurityScope');
       const insertTeamGrantStub = sinon.stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy');
@@ -319,7 +319,7 @@ describe('SecurityScopeService', () => {
 
     it('A4: ALLOW statement URN already has a scope → existing scope reused, mapping inserted, anchor re-queued', async () => {
       sinon
-        .stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy')
+        .stub(SecurityScopeRepository.prototype, 'findActiveAllowStatementsForApprovedPolicy')
         .resolves([{ policy_statement_id: statementOneId, submission_feature_urn: urnOne }]);
 
       sinon.stub(SecurityScopeService.dependencies, 'computeScopeHash').returns('hash-1');
@@ -348,7 +348,7 @@ describe('SecurityScopeService', () => {
 
     it('A5: called twice with the same args → both resolve (idempotency)', async () => {
       sinon
-        .stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy')
+        .stub(SecurityScopeRepository.prototype, 'findActiveAllowStatementsForApprovedPolicy')
         .resolves([{ policy_statement_id: statementOneId, submission_feature_urn: urnOne }]);
       sinon.stub(SecurityScopeService.dependencies, 'computeScopeHash').returns('hash-1');
       sinon
@@ -373,7 +373,7 @@ describe('SecurityScopeService', () => {
     });
 
     it('A6: publish failure on the first statement aborts before the team grant runs', async () => {
-      sinon.stub(SecurityScopeRepository.prototype, 'getActiveAllowStatementsForApprovedPolicy').resolves([
+      sinon.stub(SecurityScopeRepository.prototype, 'findActiveAllowStatementsForApprovedPolicy').resolves([
         { policy_statement_id: statementOneId, submission_feature_urn: urnOne },
         { policy_statement_id: statementTwoId, submission_feature_urn: urnTwo }
       ]);

--- a/api/src/services/access-policy/security-scope-service.test.ts
+++ b/api/src/services/access-policy/security-scope-service.test.ts
@@ -354,14 +354,22 @@ describe('SecurityScopeService', () => {
       sinon
         .stub(SecurityScopeRepository.prototype, 'insertSecurityScope')
         .resolves({ security_scope_id: scopeIdOne, scope_hash: 'hash-1' });
-      sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
+      const insertMappingStub = sinon.stub(SecurityScopeRepository.prototype, 'insertPolicyStatementScope').resolves();
       sinon
         .stub(SecurityScopeService.dependencies, 'publishComputeScopeAnchorsJob')
         .resolves({ status: 'published', jobId: 'job-1' });
-      sinon.stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy').resolves();
+      const insertTeamGrantStub = sinon
+        .stub(SecurityScopeRepository.prototype, 'insertTeamSecurityScopesForPolicy')
+        .resolves();
 
       await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
       await service.materializeStatementScopesAndTeamAccess(teamId, policyId);
+
+      // Idempotency at this layer means the service runs the same chain on each call
+      // without early-exit or throw. SQL-level dedup (ON CONFLICT DO NOTHING) is the
+      // production safety net; the integration test suite covers that.
+      expect(insertMappingStub).to.have.been.calledTwice;
+      expect(insertTeamGrantStub).to.have.been.calledTwice;
     });
 
     it('A6: publish failure on the first statement aborts before the team grant runs', async () => {

--- a/api/src/services/access-policy/security-scope-service.ts
+++ b/api/src/services/access-policy/security-scope-service.ts
@@ -9,12 +9,22 @@ import { AnchorBatchResult, SecurityScopeUrn } from './security-scope-service.in
 const defaultLog = getLogger('security-scope-service');
 
 /**
- * Service for managing normalized security scopes — the access model that replaces
- * the materialized team_feature cache.
+ * Service for managing the team-access scope cache — the normalized model that
+ * replaces the materialized team_feature cache.
  *
- * Orchestrates scope creation, policy-statement-to-scope mapping, team scope
- * derivation, and anchor computation triggers. Repository handles all SQL;
- * this service handles the sequencing and decision logic.
+ * The cache only describes standing access grants. It materializes lazily when a
+ * team gains access through a `team_policy` link or when a policy's status flips
+ * to `approved`. Statement creation alone never produces cache rows — a policy
+ * without a `team_policy` link is a stored filter expression, not an access grant.
+ * Non-access policies (download, data_request, security_reason) consequently
+ * leave the cache untouched until they are linked to a team and approved.
+ *
+ * Materialization order: ALLOW statements on an approved policy are materialized
+ * into `security_scope` + `policy_statement_scope` rows before the team-grant
+ * insert runs — the team-grant SQL joins through `policy_statement_scope` and
+ * requires those rows to already exist in the same connection/transaction.
+ *
+ * Repository handles all SQL; this service handles sequencing and decision logic.
  */
 export class SecurityScopeService extends DBService {
   securityScopeRepository: SecurityScopeRepository;
@@ -33,7 +43,13 @@ export class SecurityScopeService extends DBService {
   }
 
   /**
-   * Create a security scope and policy_statement_scope mapping for a policy statement.
+   * Materialize the `security_scope` + `policy_statement_scope` rows for one
+   * policy statement and publish its anchor-computation job.
+   *
+   * Encapsulates the hash → insert-or-reuse → mapping → publish-anchor-job flow.
+   * The caller is `materializeStatementScopesAndTeamAccess`, which invokes this
+   * helper once per active ALLOW statement on an approved policy before issuing
+   * the team-access insert.
    *
    * Always publishes a background job to compute anchors — the secured subtree
    * roots that the walk-up search strategy checks against. For new scopes this
@@ -46,7 +62,7 @@ export class SecurityScopeService extends DBService {
    * @param urn The submission_feature_urn (e.g., 'urn:10:telemetry:*')
    * @returns The security_scope_id (new or existing)
    */
-  async createScopeForPolicyStatement(policyStatementId: string, urn: string): Promise<string> {
+  async materializeScopeForPolicyStatement(policyStatementId: string, urn: string): Promise<string> {
     const scopeHash = SecurityScopeService.dependencies.computeScopeHash(urn);
 
     const inserted = await this.securityScopeRepository.insertSecurityScope(scopeHash);
@@ -60,7 +76,7 @@ export class SecurityScopeService extends DBService {
       });
 
       defaultLog.info({
-        label: 'createScopeForPolicyStatement',
+        label: 'materializeScopeForPolicyStatement',
         message: 'New security scope created, anchor computation job published',
         securityScopeId: inserted.security_scope_id,
         scopeHash
@@ -81,7 +97,7 @@ export class SecurityScopeService extends DBService {
     });
 
     defaultLog.info({
-      label: 'createScopeForPolicyStatement',
+      label: 'materializeScopeForPolicyStatement',
       message: 'Existing security scope reused, anchor computation job published',
       securityScopeId: existing.security_scope_id,
       scopeHash
@@ -143,15 +159,47 @@ export class SecurityScopeService extends DBService {
   }
 
   /**
-   * Grant a team access to all scopes derived from a specific policy.
+   * Materialize the access-cache rows for one (team, policy) pair.
    *
-   * Called when a team-policy association is created. Walks the policy's statements
-   * to find their mapped scopes and inserts team_security_scope rows.
+   * The method does two things, both required for the team's access to be
+   * usable, both named in the method name:
    *
-   * @param teamId UUID of the team
-   * @param policyId UUID of the policy being assigned to the team
+   *   1. Statement scopes — global `security_scope` + `policy_statement_scope`
+   *      rows for each active ALLOW statement on the policy. These rows are
+   *      shared across every team that links to the same policy; deduplicated
+   *      by URN hash. Anchor-computation jobs are published per scope.
+   *   2. Team access — the team-specific `team_security_scope` rows that make
+   *      the cached scopes visible to this team's authorization checks.
+   *
+   * Statement scopes are materialized first so the team-access SQL can join
+   * through `policy_statement_scope`. Statements are processed sequentially
+   * (not via `Promise.all`) so a publish-anchor-job failure aborts before any
+   * team-access rows are written.
+   *
+   * This is the lazy-materialization entry point — invoked when a `team_policy`
+   * link is created or when a policy's status flips to `approved`. Statement
+   * creation alone never produces cache rows; a policy without a `team_policy`
+   * link is a stored filter expression, not an access grant.
+   *
+   * Both access gates (`policy.status='approved'`, `policy_statement.effect='ALLOW'`)
+   * live in the SQL that returns the statement list. When the repository
+   * returns `[]` — either gate filtered everything out — the method short-circuits
+   * before writing any rows.
+   *
+   * @param teamId UUID of the team gaining access
+   * @param policyId UUID of the policy whose ALLOW statements grant the access
    */
-  async grantTeamScopesForPolicy(teamId: string, policyId: string): Promise<void> {
+  async materializeStatementScopesAndTeamAccess(teamId: string, policyId: string): Promise<void> {
+    const statements = await this.securityScopeRepository.getActiveAllowStatementsForApprovedPolicy(policyId);
+
+    if (statements.length === 0) {
+      return;
+    }
+
+    for (const statement of statements) {
+      await this.materializeScopeForPolicyStatement(statement.policy_statement_id, statement.submission_feature_urn);
+    }
+
     await this.securityScopeRepository.insertTeamSecurityScopesForPolicy(teamId, policyId);
   }
 

--- a/api/src/services/access-policy/security-scope-service.ts
+++ b/api/src/services/access-policy/security-scope-service.ts
@@ -190,7 +190,7 @@ export class SecurityScopeService extends DBService {
    * @param policyId UUID of the policy whose ALLOW statements grant the access
    */
   async materializeStatementScopesAndTeamAccess(teamId: string, policyId: string): Promise<void> {
-    const statements = await this.securityScopeRepository.getActiveAllowStatementsForApprovedPolicy(policyId);
+    const statements = await this.securityScopeRepository.findActiveAllowStatementsForApprovedPolicy(policyId);
 
     if (statements.length === 0) {
       return;

--- a/api/src/services/access-policy/security-scope-service.ts
+++ b/api/src/services/access-policy/security-scope-service.ts
@@ -47,9 +47,8 @@ export class SecurityScopeService extends DBService {
    * policy statement and publish its anchor-computation job.
    *
    * Encapsulates the hash → insert-or-reuse → mapping → publish-anchor-job flow.
-   * The caller is `materializeStatementScopesAndTeamAccess`, which invokes this
-   * helper once per active ALLOW statement on an approved policy before issuing
-   * the team-access insert.
+   * The caller is `materializePolicyStatementScopes`, which invokes this
+   * helper once per active ALLOW statement on an approved policy.
    *
    * Always publishes a background job to compute anchors — the secured subtree
    * roots that the walk-up search strategy checks against. For new scopes this
@@ -159,48 +158,82 @@ export class SecurityScopeService extends DBService {
   }
 
   /**
-   * Materialize the access-cache rows for one (team, policy) pair.
+   * Materialize the policy-wide access-cache rows for a policy's ALLOW statements.
    *
-   * The method does two things, both required for the team's access to be
-   * usable, both named in the method name:
-   *
-   *   1. Statement scopes — global `security_scope` + `policy_statement_scope`
-   *      rows for each active ALLOW statement on the policy. These rows are
-   *      shared across every team that links to the same policy; deduplicated
-   *      by URN hash. Anchor-computation jobs are published per scope.
-   *   2. Team access — the team-specific `team_security_scope` rows that make
-   *      the cached scopes visible to this team's authorization checks.
-   *
-   * Statement scopes are materialized first so the team-access SQL can join
-   * through `policy_statement_scope`. Statements are processed sequentially
-   * (not via `Promise.all`) so a publish-anchor-job failure aborts before any
-   * team-access rows are written.
-   *
-   * This is the lazy-materialization entry point — invoked when a `team_policy`
-   * link is created or when a policy's status flips to `approved`. Statement
-   * creation alone never produces cache rows; a policy without a `team_policy`
-   * link is a stored filter expression, not an access grant.
+   * Inserts (or de-duplicates by hash) `security_scope` and
+   * `policy_statement_scope` rows for every active ALLOW statement on the
+   * policy, and publishes one anchor-computation job per scope. These rows are
+   * shared across every team that links to the same policy.
    *
    * Both access gates (`policy.status='approved'`, `policy_statement.effect='ALLOW'`)
    * live in the SQL that returns the statement list. When the repository
-   * returns `[]` — either gate filtered everything out — the method short-circuits
-   * before writing any rows.
+   * returns `[]` — either gate filtered everything out — the method
+   * short-circuits and returns `false` so callers can skip the team-grant step.
+   * Statements are processed sequentially (not via `Promise.all`) so a
+   * publish-anchor-job failure aborts before more work is queued.
    *
-   * @param teamId UUID of the team gaining access
-   * @param policyId UUID of the policy whose ALLOW statements grant the access
+   * This is the policy-wide half of the lazy-materialization entry point.
+   * Callers that also need to grant team access for this policy should invoke
+   * `grantTeamAccessForPolicy(teamId, policyId)` after this method returns
+   * `true`. Splitting the calls lets the fan-out path (one policy → N teams)
+   * materialize statement scopes once and only loop per team for the team-grant
+   * insert.
+   *
+   * @param policyId UUID of the policy whose ALLOW statements should be materialized
+   * @returns `true` if statement scopes were materialized, `false` if the policy
+   *   had no active ALLOW statements (gate-filtered or not approved)
    */
-  async materializeStatementScopesAndTeamAccess(teamId: string, policyId: string): Promise<void> {
+  async materializePolicyStatementScopes(policyId: string): Promise<boolean> {
     const statements = await this.securityScopeRepository.findActiveAllowStatementsForApprovedPolicy(policyId);
 
     if (statements.length === 0) {
-      return;
+      return false;
     }
 
     for (const statement of statements) {
       await this.materializeScopeForPolicyStatement(statement.policy_statement_id, statement.submission_feature_urn);
     }
 
+    return true;
+  }
+
+  /**
+   * Insert the team-specific `team_security_scope` rows for a (team, policy)
+   * pair.
+   *
+   * Joins `team_policy → policy_statement → policy_statement_scope` to produce
+   * the team's grant rows. The SQL re-asserts both access gates
+   * (`p.status='approved'`, `effect='ALLOW'`) and uses `ON CONFLICT DO NOTHING`
+   * for idempotency. Callers should invoke `materializePolicyStatementScopes`
+   * first when the policy may not yet have its scope mappings — otherwise the
+   * join returns zero rows and no access is granted.
+   *
+   * @param teamId UUID of the team gaining access
+   * @param policyId UUID of the policy whose ALLOW statements grant the access
+   */
+  async grantTeamAccessForPolicy(teamId: string, policyId: string): Promise<void> {
     await this.securityScopeRepository.insertTeamSecurityScopesForPolicy(teamId, policyId);
+  }
+
+  /**
+   * Convenience wrapper for the common single-(team, policy) materialization
+   * sequence: materialize the policy's statement scopes, then grant the team's
+   * access. Equivalent to:
+   *
+   *   const materialized = await materializePolicyStatementScopes(policyId);
+   *   if (materialized) await grantTeamAccessForPolicy(teamId, policyId);
+   *
+   * Fan-out callers (one policy → N teams) should call the two methods
+   * directly so the statement-scope materialization runs once, not per team.
+   *
+   * @param teamId UUID of the team gaining access
+   * @param policyId UUID of the policy whose ALLOW statements grant the access
+   */
+  async materializeStatementScopesAndTeamAccess(teamId: string, policyId: string): Promise<void> {
+    const materialized = await this.materializePolicyStatementScopes(policyId);
+    if (materialized) {
+      await this.grantTeamAccessForPolicy(teamId, policyId);
+    }
   }
 
   /**

--- a/api/src/services/access-policy/team-policy-service.test.ts
+++ b/api/src/services/access-policy/team-policy-service.test.ts
@@ -33,9 +33,10 @@ describe('TeamPolicyService', () => {
 
       const getExistingStub = sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves(mockTeamPolicy);
-      const grantScopesStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -48,11 +49,35 @@ describe('TeamPolicyService', () => {
         policyIds: ['33333333-3333-3333-3333-333333333333']
       });
       expect(insertStub).to.have.been.calledWith(input);
-      expect(grantScopesStub).to.have.been.calledOnce;
-      expect(grantScopesStub).to.have.been.calledWith(
+      expect(materializeStub).to.have.been.calledOnceWith('33333333-3333-3333-3333-333333333333');
+      expect(grantStub).to.have.been.calledOnceWith(
         '22222222-2222-2222-2222-222222222222',
         '33333333-3333-3333-3333-333333333333'
       );
+      expect(result).to.eql(mockTeamPolicy);
+    });
+
+    it('should skip the team grant when the policy has no ALLOW statements to materialize', async () => {
+      const mockTeamPolicy: TeamPolicy = {
+        team_policy_id: '11111111-1111-1111-1111-111111111111',
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      };
+
+      sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
+      sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves(mockTeamPolicy);
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(false);
+      const grantStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
+
+      const result = await service.createTeamPolicy({
+        team_id: '22222222-2222-2222-2222-222222222222',
+        policy_id: '33333333-3333-3333-3333-333333333333'
+      });
+
+      expect(materializeStub).to.have.been.calledOnce;
+      expect(grantStub).to.not.have.been.called;
       expect(result).to.eql(mockTeamPolicy);
     });
 
@@ -69,9 +94,10 @@ describe('TeamPolicyService', () => {
         .stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId')
         .resolves([existingTeamPolicy]);
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy');
-      const grantScopesStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -84,7 +110,8 @@ describe('TeamPolicyService', () => {
         policyIds: ['33333333-3333-3333-3333-333333333333']
       });
       expect(insertStub).to.not.have.been.called;
-      expect(grantScopesStub).to.not.have.been.called;
+      expect(materializeStub).to.not.have.been.called;
+      expect(grantStub).to.not.have.been.called;
       expect(result).to.eql({
         team_policy_id: '11111111-1111-1111-1111-111111111111',
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -126,9 +153,10 @@ describe('TeamPolicyService', () => {
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
 
-      const grantScopesStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -140,12 +168,15 @@ describe('TeamPolicyService', () => {
       });
 
       expect(insertStub).to.have.been.calledTwice;
-      expect(grantScopesStub).to.have.been.calledTwice;
-      expect(grantScopesStub.firstCall).to.have.been.calledWith(
+      expect(materializeStub).to.have.been.calledTwice;
+      expect(materializeStub.firstCall).to.have.been.calledWith('33333333-3333-3333-3333-333333333333');
+      expect(materializeStub.secondCall).to.have.been.calledWith('55555555-5555-5555-5555-555555555555');
+      expect(grantStub).to.have.been.calledTwice;
+      expect(grantStub.firstCall).to.have.been.calledWith(
         '22222222-2222-2222-2222-222222222222',
         '33333333-3333-3333-3333-333333333333'
       );
-      expect(grantScopesStub.secondCall).to.have.been.calledWith(
+      expect(grantStub.secondCall).to.have.been.calledWith(
         '22222222-2222-2222-2222-222222222222',
         '55555555-5555-5555-5555-555555555555'
       );
@@ -180,9 +211,10 @@ describe('TeamPolicyService', () => {
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
 
-      const grantScopesStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -198,9 +230,9 @@ describe('TeamPolicyService', () => {
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
 
-      // Scope grant only for the newly created policy, not the pre-existing one
-      expect(grantScopesStub).to.have.been.calledOnce;
-      expect(grantScopesStub).to.have.been.calledWith(
+      // Materialize + grant only for the newly created policy, not the pre-existing one
+      expect(materializeStub).to.have.been.calledOnceWith('55555555-5555-5555-5555-555555555555');
+      expect(grantStub).to.have.been.calledOnceWith(
         '22222222-2222-2222-2222-222222222222',
         '55555555-5555-5555-5555-555555555555'
       );
@@ -226,16 +258,18 @@ describe('TeamPolicyService', () => {
       ]);
 
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy');
-      const grantScopesStub = sinon
-        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
-        .resolves();
+      const materializeStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializePolicyStatementScopes')
+        .resolves(true);
+      const grantStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamAccessForPolicy').resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333'
       ]);
 
       expect(insertStub).to.not.have.been.called;
-      expect(grantScopesStub).to.not.have.been.called;
+      expect(materializeStub).to.not.have.been.called;
+      expect(grantStub).to.not.have.been.called;
       expect(result).to.eql([]);
     });
   });

--- a/api/src/services/access-policy/team-policy-service.test.ts
+++ b/api/src/services/access-policy/team-policy-service.test.ts
@@ -33,7 +33,9 @@ describe('TeamPolicyService', () => {
 
       const getExistingStub = sinon.stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId').resolves([]);
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves(mockTeamPolicy);
-      const grantScopesStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamScopesForPolicy').resolves();
+      const grantScopesStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -67,7 +69,9 @@ describe('TeamPolicyService', () => {
         .stub(TeamPolicyRepository.prototype, 'getPoliciesByTeamId')
         .resolves([existingTeamPolicy]);
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy');
-      const grantScopesStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamScopesForPolicy').resolves();
+      const grantScopesStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
       const input: CreateTeamPolicy = {
         team_id: '22222222-2222-2222-2222-222222222222',
@@ -122,7 +126,9 @@ describe('TeamPolicyService', () => {
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
 
-      const grantScopesStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamScopesForPolicy').resolves();
+      const grantScopesStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -174,7 +180,9 @@ describe('TeamPolicyService', () => {
         policy_id: '55555555-5555-5555-5555-555555555555'
       });
 
-      const grantScopesStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamScopesForPolicy').resolves();
+      const grantScopesStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333',
@@ -218,7 +226,9 @@ describe('TeamPolicyService', () => {
       ]);
 
       const insertStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy');
-      const grantScopesStub = sinon.stub(SecurityScopeService.prototype, 'grantTeamScopesForPolicy').resolves();
+      const grantScopesStub = sinon
+        .stub(SecurityScopeService.prototype, 'materializeStatementScopesAndTeamAccess')
+        .resolves();
 
       const result = await service.createTeamPolicies('22222222-2222-2222-2222-222222222222', [
         '33333333-3333-3333-3333-333333333333'

--- a/api/src/services/access-policy/team-policy-service.ts
+++ b/api/src/services/access-policy/team-policy-service.ts
@@ -22,10 +22,10 @@ export class TeamPolicyService extends DBService {
    * Inserting a `team_policy` link is the trigger that lazily builds the
    * normalized scope cache (`security_scope`, `policy_statement_scope`,
    * `team_security_scope`) for the team. The materialization runs via
-   * `SecurityScopeService.materializeStatementScopesAndTeamAccess`, which
-   * short-circuits when the policy is not `status='approved'` or has no
-   * `ALLOW` statements — so unapproved or empty policies create the link
-   * without granting any access.
+   * `SecurityScopeService.materializePolicyStatementScopes` followed by
+   * `grantTeamAccessForPolicy`. The first call short-circuits when the policy
+   * is not `status='approved'` or has no `ALLOW` statements — so unapproved or
+   * empty policies create the link without granting any access.
    *
    * If the (team, policy) link already exists, returns the existing record
    * without re-materializing.
@@ -51,11 +51,12 @@ export class TeamPolicyService extends DBService {
     const teamPolicy = await this.teamPolicyRepository.insertTeamPolicy(teamPolicyData);
 
     // Materialize the access cache for this (team, policy) pair: statement scopes
-    // (shared across teams) and the team's access rows that point at them.
-    await this.securityScopeService.materializeStatementScopesAndTeamAccess(
-      teamPolicyData.team_id,
-      teamPolicyData.policy_id
-    );
+    // (shared across teams) first, then the team's access rows that point at them.
+    // Skip the team-grant insert when there's nothing to grant.
+    const materialized = await this.securityScopeService.materializePolicyStatementScopes(teamPolicyData.policy_id);
+    if (materialized) {
+      await this.securityScopeService.grantTeamAccessForPolicy(teamPolicyData.team_id, teamPolicyData.policy_id);
+    }
 
     return teamPolicy;
   }
@@ -91,7 +92,10 @@ export class TeamPolicyService extends DBService {
     // Materialize the access cache for newly created team-policy associations.
     // Pre-existing policies already had their cache rows materialized on first creation.
     for (const policyId of policyIdsToCreate) {
-      await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
+      const materialized = await this.securityScopeService.materializePolicyStatementScopes(policyId);
+      if (materialized) {
+        await this.securityScopeService.grantTeamAccessForPolicy(teamId, policyId);
+      }
     }
 
     return createdTeamPolicies;

--- a/api/src/services/access-policy/team-policy-service.ts
+++ b/api/src/services/access-policy/team-policy-service.ts
@@ -17,10 +17,21 @@ export class TeamPolicyService extends DBService {
   }
 
   /**
-   * Create a new team policy record.
+   * Create a team policy record and materialize the access cache for the pair.
+   *
+   * Inserting a `team_policy` link is the trigger that lazily builds the
+   * normalized scope cache (`security_scope`, `policy_statement_scope`,
+   * `team_security_scope`) for the team. The materialization runs via
+   * `SecurityScopeService.materializeStatementScopesAndTeamAccess`, which
+   * short-circuits when the policy is not `status='approved'` or has no
+   * `ALLOW` statements — so unapproved or empty policies create the link
+   * without granting any access.
+   *
+   * If the (team, policy) link already exists, returns the existing record
+   * without re-materializing.
    *
    * @param {CreateTeamPolicy} teamPolicyData - Data required to create a new team policy.
-   * @return {Promise<TeamPolicy>} - The created team policy record.
+   * @return {Promise<TeamPolicy>} - The created (or pre-existing) team policy record.
    * @memberof TeamPolicyService
    */
   async createTeamPolicy(teamPolicyData: CreateTeamPolicy): Promise<TeamPolicy> {

--- a/api/src/services/access-policy/team-policy-service.ts
+++ b/api/src/services/access-policy/team-policy-service.ts
@@ -39,8 +39,12 @@ export class TeamPolicyService extends DBService {
 
     const teamPolicy = await this.teamPolicyRepository.insertTeamPolicy(teamPolicyData);
 
-    // Grant the team access to all scopes derived from this policy's statements
-    await this.securityScopeService.grantTeamScopesForPolicy(teamPolicyData.team_id, teamPolicyData.policy_id);
+    // Materialize the access cache for this (team, policy) pair: statement scopes
+    // (shared across teams) and the team's access rows that point at them.
+    await this.securityScopeService.materializeStatementScopesAndTeamAccess(
+      teamPolicyData.team_id,
+      teamPolicyData.policy_id
+    );
 
     return teamPolicy;
   }
@@ -73,10 +77,10 @@ export class TeamPolicyService extends DBService {
       )
     );
 
-    // Grant scopes only for newly created team-policy associations.
-    // Pre-existing policies already had their scopes granted on first creation.
+    // Materialize the access cache for newly created team-policy associations.
+    // Pre-existing policies already had their cache rows materialized on first creation.
     for (const policyId of policyIdsToCreate) {
-      await this.securityScopeService.grantTeamScopesForPolicy(teamId, policyId);
+      await this.securityScopeService.materializeStatementScopesAndTeamAccess(teamId, policyId);
     }
 
     return createdTeamPolicies;

--- a/api/src/services/download/download-policy-service.test.ts
+++ b/api/src/services/download/download-policy-service.test.ts
@@ -159,7 +159,7 @@ describe('DownloadPolicyService', () => {
       // The boundary stubs: if the production service ever wires these in, these
       // assertions fail and the access-grant boundary is restored.
       const createScopeStub = sinon
-        .stub(SecurityScopeService.prototype, 'createScopeForPolicyStatement')
+        .stub(SecurityScopeService.prototype, 'materializeScopeForPolicyStatement')
         .resolves('scope-1');
       const insertTeamPolicyStub = sinon.stub(TeamPolicyRepository.prototype, 'insertTeamPolicy').resolves({
         team_policy_id: 'tp1',

--- a/database/src/seeds/07_access_policy.ts
+++ b/database/src/seeds/07_access_policy.ts
@@ -28,6 +28,7 @@ export async function seed(knex: Knex): Promise<void> {
       .insert({
         name: 'Telemetry Access',
         description: 'Grants read access to all Telemetry submission features',
+        status: 'approved',
         create_user: createUser
       })
       .returning('*');
@@ -137,6 +138,7 @@ export async function seed(knex: Knex): Promise<void> {
       .insert({
         name: 'Secret Sampling Sites Access',
         description: 'Grants unrestricted access to all submission features and data',
+        status: 'approved',
         create_user: createUser
       })
       .returning('*');


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-985](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-985)

## Description of Changes

This ticket updates `SecurityScopeService` so security scopes are only created and maintained for access-oriented policies.

`security_scope` should not be treated as the generic scope mechanism for all policies. It is an access cache used to make search authorization fast for teams with active `team_policy` grants.

Policies used only for data requests, downloads, security reasons, or other non-access workflows should not create security scopes, anchors, or team scope mappings.

Acceptance Criteria

1. Restrict Security Scope Creation to Access Grants

Create `security_scope` records only when a policy is linked through `team_policy`  
Do not create `security_scope` records for generic policy creation  
Do not create `security_scope` records when policy statements are created outside an access-grant flow  
Do not create `security_scope` records for policies linked only to `data_request`, `download`, or `security_reason`  
Treat `security_scope` as an access cache, not as the generic policy scope model  

2. Update SecurityScopeService Responsibilities

Update `SecurityScopeService` so its public methods clearly operate on team access grants  
Ensure `createScopeForPolicyStatement` is only called from access-oriented flows  
Prefer naming or comments that make the access-only purpose clear  
Keep anchor computation and team scope derivation inside this service  
Remove assumptions that every policy statement should resolve to a security scope  

3. Create Scopes When Team Access Is Granted

When a `team_policy` is created, resolve the active policy statements for that policy  
For each relevant policy statement URN, compute or reuse the matching `security_scope`  
Create or reuse the policy-statement-to-scope mapping needed for access checks  
Publish anchor computation jobs for newly created or reused scopes where required by current idempotent behavior  
Insert or rebuild `team_security_scope` rows for the granted team access  

4. Keep Non-Access Policies Scope-Free

Creating a data request policy should not create security scopes  
Creating a download policy should not create security scopes  
Creating a security reason policy should not create security scopes  
Updating policy statements for non-access policies should not enqueue anchor computation jobs  
Non-access policy consumers should evaluate their policies directly instead of relying on `security_scope`  

5. Preserve Team Access Behavior

Existing search authorization should continue to use active team access mappings  
Authenticated users should see secured features only when their team has access through `team_policy`  
Anonymous users should continue to see only unsecured features  
Existing `team_security_scope` behavior should remain valid for active team policies  
Search authorization should not consider policies that are not linked through `team_policy`  

6. Update Team Policy Lifecycle Handling

When a `team_policy` is created, create/reuse required scopes and grant team access to them  
When a `team_policy` is removed or end-dated, rebuild or remove the affected team access mappings  
Ensure teams can still reach shared scopes through other active team policies  
Avoid deleting shared scopes or anchors while they are still used by another active team access grant  
Keep rebuild behavior idempotent and safe to retry  

7. Update Anchor Computation Triggers

Publish anchor computation jobs only for scopes used by team access  
Do not recompute anchors for policies that are not linked to `team_policy`  
Keep anchor computation idempotent for retry and partial completion  
Continue to support anchor recomputation when secured features change within a submission  
Ensure orphaned access scopes can still be cleaned up safely  

8. Update Policy Statement Cleanup

When policy statements are removed from an access policy, remove or update their access scope mappings  
Rebuild affected team security scopes after access policy statement changes  
Do not run security scope cleanup for policy statements that were never part of a team access grant  
Preserve shared scope rows when other active access policies still reference them  
Clean up orphaned access scope data only when no active access mappings remain  

9. Clarify Service Documentation

Update service comments to describe `security_scope` as a team access cache  
Remove documentation that describes security scopes as generic policy scopes  
Clarify that policy URNs are generic statement scopes, while security scopes are access materializations  
Clarify that data request, download, and security reason policies do not use `security_scope`  
Keep comments aligned with the actual call graph and lifecycle behavior  

10. Preserve Existing Database Model Where Possible

Reuse the existing `security_scope`, policy-statement mapping, anchor, and team scope tables where appropriate  
Avoid adding a new generic policy scope table in this ticket  
Avoid broad schema churn unless required to enforce access-only scope creation  
Keep existing unique indexes and idempotent insert behavior  
Preserve existing search authorization SQL shape where possible  

11. Prevent Incorrect Access Leakage

Ensure download policies cannot accidentally grant search access  
Ensure data request policies cannot grant access until approved into `team_policy`  
Ensure security reason policies cannot grant search access  
Ensure only active team access grants participate in authorization  
Ensure stale scope mappings do not cause users to see secured features they should not see  

## Testing Notes

API change only:

```bash
make test
make test-db
```


