### PR TITLE
SIMSBIOHUB-1013: Fix for incorrect Ticket SQL

### DIFF
--- a/api/src/repositories/upload/submission-upload-repository.test.ts
+++ b/api/src/repositories/upload/submission-upload-repository.test.ts
@@ -207,6 +207,7 @@ describe('SubmissionUploadRepository', () => {
       expect(sqlStub.firstCall.args[0].text).to.contain('sus.create_date DESC');
       expect(sqlStub.firstCall.args[0].text).to.contain('sus.submission_upload_status_id DESC');
       expect(sqlStub.firstCall.args[0].text).to.contain('LIMIT 1');
+      expect(sqlStub.firstCall.args[0].text).to.contain('sv.validation');
     });
   });
 

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -209,7 +209,7 @@ export class SubmissionUploadRepository extends BaseRepository {
         submitter.user_identifier AS submitted_by_identifier,
         su.status AS upload_status,
         sus.status AS review_status,
-        validation.validation,
+        sv.validation,
         COALESCE(reviews.reviews, '[]'::json) AS reviews
       FROM
         submission_upload su


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1013](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1013)

## Description of Changes

- Fix `findSubmissionUploadsByTicketId` SQL: use `sv.validation` instead of `validation.validation` (regression from #438).
- Restores GET `/api/administrative/tickets/{ticketId}` and admin ticket detail pages that were returning 500.
- Add test assertion that generated SQL includes `sv.validation`.

## Testing Notes

- Open `/admin/tickets/{ticketId}` and confirm the API returns 200 and the page loads (especially tickets with submission uploads).
