### PR TITLE
SIMSBIOHUB-1005: Add policy_id to Security Rules

### DIFF
--- a/api/src/models/persecution-and-harm.ts
+++ b/api/src/models/persecution-and-harm.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const PersecutionAndHarmSecurity = z.object({
+  persecution_or_harm_id: z.number(),
+  persecution_or_harm_type_id: z.number(),
+  wldtaxonomic_units_id: z.number(),
+  name: z.string(),
+  description: z.string().nullable().optional()
+});
+
+export type PersecutionAndHarmSecurity = z.infer<typeof PersecutionAndHarmSecurity>;
+
+export const SecurityReason = z.object({
+  id: z.number(),
+  type_id: z.number()
+});
+
+export type SecurityReason = z.infer<typeof SecurityReason>;
+
+export const ArtifactPersecution = z.object({
+  artifact_persecution_id: z.number(),
+  persecution_or_harm_id: z.number(),
+  artifact_id: z.number()
+});
+
+export type ArtifactPersecution = z.infer<typeof ArtifactPersecution>;

--- a/api/src/models/security-category.ts
+++ b/api/src/models/security-category.ts
@@ -1,5 +1,20 @@
 import { z } from 'zod';
 
+export const SecurityCategoryRecord = z.object({
+  security_category_id: z.number(),
+  name: z.string(),
+  description: z.string(),
+  record_effective_date: z.string(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type SecurityCategoryRecord = z.infer<typeof SecurityCategoryRecord>;
+
 export const SecurityCategoryWithRuleCount = z.object({
   security_category_id: z.number(),
   name: z.string(),

--- a/api/src/models/security-rule.ts
+++ b/api/src/models/security-rule.ts
@@ -1,5 +1,37 @@
 import { z } from 'zod';
 
+export const SecurityRuleRecord = z.object({
+  security_rule_id: z.number(),
+  policy_id: z.string().uuid().nullable(),
+  name: z.string(),
+  description: z.string(),
+  record_effective_date: z.string(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type SecurityRuleRecord = z.infer<typeof SecurityRuleRecord>;
+
+export const SecurityRuleAndCategory = z.object({
+  security_rule_id: z.number(),
+  policy_id: z.string().uuid().nullable(),
+  name: z.string(),
+  description: z.string(),
+  record_effective_date: z.string(),
+  record_end_date: z.string().nullable(),
+  security_category_id: z.number(),
+  category_name: z.string(),
+  category_description: z.string(),
+  category_record_effective_date: z.string(),
+  category_record_end_date: z.string().nullable()
+});
+
+export type SecurityRuleAndCategory = z.infer<typeof SecurityRuleAndCategory>;
+
 export const SecurityRuleWithFeatureCount = z.object({
   security_rule_id: z.number(),
   name: z.string(),

--- a/api/src/models/submission-feature-security.ts
+++ b/api/src/models/submission-feature-security.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const SubmissionFeatureSecurityRecord = z.object({
+  submission_feature_security_id: z.number(),
+  submission_feature_id: z.number(),
+  security_rule_id: z.number(),
+  record_effective_date: z.string(),
+  record_end_date: z.string().nullable(),
+  create_date: z.string(),
+  create_user: z.number(),
+  update_date: z.string().nullable(),
+  update_user: z.number().nullable(),
+  revision_count: z.number()
+});
+
+export type SubmissionFeatureSecurityRecord = z.infer<typeof SubmissionFeatureSecurityRecord>;
+
+export const SubmissionFeatureSecurityRulesSummary = z.object({
+  rules: z.array(
+    z.object({
+      security_rule_id: z.number(),
+      count: z.number()
+    })
+  )
+});
+
+export type SubmissionFeatureSecurityRulesSummary = z.infer<typeof SubmissionFeatureSecurityRulesSummary>;

--- a/api/src/paths/administrative/security/rules.test.ts
+++ b/api/src/paths/administrative/security/rules.test.ts
@@ -1,0 +1,104 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
+import * as db from '../../../database/db';
+import { ApiError } from '../../../errors/api-error';
+import { SecurityService } from '../../../services/security-service';
+import { getActiveSecurityRules } from './rules';
+
+chai.use(sinonChai);
+
+describe('administrative/security/rules', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('GET/getActiveSecurityRules', () => {
+    it('throws error if DB connection fails to open', async () => {
+      const mockDBConnection = getMockDBConnection({
+        commit: sinon.stub(),
+        rollback: sinon.stub(),
+        release: sinon.stub()
+      });
+
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+      sinon.stub(mockDBConnection, 'open').rejects(new Error('DB open failed'));
+
+      const requestHandler = getActiveSecurityRules();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail('Expected handler to throw');
+      } catch (error) {
+        expect((error as ApiError).message).to.equal('DB open failed');
+        expect(mockDBConnection.rollback).to.have.been.calledOnce;
+        expect(mockDBConnection.release).to.have.been.calledOnce;
+      }
+    });
+
+    it('returns active rules with policy_id', async () => {
+      const mockDBConnection = getMockDBConnection({
+        commit: sinon.stub(),
+        rollback: sinon.stub(),
+        release: sinon.stub()
+      });
+
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+      const mockRules = [
+        {
+          security_rule_id: 1,
+          policy_id: 'f4b2f372-98b2-4faa-b98e-91ea2296e370',
+          name: 'Caribou',
+          description: 'Sensitive data',
+          record_effective_date: '2026-01-01',
+          record_end_date: null,
+          security_category_id: 1,
+          category_name: 'Government Interests',
+          category_description: 'Category',
+          category_record_effective_date: '2026-01-01',
+          category_record_end_date: null
+        }
+      ];
+
+      sinon.stub(SecurityService.prototype, 'getActiveRulesAndCategories').resolves(mockRules as any);
+
+      const requestHandler = getActiveSecurityRules();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(mockDBConnection.commit).to.have.been.calledOnce;
+      expect(mockDBConnection.release).to.have.been.calledOnce;
+      expect(mockRes.statusValue).to.equal(200);
+      expect(mockRes.jsonValue).to.eql(mockRules);
+      expect(mockRes.jsonValue[0].policy_id).to.equal('f4b2f372-98b2-4faa-b98e-91ea2296e370');
+    });
+
+    it('rolls back and rethrows if service throws', async () => {
+      const mockDBConnection = getMockDBConnection({
+        commit: sinon.stub(),
+        rollback: sinon.stub(),
+        release: sinon.stub()
+      });
+
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+      sinon.stub(SecurityService.prototype, 'getActiveRulesAndCategories').rejects(new Error('Service error'));
+
+      const requestHandler = getActiveSecurityRules();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail('Expected handler to throw');
+      } catch (error) {
+        expect((error as ApiError).message).to.equal('Service error');
+        expect(mockDBConnection.rollback).to.have.been.calledOnce;
+        expect(mockDBConnection.release).to.have.been.calledOnce;
+      }
+    });
+  });
+});

--- a/api/src/paths/administrative/security/rules.ts
+++ b/api/src/paths/administrative/security/rules.ts
@@ -42,7 +42,6 @@ GET.apiDoc = {
               type: 'object',
               required: [
                 'security_rule_id',
-                'policy_id',
                 'name',
                 'description',
                 'record_effective_date',
@@ -59,7 +58,8 @@ GET.apiDoc = {
                 },
                 policy_id: {
                   type: 'string',
-                  format: 'uuid'
+                  format: 'uuid',
+                  nullable: true
                 },
                 name: {
                   type: 'string'

--- a/api/src/paths/administrative/security/rules.ts
+++ b/api/src/paths/administrative/security/rules.ts
@@ -42,6 +42,7 @@ GET.apiDoc = {
               type: 'object',
               required: [
                 'security_rule_id',
+                'policy_id',
                 'name',
                 'description',
                 'record_effective_date',
@@ -55,6 +56,10 @@ GET.apiDoc = {
               properties: {
                 security_rule_id: {
                   type: 'integer'
+                },
+                policy_id: {
+                  type: 'string',
+                  format: 'uuid'
                 },
                 name: {
                   type: 'string'

--- a/api/src/repositories/security-repository.test.ts
+++ b/api/src/repositories/security-repository.test.ts
@@ -265,6 +265,7 @@ describe('SecurityRepository', () => {
         rows: [
           {
             security_rule_id: 1,
+            policy_id: 'f4b2f372-98b2-4faa-b98e-91ea2296e370',
             name: 'name',
             description: 'description',
             record_effective_date: 1,

--- a/api/src/repositories/security-repository.ts
+++ b/api/src/repositories/security-repository.ts
@@ -23,6 +23,7 @@ export type PersecutionAndHarmSecurity = z.infer<typeof PersecutionAndHarmSecuri
 
 export const SecurityRuleRecord = z.object({
   security_rule_id: z.number(),
+  policy_id: z.string().uuid(),
   name: z.string(),
   description: z.string(),
   record_effective_date: z.string(),
@@ -51,6 +52,7 @@ export type SecurityCategoryRecord = z.infer<typeof SecurityCategoryRecord>;
 
 export const SecurityRuleAndCategory = z.object({
   security_rule_id: z.number(),
+  policy_id: z.string().uuid(),
   name: z.string(),
   description: z.string(),
   record_effective_date: z.string(),
@@ -330,6 +332,7 @@ export class SecurityRepository extends BaseRepository {
     const sql = SQL`
       SELECT 
         sr.security_rule_id,
+        sr.policy_id,
         sr.name,
         sr.description,
         sr.record_effective_date,
@@ -357,7 +360,20 @@ export class SecurityRepository extends BaseRepository {
   async getActiveSecurityRules(): Promise<SecurityRuleRecord[]> {
     defaultLog.debug({ label: 'getActiveSecurityRules' });
     const sql = SQL`
-      SELECT * FROM security_rule WHERE record_end_date IS NULL;
+      SELECT
+        security_rule_id,
+        policy_id,
+        name,
+        description,
+        record_effective_date,
+        record_end_date,
+        create_date,
+        create_user,
+        update_date,
+        update_user,
+        revision_count
+      FROM security_rule
+      WHERE record_end_date IS NULL;
     `;
     const response = await this.connection.sql(sql, SecurityRuleRecord);
     return response.rows;

--- a/api/src/repositories/security-repository.ts
+++ b/api/src/repositories/security-repository.ts
@@ -3,106 +3,23 @@ import { z } from 'zod';
 import { getKnex } from '../database/db';
 import { ApiExecuteSQLError } from '../errors/api-error';
 import { CountResult } from '../models/count';
-import { SecurityCategoryWithRuleCount } from '../models/security-category';
-import { SecurityRuleWithFeatureCount, SecuritySearchFilters } from '../models/security-rule';
+import { ArtifactPersecution, PersecutionAndHarmSecurity } from '../models/persecution-and-harm';
+import { SecurityCategoryRecord, SecurityCategoryWithRuleCount } from '../models/security-category';
+import {
+  SecurityRuleAndCategory,
+  SecurityRuleRecord,
+  SecurityRuleWithFeatureCount,
+  SecuritySearchFilters
+} from '../models/security-rule';
+import {
+  SubmissionFeatureSecurityRecord,
+  SubmissionFeatureSecurityRulesSummary
+} from '../models/submission-feature-security';
 import { getLogger } from '../utils/logger';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 
 const defaultLog = getLogger('repositories/security-repository');
-
-export const PersecutionAndHarmSecurity = z.object({
-  persecution_or_harm_id: z.number(),
-  persecution_or_harm_type_id: z.number(),
-  wldtaxonomic_units_id: z.number(),
-  name: z.string(),
-  description: z.string().nullable().optional()
-});
-
-export type PersecutionAndHarmSecurity = z.infer<typeof PersecutionAndHarmSecurity>;
-
-export const SecurityRuleRecord = z.object({
-  security_rule_id: z.number(),
-  policy_id: z.string().uuid(),
-  name: z.string(),
-  description: z.string(),
-  record_effective_date: z.string(),
-  record_end_date: z.string().nullable(),
-  create_date: z.string(),
-  create_user: z.number(),
-  update_date: z.string().nullable(),
-  update_user: z.number().nullable(),
-  revision_count: z.number()
-});
-export type SecurityRuleRecord = z.infer<typeof SecurityRuleRecord>;
-
-export const SecurityCategoryRecord = z.object({
-  security_category_id: z.number(),
-  name: z.string(),
-  description: z.string(),
-  record_effective_date: z.string(),
-  record_end_date: z.string().nullable(),
-  create_date: z.string(),
-  create_user: z.number(),
-  update_date: z.string().nullable(),
-  update_user: z.number().nullable(),
-  revision_count: z.number()
-});
-export type SecurityCategoryRecord = z.infer<typeof SecurityCategoryRecord>;
-
-export const SecurityRuleAndCategory = z.object({
-  security_rule_id: z.number(),
-  policy_id: z.string().uuid(),
-  name: z.string(),
-  description: z.string(),
-  record_effective_date: z.string(),
-  record_end_date: z.string().nullable(),
-  security_category_id: z.number(),
-  category_name: z.string(),
-  category_description: z.string(),
-  category_record_effective_date: z.string(),
-  category_record_end_date: z.string().nullable()
-});
-export type SecurityRuleAndCategory = z.infer<typeof SecurityRuleAndCategory>;
-
-export const SubmissionFeatureSecurityRecord = z.object({
-  submission_feature_security_id: z.number(),
-  submission_feature_id: z.number(),
-  security_rule_id: z.number(),
-  record_effective_date: z.string(),
-  record_end_date: z.string().nullable(),
-  create_date: z.string(),
-  create_user: z.number(),
-  update_date: z.string().nullable(),
-  update_user: z.number().nullable(),
-  revision_count: z.number()
-});
-export type SubmissionFeatureSecurityRecord = z.infer<typeof SubmissionFeatureSecurityRecord>;
-
-export const SubmissionFeatureSecurityRulesSummary = z.object({
-  rules: z.array(
-    z.object({
-      security_rule_id: z.number(),
-      count: z.number()
-    })
-  )
-});
-
-export type SubmissionFeatureSecurityRulesSummary = z.infer<typeof SubmissionFeatureSecurityRulesSummary>;
-
-export const SecurityReason = z.object({
-  id: z.number(),
-  type_id: z.number()
-});
-export type SecurityReason = z.infer<typeof SecurityReason>;
-
-export const ArtifactPersecution = z.object({
-  artifact_persecution_id: z.number(),
-  persecution_or_harm_id: z.number(),
-  artifact_id: z.number()
-});
-
-export type ArtifactPersecution = z.infer<typeof ArtifactPersecution>;
 
 export enum SECURITY_APPLIED_STATUS {
   SECURED = 'SECURED',

--- a/api/src/services/security-rule-expression-service.test.ts
+++ b/api/src/services/security-rule-expression-service.test.ts
@@ -67,5 +67,88 @@ describe('SecurityRuleExpressionService', () => {
         replacePolicyStatementExpressionStub.calledOnceWithExactly('22222222-2222-2222-2222-222222222222', 'expr-new')
       ).to.equal(true);
     });
+
+    it('still syncs policy expression when security rule expression is already linked', async () => {
+      const service = new SecurityRuleExpressionService(getMockDBConnection());
+
+      sinon.stub(SecurityRuleExpressionRepository.prototype, 'getSecurityRuleExpressionsBySecurityRuleId').resolves([
+        {
+          security_rule_expression_id: 'sre-1',
+          security_rule_id: 7,
+          expression_id: 'expr-current'
+        }
+      ] as any);
+      const endStub = sinon
+        .stub(SecurityRuleExpressionRepository.prototype, 'deleteSecurityRuleExpressionsBySecurityRuleId')
+        .resolves([] as any);
+      const insertStub = sinon
+        .stub(SecurityRuleExpressionRepository.prototype, 'insertSecurityRuleExpression')
+        .resolves({} as any);
+      sinon.stub(SecurityRepository.prototype, 'getActiveSecurityRules').resolves([
+        {
+          security_rule_id: 7,
+          policy_id: '11111111-1111-1111-1111-111111111111'
+        }
+      ] as any);
+      sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([
+        {
+          policy_statement_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '11111111-1111-1111-1111-111111111111',
+          effect: 'allow',
+          submission_feature_urn: 'urn:*:*:*'
+        }
+      ] as any);
+      const replacePolicyStatementExpressionStub = sinon
+        .stub(PolicyStatementExpressionService.prototype, 'replacePolicyStatementExpression')
+        .resolves();
+
+      await service.replaceSecurityRuleExpression(7, 'expr-current');
+
+      expect(endStub.called).to.equal(false);
+      expect(insertStub.called).to.equal(false);
+      expect(
+        replacePolicyStatementExpressionStub.calledOnceWithExactly(
+          '22222222-2222-2222-2222-222222222222',
+          'expr-current'
+        )
+      ).to.equal(true);
+    });
+
+    it('skips policy synchronization when active rule has no policy_id', async () => {
+      const service = new SecurityRuleExpressionService(getMockDBConnection());
+
+      sinon.stub(SecurityRuleExpressionRepository.prototype, 'getSecurityRuleExpressionsBySecurityRuleId').resolves([
+        {
+          security_rule_expression_id: 'sre-1',
+          security_rule_id: 7,
+          expression_id: 'expr-old'
+        }
+      ] as any);
+      sinon
+        .stub(SecurityRuleExpressionRepository.prototype, 'deleteSecurityRuleExpressionsBySecurityRuleId')
+        .resolves([] as any);
+      sinon.stub(SecurityRuleExpressionRepository.prototype, 'insertSecurityRuleExpression').resolves({
+        security_rule_expression_id: 'sre-2',
+        security_rule_id: 7,
+        expression_id: 'expr-new'
+      } as any);
+      sinon.stub(SecurityRepository.prototype, 'getActiveSecurityRules').resolves([
+        {
+          security_rule_id: 7,
+          policy_id: null
+        }
+      ] as any);
+      const getPolicyStatementsStub = sinon
+        .stub(PolicyStatementRepository.prototype, 'getPolicyStatements')
+        .resolves([] as any);
+      const replacePolicyStatementExpressionStub = sinon
+        .stub(PolicyStatementExpressionService.prototype, 'replacePolicyStatementExpression')
+        .resolves();
+
+      await service.replaceSecurityRuleExpression(7, 'expr-new');
+
+      expect(getPolicyStatementsStub.called).to.equal(false);
+      expect(replacePolicyStatementExpressionStub.called).to.equal(false);
+    });
   });
 });

--- a/api/src/services/security-rule-expression-service.test.ts
+++ b/api/src/services/security-rule-expression-service.test.ts
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import { getMockDBConnection } from '../__mocks__/db';
+import { PolicyStatementRepository } from '../repositories/authorization/policy-statement-repository';
+import { SecurityRepository } from '../repositories/security-repository';
 import { SecurityRuleExpressionRepository } from '../repositories/security-rule-expression-repository';
+import { PolicyStatementExpressionService } from './access-policy/policy-statement-expression-service';
 import { SecurityRuleExpressionService } from './security-rule-expression-service';
 
 describe('SecurityRuleExpressionService', () => {
@@ -31,6 +34,23 @@ describe('SecurityRuleExpressionService', () => {
           security_rule_id: 7,
           expression_id: 'expr-new'
         } as any);
+      const getActiveRulesStub = sinon.stub(SecurityRepository.prototype, 'getActiveSecurityRules').resolves([
+        {
+          security_rule_id: 7,
+          policy_id: '11111111-1111-1111-1111-111111111111'
+        }
+      ] as any);
+      const getPolicyStatementsStub = sinon.stub(PolicyStatementRepository.prototype, 'getPolicyStatements').resolves([
+        {
+          policy_statement_id: '22222222-2222-2222-2222-222222222222',
+          policy_id: '11111111-1111-1111-1111-111111111111',
+          effect: 'allow',
+          submission_feature_urn: 'urn:*:*:*'
+        }
+      ] as any);
+      const replacePolicyStatementExpressionStub = sinon
+        .stub(PolicyStatementExpressionService.prototype, 'replacePolicyStatementExpression')
+        .resolves();
 
       await service.replaceSecurityRuleExpression(7, 'expr-new');
 
@@ -40,6 +60,11 @@ describe('SecurityRuleExpressionService', () => {
           security_rule_id: 7,
           expression_id: 'expr-new'
         })
+      ).to.equal(true);
+      expect(getActiveRulesStub.calledOnce).to.equal(true);
+      expect(getPolicyStatementsStub.calledOnceWithExactly('11111111-1111-1111-1111-111111111111')).to.equal(true);
+      expect(
+        replacePolicyStatementExpressionStub.calledOnceWithExactly('22222222-2222-2222-2222-222222222222', 'expr-new')
       ).to.equal(true);
     });
   });

--- a/api/src/services/security-rule-expression-service.ts
+++ b/api/src/services/security-rule-expression-service.ts
@@ -1,9 +1,17 @@
 import { IDBConnection } from '../database/db';
+import { ApiExecuteSQLError } from '../errors/api-error';
+import { PolicyEffect, PolicyStatement } from '../models/policy-statement';
+import { PolicyStatementRepository } from '../repositories/authorization/policy-statement-repository';
+import { SecurityRepository } from '../repositories/security-repository';
 import { SecurityRuleExpressionRepository } from '../repositories/security-rule-expression-repository';
+import { PolicyStatementExpressionService } from './access-policy/policy-statement-expression-service';
 import { DBService } from './db-service';
 
 export class SecurityRuleExpressionService extends DBService {
   securityRuleExpressionRepository: SecurityRuleExpressionRepository;
+  securityRepository: SecurityRepository;
+  policyStatementRepository: PolicyStatementRepository;
+  policyStatementExpressionService: PolicyStatementExpressionService;
 
   /**
    * Build a security-rule expression service.
@@ -13,6 +21,9 @@ export class SecurityRuleExpressionService extends DBService {
   constructor(connection: IDBConnection) {
     super(connection);
     this.securityRuleExpressionRepository = new SecurityRuleExpressionRepository(connection);
+    this.securityRepository = new SecurityRepository(connection);
+    this.policyStatementRepository = new PolicyStatementRepository(connection);
+    this.policyStatementExpressionService = new PolicyStatementExpressionService(connection);
   }
 
   /**
@@ -46,5 +57,39 @@ export class SecurityRuleExpressionService extends DBService {
       security_rule_id: securityRuleId,
       expression_id: expressionId
     });
+
+    const securityRule = await this.getActiveSecurityRuleById(securityRuleId);
+    const policyStatements = await this.policyStatementRepository.getPolicyStatements(securityRule.policy_id);
+    const mappedStatement = this.getMappedPolicyStatement(policyStatements);
+
+    if (!mappedStatement) {
+      throw new ApiExecuteSQLError('No mapped policy statement found for security rule policy');
+    }
+
+    await this.policyStatementExpressionService.replacePolicyStatementExpression(
+      mappedStatement.policy_statement_id,
+      expressionId
+    );
+  }
+
+  private async getActiveSecurityRuleById(securityRuleId: number): Promise<{ policy_id: string }> {
+    const activeRules = await this.securityRepository.getActiveSecurityRules();
+    const activeRule = activeRules.find((rule) => rule.security_rule_id === securityRuleId);
+
+    if (!activeRule) {
+      throw new ApiExecuteSQLError('Active security rule not found for expression update');
+    }
+
+    return activeRule;
+  }
+
+  private getMappedPolicyStatement(policyStatements: PolicyStatement[]): PolicyStatement | undefined {
+    return (
+      policyStatements.find(
+        (statement) => statement.effect === PolicyEffect.ALLOW && statement.submission_feature_urn === 'urn:*:*:*'
+      ) ??
+      policyStatements.find((statement) => statement.effect === PolicyEffect.ALLOW) ??
+      policyStatements[0]
+    );
   }
 }

--- a/api/src/services/security-rule-expression-service.ts
+++ b/api/src/services/security-rule-expression-service.ts
@@ -1,6 +1,6 @@
 import { IDBConnection } from '../database/db';
 import { ApiExecuteSQLError } from '../errors/api-error';
-import { PolicyEffect, PolicyStatement } from '../models/policy-statement';
+import { PolicyEffect } from '../models/policy-statement';
 import { PolicyStatementRepository } from '../repositories/authorization/policy-statement-repository';
 import { SecurityRepository } from '../repositories/security-repository';
 import { SecurityRuleExpressionRepository } from '../repositories/security-rule-expression-repository';
@@ -31,13 +31,18 @@ export class SecurityRuleExpressionService extends DBService {
    *
    * Behavior:
    * 1. Load active security-rule links.
-   * 2. Return early when already linked to the requested expression.
-   * 3. Soft-delete existing links when the target changes.
-   * 4. Insert the replacement active link.
+   * 2. Soft-delete existing links when the target changes.
+   * 3. Insert the replacement active link when needed.
+   * 4. Synchronize the mapped `urn:*:*:*` ALLOW policy statement expression link.
+   *
+   * Notes:
+   * - Policy synchronization runs regardless of whether the security-rule link was already correct.
+   * - If the active security rule has no `policy_id`, synchronization is skipped.
    *
    * @param {number} securityRuleId - Security rule identifier.
    * @param {string} expressionId - Expression identifier.
    * @return {Promise<void>} Resolves once the link points to `expressionId`.
+   * @memberof SecurityRuleExpressionService
    */
   async replaceSecurityRuleExpression(securityRuleId: number, expressionId: string): Promise<void> {
     const existingLinks = await this.securityRuleExpressionRepository.getSecurityRuleExpressionsBySecurityRuleId(
@@ -45,22 +50,27 @@ export class SecurityRuleExpressionService extends DBService {
     );
     const alreadyLinked = existingLinks.length === 1 && existingLinks[0].expression_id === expressionId;
 
-    if (alreadyLinked) {
-      return;
-    }
-
-    if (existingLinks.length > 0) {
+    if (!alreadyLinked && existingLinks.length > 0) {
       await this.securityRuleExpressionRepository.deleteSecurityRuleExpressionsBySecurityRuleId(securityRuleId);
     }
 
-    await this.securityRuleExpressionRepository.insertSecurityRuleExpression({
-      security_rule_id: securityRuleId,
-      expression_id: expressionId
-    });
+    if (!alreadyLinked) {
+      await this.securityRuleExpressionRepository.insertSecurityRuleExpression({
+        security_rule_id: securityRuleId,
+        expression_id: expressionId
+      });
+    }
 
     const securityRule = await this.getActiveSecurityRuleById(securityRuleId);
+
+    if (!securityRule.policy_id) {
+      return;
+    }
+
     const policyStatements = await this.policyStatementRepository.getPolicyStatements(securityRule.policy_id);
-    const mappedStatement = this.getMappedPolicyStatement(policyStatements);
+    const mappedStatement = policyStatements.find(
+      (statement) => statement.effect === PolicyEffect.ALLOW && statement.submission_feature_urn === 'urn:*:*:*'
+    );
 
     if (!mappedStatement) {
       throw new ApiExecuteSQLError('No mapped policy statement found for security rule policy');
@@ -72,7 +82,14 @@ export class SecurityRuleExpressionService extends DBService {
     );
   }
 
-  private async getActiveSecurityRuleById(securityRuleId: number): Promise<{ policy_id: string }> {
+  /**
+   * Resolve one active security rule by id.
+   *
+   * @param {number} securityRuleId - Security rule identifier.
+   * @return {Promise<{ policy_id: string | null }>} Active rule projection with policy linkage.
+   * @memberof SecurityRuleExpressionService
+   */
+  private async getActiveSecurityRuleById(securityRuleId: number): Promise<{ policy_id: string | null }> {
     const activeRules = await this.securityRepository.getActiveSecurityRules();
     const activeRule = activeRules.find((rule) => rule.security_rule_id === securityRuleId);
 
@@ -81,15 +98,5 @@ export class SecurityRuleExpressionService extends DBService {
     }
 
     return activeRule;
-  }
-
-  private getMappedPolicyStatement(policyStatements: PolicyStatement[]): PolicyStatement | undefined {
-    return (
-      policyStatements.find(
-        (statement) => statement.effect === PolicyEffect.ALLOW && statement.submission_feature_urn === 'urn:*:*:*'
-      ) ??
-      policyStatements.find((statement) => statement.effect === PolicyEffect.ALLOW) ??
-      policyStatements[0]
-    );
   }
 }

--- a/api/src/services/security-service.ts
+++ b/api/src/services/security-service.ts
@@ -1,18 +1,18 @@
 import { IDBConnection } from '../database/db';
 import { HTTP403 } from '../errors/http-error';
-import { SecurityCategoryWithRuleCount } from '../models/security-category';
-import { SecurityRuleWithFeatureCount, SecuritySearchFilters } from '../models/security-rule';
+import { ArtifactPersecution, PersecutionAndHarmSecurity } from '../models/persecution-and-harm';
+import { SecurityCategoryRecord, SecurityCategoryWithRuleCount } from '../models/security-category';
 import {
-  ArtifactPersecution,
-  PersecutionAndHarmSecurity,
-  SECURITY_APPLIED_STATUS,
-  SecurityCategoryRecord,
-  SecurityRepository,
   SecurityRuleAndCategory,
   SecurityRuleRecord,
+  SecurityRuleWithFeatureCount,
+  SecuritySearchFilters
+} from '../models/security-rule';
+import {
   SubmissionFeatureSecurityRecord,
   SubmissionFeatureSecurityRulesSummary
-} from '../repositories/security-repository';
+} from '../models/submission-feature-security';
+import { SECURITY_APPLIED_STATUS, SecurityRepository } from '../repositories/security-repository';
 import { getS3SignedURL } from '../utils/file-utils';
 import { getLogger } from '../utils/logger';
 import { ApiPaginationOptions } from '../zod-schema/pagination';

--- a/database/src/migrations/20260515123000_security_rule_policy_id.ts
+++ b/database/src/migrations/20260515123000_security_rule_policy_id.ts
@@ -113,7 +113,7 @@ export async function up(knex: Knex): Promise<void> {
     )
     SELECT
       map.policy_id,
-      'ALLOW'::policy_effect,
+      'allow'::policy_effect,
       'urn:*:*:*',
       sr.record_end_date,
       sr.create_user
@@ -129,7 +129,7 @@ export async function up(knex: Knex): Promise<void> {
     JOIN policy_statement ps
       ON ps.policy_id = map.policy_id
     WHERE ps.submission_feature_urn = 'urn:*:*:*'
-      AND ps.effect = 'ALLOW'::policy_effect
+      AND ps.effect = 'allow'::policy_effect
       AND ps.record_end_date IS NOT DISTINCT FROM (
         SELECT sr.record_end_date
         FROM security_rule sr

--- a/database/src/migrations/20260515123000_security_rule_policy_id.ts
+++ b/database/src/migrations/20260515123000_security_rule_policy_id.ts
@@ -5,8 +5,10 @@ import { Knex } from 'knex';
  *
  * Notes:
  * - One policy row is created per existing security_rule row.
- * - Rollback removes the foreign key/index/column only and intentionally keeps
- *   created policy rows, because they are now domain data and may be referenced.
+ * - One policy_statement row is created per mapped policy, and expression links
+ *   are bridged from security_rule_expression to policy_statement_expression.
+ * - Rollback removes bridged policy statement rows and links, plus the
+ *   security_rule foreign key/index/column. It intentionally keeps policy rows.
  */
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
@@ -94,6 +96,63 @@ export async function up(knex: Knex): Promise<void> {
 
     CREATE INDEX idx_security_rule_policy_id ON security_rule(policy_id);
 
+    --------------------------------------------------------------------------------
+    -- Create one policy statement per mapped policy.
+    --------------------------------------------------------------------------------
+    CREATE TEMP TABLE tmp_security_rule_policy_statement_map (
+      security_rule_id integer PRIMARY KEY,
+      policy_statement_id uuid NOT NULL
+    );
+
+    INSERT INTO policy_statement (
+      policy_id,
+      effect,
+      submission_feature_urn,
+      record_end_date,
+      create_user
+    )
+    SELECT
+      map.policy_id,
+      'ALLOW'::policy_effect,
+      'urn:*:*:*',
+      sr.record_end_date,
+      sr.create_user
+    FROM security_rule sr
+    JOIN tmp_security_rule_policy_map map
+      ON map.security_rule_id = sr.security_rule_id;
+
+    INSERT INTO tmp_security_rule_policy_statement_map (security_rule_id, policy_statement_id)
+    SELECT
+      map.security_rule_id,
+      ps.policy_statement_id
+    FROM tmp_security_rule_policy_map map
+    JOIN policy_statement ps
+      ON ps.policy_id = map.policy_id
+    WHERE ps.submission_feature_urn = 'urn:*:*:*'
+      AND ps.effect = 'ALLOW'::policy_effect
+      AND ps.record_end_date IS NOT DISTINCT FROM (
+        SELECT sr.record_end_date
+        FROM security_rule sr
+        WHERE sr.security_rule_id = map.security_rule_id
+      );
+
+    --------------------------------------------------------------------------------
+    -- Bridge active security rule expression links to policy statements.
+    --------------------------------------------------------------------------------
+    INSERT INTO policy_statement_expression (
+      policy_statement_id,
+      expression_id,
+      create_user
+    )
+    SELECT
+      statement_map.policy_statement_id,
+      sre.expression_id,
+      sre.create_user
+    FROM security_rule_expression sre
+    JOIN tmp_security_rule_policy_statement_map statement_map
+      ON statement_map.security_rule_id = sre.security_rule_id
+    WHERE sre.record_end_date IS NULL;
+
     COMMENT ON COLUMN security_rule.policy_id IS
       'Foreign key to the policy that defines feature-matching logic for this security rule.';
   `);
@@ -102,6 +161,15 @@ export async function up(knex: Knex): Promise<void> {
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
+
+    DELETE FROM policy_statement_expression pse
+    USING policy_statement ps, security_rule sr
+    WHERE pse.policy_statement_id = ps.policy_statement_id
+      AND ps.policy_id = sr.policy_id;
+
+    DELETE FROM policy_statement ps
+    USING security_rule sr
+    WHERE ps.policy_id = sr.policy_id;
 
     DROP INDEX IF EXISTS idx_security_rule_policy_id;
 

--- a/database/src/migrations/20260515123000_security_rule_policy_id.ts
+++ b/database/src/migrations/20260515123000_security_rule_policy_id.ts
@@ -1,157 +1,24 @@
 import { Knex } from 'knex';
 
 /**
- * Adds a policy reference to each security rule.
+ * Adds an optional policy reference to security rules.
  *
  * Notes:
- * - One policy row is created per existing security_rule row.
- * - One policy_statement row is created per mapped policy, and expression links
- *   are bridged from security_rule_expression to policy_statement_expression.
- * - Rollback removes bridged policy statement rows and links, plus the
- *   security_rule foreign key/index/column. It intentionally keeps policy rows.
+ * - policy_id is nullable to support security rules that do not map to policies.
+ * - No data backfill is performed; policy linkage is handled at runtime.
  */
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
-    --------------------------------------------------------------------------------
-    -- Validate source data before creating mapped policies.
-    --------------------------------------------------------------------------------
-    DO $$
-    BEGIN
-      IF EXISTS (
-        SELECT 1
-        FROM security_rule sr
-        WHERE sr.record_end_date IS NULL
-        GROUP BY sr.name
-        HAVING COUNT(*) > 1
-      ) THEN
-        RAISE EXCEPTION
-          'Cannot map security_rule -> policy: duplicate active security_rule.name values detected';
-      END IF;
-
-      IF EXISTS (
-        SELECT 1
-        FROM security_rule sr
-        JOIN policy p ON p.name = sr.name
-        WHERE sr.record_end_date IS NULL
-          AND p.record_end_date IS NULL
-      ) THEN
-        RAISE EXCEPTION
-          'Cannot map security_rule -> policy: an active policy already exists for at least one active security rule name';
-      END IF;
-    END $$;
-
-    --------------------------------------------------------------------------------
-    -- Build deterministic security_rule_id -> policy_id map.
-    --------------------------------------------------------------------------------
-    CREATE TEMP TABLE tmp_security_rule_policy_map (
-      security_rule_id integer PRIMARY KEY,
-      policy_id uuid NOT NULL
-    );
-
-    INSERT INTO tmp_security_rule_policy_map (security_rule_id, policy_id)
-    SELECT
-      sr.security_rule_id,
-      public.gen_random_uuid()
-    FROM security_rule sr;
-
-    --------------------------------------------------------------------------------
-    -- Create one policy per security rule.
-    --------------------------------------------------------------------------------
-    INSERT INTO policy (
-      policy_id,
-      name,
-      description,
-      record_end_date,
-      create_user,
-      status
-    )
-    SELECT
-      map.policy_id,
-      sr.name,
-      COALESCE(sr.description, 'Auto-generated policy for security rule "' || sr.name || '"'),
-      sr.record_end_date,
-      sr.create_user,
-      'approved'::policy_status
-    FROM security_rule sr
-    JOIN tmp_security_rule_policy_map map
-      ON map.security_rule_id = sr.security_rule_id;
-
-    --------------------------------------------------------------------------------
-    -- Add and backfill security_rule.policy_id, then enforce integrity.
-    --------------------------------------------------------------------------------
     ALTER TABLE security_rule
       ADD COLUMN policy_id uuid;
 
-    UPDATE security_rule sr
-    SET policy_id = map.policy_id
-    FROM tmp_security_rule_policy_map map
-    WHERE map.security_rule_id = sr.security_rule_id;
-
     ALTER TABLE security_rule
-      ALTER COLUMN policy_id SET NOT NULL,
       ADD CONSTRAINT security_rule_policy_fk
         FOREIGN KEY (policy_id) REFERENCES policy(policy_id);
 
     CREATE INDEX idx_security_rule_policy_id ON security_rule(policy_id);
-
-    --------------------------------------------------------------------------------
-    -- Create one policy statement per mapped policy.
-    --------------------------------------------------------------------------------
-    CREATE TEMP TABLE tmp_security_rule_policy_statement_map (
-      security_rule_id integer PRIMARY KEY,
-      policy_statement_id uuid NOT NULL
-    );
-
-    INSERT INTO policy_statement (
-      policy_id,
-      effect,
-      submission_feature_urn,
-      record_end_date,
-      create_user
-    )
-    SELECT
-      map.policy_id,
-      'allow'::policy_effect,
-      'urn:*:*:*',
-      sr.record_end_date,
-      sr.create_user
-    FROM security_rule sr
-    JOIN tmp_security_rule_policy_map map
-      ON map.security_rule_id = sr.security_rule_id;
-
-    INSERT INTO tmp_security_rule_policy_statement_map (security_rule_id, policy_statement_id)
-    SELECT
-      map.security_rule_id,
-      ps.policy_statement_id
-    FROM tmp_security_rule_policy_map map
-    JOIN policy_statement ps
-      ON ps.policy_id = map.policy_id
-    WHERE ps.submission_feature_urn = 'urn:*:*:*'
-      AND ps.effect = 'allow'::policy_effect
-      AND ps.record_end_date IS NOT DISTINCT FROM (
-        SELECT sr.record_end_date
-        FROM security_rule sr
-        WHERE sr.security_rule_id = map.security_rule_id
-      );
-
-    --------------------------------------------------------------------------------
-    -- Bridge active security rule expression links to policy statements.
-    --------------------------------------------------------------------------------
-    INSERT INTO policy_statement_expression (
-      policy_statement_id,
-      expression_id,
-      create_user
-    )
-    SELECT
-      statement_map.policy_statement_id,
-      sre.expression_id,
-      sre.create_user
-    FROM security_rule_expression sre
-    JOIN tmp_security_rule_policy_statement_map statement_map
-      ON statement_map.security_rule_id = sre.security_rule_id
-    WHERE sre.record_end_date IS NULL;
 
     COMMENT ON COLUMN security_rule.policy_id IS
       'Foreign key to the policy that defines feature-matching logic for this security rule.';
@@ -161,15 +28,6 @@ export async function up(knex: Knex): Promise<void> {
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
-
-    DELETE FROM policy_statement_expression pse
-    USING policy_statement ps, security_rule sr
-    WHERE pse.policy_statement_id = ps.policy_statement_id
-      AND ps.policy_id = sr.policy_id;
-
-    DELETE FROM policy_statement ps
-    USING security_rule sr
-    WHERE ps.policy_id = sr.policy_id;
 
     DROP INDEX IF EXISTS idx_security_rule_policy_id;
 

--- a/database/src/migrations/20260515123000_security_rule_policy_id.ts
+++ b/database/src/migrations/20260515123000_security_rule_policy_id.ts
@@ -1,0 +1,112 @@
+import { Knex } from 'knex';
+
+/**
+ * Adds a policy reference to each security rule.
+ *
+ * Notes:
+ * - One policy row is created per existing security_rule row.
+ * - Rollback removes the foreign key/index/column only and intentionally keeps
+ *   created policy rows, because they are now domain data and may be referenced.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Validate source data before creating mapped policies.
+    --------------------------------------------------------------------------------
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM security_rule sr
+        WHERE sr.record_end_date IS NULL
+        GROUP BY sr.name
+        HAVING COUNT(*) > 1
+      ) THEN
+        RAISE EXCEPTION
+          'Cannot map security_rule -> policy: duplicate active security_rule.name values detected';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM security_rule sr
+        JOIN policy p ON p.name = sr.name
+        WHERE sr.record_end_date IS NULL
+          AND p.record_end_date IS NULL
+      ) THEN
+        RAISE EXCEPTION
+          'Cannot map security_rule -> policy: an active policy already exists for at least one active security rule name';
+      END IF;
+    END $$;
+
+    --------------------------------------------------------------------------------
+    -- Build deterministic security_rule_id -> policy_id map.
+    --------------------------------------------------------------------------------
+    CREATE TEMP TABLE tmp_security_rule_policy_map (
+      security_rule_id integer PRIMARY KEY,
+      policy_id uuid NOT NULL
+    );
+
+    INSERT INTO tmp_security_rule_policy_map (security_rule_id, policy_id)
+    SELECT
+      sr.security_rule_id,
+      public.gen_random_uuid()
+    FROM security_rule sr;
+
+    --------------------------------------------------------------------------------
+    -- Create one policy per security rule.
+    --------------------------------------------------------------------------------
+    INSERT INTO policy (
+      policy_id,
+      name,
+      description,
+      record_end_date,
+      create_user,
+      status
+    )
+    SELECT
+      map.policy_id,
+      sr.name,
+      COALESCE(sr.description, 'Auto-generated policy for security rule "' || sr.name || '"'),
+      sr.record_end_date,
+      sr.create_user,
+      'approved'::policy_status
+    FROM security_rule sr
+    JOIN tmp_security_rule_policy_map map
+      ON map.security_rule_id = sr.security_rule_id;
+
+    --------------------------------------------------------------------------------
+    -- Add and backfill security_rule.policy_id, then enforce integrity.
+    --------------------------------------------------------------------------------
+    ALTER TABLE security_rule
+      ADD COLUMN policy_id uuid;
+
+    UPDATE security_rule sr
+    SET policy_id = map.policy_id
+    FROM tmp_security_rule_policy_map map
+    WHERE map.security_rule_id = sr.security_rule_id;
+
+    ALTER TABLE security_rule
+      ALTER COLUMN policy_id SET NOT NULL,
+      ADD CONSTRAINT security_rule_policy_fk
+        FOREIGN KEY (policy_id) REFERENCES policy(policy_id);
+
+    CREATE INDEX idx_security_rule_policy_id ON security_rule(policy_id);
+
+    COMMENT ON COLUMN security_rule.policy_id IS
+      'Foreign key to the policy that defines feature-matching logic for this security rule.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    DROP INDEX IF EXISTS idx_security_rule_policy_id;
+
+    ALTER TABLE security_rule
+      DROP CONSTRAINT IF EXISTS security_rule_policy_fk,
+      DROP COLUMN IF EXISTS policy_id;
+  `);
+}

--- a/database/src/seeds/05_security_test_data.ts
+++ b/database/src/seeds/05_security_test_data.ts
@@ -77,14 +77,9 @@ export const insertSecurityRuleRecord = async (
   const effective_date = faker.date.past().toISOString();
   const create_user = 1;
 
-  const policy = await knex.raw(`
-    INSERT INTO policy (name, description, create_user, status)
-    VALUES ($$${name}$$, $$Auto-generated policy for security rule "${name}"$$, ${create_user}, 'approved')
-    RETURNING policy_id;`);
-
   const res = await knex.raw(`
-    INSERT INTO security_rule (security_category_id, policy_id, name, description, record_effective_date, record_end_date, create_user)
-    VALUES (${security_category_id}, '${policy.rows[0].policy_id}', $$${name}$$, $$${description}$$, $$${effective_date}$$, null, ${create_user})
+    INSERT INTO security_rule (security_category_id, name, description, record_effective_date, record_end_date, create_user)
+    VALUES (${security_category_id}, $$${name}$$, $$${description}$$, $$${effective_date}$$, null, ${create_user})
     RETURNING security_rule_id;`);
 
   return res.rows[0].security_rule_id;

--- a/database/src/seeds/05_security_test_data.ts
+++ b/database/src/seeds/05_security_test_data.ts
@@ -75,10 +75,16 @@ export const insertSecurityRuleRecord = async (
 ): Promise<number> => {
   const { security_category_id, name, description } = row;
   const effective_date = faker.date.past().toISOString();
+  const create_user = 1;
+
+  const policy = await knex.raw(`
+    INSERT INTO policy (name, description, create_user, status)
+    VALUES ($$${name}$$, $$Auto-generated policy for security rule "${name}"$$, ${create_user}, 'approved')
+    RETURNING policy_id;`);
 
   const res = await knex.raw(`
-    INSERT INTO security_rule (security_category_id, name, description, record_effective_date, record_end_date)
-    VALUES (${security_category_id}, $$${name}$$, $$${description}$$, $$${effective_date}$$, null)
+    INSERT INTO security_rule (security_category_id, policy_id, name, description, record_effective_date, record_end_date, create_user)
+    VALUES (${security_category_id}, '${policy.rows[0].policy_id}', $$${name}$$, $$${description}$$, $$${effective_date}$$, null, ${create_user})
     RETURNING security_rule_id;`);
 
   return res.rows[0].security_rule_id;


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1005

## Description of Changes

- Adds nullable `security_rule.policy_id` (FK to `policy`, indexed). Rules without property-based policies may remain unlinked.
- Migration adds the column, FK, and index only; no policy or expression backfill.
- `replaceSecurityRuleExpression` dual-writes security rule and policy statement expression links when `policy_id` is set; policy sync runs on every call and is skipped when `policy_id` is null.
- Exposes nullable `policy_id` on active security rule retrieval (repository, Zod models, OpenAPI).
- Moves security Zod schemas into model files; seeds no longer require a policy per rule.

## Testing Notes

- Ran targeted API tests:
  - `npm test -- src/services/security-rule-expression-service.test.ts src/services/access-policy/policy-statement-expression-service.test.ts`
- Confirmed lint diagnostics are clean for modified files.
