### PR TITLE
SIMSBIOHUB-1015: Populate `submission_feature_property_feature`

### DIFF
--- a/api/src/__integration__/db/data-request-service.integration.ts
+++ b/api/src/__integration__/db/data-request-service.integration.ts
@@ -4,9 +4,10 @@
 // preserves the deny-all baseline for the administrative ticket-bound flow.
 //
 // Also verifies:
-//   - The requester is always a member of both auto-created teams (the
-//     `system_user_ids` picker captures additional collaborators, not the
-//     canonical access list).
+//   - The service treats `system_user_ids` as the canonical team membership and
+//     does NOT auto-add the requester. The search route unions `requested_by`
+//     into `system_user_ids` before calling (covered at the route layer in
+//     paths/data-request); the admin ticket flow passes the picker as-is.
 //   - Unknown feature-type names are rejected with HTTP400 before any DB
 //     write, leaving no partial state behind.
 //   - A failure mid-way through `createDataRequestForTicket` rolls back the
@@ -145,10 +146,13 @@ describe('DataRequestService (integration)', function () {
       const collaborator = await createUser('I1-coll');
       const expression = buildExpression('I1-tree');
 
+      // The search route unions `requested_by` into `system_user_ids` before calling the service
+      // (paths/data-request/index.ts), so the service receives the requester as part of the
+      // canonical member list. Mirror that here.
       const dataRequest = await service.createDataRequest({
         requested_by: requester,
         reason: 'I1 search-driven happy path covering the full row shape',
-        system_user_ids: [collaborator],
+        system_user_ids: [requester, collaborator],
         featureTypes: ['dataset'],
         expression
       });
@@ -207,7 +211,7 @@ describe('DataRequestService (integration)', function () {
       const dataRequestTeamId = drRows.rows[0].team_id as string;
       expect(policyTeamId).to.not.equal(dataRequestTeamId);
 
-      // Each auto-created team has exactly the requester + collaborator union (no duplicates).
+      // Each auto-created team has exactly the deduped `system_user_ids` the service was given.
       expect(await teamMemberIds(dataRequestTeamId)).to.deep.equal([requester, collaborator].sort((a, b) => a - b));
       expect(await teamMemberIds(policyTeamId)).to.deep.equal([requester, collaborator].sort((a, b) => a - b));
 
@@ -282,7 +286,7 @@ describe('DataRequestService (integration)', function () {
   });
 
   describe('createDataRequestForTicket (legacy ticket-bound flow)', () => {
-    it('I4: empty `featureTypes` preserves the deny-all baseline and unions the requester into both auto-created teams', async () => {
+    it('I4: empty `featureTypes` preserves the deny-all baseline; the admin flow seeds both teams from the picker selection as-is (requester not auto-added)', async () => {
       const requester = await createUser('I4-req');
       const collaborator = await createUser('I4-coll');
 
@@ -316,7 +320,9 @@ describe('DataRequestService (integration)', function () {
       `);
       expect(links.rows[0].n).to.equal(0);
 
-      // Both DR-owned teams contain the requester + collaborator union (latent-bug fix coverage).
+      // The admin ticket flow passes the picker selection as-is and does NOT auto-add the
+      // requester (see DataRequestService contract + paths/tickets/{ticketId}/data-request).
+      // Both DR-owned teams therefore contain exactly the picker selection.
       const dataRequestTeamId = dataRequest.team_id;
       const policyTeamRows = await connection.sql(SQL`
         SELECT team_id FROM team_policy WHERE policy_id = ${dataRequest.policy_id};
@@ -324,12 +330,12 @@ describe('DataRequestService (integration)', function () {
       expect(policyTeamRows.rowCount).to.equal(1);
       const policyTeamId = policyTeamRows.rows[0].team_id as string;
 
-      const expectedMembers = [requester, collaborator].sort((a, b) => a - b);
+      const expectedMembers = [collaborator];
       expect(await teamMemberIds(dataRequestTeamId)).to.deep.equal(expectedMembers);
       expect(await teamMemberIds(policyTeamId)).to.deep.equal(expectedMembers);
     });
 
-    it('I5: empty `system_user_ids` still seeds each auto-created team with the requester (the picker is additional collaborators, not the access list)', async () => {
+    it('I5: empty `system_user_ids` in the admin flow yields empty teams (the picker is the canonical access list; the requester is not auto-added)', async () => {
       const requester = await createUser('I5-req');
 
       const ticket = await ticketService.createTicket({
@@ -351,8 +357,9 @@ describe('DataRequestService (integration)', function () {
       `);
       expect(policyTeamRows.rowCount).to.equal(1);
 
-      expect(await teamMemberIds(dataRequest.team_id)).to.deep.equal([requester]);
-      expect(await teamMemberIds(policyTeamRows.rows[0].team_id as string)).to.deep.equal([requester]);
+      // The admin flow does not auto-add the requester, so an empty picker yields empty teams.
+      expect(await teamMemberIds(dataRequest.team_id)).to.deep.equal([]);
+      expect(await teamMemberIds(policyTeamRows.rows[0].team_id as string)).to.deep.equal([]);
     });
   });
 

--- a/api/src/__integration__/db/submission-feature-property-feature-ingestion.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-feature-ingestion.integration.ts
@@ -23,7 +23,6 @@
 // Requires: database container running with seed data.
 
 import { expect } from 'chai';
-import crypto from 'crypto';
 import { describe } from 'mocha';
 import sinon from 'sinon';
 import SQL from 'sql-template-strings';
@@ -31,7 +30,13 @@ import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } 
 import { SubmissionFeaturePropertyIngestionRepository } from '../../repositories/submission-feature-property-ingestion-repository';
 import { SubmissionFeaturePropertyIngestionService } from '../../services/ingestion/submission-feature-property-ingestion-service';
 import { SubmissionUploadReviewService } from '../../services/upload/submission-upload-review-service';
-import { createTestSubmission, getOrCreateIntegrationTicketId } from '../helpers/test-submission-helpers';
+import {
+  createFeatureTypeProperty,
+  createTestUpload,
+  getPropertyFeatureRows as fetchPropertyFeatureRows,
+  getSubmissionFeatureErrors
+} from '../helpers/test-feature-property-helpers';
+import { createTestSubmission } from '../helpers/test-submission-helpers';
 
 describe('SubmissionFeaturePropertyIngestionService — feature property indexing (integration)', function () {
   this.timeout(15000);
@@ -61,92 +66,6 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
 
   // --- local fixture helpers -----------------------------------------------
 
-  /** Resolve a seeded feature_type by name to its id. */
-  async function featureTypeIdByName(name: string): Promise<number> {
-    const result = await connection.sql(SQL`
-      SELECT feature_type_id FROM feature_type WHERE name = ${name} LIMIT 1;
-    `);
-    return result.rows[0].feature_type_id;
-  }
-
-  /** Create a real submission_upload row for a submission and return its uuid. */
-  async function createTestUpload(submissionId: number): Promise<string> {
-    const systemUserId = connection.systemUserId();
-
-    const uploadResult = await connection.sql(SQL`
-      INSERT INTO upload (upload_status, record_end_date, create_user)
-      VALUES ('completed', now(), ${systemUserId})
-      RETURNING upload_id;
-    `);
-    const uploadId = uploadResult.rows[0].upload_id;
-
-    const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
-
-    const bridgeResult = await connection.sql(SQL`
-      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
-      VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
-      RETURNING submission_upload_id;
-    `);
-
-    return bridgeResult.rows[0].submission_upload_id;
-  }
-
-  /**
-   * Create a synthetic `feature`-typed feature_property and assign it to a source feature type via
-   * feature_type_property with an allowed target type. Mirrors download-parquet's
-   * insertCodeFeatureProperty but for the 'feature' property type plus the allowed-target column.
-   *
-   * @returns The new feature_type_property_id and the feature_property.name to use as the
-   *   data.properties key on source features.
-   */
-  async function createFeatureTypeProperty(params: {
-    sourceFeatureTypeName: string;
-    allowedTargetFeatureTypeName: string | null;
-    allowMultiple?: boolean;
-  }): Promise<{ featureTypePropertyId: number; propertyName: string }> {
-    const systemUserId = connection.systemUserId();
-
-    const fptResult = await connection.sql(SQL`
-      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'feature';
-    `);
-    const featurePropertyTypeId = fptResult.rows[0].feature_property_type_id;
-
-    const propertyName = `test_feature_ref_${crypto.randomInt(0, 1_000_000_000)}`;
-    const fpResult = await connection.sql(SQL`
-      INSERT INTO feature_property (feature_property_type_id, name, display_name, record_effective_date, create_user)
-      VALUES (${featurePropertyTypeId}, ${propertyName}, ${propertyName}, now(), ${systemUserId})
-      RETURNING feature_property_id;
-    `);
-    const featurePropertyId = fpResult.rows[0].feature_property_id;
-
-    const allowedFeatureTypeId =
-      params.allowedTargetFeatureTypeName === null
-        ? null
-        : await featureTypeIdByName(params.allowedTargetFeatureTypeName);
-
-    const ftpResult = await connection.sql(SQL`
-      INSERT INTO feature_type_property (
-        feature_type_id,
-        feature_property_id,
-        allow_multiple,
-        allowed_referenced_feature_type_id,
-        record_effective_date,
-        create_user
-      )
-      VALUES (
-        (SELECT feature_type_id FROM feature_type WHERE name = ${params.sourceFeatureTypeName} LIMIT 1),
-        ${featurePropertyId},
-        ${params.allowMultiple ?? false},
-        ${allowedFeatureTypeId},
-        now(),
-        ${systemUserId}
-      )
-      RETURNING feature_type_property_id;
-    `);
-
-    return { featureTypePropertyId: ftpResult.rows[0].feature_type_property_id, propertyName };
-  }
-
   /**
    * Insert one active submission_feature under a specific upload with an explicit source_id and data
    * JSON. Resolution joins on source_id, which createTestFeature does not set and which mints its own
@@ -154,7 +73,7 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
    *
    * @returns The new submission_feature_id.
    */
-  async function insertFeature(params: {
+  async function insertFeatureRow(params: {
     submissionId: number;
     submissionUploadId: string;
     featureTypeName: string;
@@ -191,35 +110,55 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
     return result.rows[0].submission_feature_id;
   }
 
-  /**
-   * Fetch grouped error rows for an upload, ordered by code.
-   *
-   * Filters to count > 0: the engine writes a benign count-0 `UNRESOLVED_PARENT` diagnostic row for
-   * every feature, and the Phase 9 fail-fast gate keys off `SUM(count)`, so only count > 0 rows are
-   * upload-blocking. Matching that semantics keeps assertions about "the errors" meaningful.
-   */
-  async function getErrors(uploadId: string): Promise<{ error_code: string; count: number }[]> {
-    const result = await connection.sql(SQL`
-      SELECT error_code, count
-      FROM submission_feature_error
-      WHERE submission_upload_id = ${uploadId}::uuid
-        AND count > 0
-      ORDER BY error_code;
-    `);
-    return result.rows;
+  /** A submission + upload + one feature_type_property config, plus an upload-bound feature inserter. */
+  interface FeatureScenario {
+    submissionId: number;
+    uploadId: string;
+    featureTypePropertyId: number;
+    propertyName: string;
+    /** Insert a submission_feature into this scenario's submission + upload. */
+    insertFeature: (featureTypeName: string, sourceId: string, data?: Record<string, unknown>) => Promise<number>;
   }
 
-  /** Fetch canonical property-feature rows for a source feature. */
-  async function getPropertyFeatureRows(
+  /**
+   * Stand up the common arrange block: a submission, a real upload, and one synthetic feature_type_property
+   * config (defaulting to mortality → observation_subcount). The returned `insertFeature` is bound to the
+   * scenario's submission + upload so tests only state the feature type, source_id, and data that vary.
+   */
+  async function seedFeatureScenario(config?: {
+    sourceFeatureTypeName?: string;
+    allowedTargetFeatureTypeName?: string | null;
+    allowMultiple?: boolean;
+  }): Promise<FeatureScenario> {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(connection, submissionId);
+    const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty(
+      connection,
+      config?.sourceFeatureTypeName ?? 'mortality',
+      config?.allowedTargetFeatureTypeName === undefined ? 'observation_subcount' : config.allowedTargetFeatureTypeName,
+      config?.allowMultiple
+    );
+
+    return {
+      submissionId,
+      uploadId,
+      featureTypePropertyId,
+      propertyName,
+      insertFeature: (featureTypeName, sourceId, data = {}) =>
+        insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName, sourceId, data })
+    };
+  }
+
+  /** Grouped, upload-blocking error rows (count > 0) for an upload. */
+  function getErrors(uploadId: string): Promise<{ error_code: string; count: number }[]> {
+    return getSubmissionFeatureErrors(connection, uploadId, true);
+  }
+
+  /** Canonical property-feature rows for a source feature. */
+  function getPropertyFeatureRows(
     sourceFeatureId: number
   ): Promise<{ referenced_submission_feature_id: number; feature_type_property_id: number }[]> {
-    const result = await connection.sql(SQL`
-      SELECT referenced_submission_feature_id, feature_type_property_id
-      FROM submission_feature_property_feature
-      WHERE submission_feature_id = ${sourceFeatureId}
-      ORDER BY referenced_submission_feature_id;
-    `);
-    return result.rows;
+    return fetchPropertyFeatureRows(connection, sourceFeatureId);
   }
 
   /** Count all canonical property-feature rows written for an upload's features. */
@@ -236,26 +175,11 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   // --- scenarios -----------------------------------------------------------
 
   it('1: happy path — one canonical row, no errors', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, featureTypePropertyId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    const targetFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'area1',
-      data: {}
-    });
-    const sourceFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'feature::area1' } }
+    const targetFeatureId = await insertFeature('observation_subcount', 'area1');
+    const sourceFeatureId = await insertFeature('mortality', 'period-1', {
+      properties: { [propertyName]: 'feature::area1' }
     });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
@@ -269,26 +193,11 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('2: idempotent rerun — identical canonical row set, no duplicates/orphans', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, featureTypePropertyId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    const targetFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'area1',
-      data: {}
-    });
-    const sourceFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'feature::area1' } }
+    const targetFeatureId = await insertFeature('observation_subcount', 'area1');
+    const sourceFeatureId = await insertFeature('mortality', 'period-1', {
+      properties: { [propertyName]: 'feature::area1' }
     });
 
     await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
@@ -304,27 +213,10 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('3: unresolved reference (feature::nope) — one UNRESOLVED_FEATURE_REFERENCE, zero canonical rows', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'area1',
-      data: {}
-    });
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'feature::nope' } }
-    });
+    await insertFeature('observation_subcount', 'area1');
+    await insertFeature('mortality', 'period-1', { properties: { [propertyName]: 'feature::nope' } });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
     expect(outcome.status).to.equal('invalid');
@@ -336,27 +228,10 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('4: malformed reference (features::area1) — one INVALID_FEATURE_REFERENCE_FORMAT, zero canonical rows', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'area1',
-      data: {}
-    });
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'features::area1' } }
-    });
+    await insertFeature('observation_subcount', 'area1');
+    await insertFeature('mortality', 'period-1', { properties: { [propertyName]: 'features::area1' } });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
     expect(outcome.status).to.equal('invalid');
@@ -368,28 +243,11 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('5: wrong-type resolution — one INVALID_FEATURE_REFERENCE_TYPE, zero canonical rows', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    // Config allows sample_site, but the reference resolves to a sample_technique sibling.
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    // Config allows observation_subcount, but the reference resolves to a species_observation sibling.
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'species_observation',
-      sourceId: 'tech1',
-      data: {}
-    });
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'feature::tech1' } }
-    });
+    await insertFeature('species_observation', 'tech1');
+    await insertFeature('mortality', 'period-1', { properties: { [propertyName]: 'feature::tech1' } });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
     expect(outcome.status).to.equal('invalid');
@@ -401,50 +259,15 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('6: two valid + one invalid in the same upload — zero canonical rows for the WHOLE upload (Phase 9 gate)', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'area1',
-      data: {}
-    });
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'area2',
-      data: {}
-    });
+    await insertFeature('observation_subcount', 'area1');
+    await insertFeature('observation_subcount', 'area2');
     // Two valid references...
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'feature::area1' } }
-    });
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-2',
-      data: { properties: { [propertyName]: 'feature::area2' } }
-    });
+    await insertFeature('mortality', 'period-1', { properties: { [propertyName]: 'feature::area1' } });
+    await insertFeature('mortality', 'period-2', { properties: { [propertyName]: 'feature::area2' } });
     // ...and one unresolved reference, which fails the whole upload.
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-3',
-      data: { properties: { [propertyName]: 'feature::nope' } }
-    });
+    await insertFeature('mortality', 'period-3', { properties: { [propertyName]: 'feature::nope' } });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
     expect(outcome.status).to.equal('invalid');
@@ -456,34 +279,12 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('7: multi-valued ["feature::s1","feature::s2"] both resolve & allowed — two canonical rows', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount',
-      allowMultiple: true
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario({ allowMultiple: true });
 
-    const targetA = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 's1',
-      data: {}
-    });
-    const targetB = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 's2',
-      data: {}
-    });
-    const sourceFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: ['feature::s1', 'feature::s2'] } }
+    const targetA = await insertFeature('observation_subcount', 's1');
+    const targetB = await insertFeature('observation_subcount', 's2');
+    const sourceFeatureId = await insertFeature('mortality', 'period-1', {
+      properties: { [propertyName]: ['feature::s1', 'feature::s2'] }
     });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
@@ -498,27 +299,11 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('8: multi-valued ["feature::s1","feature::s1"] exact duplicate — one canonical row (ON CONFLICT dedup)', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount',
-      allowMultiple: true
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario({ allowMultiple: true });
 
-    const targetA = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 's1',
-      data: {}
-    });
-    const sourceFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: ['feature::s1', 'feature::s1'] } }
+    const targetA = await insertFeature('observation_subcount', 's1');
+    const sourceFeatureId = await insertFeature('mortality', 'period-1', {
+      properties: { [propertyName]: ['feature::s1', 'feature::s1'] }
     });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
@@ -531,28 +316,10 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('9: single-valued prop given ["feature::s1"] array — MULTIPLE_VALUES_NOT_ALLOWED, zero canonical rows', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount',
-      allowMultiple: false
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario({ allowMultiple: false });
 
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 's1',
-      data: {}
-    });
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: ['feature::s1'] } }
-    });
+    await insertFeature('observation_subcount', 's1');
+    await insertFeature('mortality', 'period-1', { properties: { [propertyName]: ['feature::s1'] } });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
     expect(outcome.status).to.equal('invalid');
@@ -563,20 +330,14 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('10: self-reference — INVALID_FEATURE_REFERENCE_SELF, zero canonical rows (upload blocked)', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    // Source is a sample_site; config allows sample_site; the property points at its own source_id.
-    const { propertyName } = await createFeatureTypeProperty({
+    // Source is an observation_subcount; config allows observation_subcount; the property points at its own source_id.
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario({
       sourceFeatureTypeName: 'observation_subcount',
       allowedTargetFeatureTypeName: 'observation_subcount'
     });
 
-    const sourceFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'self-area',
-      data: { properties: { [propertyName]: 'feature::self-area' } }
+    const sourceFeatureId = await insertFeature('observation_subcount', 'self-area', {
+      properties: { [propertyName]: 'feature::self-area' }
     });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
@@ -589,39 +350,16 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('11: channel separation — data.content lands in submission_feature_feature, prop in submission_feature_property_feature', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario();
 
     // propTarget: referenced by the feature-valued property.
-    const propTargetId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'prop-target',
-      data: {}
-    });
+    const propTargetId = await insertFeature('observation_subcount', 'prop-target');
     // contentTarget: referenced by data.content (a distinct relationship channel).
-    const contentTargetId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'species_observation',
-      sourceId: 'content-target',
-      data: {}
-    });
+    const contentTargetId = await insertFeature('species_observation', 'content-target');
     // Source carries BOTH a data.content reference AND a feature-valued property.
-    const sourceFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: {
-        content: ['content-target'],
-        properties: { [propertyName]: 'feature::prop-target' }
-      }
+    const sourceFeatureId = await insertFeature('mortality', 'period-1', {
+      content: ['content-target'],
+      properties: { [propertyName]: 'feature::prop-target' }
     });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
@@ -648,26 +386,11 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('12: whitespace (feature:: area1) — resolves to area1, one canonical row', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    const targetFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'area1',
-      data: {}
-    });
-    const sourceFeatureId = await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'feature:: area1' } }
+    const targetFeatureId = await insertFeature('observation_subcount', 'area1');
+    const sourceFeatureId = await insertFeature('mortality', 'period-1', {
+      properties: { [propertyName]: 'feature:: area1' }
     });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
@@ -680,32 +403,12 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   });
 
   it('13: circular reference (A.prop -> B, B.prop -> A) — CIRCULAR_FEATURE_REFERENCE, zero canonical rows', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    // A (sample_period) -> B (sample_site); B (sample_site) -> A (sample_period). Both types allowed.
-    const { propertyName: propAtoB } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
-    const { propertyName: propBtoA } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'observation_subcount',
-      allowedTargetFeatureTypeName: 'mortality'
-    });
+    // A (mortality) -> B (observation_subcount); B (observation_subcount) -> A (mortality). Both types allowed.
+    const { submissionId, uploadId, propertyName: propAtoB, insertFeature } = await seedFeatureScenario();
+    const { propertyName: propBtoA } = await createFeatureTypeProperty(connection, 'observation_subcount', 'mortality');
 
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'a',
-      data: { properties: { [propAtoB]: 'feature::b' } }
-    });
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'observation_subcount',
-      sourceId: 'b',
-      data: { properties: { [propBtoA]: 'feature::a' } }
-    });
+    await insertFeature('mortality', 'a', { properties: { [propAtoB]: 'feature::b' } });
+    await insertFeature('observation_subcount', 'b', { properties: { [propBtoA]: 'feature::a' } });
 
     const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
     expect(outcome.status).to.equal('invalid');
@@ -718,20 +421,9 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
   // AC-14: the new error codes surface through the existing aggregate-error reader, with no
   // feature-specific wiring — they are plain rows in submission_feature_error.
   it('14: new error codes surface via getIngestionErrorCountsByCode', async () => {
-    const submissionId = await createTestSubmission(connection);
-    const uploadId = await createTestUpload(submissionId);
-    const { propertyName } = await createFeatureTypeProperty({
-      sourceFeatureTypeName: 'mortality',
-      allowedTargetFeatureTypeName: 'observation_subcount'
-    });
+    const { submissionId, uploadId, propertyName, insertFeature } = await seedFeatureScenario();
 
-    await insertFeature({
-      submissionId,
-      submissionUploadId: uploadId,
-      featureTypeName: 'mortality',
-      sourceId: 'period-1',
-      data: { properties: { [propertyName]: 'feature::nope' } }
-    });
+    await insertFeature('mortality', 'period-1', { properties: { [propertyName]: 'feature::nope' } });
 
     await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
 

--- a/api/src/__integration__/db/submission-feature-property-feature-ingestion.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-feature-ingestion.integration.ts
@@ -1,0 +1,741 @@
+// Service-level integration tests for the feature-backed property indexing engine.
+//
+// Drives the FULL pipeline end-to-end via
+// SubmissionFeaturePropertyIngestionService.indexSubmissionPropertiesBySubmissionUploadId, then
+// asserts on the canonical table (submission_feature_property_feature) and the error accumulator
+// (submission_feature_error). Unlike the repository-level suite (which hand-inserts staging
+// candidates to observe each branch in isolation), these tests set up real submission_feature rows
+// whose data.properties carry `feature::<source_id>` values, so the populate/parse/resolve phases
+// run for real and the Phase 9 fail-fast gate is exercised: any error zeroes ALL canonical writes
+// for the whole upload.
+//
+// Scope C — no production catalog is touched. Each test mints a SYNTHETIC `feature`-typed
+// feature_property + feature_type_property (with allowed_referenced_feature_type_id) and uses
+// pre-seeded feature types for the source/target features. The chosen types (mortality,
+// observation_subcount, species_observation) carry NO required catalog properties, so the full
+// pipeline reaches the canonical-insert phase without unrelated MISSING_REQUIRED_PROPERTY errors
+// from the seeded type's other required fields.
+//
+// Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
+//
+// Run: docker compose exec api npx mocha --config .mocharc.integration.json \
+//        'src/__integration__/db/submission-feature-property-feature-ingestion.integration.ts'
+// Requires: database container running with seed data.
+
+import { expect } from 'chai';
+import crypto from 'crypto';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import SQL from 'sql-template-strings';
+import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { SubmissionFeaturePropertyIngestionRepository } from '../../repositories/submission-feature-property-ingestion-repository';
+import { SubmissionFeaturePropertyIngestionService } from '../../services/ingestion/submission-feature-property-ingestion-service';
+import { SubmissionUploadReviewService } from '../../services/upload/submission-upload-review-service';
+import { createTestSubmission, getOrCreateIntegrationTicketId } from '../helpers/test-submission-helpers';
+
+describe('SubmissionFeaturePropertyIngestionService — feature property indexing (integration)', function () {
+  this.timeout(15000);
+
+  let connection: IDBConnection;
+  let service: SubmissionFeaturePropertyIngestionService;
+  let repo: SubmissionFeaturePropertyIngestionRepository;
+
+  before(() => initDBPool(defaultPoolConfig));
+
+  beforeEach(async () => {
+    connection = getAPIUserDBConnection();
+    await connection.open();
+    service = new SubmissionFeaturePropertyIngestionService(connection);
+    repo = new SubmissionFeaturePropertyIngestionRepository(connection);
+
+    // The default-review request is the last step of a successful index run and is unrelated to the
+    // feature-property engine under test. Stub it so the assertions target the engine's outputs.
+    sinon.stub(SubmissionUploadReviewService.prototype, 'requestDefaultReviewsForUpload').resolves();
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    await connection.rollback();
+    connection.release();
+  });
+
+  // --- local fixture helpers -----------------------------------------------
+
+  /** Resolve a seeded feature_type by name to its id. */
+  async function featureTypeIdByName(name: string): Promise<number> {
+    const result = await connection.sql(SQL`
+      SELECT feature_type_id FROM feature_type WHERE name = ${name} LIMIT 1;
+    `);
+    return result.rows[0].feature_type_id;
+  }
+
+  /** Create a real submission_upload row for a submission and return its uuid. */
+  async function createTestUpload(submissionId: number): Promise<string> {
+    const systemUserId = connection.systemUserId();
+
+    const uploadResult = await connection.sql(SQL`
+      INSERT INTO upload (upload_status, record_end_date, create_user)
+      VALUES ('completed', now(), ${systemUserId})
+      RETURNING upload_id;
+    `);
+    const uploadId = uploadResult.rows[0].upload_id;
+
+    const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
+
+    const bridgeResult = await connection.sql(SQL`
+      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+      VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
+      RETURNING submission_upload_id;
+    `);
+
+    return bridgeResult.rows[0].submission_upload_id;
+  }
+
+  /**
+   * Create a synthetic `feature`-typed feature_property and assign it to a source feature type via
+   * feature_type_property with an allowed target type. Mirrors download-parquet's
+   * insertCodeFeatureProperty but for the 'feature' property type plus the allowed-target column.
+   *
+   * @returns The new feature_type_property_id and the feature_property.name to use as the
+   *   data.properties key on source features.
+   */
+  async function createFeatureTypeProperty(params: {
+    sourceFeatureTypeName: string;
+    allowedTargetFeatureTypeName: string | null;
+    allowMultiple?: boolean;
+  }): Promise<{ featureTypePropertyId: number; propertyName: string }> {
+    const systemUserId = connection.systemUserId();
+
+    const fptResult = await connection.sql(SQL`
+      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'feature';
+    `);
+    const featurePropertyTypeId = fptResult.rows[0].feature_property_type_id;
+
+    const propertyName = `test_feature_ref_${crypto.randomInt(0, 1_000_000_000)}`;
+    const fpResult = await connection.sql(SQL`
+      INSERT INTO feature_property (feature_property_type_id, name, display_name, record_effective_date, create_user)
+      VALUES (${featurePropertyTypeId}, ${propertyName}, ${propertyName}, now(), ${systemUserId})
+      RETURNING feature_property_id;
+    `);
+    const featurePropertyId = fpResult.rows[0].feature_property_id;
+
+    const allowedFeatureTypeId =
+      params.allowedTargetFeatureTypeName === null
+        ? null
+        : await featureTypeIdByName(params.allowedTargetFeatureTypeName);
+
+    const ftpResult = await connection.sql(SQL`
+      INSERT INTO feature_type_property (
+        feature_type_id,
+        feature_property_id,
+        allow_multiple,
+        allowed_referenced_feature_type_id,
+        record_effective_date,
+        create_user
+      )
+      VALUES (
+        (SELECT feature_type_id FROM feature_type WHERE name = ${params.sourceFeatureTypeName} LIMIT 1),
+        ${featurePropertyId},
+        ${params.allowMultiple ?? false},
+        ${allowedFeatureTypeId},
+        now(),
+        ${systemUserId}
+      )
+      RETURNING feature_type_property_id;
+    `);
+
+    return { featureTypePropertyId: ftpResult.rows[0].feature_type_property_id, propertyName };
+  }
+
+  /**
+   * Insert one active submission_feature under a specific upload with an explicit source_id and data
+   * JSON. Resolution joins on source_id, which createTestFeature does not set and which mints its own
+   * upload — so this ticket inserts source + target features into ONE upload directly.
+   *
+   * @returns The new submission_feature_id.
+   */
+  async function insertFeature(params: {
+    submissionId: number;
+    submissionUploadId: string;
+    featureTypeName: string;
+    sourceId: string;
+    data: Record<string, unknown>;
+  }): Promise<number> {
+    const systemUserId = connection.systemUserId();
+    const dataJson = JSON.stringify(params.data);
+
+    const result = await connection.sql(SQL`
+      INSERT INTO submission_feature (
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        source_id,
+        data,
+        data_byte_size,
+        record_effective_date,
+        create_user
+      )
+      VALUES (
+        ${params.submissionId},
+        ${params.submissionUploadId}::uuid,
+        (SELECT feature_type_id FROM feature_type WHERE name = ${params.featureTypeName} LIMIT 1),
+        ${params.sourceId},
+        ${dataJson}::jsonb,
+        octet_length(${dataJson}::jsonb::text) + 500,
+        now(),
+        ${systemUserId}
+      )
+      RETURNING submission_feature_id;
+    `);
+
+    return result.rows[0].submission_feature_id;
+  }
+
+  /**
+   * Fetch grouped error rows for an upload, ordered by code.
+   *
+   * Filters to count > 0: the engine writes a benign count-0 `UNRESOLVED_PARENT` diagnostic row for
+   * every feature, and the Phase 9 fail-fast gate keys off `SUM(count)`, so only count > 0 rows are
+   * upload-blocking. Matching that semantics keeps assertions about "the errors" meaningful.
+   */
+  async function getErrors(uploadId: string): Promise<{ error_code: string; count: number }[]> {
+    const result = await connection.sql(SQL`
+      SELECT error_code, count
+      FROM submission_feature_error
+      WHERE submission_upload_id = ${uploadId}::uuid
+        AND count > 0
+      ORDER BY error_code;
+    `);
+    return result.rows;
+  }
+
+  /** Fetch canonical property-feature rows for a source feature. */
+  async function getPropertyFeatureRows(
+    sourceFeatureId: number
+  ): Promise<{ referenced_submission_feature_id: number; feature_type_property_id: number }[]> {
+    const result = await connection.sql(SQL`
+      SELECT referenced_submission_feature_id, feature_type_property_id
+      FROM submission_feature_property_feature
+      WHERE submission_feature_id = ${sourceFeatureId}
+      ORDER BY referenced_submission_feature_id;
+    `);
+    return result.rows;
+  }
+
+  /** Count all canonical property-feature rows written for an upload's features. */
+  async function countPropertyFeatureRowsForUpload(uploadId: string): Promise<number> {
+    const result = await connection.sql(SQL`
+      SELECT COUNT(*)::integer AS count
+      FROM submission_feature_property_feature sfpf
+      JOIN submission_feature sf ON sf.submission_feature_id = sfpf.submission_feature_id
+      WHERE sf.submission_upload_id = ${uploadId}::uuid;
+    `);
+    return result.rows[0].count;
+  }
+
+  // --- scenarios -----------------------------------------------------------
+
+  it('1: happy path — one canonical row, no errors', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    const targetFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'area1',
+      data: {}
+    });
+    const sourceFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'feature::area1' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('ok');
+
+    expect(await getErrors(uploadId)).to.have.lengthOf(0);
+    const rows = await getPropertyFeatureRows(sourceFeatureId);
+    expect(rows).to.have.lengthOf(1);
+    expect(rows[0].referenced_submission_feature_id).to.equal(targetFeatureId);
+    expect(rows[0].feature_type_property_id).to.equal(featureTypePropertyId);
+  });
+
+  it('2: idempotent rerun — identical canonical row set, no duplicates/orphans', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    const targetFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'area1',
+      data: {}
+    });
+    const sourceFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'feature::area1' } }
+    });
+
+    await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    const firstRun = await getPropertyFeatureRows(sourceFeatureId);
+
+    await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    const secondRun = await getPropertyFeatureRows(sourceFeatureId);
+
+    expect(firstRun).to.have.lengthOf(1);
+    expect(secondRun).to.deep.equal(firstRun);
+    expect(secondRun[0].referenced_submission_feature_id).to.equal(targetFeatureId);
+    expect(secondRun[0].feature_type_property_id).to.equal(featureTypePropertyId);
+  });
+
+  it('3: unresolved reference (feature::nope) — one UNRESOLVED_FEATURE_REFERENCE, zero canonical rows', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'area1',
+      data: {}
+    });
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'feature::nope' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('invalid');
+
+    const errors = await getErrors(uploadId);
+    expect(errors).to.have.lengthOf(1);
+    expect(errors[0].error_code).to.equal('UNRESOLVED_FEATURE_REFERENCE');
+    expect(await countPropertyFeatureRowsForUpload(uploadId)).to.equal(0);
+  });
+
+  it('4: malformed reference (features::area1) — one INVALID_FEATURE_REFERENCE_FORMAT, zero canonical rows', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'area1',
+      data: {}
+    });
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'features::area1' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('invalid');
+
+    const errors = await getErrors(uploadId);
+    expect(errors).to.have.lengthOf(1);
+    expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_FORMAT');
+    expect(await countPropertyFeatureRowsForUpload(uploadId)).to.equal(0);
+  });
+
+  it('5: wrong-type resolution — one INVALID_FEATURE_REFERENCE_TYPE, zero canonical rows', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    // Config allows sample_site, but the reference resolves to a sample_technique sibling.
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'species_observation',
+      sourceId: 'tech1',
+      data: {}
+    });
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'feature::tech1' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('invalid');
+
+    const errors = await getErrors(uploadId);
+    expect(errors).to.have.lengthOf(1);
+    expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_TYPE');
+    expect(await countPropertyFeatureRowsForUpload(uploadId)).to.equal(0);
+  });
+
+  it('6: two valid + one invalid in the same upload — zero canonical rows for the WHOLE upload (Phase 9 gate)', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'area1',
+      data: {}
+    });
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'area2',
+      data: {}
+    });
+    // Two valid references...
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'feature::area1' } }
+    });
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-2',
+      data: { properties: { [propertyName]: 'feature::area2' } }
+    });
+    // ...and one unresolved reference, which fails the whole upload.
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-3',
+      data: { properties: { [propertyName]: 'feature::nope' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('invalid');
+
+    const errors = await getErrors(uploadId);
+    expect(errors.some((e) => e.error_code === 'UNRESOLVED_FEATURE_REFERENCE')).to.equal(true);
+    // The valid siblings are NOT inserted — the whole upload is blocked.
+    expect(await countPropertyFeatureRowsForUpload(uploadId)).to.equal(0);
+  });
+
+  it('7: multi-valued ["feature::s1","feature::s2"] both resolve & allowed — two canonical rows', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount',
+      allowMultiple: true
+    });
+
+    const targetA = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 's1',
+      data: {}
+    });
+    const targetB = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 's2',
+      data: {}
+    });
+    const sourceFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: ['feature::s1', 'feature::s2'] } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('ok');
+
+    expect(await getErrors(uploadId)).to.have.lengthOf(0);
+    const rows = await getPropertyFeatureRows(sourceFeatureId);
+    expect(rows).to.have.lengthOf(2);
+    expect(rows.map((r) => r.referenced_submission_feature_id).sort((a, b) => a - b)).to.deep.equal(
+      [targetA, targetB].sort((a, b) => a - b)
+    );
+  });
+
+  it('8: multi-valued ["feature::s1","feature::s1"] exact duplicate — one canonical row (ON CONFLICT dedup)', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount',
+      allowMultiple: true
+    });
+
+    const targetA = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 's1',
+      data: {}
+    });
+    const sourceFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: ['feature::s1', 'feature::s1'] } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('ok');
+
+    expect(await getErrors(uploadId)).to.have.lengthOf(0);
+    const rows = await getPropertyFeatureRows(sourceFeatureId);
+    expect(rows).to.have.lengthOf(1);
+    expect(rows[0].referenced_submission_feature_id).to.equal(targetA);
+  });
+
+  it('9: single-valued prop given ["feature::s1"] array — MULTIPLE_VALUES_NOT_ALLOWED, zero canonical rows', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount',
+      allowMultiple: false
+    });
+
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 's1',
+      data: {}
+    });
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: ['feature::s1'] } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('invalid');
+
+    const errors = await getErrors(uploadId);
+    expect(errors.some((e) => e.error_code === 'MULTIPLE_VALUES_NOT_ALLOWED')).to.equal(true);
+    expect(await countPropertyFeatureRowsForUpload(uploadId)).to.equal(0);
+  });
+
+  it('10: self-reference — INVALID_FEATURE_REFERENCE_SELF, zero canonical rows (upload blocked)', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    // Source is a sample_site; config allows sample_site; the property points at its own source_id.
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'observation_subcount',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    const sourceFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'self-area',
+      data: { properties: { [propertyName]: 'feature::self-area' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('invalid');
+
+    const errors = await getErrors(uploadId);
+    expect(errors.some((e) => e.error_code === 'INVALID_FEATURE_REFERENCE_SELF')).to.equal(true);
+    expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    expect(await countPropertyFeatureRowsForUpload(uploadId)).to.equal(0);
+  });
+
+  it('11: channel separation — data.content lands in submission_feature_feature, prop in submission_feature_property_feature', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    // propTarget: referenced by the feature-valued property.
+    const propTargetId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'prop-target',
+      data: {}
+    });
+    // contentTarget: referenced by data.content (a distinct relationship channel).
+    const contentTargetId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'species_observation',
+      sourceId: 'content-target',
+      data: {}
+    });
+    // Source carries BOTH a data.content reference AND a feature-valued property.
+    const sourceFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: {
+        content: ['content-target'],
+        properties: { [propertyName]: 'feature::prop-target' }
+      }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('ok');
+
+    // The property reference lands ONLY in submission_feature_property_feature.
+    const propRows = await getPropertyFeatureRows(sourceFeatureId);
+    expect(propRows).to.have.lengthOf(1);
+    expect(propRows[0].referenced_submission_feature_id).to.equal(propTargetId);
+
+    // The data.content reference lands ONLY in submission_feature_feature.
+    const sffResult = await connection.sql(SQL`
+      SELECT source_feature_id, target_feature_id
+      FROM submission_feature_feature
+      WHERE source_feature_id = ${sourceFeatureId};
+    `);
+    expect(sffResult.rows).to.have.lengthOf(1);
+    expect(sffResult.rows[0].target_feature_id).to.equal(contentTargetId);
+
+    // No cross-write: the property table never holds the content target,
+    // and the relationship table never holds the property target.
+    expect(propRows.some((r) => r.referenced_submission_feature_id === contentTargetId)).to.equal(false);
+    expect(sffResult.rows.some((r) => r.target_feature_id === propTargetId)).to.equal(false);
+  });
+
+  it('12: whitespace (feature:: area1) — resolves to area1, one canonical row', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    const targetFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'area1',
+      data: {}
+    });
+    const sourceFeatureId = await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'feature:: area1' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('ok');
+
+    expect(await getErrors(uploadId)).to.have.lengthOf(0);
+    const rows = await getPropertyFeatureRows(sourceFeatureId);
+    expect(rows).to.have.lengthOf(1);
+    expect(rows[0].referenced_submission_feature_id).to.equal(targetFeatureId);
+  });
+
+  it('13: circular reference (A.prop -> B, B.prop -> A) — CIRCULAR_FEATURE_REFERENCE, zero canonical rows', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    // A (sample_period) -> B (sample_site); B (sample_site) -> A (sample_period). Both types allowed.
+    const { propertyName: propAtoB } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+    const { propertyName: propBtoA } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'observation_subcount',
+      allowedTargetFeatureTypeName: 'mortality'
+    });
+
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'a',
+      data: { properties: { [propAtoB]: 'feature::b' } }
+    });
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'observation_subcount',
+      sourceId: 'b',
+      data: { properties: { [propBtoA]: 'feature::a' } }
+    });
+
+    const outcome = await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+    expect(outcome.status).to.equal('invalid');
+
+    const errors = await getErrors(uploadId);
+    expect(errors.filter((e) => e.error_code === 'CIRCULAR_FEATURE_REFERENCE').length).to.be.greaterThan(0);
+    expect(await countPropertyFeatureRowsForUpload(uploadId)).to.equal(0);
+  });
+
+  // AC-14: the new error codes surface through the existing aggregate-error reader, with no
+  // feature-specific wiring — they are plain rows in submission_feature_error.
+  it('14: new error codes surface via getIngestionErrorCountsByCode', async () => {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(submissionId);
+    const { propertyName } = await createFeatureTypeProperty({
+      sourceFeatureTypeName: 'mortality',
+      allowedTargetFeatureTypeName: 'observation_subcount'
+    });
+
+    await insertFeature({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'mortality',
+      sourceId: 'period-1',
+      data: { properties: { [propertyName]: 'feature::nope' } }
+    });
+
+    await service.indexSubmissionPropertiesBySubmissionUploadId(submissionId, uploadId);
+
+    const counts = await repo.getIngestionErrorCountsByCode(uploadId);
+    expect(counts.some((c) => c.error_code === 'UNRESOLVED_FEATURE_REFERENCE')).to.equal(true);
+  });
+});

--- a/api/src/__integration__/db/submission-feature-property-feature-ingestion.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-feature-ingestion.integration.ts
@@ -10,8 +10,8 @@
 // for the whole upload.
 //
 // Scope C — no production catalog is touched. Each test mints a SYNTHETIC `feature`-typed
-// feature_property + feature_type_property (with allowed_referenced_feature_type_id) and uses
-// pre-seeded feature types for the source/target features. The chosen types (mortality,
+// feature_property + feature_type_property (with allowed targets in feature_type_property_feature)
+// and uses pre-seeded feature types for the source/target features. The chosen types (mortality,
 // observation_subcount, species_observation) carry NO required catalog properties, so the full
 // pipeline reaches the canonical-insert phase without unrelated MISSING_REQUIRED_PROPERTY errors
 // from the seeded type's other required fields.
@@ -127,7 +127,7 @@ describe('SubmissionFeaturePropertyIngestionService — feature property indexin
    */
   async function seedFeatureScenario(config?: {
     sourceFeatureTypeName?: string;
-    allowedTargetFeatureTypeName?: string | null;
+    allowedTargetFeatureTypeName?: string | string[] | null;
     allowMultiple?: boolean;
   }): Promise<FeatureScenario> {
     const submissionId = await createTestSubmission(connection);

--- a/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
@@ -1,0 +1,851 @@
+// Integration tests for SubmissionFeaturePropertyIngestionRepository — drives three methods that
+// read ALREADY-RESOLVED candidate rows from the UNLOGGED staging table
+// (submission_upload_staging_feature_candidate) directly, so each branch/gate is observable in
+// isolation (no service, no populate/resolve step, no Phase 9 gate):
+//
+//   - recordFeaturePropertyResolutionErrorsBySubmissionUploadId — groups four error categories into
+//     submission_feature_error: INVALID_FEATURE_REFERENCE_FORMAT, UNRESOLVED_FEATURE_REFERENCE,
+//     INVALID_FEATURE_REFERENCE_TYPE, INVALID_FEATURE_REFERENCE_SELF.
+//   - recordCircularFeatureReferenceErrorsBySubmissionUploadId — recursive-CTE cycle detection over
+//     the property-feature edges, recording CIRCULAR_FEATURE_REFERENCE for edges in a cycle (length ≥ 2).
+//   - insertFeaturePropertiesBySubmissionUploadId — gated INSERT…SELECT into
+//     submission_feature_property_feature with ON CONFLICT DO NOTHING.
+//
+// Fixtures hand-populate the staging table directly: the candidate's submission_upload_id is just a
+// filter key (the UNLOGGED staging table has no FK), so each test mints its own uuid. The canonical
+// tables DO have FKs, so real submission_feature rows and a feature_type_property config row are
+// created per test.
+//
+// Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
+//
+// Run: docker compose exec api npx mocha --config .mocharc.integration.json \
+//        'src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts'
+// Requires: database container running.
+
+import { expect } from 'chai';
+import crypto from 'crypto';
+import { describe } from 'mocha';
+import SQL from 'sql-template-strings';
+import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { SubmissionFeaturePropertyIngestionRepository } from '../../repositories/submission-feature-property-ingestion-repository';
+import {
+  createTestFeature,
+  createTestSubmission,
+  getOrCreateIntegrationTicketId
+} from '../helpers/test-submission-helpers';
+
+describe('SubmissionFeaturePropertyIngestionRepository (integration)', function () {
+  this.timeout(15000);
+
+  let connection: IDBConnection;
+  let repo: SubmissionFeaturePropertyIngestionRepository;
+
+  before(() => initDBPool(defaultPoolConfig));
+
+  beforeEach(async () => {
+    connection = getAPIUserDBConnection();
+    await connection.open();
+    repo = new SubmissionFeaturePropertyIngestionRepository(connection);
+  });
+
+  afterEach(async () => {
+    await connection.rollback();
+    connection.release();
+  });
+
+  // --- local helpers -------------------------------------------------------
+
+  /**
+   * Create a real `submission_upload` row for a submission and return its `submission_upload_id` uuid.
+   *
+   * The error-recording method writes the candidate's `submission_upload_id` into
+   * `submission_feature_error`, which has an FK to `submission_upload` — so those tests need a real
+   * upload uuid (a bare random uuid violates the FK). The candidate's `submission_upload_id` itself is
+   * just a filter key against the UNLOGGED staging table (no FK), so any uuid works there; using the
+   * real one keeps both paths consistent.
+   */
+  async function createTestUpload(submissionId: number): Promise<string> {
+    const systemUserId = connection.systemUserId();
+
+    const uploadResult = await connection.sql(SQL`
+      INSERT INTO upload (upload_status, record_end_date, create_user)
+      VALUES ('completed', now(), ${systemUserId})
+      RETURNING upload_id;
+    `);
+    const uploadId = uploadResult.rows[0].upload_id;
+
+    const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
+
+    const bridgeResult = await connection.sql(SQL`
+      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+      VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
+      RETURNING submission_upload_id;
+    `);
+
+    return bridgeResult.rows[0].submission_upload_id;
+  }
+
+  /** Resolve a seeded feature_type by name to its id. */
+  async function featureTypeIdByName(name: string): Promise<number> {
+    const result = await connection.sql(SQL`
+      SELECT feature_type_id FROM feature_type WHERE name = ${name} LIMIT 1;
+    `);
+    return result.rows[0].feature_type_id;
+  }
+
+  /**
+   * Create a feature-typed feature_property + feature_type_property config row for a source feature
+   * type. Mirrors insertCodeFeatureProperty but for the 'feature' property type.
+   *
+   * @param sourceFeatureTypeName Feature type the property is attached to (the referencing feature).
+   * @param allowedTargetFeatureTypeName Allowed target feature type name, or null for "no permitted target".
+   * @param allowMultiple Whether the property may carry multiple references.
+   * @returns The new feature_type_property_id and the resolved allowedFeatureTypeId (or null).
+   */
+  async function createFeatureTypeProperty(
+    sourceFeatureTypeName: string,
+    allowedTargetFeatureTypeName: string | null,
+    allowMultiple = false
+  ): Promise<{ featureTypePropertyId: number; allowedFeatureTypeId: number | null }> {
+    const systemUserId = connection.systemUserId();
+
+    await connection.sql(SQL`
+      INSERT INTO feature_property_type (name, record_effective_date, create_user)
+      SELECT 'feature', now(), ${systemUserId}
+      WHERE NOT EXISTS (SELECT 1 FROM feature_property_type WHERE name = 'feature');
+    `);
+
+    const fptResult = await connection.sql(SQL`
+      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'feature';
+    `);
+    const featurePropertyTypeId = fptResult.rows[0].feature_property_type_id;
+
+    const uniqueSuffix = crypto.randomInt(0, 1_000_000_000);
+    const fpResult = await connection.sql(SQL`
+      INSERT INTO feature_property (feature_property_type_id, name, display_name, record_effective_date, create_user)
+      VALUES (
+        ${featurePropertyTypeId},
+        ${'test_feature_ref_' + uniqueSuffix},
+        ${'Test Feature Ref ' + uniqueSuffix},
+        now(),
+        ${systemUserId}
+      )
+      RETURNING feature_property_id;
+    `);
+    const featurePropertyId = fpResult.rows[0].feature_property_id;
+
+    const allowedFeatureTypeId =
+      allowedTargetFeatureTypeName === null ? null : await featureTypeIdByName(allowedTargetFeatureTypeName);
+
+    const ftpResult = await connection.sql(SQL`
+      INSERT INTO feature_type_property (
+        feature_type_id,
+        feature_property_id,
+        allow_multiple,
+        allowed_referenced_feature_type_id,
+        record_effective_date,
+        create_user
+      )
+      VALUES (
+        (SELECT feature_type_id FROM feature_type WHERE name = ${sourceFeatureTypeName} LIMIT 1),
+        ${featurePropertyId},
+        ${allowMultiple},
+        ${allowedFeatureTypeId},
+        now(),
+        ${systemUserId}
+      )
+      RETURNING feature_type_property_id;
+    `);
+
+    return { featureTypePropertyId: ftpResult.rows[0].feature_type_property_id, allowedFeatureTypeId };
+  }
+
+  /** Insert one row into the UNLOGGED staging candidate table. */
+  async function insertCandidate(params: {
+    uploadId: string;
+    sourceFeatureId: number;
+    featureTypePropertyId: number;
+    propertyName: string;
+    rawValue: string;
+    isFormatValid: boolean;
+    parsedSourceId: string | null;
+    referencedFeatureId: number | null;
+    referencedFeatureTypeId: number | null;
+  }): Promise<void> {
+    await connection.sql(SQL`
+      INSERT INTO submission_upload_staging_feature_candidate (
+        submission_upload_id,
+        submission_feature_id,
+        property_name,
+        feature_type_property_id,
+        raw_value,
+        is_format_valid,
+        parsed_source_id,
+        referenced_submission_feature_id,
+        referenced_feature_type_id
+      )
+      VALUES (
+        ${params.uploadId}::uuid,
+        ${params.sourceFeatureId},
+        ${params.propertyName},
+        ${params.featureTypePropertyId},
+        ${JSON.stringify(params.rawValue)}::jsonb,
+        ${params.isFormatValid},
+        ${params.parsedSourceId},
+        ${params.referencedFeatureId},
+        ${params.referencedFeatureTypeId}
+      );
+    `);
+  }
+
+  /** Soft-delete a feature_type_property config row by ending its record. */
+  async function softDeleteFeatureTypeProperty(featureTypePropertyId: number): Promise<void> {
+    await connection.sql(SQL`
+      UPDATE feature_type_property SET record_end_date = now() WHERE feature_type_property_id = ${featureTypePropertyId};
+    `);
+  }
+
+  /** Fetch grouped error rows for an upload scope. */
+  async function getErrors(uploadId: string): Promise<{ error_code: string; count: number }[]> {
+    const result = await connection.sql(SQL`
+      SELECT error_code, count
+      FROM submission_feature_error
+      WHERE submission_upload_id = ${uploadId}::uuid
+      ORDER BY error_code;
+    `);
+    return result.rows;
+  }
+
+  /** Count canonical property-feature rows for a source feature. */
+  async function getPropertyFeatureRows(
+    sourceFeatureId: number
+  ): Promise<{ referenced_submission_feature_id: number; feature_type_property_id: number }[]> {
+    const result = await connection.sql(SQL`
+      SELECT referenced_submission_feature_id, feature_type_property_id
+      FROM submission_feature_property_feature
+      WHERE submission_feature_id = ${sourceFeatureId};
+    `);
+    return result.rows;
+  }
+
+  // --- recordFeaturePropertyResolutionErrorsBySubmissionUploadId -----------
+
+  describe('recordFeaturePropertyResolutionErrorsBySubmissionUploadId', () => {
+    it('records INVALID_FEATURE_REFERENCE_FORMAT for malformed values', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'garbage-value',
+        isFormatValid: false,
+        parsedSourceId: null,
+        referencedFeatureId: null,
+        referencedFeatureTypeId: null
+      });
+
+      await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_FORMAT');
+    });
+
+    it('records UNRESOLVED_FEATURE_REFERENCE when resolution misses', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::nope',
+        isFormatValid: true,
+        parsedSourceId: 'nope',
+        referencedFeatureId: null,
+        referencedFeatureTypeId: null
+      });
+
+      await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].error_code).to.equal('UNRESOLVED_FEATURE_REFERENCE');
+    });
+
+    it('records INVALID_FEATURE_REFERENCE_TYPE when resolved type not allowed', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      // Config allows sample_site, but the candidate resolved to a sample_technique feature.
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const wrongTypeFeatureId = await createTestFeature(connection, submissionId, 'sample_technique', {});
+      const wrongTypeId = await featureTypeIdByName('sample_technique');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::tech1',
+        isFormatValid: true,
+        parsedSourceId: 'tech1',
+        referencedFeatureId: wrongTypeFeatureId,
+        referencedFeatureTypeId: wrongTypeId
+      });
+
+      await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_TYPE');
+    });
+
+    it('records INVALID_FEATURE_REFERENCE_TYPE when property has no allowed target', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      // Config allows NO target — every reference is rejected.
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', null);
+      const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const targetTypeId = await featureTypeIdByName('sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::area1',
+        isFormatValid: true,
+        parsedSourceId: 'area1',
+        referencedFeatureId: targetFeatureId,
+        referencedFeatureTypeId: targetTypeId
+      });
+
+      await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_TYPE');
+    });
+
+    it('records INVALID_FEATURE_REFERENCE_SELF (and no TYPE error) for a self-reference', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      // Source is a sample_site; config allows sample_site; candidate points at its own feature.
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_site', 'sample_site');
+      const sampleSiteTypeId = await featureTypeIdByName('sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::self',
+        isFormatValid: true,
+        parsedSourceId: 'self',
+        referencedFeatureId: sourceFeatureId,
+        referencedFeatureTypeId: sampleSiteTypeId
+      });
+
+      await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_SELF');
+      // A self-reference is reported once as SELF, never double-counted as TYPE.
+      expect(errors.filter((e) => e.error_code === 'INVALID_FEATURE_REFERENCE_TYPE')).to.have.lengthOf(0);
+    });
+
+    it('ignores a soft-deleted feature_type_property config (type branch)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      await softDeleteFeatureTypeProperty(featureTypePropertyId);
+
+      const wrongTypeFeatureId = await createTestFeature(connection, submissionId, 'sample_technique', {});
+      const wrongTypeId = await featureTypeIdByName('sample_technique');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::tech1',
+        isFormatValid: true,
+        parsedSourceId: 'tech1',
+        referencedFeatureId: wrongTypeFeatureId,
+        referencedFeatureTypeId: wrongTypeId
+      });
+
+      await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(0);
+    });
+
+    it('aggregates duplicate errors into one grouped row with a count', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+
+      // Two malformed candidates sharing property_name + feature_type_property_id.
+      for (let i = 0; i < 2; i++) {
+        await insertCandidate({
+          uploadId,
+          sourceFeatureId,
+          featureTypePropertyId,
+          propertyName: 'site_ref',
+          rawValue: 'garbage-' + i,
+          isFormatValid: false,
+          parsedSourceId: null,
+          referencedFeatureId: null,
+          referencedFeatureTypeId: null
+        });
+      }
+
+      await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_FORMAT');
+      expect(errors[0].count).to.equal(2);
+    });
+  });
+
+  // --- recordCircularFeatureReferenceErrorsBySubmissionUploadId ------------
+
+  describe('recordCircularFeatureReferenceErrorsBySubmissionUploadId', () => {
+    it('flags both edges of a 2-node cycle (A->B, B->A)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const typeA = await featureTypeIdByName('sample_period');
+      const typeB = await featureTypeIdByName('sample_site');
+      // Distinct configs so the two cyclic edges fall into separate grouped error rows.
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_period');
+
+      // A -> B
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureA,
+        featureTypePropertyId: ftpA,
+        propertyName: 'a_to_b',
+        rawValue: 'feature::b',
+        isFormatValid: true,
+        parsedSourceId: 'b',
+        referencedFeatureId: featureB,
+        referencedFeatureTypeId: typeB
+      });
+      // B -> A
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureB,
+        featureTypePropertyId: ftpB,
+        propertyName: 'b_to_a',
+        rawValue: 'feature::a',
+        isFormatValid: true,
+        parsedSourceId: 'a',
+        referencedFeatureId: featureA,
+        referencedFeatureTypeId: typeA
+      });
+
+      await repo.recordCircularFeatureReferenceErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(2);
+      expect(errors.every((e) => e.error_code === 'CIRCULAR_FEATURE_REFERENCE')).to.equal(true);
+    });
+
+    it('flags all three edges of a 3-node cycle (A->B, B->C, C->A)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const featureC = await createTestFeature(connection, submissionId, 'sample_technique', {});
+      const typeA = await featureTypeIdByName('sample_period');
+      const typeB = await featureTypeIdByName('sample_site');
+      const typeC = await featureTypeIdByName('sample_technique');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_technique');
+      const { featureTypePropertyId: ftpC } = await createFeatureTypeProperty('sample_technique', 'sample_period');
+
+      // A -> B
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureA,
+        featureTypePropertyId: ftpA,
+        propertyName: 'a_to_b',
+        rawValue: 'feature::b',
+        isFormatValid: true,
+        parsedSourceId: 'b',
+        referencedFeatureId: featureB,
+        referencedFeatureTypeId: typeB
+      });
+      // B -> C
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureB,
+        featureTypePropertyId: ftpB,
+        propertyName: 'b_to_c',
+        rawValue: 'feature::c',
+        isFormatValid: true,
+        parsedSourceId: 'c',
+        referencedFeatureId: featureC,
+        referencedFeatureTypeId: typeC
+      });
+      // C -> A
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureC,
+        featureTypePropertyId: ftpC,
+        propertyName: 'c_to_a',
+        rawValue: 'feature::a',
+        isFormatValid: true,
+        parsedSourceId: 'a',
+        referencedFeatureId: featureA,
+        referencedFeatureTypeId: typeA
+      });
+
+      await repo.recordCircularFeatureReferenceErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(3);
+      expect(errors.every((e) => e.error_code === 'CIRCULAR_FEATURE_REFERENCE')).to.equal(true);
+    });
+
+    it('does NOT flag an acyclic chain (A->B, B->C)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const featureC = await createTestFeature(connection, submissionId, 'sample_technique', {});
+      const typeB = await featureTypeIdByName('sample_site');
+      const typeC = await featureTypeIdByName('sample_technique');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_technique');
+
+      // A -> B
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureA,
+        featureTypePropertyId: ftpA,
+        propertyName: 'a_to_b',
+        rawValue: 'feature::b',
+        isFormatValid: true,
+        parsedSourceId: 'b',
+        referencedFeatureId: featureB,
+        referencedFeatureTypeId: typeB
+      });
+      // B -> C
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureB,
+        featureTypePropertyId: ftpB,
+        propertyName: 'b_to_c',
+        rawValue: 'feature::c',
+        isFormatValid: true,
+        parsedSourceId: 'c',
+        referencedFeatureId: featureC,
+        referencedFeatureTypeId: typeC
+      });
+
+      await repo.recordCircularFeatureReferenceErrorsBySubmissionUploadId(uploadId);
+
+      expect(await getErrors(uploadId)).to.have.lengthOf(0);
+    });
+
+    it('does NOT flag a self-loop (A->A) — handled by the SELF rule, excluded from the edge set', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const featureA = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const typeA = await featureTypeIdByName('sample_site');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_site', 'sample_site');
+
+      // A -> A
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureA,
+        featureTypePropertyId: ftpA,
+        propertyName: 'a_to_a',
+        rawValue: 'feature::a',
+        isFormatValid: true,
+        parsedSourceId: 'a',
+        referencedFeatureId: featureA,
+        referencedFeatureTypeId: typeA
+      });
+
+      await repo.recordCircularFeatureReferenceErrorsBySubmissionUploadId(uploadId);
+
+      expect(await getErrors(uploadId)).to.have.lengthOf(0);
+    });
+
+    it('does NOT flag a would-be 2-cycle when one edge is not format-valid', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const typeA = await featureTypeIdByName('sample_period');
+      const typeB = await featureTypeIdByName('sample_site');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_period');
+
+      // A -> B (valid)
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureA,
+        featureTypePropertyId: ftpA,
+        propertyName: 'a_to_b',
+        rawValue: 'feature::b',
+        isFormatValid: true,
+        parsedSourceId: 'b',
+        referencedFeatureId: featureB,
+        referencedFeatureTypeId: typeB
+      });
+      // B -> A (NOT format-valid — breaks the would-be cycle; excluded from the edge graph)
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId: featureB,
+        featureTypePropertyId: ftpB,
+        propertyName: 'b_to_a',
+        rawValue: 'garbage',
+        isFormatValid: false,
+        parsedSourceId: null,
+        referencedFeatureId: featureA,
+        referencedFeatureTypeId: typeA
+      });
+
+      await repo.recordCircularFeatureReferenceErrorsBySubmissionUploadId(uploadId);
+
+      expect(await getErrors(uploadId)).to.have.lengthOf(0);
+    });
+  });
+
+  // --- insertFeaturePropertiesBySubmissionUploadId -------------------------
+
+  describe('insertFeaturePropertiesBySubmissionUploadId', () => {
+    it('inserts one canonical row when all gates pass', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const targetTypeId = await featureTypeIdByName('sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::area1',
+        isFormatValid: true,
+        parsedSourceId: 'area1',
+        referencedFeatureId: targetFeatureId,
+        referencedFeatureTypeId: targetTypeId
+      });
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      const rows = await getPropertyFeatureRows(sourceFeatureId);
+      expect(rows).to.have.lengthOf(1);
+      expect(rows[0].referenced_submission_feature_id).to.equal(targetFeatureId);
+      expect(rows[0].feature_type_property_id).to.equal(featureTypePropertyId);
+    });
+
+    it('skips candidates with invalid format', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const targetTypeId = await featureTypeIdByName('sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'garbage',
+        isFormatValid: false,
+        parsedSourceId: null,
+        referencedFeatureId: targetFeatureId,
+        referencedFeatureTypeId: targetTypeId
+      });
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    });
+
+    it('skips candidates with null resolution', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::nope',
+        isFormatValid: true,
+        parsedSourceId: 'nope',
+        referencedFeatureId: null,
+        referencedFeatureTypeId: null
+      });
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    });
+
+    it('skips candidates whose resolved type is not allowed', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const wrongTypeFeatureId = await createTestFeature(connection, submissionId, 'sample_technique', {});
+      const wrongTypeId = await featureTypeIdByName('sample_technique');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::tech1',
+        isFormatValid: true,
+        parsedSourceId: 'tech1',
+        referencedFeatureId: wrongTypeFeatureId,
+        referencedFeatureTypeId: wrongTypeId
+      });
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    });
+
+    it('excludes self-references', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_site', 'sample_site');
+      const sampleSiteTypeId = await featureTypeIdByName('sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::self',
+        isFormatValid: true,
+        parsedSourceId: 'self',
+        referencedFeatureId: sourceFeatureId,
+        referencedFeatureTypeId: sampleSiteTypeId
+      });
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    });
+
+    it('dedups exact-duplicate references to one row', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site', true);
+      const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const targetTypeId = await featureTypeIdByName('sample_site');
+
+      // Two identical valid candidates (same source, config, referenced feature).
+      for (let i = 0; i < 2; i++) {
+        await insertCandidate({
+          uploadId,
+          sourceFeatureId,
+          featureTypePropertyId,
+          propertyName: 'site_ref',
+          rawValue: 'feature::area1',
+          isFormatValid: true,
+          parsedSourceId: 'area1',
+          referencedFeatureId: targetFeatureId,
+          referencedFeatureTypeId: targetTypeId
+        });
+      }
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(1);
+    });
+
+    it('writes only submission_feature_property_feature, never submission_feature_feature', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const targetTypeId = await featureTypeIdByName('sample_site');
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::area1',
+        isFormatValid: true,
+        parsedSourceId: 'area1',
+        referencedFeatureId: targetFeatureId,
+        referencedFeatureTypeId: targetTypeId
+      });
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(1);
+
+      const sffResult = await connection.sql(SQL`
+        SELECT COUNT(*)::integer AS count
+        FROM submission_feature_feature
+        WHERE source_feature_id = ${sourceFeatureId};
+      `);
+      expect(sffResult.rows[0].count).to.equal(0);
+    });
+
+    it('ignores a soft-deleted feature_type_property config', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
+      const targetTypeId = await featureTypeIdByName('sample_site');
+      await softDeleteFeatureTypeProperty(featureTypePropertyId);
+
+      await insertCandidate({
+        uploadId,
+        sourceFeatureId,
+        featureTypePropertyId,
+        propertyName: 'site_ref',
+        rawValue: 'feature::area1',
+        isFormatValid: true,
+        parsedSourceId: 'area1',
+        referencedFeatureId: targetFeatureId,
+        referencedFeatureTypeId: targetTypeId
+      });
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    });
+  });
+});

--- a/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
@@ -132,24 +132,24 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
    */
   async function seedSourceAndConfig(
     sourceType = 'sample_period',
-    allowedTargetType: string | null = 'sample_site',
+    allowedTargetType: string | string[] | null = 'sample_site',
     allowMultiple = false
   ): Promise<{
     submissionId: number;
     uploadId: string;
     sourceFeatureId: number;
     featureTypePropertyId: number;
-    allowedFeatureTypeId: number | null;
+    allowedFeatureTypeIds: number[];
   }> {
     const { submissionId, uploadId } = await seedUpload();
     const sourceFeatureId = await createTestFeature(connection, submissionId, sourceType, {});
-    const { featureTypePropertyId, allowedFeatureTypeId } = await createFeatureTypeProperty(
+    const { featureTypePropertyId, allowedFeatureTypeIds } = await createFeatureTypeProperty(
       connection,
       sourceType,
       allowedTargetType,
       allowMultiple
     );
-    return { submissionId, uploadId, sourceFeatureId, featureTypePropertyId, allowedFeatureTypeId };
+    return { submissionId, uploadId, sourceFeatureId, featureTypePropertyId, allowedFeatureTypeIds };
   }
 
   /** All grouped error rows for an upload scope. */

--- a/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
@@ -252,8 +252,10 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
       await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
 
       const errors = await getErrors(uploadId);
-      expect(errors).to.have.lengthOf(1);
-      expect(errors[0].error_code).to.equal('INVALID_FEATURE_REFERENCE_FORMAT');
+      // Exclusivity: a malformed value fires ONLY the FORMAT branch — never also the
+      // UNRESOLVED / TYPE / SELF branches. The four error categories are mutually exclusive,
+      // so the exact set of recorded codes must be just this one.
+      expect(errors.map((e) => e.error_code)).to.deep.equal(['INVALID_FEATURE_REFERENCE_FORMAT']);
     });
 
     it('records UNRESOLVED_FEATURE_REFERENCE when resolution misses', async () => {
@@ -527,6 +529,46 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
       expect(errors.every((e) => e.error_code === 'CIRCULAR_FEATURE_REFERENCE')).to.equal(true);
     });
 
+    it('flags every edge of a long cycle whose back-path exceeds the old depth bound (regression)', async () => {
+      // Regression for the depth-capped walk that silently accepted cycles longer than ~50 hops:
+      // closing any edge of an N-node ring requires walking the other N-1 edges, so with N-1 > 50 the
+      // old `r.depth < 50` guard never materialised the closing path and recorded ZERO errors. The
+      // transitive-closure detector has no depth bound, so all N edges are flagged.
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const type = await featureTypeIdByName('sample_site');
+      // Feature type / config are irrelevant to cycle detection (it reads only the edge endpoints), so
+      // reuse one feature type and one config for the whole ring; distinct property names keep each
+      // cyclic edge in its own grouped error row.
+      const { featureTypePropertyId: ftp } = await createFeatureTypeProperty('sample_site', 'sample_site');
+
+      const N = 55; // > old cap of 50
+      const features: number[] = [];
+      for (let i = 0; i < N; i++) {
+        features.push(await createTestFeature(connection, submissionId, 'sample_site', {}));
+      }
+      // Ring: f0 -> f1 -> ... -> f(N-1) -> f0
+      for (let i = 0; i < N; i++) {
+        await insertCandidate({
+          uploadId,
+          sourceFeatureId: features[i],
+          featureTypePropertyId: ftp,
+          propertyName: `edge_${i}`,
+          rawValue: `feature::f${(i + 1) % N}`,
+          isFormatValid: true,
+          parsedSourceId: `f${(i + 1) % N}`,
+          referencedFeatureId: features[(i + 1) % N],
+          referencedFeatureTypeId: type
+        });
+      }
+
+      await repo.recordCircularFeatureReferenceErrorsBySubmissionUploadId(uploadId);
+
+      const errors = await getErrors(uploadId);
+      expect(errors).to.have.lengthOf(N);
+      expect(errors.every((e) => e.error_code === 'CIRCULAR_FEATURE_REFERENCE')).to.equal(true);
+    });
+
     it('does NOT flag an acyclic chain (A->B, B->C)', async () => {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(submissionId);
@@ -760,6 +802,58 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
       await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
 
       expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    });
+
+    it('skips candidates whose source or target feature was soft-deleted after staging (resolve-once staleness guard)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(submissionId);
+      const targetTypeId = await featureTypeIdByName('sample_site');
+      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+
+      // Helper: soft-delete a feature (the concurrent mutation the guard defends against).
+      const softDelete = (featureId: number) =>
+        connection.sql(SQL`
+          UPDATE submission_feature SET record_end_date = now() WHERE submission_feature_id = ${featureId};
+        `);
+
+      // 1) Valid candidate — both endpoints active → inserts.
+      const liveSource = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const liveTarget = await createTestFeature(connection, submissionId, 'sample_site', {});
+      // 2) Candidate whose TARGET is soft-deleted after staging → must be skipped.
+      const sourceForDeadTarget = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const deadTarget = await createTestFeature(connection, submissionId, 'sample_site', {});
+      // 3) Candidate whose SOURCE is soft-deleted after staging → must be skipped.
+      const deadSource = await createTestFeature(connection, submissionId, 'sample_period', {});
+      const targetForDeadSource = await createTestFeature(connection, submissionId, 'sample_site', {});
+
+      for (const [source, target] of [
+        [liveSource, liveTarget],
+        [sourceForDeadTarget, deadTarget],
+        [deadSource, targetForDeadSource]
+      ]) {
+        await insertCandidate({
+          uploadId,
+          sourceFeatureId: source,
+          featureTypePropertyId,
+          propertyName: 'site_ref',
+          rawValue: 'feature::area1',
+          isFormatValid: true,
+          parsedSourceId: 'area1',
+          referencedFeatureId: target,
+          referencedFeatureTypeId: targetTypeId
+        });
+      }
+
+      // Stale the two endpoints AFTER candidates are staged.
+      await softDelete(deadTarget);
+      await softDelete(deadSource);
+
+      await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
+
+      // Only the all-active candidate inserts; the soft-deleted source and target are excluded.
+      expect(await getPropertyFeatureRows(liveSource)).to.have.lengthOf(1);
+      expect(await getPropertyFeatureRows(sourceForDeadTarget)).to.have.lengthOf(0);
+      expect(await getPropertyFeatureRows(deadSource)).to.have.lengthOf(0);
     });
 
     it('dedups exact-duplicate references to one row', async () => {

--- a/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
@@ -23,16 +23,18 @@
 // Requires: database container running.
 
 import { expect } from 'chai';
-import crypto from 'crypto';
 import { describe } from 'mocha';
 import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
 import { SubmissionFeaturePropertyIngestionRepository } from '../../repositories/submission-feature-property-ingestion-repository';
 import {
-  createTestFeature,
-  createTestSubmission,
-  getOrCreateIntegrationTicketId
-} from '../helpers/test-submission-helpers';
+  createFeatureTypeProperty,
+  createTestUpload,
+  featureTypeIdByName,
+  getPropertyFeatureRows as fetchPropertyFeatureRows,
+  getSubmissionFeatureErrors
+} from '../helpers/test-feature-property-helpers';
+import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
 
 describe('SubmissionFeaturePropertyIngestionRepository (integration)', function () {
   this.timeout(15000);
@@ -56,122 +58,34 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
   // --- local helpers -------------------------------------------------------
 
   /**
-   * Create a real `submission_upload` row for a submission and return its `submission_upload_id` uuid.
+   * Insert one row into the UNLOGGED staging candidate table.
    *
-   * The error-recording method writes the candidate's `submission_upload_id` into
-   * `submission_feature_error`, which has an FK to `submission_upload` — so those tests need a real
-   * upload uuid (a bare random uuid violates the FK). The candidate's `submission_upload_id` itself is
-   * just a filter key against the UNLOGGED staging table (no FK), so any uuid works there; using the
-   * real one keeps both paths consistent.
+   * Fields beyond the three identifiers default to a format-valid, resolved `feature::area1`
+   * candidate; each test overrides only the field(s) whose branch it exercises.
    */
-  async function createTestUpload(submissionId: number): Promise<string> {
-    const systemUserId = connection.systemUserId();
-
-    const uploadResult = await connection.sql(SQL`
-      INSERT INTO upload (upload_status, record_end_date, create_user)
-      VALUES ('completed', now(), ${systemUserId})
-      RETURNING upload_id;
-    `);
-    const uploadId = uploadResult.rows[0].upload_id;
-
-    const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
-
-    const bridgeResult = await connection.sql(SQL`
-      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
-      VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
-      RETURNING submission_upload_id;
-    `);
-
-    return bridgeResult.rows[0].submission_upload_id;
-  }
-
-  /** Resolve a seeded feature_type by name to its id. */
-  async function featureTypeIdByName(name: string): Promise<number> {
-    const result = await connection.sql(SQL`
-      SELECT feature_type_id FROM feature_type WHERE name = ${name} LIMIT 1;
-    `);
-    return result.rows[0].feature_type_id;
-  }
-
-  /**
-   * Create a feature-typed feature_property + feature_type_property config row for a source feature
-   * type. Mirrors insertCodeFeatureProperty but for the 'feature' property type.
-   *
-   * @param sourceFeatureTypeName Feature type the property is attached to (the referencing feature).
-   * @param allowedTargetFeatureTypeName Allowed target feature type name, or null for "no permitted target".
-   * @param allowMultiple Whether the property may carry multiple references.
-   * @returns The new feature_type_property_id and the resolved allowedFeatureTypeId (or null).
-   */
-  async function createFeatureTypeProperty(
-    sourceFeatureTypeName: string,
-    allowedTargetFeatureTypeName: string | null,
-    allowMultiple = false
-  ): Promise<{ featureTypePropertyId: number; allowedFeatureTypeId: number | null }> {
-    const systemUserId = connection.systemUserId();
-
-    await connection.sql(SQL`
-      INSERT INTO feature_property_type (name, record_effective_date, create_user)
-      SELECT 'feature', now(), ${systemUserId}
-      WHERE NOT EXISTS (SELECT 1 FROM feature_property_type WHERE name = 'feature');
-    `);
-
-    const fptResult = await connection.sql(SQL`
-      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'feature';
-    `);
-    const featurePropertyTypeId = fptResult.rows[0].feature_property_type_id;
-
-    const uniqueSuffix = crypto.randomInt(0, 1_000_000_000);
-    const fpResult = await connection.sql(SQL`
-      INSERT INTO feature_property (feature_property_type_id, name, display_name, record_effective_date, create_user)
-      VALUES (
-        ${featurePropertyTypeId},
-        ${'test_feature_ref_' + uniqueSuffix},
-        ${'Test Feature Ref ' + uniqueSuffix},
-        now(),
-        ${systemUserId}
-      )
-      RETURNING feature_property_id;
-    `);
-    const featurePropertyId = fpResult.rows[0].feature_property_id;
-
-    const allowedFeatureTypeId =
-      allowedTargetFeatureTypeName === null ? null : await featureTypeIdByName(allowedTargetFeatureTypeName);
-
-    const ftpResult = await connection.sql(SQL`
-      INSERT INTO feature_type_property (
-        feature_type_id,
-        feature_property_id,
-        allow_multiple,
-        allowed_referenced_feature_type_id,
-        record_effective_date,
-        create_user
-      )
-      VALUES (
-        (SELECT feature_type_id FROM feature_type WHERE name = ${sourceFeatureTypeName} LIMIT 1),
-        ${featurePropertyId},
-        ${allowMultiple},
-        ${allowedFeatureTypeId},
-        now(),
-        ${systemUserId}
-      )
-      RETURNING feature_type_property_id;
-    `);
-
-    return { featureTypePropertyId: ftpResult.rows[0].feature_type_property_id, allowedFeatureTypeId };
-  }
-
-  /** Insert one row into the UNLOGGED staging candidate table. */
   async function insertCandidate(params: {
     uploadId: string;
     sourceFeatureId: number;
     featureTypePropertyId: number;
-    propertyName: string;
-    rawValue: string;
-    isFormatValid: boolean;
-    parsedSourceId: string | null;
-    referencedFeatureId: number | null;
-    referencedFeatureTypeId: number | null;
+    propertyName?: string;
+    rawValue?: string;
+    isFormatValid?: boolean;
+    parsedSourceId?: string | null;
+    referencedFeatureId?: number | null;
+    referencedFeatureTypeId?: number | null;
   }): Promise<void> {
+    const {
+      uploadId,
+      sourceFeatureId,
+      featureTypePropertyId,
+      propertyName = 'site_ref',
+      rawValue = 'feature::area1',
+      isFormatValid = true,
+      parsedSourceId = 'area1',
+      referencedFeatureId = null,
+      referencedFeatureTypeId = null
+    } = params;
+
     await connection.sql(SQL`
       INSERT INTO submission_upload_staging_feature_candidate (
         submission_upload_id,
@@ -185,15 +99,15 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
         referenced_feature_type_id
       )
       VALUES (
-        ${params.uploadId}::uuid,
-        ${params.sourceFeatureId},
-        ${params.propertyName},
-        ${params.featureTypePropertyId},
-        ${JSON.stringify(params.rawValue)}::jsonb,
-        ${params.isFormatValid},
-        ${params.parsedSourceId},
-        ${params.referencedFeatureId},
-        ${params.referencedFeatureTypeId}
+        ${uploadId}::uuid,
+        ${sourceFeatureId},
+        ${propertyName},
+        ${featureTypePropertyId},
+        ${JSON.stringify(rawValue)}::jsonb,
+        ${isFormatValid},
+        ${parsedSourceId},
+        ${referencedFeatureId},
+        ${referencedFeatureTypeId}
       );
     `);
   }
@@ -205,48 +119,64 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     `);
   }
 
-  /** Fetch grouped error rows for an upload scope. */
-  async function getErrors(uploadId: string): Promise<{ error_code: string; count: number }[]> {
-    const result = await connection.sql(SQL`
-      SELECT error_code, count
-      FROM submission_feature_error
-      WHERE submission_upload_id = ${uploadId}::uuid
-      ORDER BY error_code;
-    `);
-    return result.rows;
+  /** Create a submission + a real upload for it. */
+  async function seedUpload(): Promise<{ submissionId: number; uploadId: string }> {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(connection, submissionId);
+    return { submissionId, uploadId };
   }
 
-  /** Count canonical property-feature rows for a source feature. */
-  async function getPropertyFeatureRows(
+  /**
+   * Stand up the common single-source arrange block: a submission, a real upload, one source feature,
+   * and one feature_type_property config (defaulting to sample_period → sample_site).
+   */
+  async function seedSourceAndConfig(
+    sourceType = 'sample_period',
+    allowedTargetType: string | null = 'sample_site',
+    allowMultiple = false
+  ): Promise<{
+    submissionId: number;
+    uploadId: string;
+    sourceFeatureId: number;
+    featureTypePropertyId: number;
+    allowedFeatureTypeId: number | null;
+  }> {
+    const { submissionId, uploadId } = await seedUpload();
+    const sourceFeatureId = await createTestFeature(connection, submissionId, sourceType, {});
+    const { featureTypePropertyId, allowedFeatureTypeId } = await createFeatureTypeProperty(
+      connection,
+      sourceType,
+      allowedTargetType,
+      allowMultiple
+    );
+    return { submissionId, uploadId, sourceFeatureId, featureTypePropertyId, allowedFeatureTypeId };
+  }
+
+  /** All grouped error rows for an upload scope. */
+  function getErrors(uploadId: string): Promise<{ error_code: string; count: number }[]> {
+    return getSubmissionFeatureErrors(connection, uploadId);
+  }
+
+  /** Canonical property-feature rows for a source feature. */
+  function getPropertyFeatureRows(
     sourceFeatureId: number
   ): Promise<{ referenced_submission_feature_id: number; feature_type_property_id: number }[]> {
-    const result = await connection.sql(SQL`
-      SELECT referenced_submission_feature_id, feature_type_property_id
-      FROM submission_feature_property_feature
-      WHERE submission_feature_id = ${sourceFeatureId};
-    `);
-    return result.rows;
+    return fetchPropertyFeatureRows(connection, sourceFeatureId);
   }
 
   // --- recordFeaturePropertyResolutionErrorsBySubmissionUploadId -----------
 
   describe('recordFeaturePropertyResolutionErrorsBySubmissionUploadId', () => {
     it('records INVALID_FEATURE_REFERENCE_FORMAT for malformed values', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'garbage-value',
         isFormatValid: false,
-        parsedSourceId: null,
-        referencedFeatureId: null,
-        referencedFeatureTypeId: null
+        parsedSourceId: null
       });
 
       await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
@@ -259,21 +189,14 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('records UNRESOLVED_FEATURE_REFERENCE when resolution misses', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'feature::nope',
-        isFormatValid: true,
-        parsedSourceId: 'nope',
-        referencedFeatureId: null,
-        referencedFeatureTypeId: null
+        parsedSourceId: 'nope'
       });
 
       await repo.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(uploadId);
@@ -284,21 +207,16 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('records INVALID_FEATURE_REFERENCE_TYPE when resolved type not allowed', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
       // Config allows sample_site, but the candidate resolved to a sample_technique feature.
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
       const wrongTypeFeatureId = await createTestFeature(connection, submissionId, 'sample_technique', {});
-      const wrongTypeId = await featureTypeIdByName('sample_technique');
+      const wrongTypeId = await featureTypeIdByName(connection, 'sample_technique');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'feature::tech1',
-        isFormatValid: true,
         parsedSourceId: 'tech1',
         referencedFeatureId: wrongTypeFeatureId,
         referencedFeatureTypeId: wrongTypeId
@@ -312,22 +230,18 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('records INVALID_FEATURE_REFERENCE_TYPE when property has no allowed target', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
       // Config allows NO target — every reference is rejected.
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', null);
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig(
+        'sample_period',
+        null
+      );
       const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const targetTypeId = await featureTypeIdByName('sample_site');
+      const targetTypeId = await featureTypeIdByName(connection, 'sample_site');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
-        rawValue: 'feature::area1',
-        isFormatValid: true,
-        parsedSourceId: 'area1',
         referencedFeatureId: targetFeatureId,
         referencedFeatureTypeId: targetTypeId
       });
@@ -340,20 +254,18 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('records INVALID_FEATURE_REFERENCE_SELF (and no TYPE error) for a self-reference', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
       // Source is a sample_site; config allows sample_site; candidate points at its own feature.
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_site', 'sample_site');
-      const sampleSiteTypeId = await featureTypeIdByName('sample_site');
+      const { uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig(
+        'sample_site',
+        'sample_site'
+      );
+      const sampleSiteTypeId = await featureTypeIdByName(connection, 'sample_site');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'feature::self',
-        isFormatValid: true,
         parsedSourceId: 'self',
         referencedFeatureId: sourceFeatureId,
         referencedFeatureTypeId: sampleSiteTypeId
@@ -369,22 +281,17 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('ignores a soft-deleted feature_type_property config (type branch)', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
       await softDeleteFeatureTypeProperty(featureTypePropertyId);
 
       const wrongTypeFeatureId = await createTestFeature(connection, submissionId, 'sample_technique', {});
-      const wrongTypeId = await featureTypeIdByName('sample_technique');
+      const wrongTypeId = await featureTypeIdByName(connection, 'sample_technique');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'feature::tech1',
-        isFormatValid: true,
         parsedSourceId: 'tech1',
         referencedFeatureId: wrongTypeFeatureId,
         referencedFeatureTypeId: wrongTypeId
@@ -397,10 +304,7 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('aggregates duplicate errors into one grouped row with a count', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
 
       // Two malformed candidates sharing property_name + feature_type_property_id.
       for (let i = 0; i < 2; i++) {
@@ -408,12 +312,9 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
           uploadId,
           sourceFeatureId,
           featureTypePropertyId,
-          propertyName: 'site_ref',
           rawValue: 'garbage-' + i,
           isFormatValid: false,
-          parsedSourceId: null,
-          referencedFeatureId: null,
-          referencedFeatureTypeId: null
+          parsedSourceId: null
         });
       }
 
@@ -430,36 +331,39 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
 
   describe('recordCircularFeatureReferenceErrorsBySubmissionUploadId', () => {
     it('flags both edges of a 2-node cycle (A->B, B->A)', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
+      const { submissionId, uploadId } = await seedUpload();
       const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
       const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const typeA = await featureTypeIdByName('sample_period');
-      const typeB = await featureTypeIdByName('sample_site');
+      const typeA = await featureTypeIdByName(connection, 'sample_period');
+      const typeB = await featureTypeIdByName(connection, 'sample_site');
       // Distinct configs so the two cyclic edges fall into separate grouped error rows.
-      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
-      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_period');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty(
+        connection,
+        'sample_period',
+        'sample_site'
+      );
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty(
+        connection,
+        'sample_site',
+        'sample_period'
+      );
 
-      // A -> B
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureA,
         featureTypePropertyId: ftpA,
         propertyName: 'a_to_b',
         rawValue: 'feature::b',
-        isFormatValid: true,
         parsedSourceId: 'b',
         referencedFeatureId: featureB,
         referencedFeatureTypeId: typeB
       });
-      // B -> A
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureB,
         featureTypePropertyId: ftpB,
         propertyName: 'b_to_a',
         rawValue: 'feature::a',
-        isFormatValid: true,
         parsedSourceId: 'a',
         referencedFeatureId: featureA,
         referencedFeatureTypeId: typeA
@@ -473,50 +377,55 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('flags all three edges of a 3-node cycle (A->B, B->C, C->A)', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
+      const { submissionId, uploadId } = await seedUpload();
       const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
       const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
       const featureC = await createTestFeature(connection, submissionId, 'sample_technique', {});
-      const typeA = await featureTypeIdByName('sample_period');
-      const typeB = await featureTypeIdByName('sample_site');
-      const typeC = await featureTypeIdByName('sample_technique');
-      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
-      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_technique');
-      const { featureTypePropertyId: ftpC } = await createFeatureTypeProperty('sample_technique', 'sample_period');
+      const typeA = await featureTypeIdByName(connection, 'sample_period');
+      const typeB = await featureTypeIdByName(connection, 'sample_site');
+      const typeC = await featureTypeIdByName(connection, 'sample_technique');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty(
+        connection,
+        'sample_period',
+        'sample_site'
+      );
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty(
+        connection,
+        'sample_site',
+        'sample_technique'
+      );
+      const { featureTypePropertyId: ftpC } = await createFeatureTypeProperty(
+        connection,
+        'sample_technique',
+        'sample_period'
+      );
 
-      // A -> B
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureA,
         featureTypePropertyId: ftpA,
         propertyName: 'a_to_b',
         rawValue: 'feature::b',
-        isFormatValid: true,
         parsedSourceId: 'b',
         referencedFeatureId: featureB,
         referencedFeatureTypeId: typeB
       });
-      // B -> C
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureB,
         featureTypePropertyId: ftpB,
         propertyName: 'b_to_c',
         rawValue: 'feature::c',
-        isFormatValid: true,
         parsedSourceId: 'c',
         referencedFeatureId: featureC,
         referencedFeatureTypeId: typeC
       });
-      // C -> A
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureC,
         featureTypePropertyId: ftpC,
         propertyName: 'c_to_a',
         rawValue: 'feature::a',
-        isFormatValid: true,
         parsedSourceId: 'a',
         referencedFeatureId: featureA,
         referencedFeatureTypeId: typeA
@@ -534,13 +443,12 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
       // closing any edge of an N-node ring requires walking the other N-1 edges, so with N-1 > 50 the
       // old `r.depth < 50` guard never materialised the closing path and recorded ZERO errors. The
       // transitive-closure detector has no depth bound, so all N edges are flagged.
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const type = await featureTypeIdByName('sample_site');
+      const { submissionId, uploadId } = await seedUpload();
+      const type = await featureTypeIdByName(connection, 'sample_site');
       // Feature type / config are irrelevant to cycle detection (it reads only the edge endpoints), so
       // reuse one feature type and one config for the whole ring; distinct property names keep each
       // cyclic edge in its own grouped error row.
-      const { featureTypePropertyId: ftp } = await createFeatureTypeProperty('sample_site', 'sample_site');
+      const { featureTypePropertyId: ftp } = await createFeatureTypeProperty(connection, 'sample_site', 'sample_site');
 
       const N = 55; // > old cap of 50
       const features: number[] = [];
@@ -555,7 +463,6 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
           featureTypePropertyId: ftp,
           propertyName: `edge_${i}`,
           rawValue: `feature::f${(i + 1) % N}`,
-          isFormatValid: true,
           parsedSourceId: `f${(i + 1) % N}`,
           referencedFeatureId: features[(i + 1) % N],
           referencedFeatureTypeId: type
@@ -570,36 +477,39 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('does NOT flag an acyclic chain (A->B, B->C)', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
+      const { submissionId, uploadId } = await seedUpload();
       const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
       const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
       const featureC = await createTestFeature(connection, submissionId, 'sample_technique', {});
-      const typeB = await featureTypeIdByName('sample_site');
-      const typeC = await featureTypeIdByName('sample_technique');
-      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
-      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_technique');
+      const typeB = await featureTypeIdByName(connection, 'sample_site');
+      const typeC = await featureTypeIdByName(connection, 'sample_technique');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty(
+        connection,
+        'sample_period',
+        'sample_site'
+      );
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty(
+        connection,
+        'sample_site',
+        'sample_technique'
+      );
 
-      // A -> B
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureA,
         featureTypePropertyId: ftpA,
         propertyName: 'a_to_b',
         rawValue: 'feature::b',
-        isFormatValid: true,
         parsedSourceId: 'b',
         referencedFeatureId: featureB,
         referencedFeatureTypeId: typeB
       });
-      // B -> C
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureB,
         featureTypePropertyId: ftpB,
         propertyName: 'b_to_c',
         rawValue: 'feature::c',
-        isFormatValid: true,
         parsedSourceId: 'c',
         referencedFeatureId: featureC,
         referencedFeatureTypeId: typeC
@@ -611,20 +521,17 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('does NOT flag a self-loop (A->A) — handled by the SELF rule, excluded from the edge set', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
+      const { submissionId, uploadId } = await seedUpload();
       const featureA = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const typeA = await featureTypeIdByName('sample_site');
-      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_site', 'sample_site');
+      const typeA = await featureTypeIdByName(connection, 'sample_site');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty(connection, 'sample_site', 'sample_site');
 
-      // A -> A
       await insertCandidate({
         uploadId,
         sourceFeatureId: featureA,
         featureTypePropertyId: ftpA,
         propertyName: 'a_to_a',
         rawValue: 'feature::a',
-        isFormatValid: true,
         parsedSourceId: 'a',
         referencedFeatureId: featureA,
         referencedFeatureTypeId: typeA
@@ -636,14 +543,21 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('does NOT flag a would-be 2-cycle when one edge is not format-valid', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
+      const { submissionId, uploadId } = await seedUpload();
       const featureA = await createTestFeature(connection, submissionId, 'sample_period', {});
       const featureB = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const typeA = await featureTypeIdByName('sample_period');
-      const typeB = await featureTypeIdByName('sample_site');
-      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty('sample_period', 'sample_site');
-      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty('sample_site', 'sample_period');
+      const typeA = await featureTypeIdByName(connection, 'sample_period');
+      const typeB = await featureTypeIdByName(connection, 'sample_site');
+      const { featureTypePropertyId: ftpA } = await createFeatureTypeProperty(
+        connection,
+        'sample_period',
+        'sample_site'
+      );
+      const { featureTypePropertyId: ftpB } = await createFeatureTypeProperty(
+        connection,
+        'sample_site',
+        'sample_period'
+      );
 
       // A -> B (valid)
       await insertCandidate({
@@ -652,7 +566,6 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
         featureTypePropertyId: ftpA,
         propertyName: 'a_to_b',
         rawValue: 'feature::b',
-        isFormatValid: true,
         parsedSourceId: 'b',
         referencedFeatureId: featureB,
         referencedFeatureTypeId: typeB
@@ -680,21 +593,14 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
 
   describe('insertFeaturePropertiesBySubmissionUploadId', () => {
     it('inserts one canonical row when all gates pass', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
       const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const targetTypeId = await featureTypeIdByName('sample_site');
+      const targetTypeId = await featureTypeIdByName(connection, 'sample_site');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
-        rawValue: 'feature::area1',
-        isFormatValid: true,
-        parsedSourceId: 'area1',
         referencedFeatureId: targetFeatureId,
         referencedFeatureTypeId: targetTypeId
       });
@@ -708,18 +614,14 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('skips candidates with invalid format', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
       const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const targetTypeId = await featureTypeIdByName('sample_site');
+      const targetTypeId = await featureTypeIdByName(connection, 'sample_site');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'garbage',
         isFormatValid: false,
         parsedSourceId: null,
@@ -733,21 +635,14 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('skips candidates with null resolution', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'feature::nope',
-        isFormatValid: true,
-        parsedSourceId: 'nope',
-        referencedFeatureId: null,
-        referencedFeatureTypeId: null
+        parsedSourceId: 'nope'
       });
 
       await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
@@ -756,20 +651,15 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('skips candidates whose resolved type is not allowed', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
       const wrongTypeFeatureId = await createTestFeature(connection, submissionId, 'sample_technique', {});
-      const wrongTypeId = await featureTypeIdByName('sample_technique');
+      const wrongTypeId = await featureTypeIdByName(connection, 'sample_technique');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'feature::tech1',
-        isFormatValid: true,
         parsedSourceId: 'tech1',
         referencedFeatureId: wrongTypeFeatureId,
         referencedFeatureTypeId: wrongTypeId
@@ -781,19 +671,17 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('excludes self-references', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_site', 'sample_site');
-      const sampleSiteTypeId = await featureTypeIdByName('sample_site');
+      const { uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig(
+        'sample_site',
+        'sample_site'
+      );
+      const sampleSiteTypeId = await featureTypeIdByName(connection, 'sample_site');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
         rawValue: 'feature::self',
-        isFormatValid: true,
         parsedSourceId: 'self',
         referencedFeatureId: sourceFeatureId,
         referencedFeatureTypeId: sampleSiteTypeId
@@ -805,10 +693,9 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('skips candidates whose source or target feature was soft-deleted after staging (resolve-once staleness guard)', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const targetTypeId = await featureTypeIdByName('sample_site');
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId } = await seedUpload();
+      const targetTypeId = await featureTypeIdByName(connection, 'sample_site');
+      const { featureTypePropertyId } = await createFeatureTypeProperty(connection, 'sample_period', 'sample_site');
 
       // Helper: soft-delete a feature (the concurrent mutation the guard defends against).
       const softDelete = (featureId: number) =>
@@ -835,10 +722,6 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
           uploadId,
           sourceFeatureId: source,
           featureTypePropertyId,
-          propertyName: 'site_ref',
-          rawValue: 'feature::area1',
-          isFormatValid: true,
-          parsedSourceId: 'area1',
           referencedFeatureId: target,
           referencedFeatureTypeId: targetTypeId
         });
@@ -857,12 +740,13 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('dedups exact-duplicate references to one row', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site', true);
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig(
+        'sample_period',
+        'sample_site',
+        true
+      );
       const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const targetTypeId = await featureTypeIdByName('sample_site');
+      const targetTypeId = await featureTypeIdByName(connection, 'sample_site');
 
       // Two identical valid candidates (same source, config, referenced feature).
       for (let i = 0; i < 2; i++) {
@@ -870,10 +754,6 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
           uploadId,
           sourceFeatureId,
           featureTypePropertyId,
-          propertyName: 'site_ref',
-          rawValue: 'feature::area1',
-          isFormatValid: true,
-          parsedSourceId: 'area1',
           referencedFeatureId: targetFeatureId,
           referencedFeatureTypeId: targetTypeId
         });
@@ -885,21 +765,14 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('writes only submission_feature_property_feature, never submission_feature_feature', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
       const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const targetTypeId = await featureTypeIdByName('sample_site');
+      const targetTypeId = await featureTypeIdByName(connection, 'sample_site');
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
-        rawValue: 'feature::area1',
-        isFormatValid: true,
-        parsedSourceId: 'area1',
         referencedFeatureId: targetFeatureId,
         referencedFeatureTypeId: targetTypeId
       });
@@ -917,22 +790,15 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('ignores a soft-deleted feature_type_property config', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(submissionId);
-      const sourceFeatureId = await createTestFeature(connection, submissionId, 'sample_period', {});
-      const { featureTypePropertyId } = await createFeatureTypeProperty('sample_period', 'sample_site');
+      const { submissionId, uploadId, sourceFeatureId, featureTypePropertyId } = await seedSourceAndConfig();
       const targetFeatureId = await createTestFeature(connection, submissionId, 'sample_site', {});
-      const targetTypeId = await featureTypeIdByName('sample_site');
+      const targetTypeId = await featureTypeIdByName(connection, 'sample_site');
       await softDeleteFeatureTypeProperty(featureTypePropertyId);
 
       await insertCandidate({
         uploadId,
         sourceFeatureId,
         featureTypePropertyId,
-        propertyName: 'site_ref',
-        rawValue: 'feature::area1',
-        isFormatValid: true,
-        parsedSourceId: 'area1',
         referencedFeatureId: targetFeatureId,
         referencedFeatureTypeId: targetTypeId
       });

--- a/api/src/__integration__/helpers/test-feature-property-helpers.ts
+++ b/api/src/__integration__/helpers/test-feature-property-helpers.ts
@@ -47,23 +47,23 @@ export async function featureTypeIdByName(connection: IDBConnection, name: strin
 
 /**
  * Create a synthetic `feature`-typed feature_property and assign it to a source feature type via
- * feature_type_property with an allowed target type. Mirrors download-parquet's
- * insertCodeFeatureProperty but for the 'feature' property type plus the allowed-target column.
- *
- * Idempotently ensures the 'feature' feature_property_type exists, so each suite is self-contained.
+ * feature_type_property, then declare its allowed target feature types in
+ * `feature_type_property_feature`. Idempotently ensures the 'feature' feature_property_type exists,
+ * so each suite is self-contained.
  *
  * @param sourceFeatureTypeName Feature type the property is attached to (the referencing feature).
- * @param allowedTargetFeatureTypeName Allowed target feature type name, or null for "no permitted target".
+ * @param allowedTargetFeatureTypeNames Allowed target feature type name(s). Pass a single string,
+ *   an array of names, or null for "no permitted target".
  * @param allowMultiple Whether the property may carry multiple references.
- * @returns The new feature_type_property_id, the resolved allowedFeatureTypeId (or null), and the
- *   feature_property.name to use as the data.properties key on source features.
+ * @returns The new feature_type_property_id, the resolved allowed feature_type_ids (empty when no
+ *   targets), and the feature_property.name to use as the data.properties key on source features.
  */
 export async function createFeatureTypeProperty(
   connection: IDBConnection,
   sourceFeatureTypeName: string,
-  allowedTargetFeatureTypeName: string | null,
+  allowedTargetFeatureTypeNames: string | string[] | null,
   allowMultiple = false
-): Promise<{ featureTypePropertyId: number; allowedFeatureTypeId: number | null; propertyName: string }> {
+): Promise<{ featureTypePropertyId: number; allowedFeatureTypeIds: number[]; propertyName: string }> {
   const systemUserId = connection.systemUserId();
 
   await connection.sql(SQL`
@@ -86,15 +86,11 @@ export async function createFeatureTypeProperty(
   `);
   const featurePropertyId = fpResult.rows[0].feature_property_id;
 
-  const allowedFeatureTypeId =
-    allowedTargetFeatureTypeName === null ? null : await featureTypeIdByName(connection, allowedTargetFeatureTypeName);
-
   const ftpResult = await connection.sql(SQL`
     INSERT INTO feature_type_property (
       feature_type_id,
       feature_property_id,
       allow_multiple,
-      allowed_referenced_feature_type_id,
       record_effective_date,
       create_user
     )
@@ -102,14 +98,35 @@ export async function createFeatureTypeProperty(
       (SELECT feature_type_id FROM feature_type WHERE name = ${sourceFeatureTypeName} LIMIT 1),
       ${featurePropertyId},
       ${allowMultiple},
-      ${allowedFeatureTypeId},
       now(),
       ${systemUserId}
     )
     RETURNING feature_type_property_id;
   `);
+  const featureTypePropertyId: number = ftpResult.rows[0].feature_type_property_id;
 
-  return { featureTypePropertyId: ftpResult.rows[0].feature_type_property_id, allowedFeatureTypeId, propertyName };
+  const targetNames =
+    allowedTargetFeatureTypeNames === null
+      ? []
+      : Array.isArray(allowedTargetFeatureTypeNames)
+      ? allowedTargetFeatureTypeNames
+      : [allowedTargetFeatureTypeNames];
+
+  const allowedFeatureTypeIds: number[] = [];
+  for (const targetName of targetNames) {
+    const targetId = await featureTypeIdByName(connection, targetName);
+    allowedFeatureTypeIds.push(targetId);
+    await connection.sql(SQL`
+      INSERT INTO feature_type_property_feature (
+        feature_type_property_id,
+        target_feature_type_id,
+        create_user
+      )
+      VALUES (${featureTypePropertyId}, ${targetId}, ${systemUserId});
+    `);
+  }
+
+  return { featureTypePropertyId, allowedFeatureTypeIds, propertyName };
 }
 
 /**

--- a/api/src/__integration__/helpers/test-feature-property-helpers.ts
+++ b/api/src/__integration__/helpers/test-feature-property-helpers.ts
@@ -1,0 +1,154 @@
+import crypto from 'crypto';
+import SQL from 'sql-template-strings';
+import { IDBConnection } from '../../database/db';
+import { getOrCreateIntegrationTicketId } from './test-submission-helpers';
+
+// Shared fixtures for the feature-property ingestion integration suites
+// (submission-feature-property-ingestion-repository + submission-feature-property-feature-ingestion).
+// These mint the catalog config and submission_upload scaffolding both suites need, and read back the
+// canonical/error tables they assert on.
+
+/**
+ * Create a real `submission_upload` row for a submission and return its `submission_upload_id` uuid.
+ *
+ * `submission_feature_error` and `submission_feature` both FK to `submission_upload`, so tests that
+ * write those need a real upload uuid (a bare random uuid violates the FK). Unlike
+ * `createTestFeature`, this mints the upload only — letting callers insert features with explicit
+ * source_ids into the same upload.
+ */
+export async function createTestUpload(connection: IDBConnection, submissionId: number): Promise<string> {
+  const systemUserId = connection.systemUserId();
+
+  const uploadResult = await connection.sql(SQL`
+    INSERT INTO upload (upload_status, record_end_date, create_user)
+    VALUES ('completed', now(), ${systemUserId})
+    RETURNING upload_id;
+  `);
+  const uploadId = uploadResult.rows[0].upload_id;
+
+  const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
+
+  const bridgeResult = await connection.sql(SQL`
+    INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+    VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
+    RETURNING submission_upload_id;
+  `);
+
+  return bridgeResult.rows[0].submission_upload_id;
+}
+
+/** Resolve a seeded feature_type by name to its id. */
+export async function featureTypeIdByName(connection: IDBConnection, name: string): Promise<number> {
+  const result = await connection.sql(SQL`
+    SELECT feature_type_id FROM feature_type WHERE name = ${name} LIMIT 1;
+  `);
+  return result.rows[0].feature_type_id;
+}
+
+/**
+ * Create a synthetic `feature`-typed feature_property and assign it to a source feature type via
+ * feature_type_property with an allowed target type. Mirrors download-parquet's
+ * insertCodeFeatureProperty but for the 'feature' property type plus the allowed-target column.
+ *
+ * Idempotently ensures the 'feature' feature_property_type exists, so each suite is self-contained.
+ *
+ * @param sourceFeatureTypeName Feature type the property is attached to (the referencing feature).
+ * @param allowedTargetFeatureTypeName Allowed target feature type name, or null for "no permitted target".
+ * @param allowMultiple Whether the property may carry multiple references.
+ * @returns The new feature_type_property_id, the resolved allowedFeatureTypeId (or null), and the
+ *   feature_property.name to use as the data.properties key on source features.
+ */
+export async function createFeatureTypeProperty(
+  connection: IDBConnection,
+  sourceFeatureTypeName: string,
+  allowedTargetFeatureTypeName: string | null,
+  allowMultiple = false
+): Promise<{ featureTypePropertyId: number; allowedFeatureTypeId: number | null; propertyName: string }> {
+  const systemUserId = connection.systemUserId();
+
+  await connection.sql(SQL`
+    INSERT INTO feature_property_type (name, record_effective_date, create_user)
+    SELECT 'feature', now(), ${systemUserId}
+    WHERE NOT EXISTS (SELECT 1 FROM feature_property_type WHERE name = 'feature');
+  `);
+
+  const fptResult = await connection.sql(SQL`
+    SELECT feature_property_type_id FROM feature_property_type WHERE name = 'feature';
+  `);
+  const featurePropertyTypeId = fptResult.rows[0].feature_property_type_id;
+
+  const uniqueSuffix = crypto.randomInt(0, 1_000_000_000);
+  const propertyName = `test_feature_ref_${uniqueSuffix}`;
+  const fpResult = await connection.sql(SQL`
+    INSERT INTO feature_property (feature_property_type_id, name, display_name, record_effective_date, create_user)
+    VALUES (${featurePropertyTypeId}, ${propertyName}, ${'Test Feature Ref ' + uniqueSuffix}, now(), ${systemUserId})
+    RETURNING feature_property_id;
+  `);
+  const featurePropertyId = fpResult.rows[0].feature_property_id;
+
+  const allowedFeatureTypeId =
+    allowedTargetFeatureTypeName === null ? null : await featureTypeIdByName(connection, allowedTargetFeatureTypeName);
+
+  const ftpResult = await connection.sql(SQL`
+    INSERT INTO feature_type_property (
+      feature_type_id,
+      feature_property_id,
+      allow_multiple,
+      allowed_referenced_feature_type_id,
+      record_effective_date,
+      create_user
+    )
+    VALUES (
+      (SELECT feature_type_id FROM feature_type WHERE name = ${sourceFeatureTypeName} LIMIT 1),
+      ${featurePropertyId},
+      ${allowMultiple},
+      ${allowedFeatureTypeId},
+      now(),
+      ${systemUserId}
+    )
+    RETURNING feature_type_property_id;
+  `);
+
+  return { featureTypePropertyId: ftpResult.rows[0].feature_type_property_id, allowedFeatureTypeId, propertyName };
+}
+
+/**
+ * Fetch grouped error rows for an upload, ordered by code.
+ *
+ * @param positiveCountsOnly When true, drops count-0 rows. The engine writes a benign count-0
+ *   `UNRESOLVED_PARENT` diagnostic row for every feature, and the Phase 9 fail-fast gate keys off
+ *   `SUM(count)`, so only count > 0 rows are upload-blocking. The repository-level suite drives
+ *   methods in isolation (no diagnostic rows) and reads all rows.
+ */
+export async function getSubmissionFeatureErrors(
+  connection: IDBConnection,
+  uploadId: string,
+  positiveCountsOnly = false
+): Promise<{ error_code: string; count: number }[]> {
+  const query = SQL`
+    SELECT error_code, count
+    FROM submission_feature_error
+    WHERE submission_upload_id = ${uploadId}::uuid
+  `;
+  if (positiveCountsOnly) {
+    query.append(SQL` AND count > 0`);
+  }
+  query.append(SQL` ORDER BY error_code;`);
+
+  const result = await connection.sql(query);
+  return result.rows;
+}
+
+/** Fetch canonical property-feature rows for a source feature, ordered by referenced feature. */
+export async function getPropertyFeatureRows(
+  connection: IDBConnection,
+  sourceFeatureId: number
+): Promise<{ referenced_submission_feature_id: number; feature_type_property_id: number }[]> {
+  const result = await connection.sql(SQL`
+    SELECT referenced_submission_feature_id, feature_type_property_id
+    FROM submission_feature_property_feature
+    WHERE submission_feature_id = ${sourceFeatureId}
+    ORDER BY referenced_submission_feature_id;
+  `);
+  return result.rows;
+}

--- a/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
@@ -114,6 +114,26 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
     });
   });
 
+  describe('populateFeatureCandidateStagingBySubmissionUploadId', () => {
+    it('resolves feature property jsonb values into feature candidate staging', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([]));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
+
+      await repository.populateFeatureCandidateStagingBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      expect(sqlStub.calledOnce).to.equal(true);
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      expect(sqlText).to.include('INSERT INTO submission_upload_staging_feature_candidate');
+      expect(sqlText).to.include('FROM submission_upload_staging_typed_property_value v');
+      expect(sqlText).to.include("WHERE v.property_type_name = 'feature'");
+      expect(sqlText).to.include("jsonb_typeof(v.logical_value) = 'string'");
+      expect(sqlText).to.include("regexp_split_to_array(btrim(v.logical_value #>> '{}'), '::')");
+      expect(sqlText).to.include('LEFT JOIN submission_feature target');
+      expect(sqlText).to.include('target.source_id = p.parsed_source_id');
+    });
+  });
+
   describe('insertCodePropertiesBySubmissionUploadId', () => {
     it('inserts resolved code candidates into submission_feature_property_code', async () => {
       const sqlStub = sinon.stub().resolves(mockQueryResult([]));
@@ -285,6 +305,8 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
       expect(sqlText).to.include('MULTIPLE_VALUES_NOT_ALLOWED');
       expect(sqlText).to.include('TYPE_MISMATCH');
       expect(sqlText).to.include('UNSUPPORTED_PROPERTY_TYPE');
+      expect(sqlText).to.include("'artifact_key', 'feature')");
+      expect(sqlText).to.include("'taxon',\n            'feature'");
     });
   });
 

--- a/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
@@ -305,8 +305,13 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
       expect(sqlText).to.include('MULTIPLE_VALUES_NOT_ALLOWED');
       expect(sqlText).to.include('TYPE_MISMATCH');
       expect(sqlText).to.include('UNSUPPORTED_PROPERTY_TYPE');
-      expect(sqlText).to.include("'artifact_key', 'feature')");
-      expect(sqlText).to.include("'taxon',\n            'feature'");
+      // `feature` must be in BOTH the string-type rule (single-line IN list) and the supported-type
+      // allowlist (multi-line NOT IN list). Normalise whitespace so the multi-line list can be
+      // reindented without breaking the assertion. `'artifact_key', 'feature')` is unique to the
+      // string rule; `'taxon', 'feature'` is unique to the allowlist.
+      const normalizedSql = sqlText.replace(/\s+/g, ' ');
+      expect(normalizedSql).to.include("'artifact_key', 'feature')");
+      expect(normalizedSql).to.include("'taxon', 'feature'");
     });
   });
 

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -1288,6 +1288,251 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   }
 
   /**
+   * Record malformed, unresolved, type-mismatched, or self-referencing feature property references.
+   *
+   * This phase writes four grouped error categories:
+   * - `INVALID_FEATURE_REFERENCE_FORMAT`: value does not match the expected `feature::<source_id>` shape
+   * - `UNRESOLVED_FEATURE_REFERENCE`: format is valid but no feature with that `source_id` exists in the upload
+   * - `INVALID_FEATURE_REFERENCE_TYPE`: the reference resolved, but the target feature's type is not allowed for this property
+   * - `INVALID_FEATURE_REFERENCE_SELF`: the reference resolved to the feature's own row
+   *
+   * The allowed target feature type is read from the property definition
+   * (`allowed_referenced_feature_type_id`) — the `feature::<id>` value itself carries no type — so a
+   * reference that resolves to a feature of any other type is rejected. An `allowed_referenced_feature_type_id`
+   * of NULL means the property authored no permitted target, so every reference is rejected (a feature-typed
+   * property with no authored target accepts nothing).
+   *
+   * A feature-valued property must not reference its own feature. A self-reference is recorded as
+   * `INVALID_FEATURE_REFERENCE_SELF` so the fail-fast gate blocks the entire upload, mirroring how a
+   * self-referencing `data.content` relationship is rejected. A self-reference is reported only once, as
+   * SELF: the type-mismatch branch carries a `referenced_submission_feature_id <> submission_feature_id`
+   * guard so it never also counts a self-reference as a TYPE error.
+   *
+   * Counts are aggregated and upserted into `submission_feature_error`.
+   *
+   * @param {string} submissionUploadId Upload scope.
+   * @returns {Promise<void>}
+   */
+  async recordFeaturePropertyResolutionErrorsBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+    const sql = SQL`
+      WITH format_errors AS (
+        SELECT
+          c.submission_upload_id,
+          c.property_name,
+          c.feature_type_property_id,
+          'INVALID_FEATURE_REFERENCE_FORMAT'::text AS error_code,
+          'Feature property value must match feature::<source_id>'::text AS error_message
+        FROM submission_upload_staging_feature_candidate c
+        WHERE c.submission_upload_id = ${submissionUploadId}::uuid
+          AND NOT c.is_format_valid
+      ),
+      unresolved AS (
+        SELECT
+          c.submission_upload_id,
+          c.property_name,
+          c.feature_type_property_id,
+          'UNRESOLVED_FEATURE_REFERENCE'::text AS error_code,
+          'Failed to resolve feature reference source_id within upload'::text AS error_message
+        FROM submission_upload_staging_feature_candidate c
+        WHERE c.submission_upload_id = ${submissionUploadId}::uuid
+          AND c.is_format_valid
+          AND c.referenced_submission_feature_id IS NULL
+      ),
+      type_mismatch AS (
+        SELECT
+          c.submission_upload_id,
+          c.property_name,
+          c.feature_type_property_id,
+          'INVALID_FEATURE_REFERENCE_TYPE'::text AS error_code,
+          'Referenced feature type is not allowed for this property'::text AS error_message
+        FROM submission_upload_staging_feature_candidate c
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = c.feature_type_property_id
+         AND ftp.record_end_date IS NULL
+        WHERE c.submission_upload_id = ${submissionUploadId}::uuid
+          AND c.is_format_valid
+          AND c.referenced_submission_feature_id IS NOT NULL
+          AND c.referenced_submission_feature_id <> c.submission_feature_id
+          AND (
+            ftp.allowed_referenced_feature_type_id IS NULL
+            OR c.referenced_feature_type_id <> ftp.allowed_referenced_feature_type_id
+          )
+      ),
+      self_reference AS (
+        SELECT
+          c.submission_upload_id,
+          c.property_name,
+          c.feature_type_property_id,
+          'INVALID_FEATURE_REFERENCE_SELF'::text AS error_code,
+          'Feature property cannot reference its own feature'::text AS error_message
+        FROM submission_upload_staging_feature_candidate c
+        WHERE c.submission_upload_id = ${submissionUploadId}::uuid
+          AND c.is_format_valid
+          AND c.referenced_submission_feature_id IS NOT NULL
+          AND c.referenced_submission_feature_id = c.submission_feature_id
+      ),
+      grouped_errors AS (
+        SELECT
+          aggregated.submission_upload_id,
+          aggregated.property_name,
+          aggregated.feature_type_property_id,
+          aggregated.error_code,
+          aggregated.error_message,
+          COUNT(*)::integer AS count
+        FROM (
+          SELECT * FROM format_errors
+          UNION ALL
+          SELECT * FROM unresolved
+          UNION ALL
+          SELECT * FROM type_mismatch
+          UNION ALL
+          SELECT * FROM self_reference
+        ) AS aggregated
+        GROUP BY
+          aggregated.submission_upload_id,
+          aggregated.property_name,
+          aggregated.feature_type_property_id,
+          aggregated.error_code,
+          aggregated.error_message
+      )
+      INSERT INTO submission_feature_error (
+        submission_upload_id,
+        property_name,
+        feature_type_property_id,
+        error_code,
+        error_message,
+        count,
+        details
+      )
+      SELECT
+        submission_upload_id,
+        property_name,
+        feature_type_property_id,
+        error_code,
+        error_message,
+        count,
+        NULL::jsonb
+      FROM grouped_errors
+      ON CONFLICT (
+        submission_upload_id,
+        error_code,
+        feature_type_property_id,
+        property_name
+      )
+      DO UPDATE SET
+        count = submission_feature_error.count + EXCLUDED.count,
+        error_message = EXCLUDED.error_message,
+        details = COALESCE(EXCLUDED.details, submission_feature_error.details);
+    `;
+
+    await this.connection.sql(sql);
+  }
+
+  /**
+   * Record feature property references that participate in a circular dependency.
+   *
+   * Feature-valued property references form a directed graph over features: an edge `a -> b` means
+   * feature `a` has a feature-valued property pointing at feature `b`. These references must not form a
+   * cycle of length two or more (`a -> b -> a`, directly or transitively); a cycle would corrupt
+   * downstream closure traversal, so every property whose reference participates in a cycle is recorded
+   * as `CIRCULAR_FEATURE_REFERENCE` and the fail-fast gate blocks the entire upload.
+   *
+   * Single-feature self-loops are handled separately by the self-reference rule and are excluded from
+   * the edge set here. The scope is the property-feature channel only; cycles routed through
+   * `data.content` relationships or parent/child edges are not considered.
+   *
+   * The recursive walk is bounded so it terminates and stays cheap: a simple-path guard
+   * (`NOT dst = ANY(path)`) prevents revisiting a node, and a depth cap stops runaway recursion on
+   * pathological graphs. The work is upload-scoped and runs off the HTTP request flow.
+   *
+   * Counts are aggregated and upserted into `submission_feature_error`.
+   *
+   * @param {string} submissionUploadId Upload scope.
+   * @returns {Promise<void>}
+   */
+  async recordCircularFeatureReferenceErrorsBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+    const sql = SQL`
+      WITH RECURSIVE edges AS (
+        SELECT
+          c.submission_feature_id AS src,
+          c.referenced_submission_feature_id AS dst
+        FROM submission_upload_staging_feature_candidate c
+        WHERE c.submission_upload_id = ${submissionUploadId}::uuid
+          AND c.is_format_valid
+          AND c.referenced_submission_feature_id IS NOT NULL
+          AND c.referenced_submission_feature_id <> c.submission_feature_id
+      ),
+      reachable AS (
+        SELECT e.src AS origin, e.dst AS node, ARRAY[e.src, e.dst] AS path, 1 AS depth
+        FROM edges e
+        UNION ALL
+        SELECT r.origin, e.dst, r.path || e.dst, r.depth + 1
+        FROM reachable r
+        JOIN edges e ON e.src = r.node
+        WHERE NOT e.dst = ANY(r.path)
+          AND r.depth < 50
+      ),
+      cyclic AS (
+        SELECT
+          c.submission_upload_id,
+          c.property_name,
+          c.feature_type_property_id
+        FROM submission_upload_staging_feature_candidate c
+        WHERE c.submission_upload_id = ${submissionUploadId}::uuid
+          AND c.is_format_valid
+          AND c.referenced_submission_feature_id IS NOT NULL
+          AND c.referenced_submission_feature_id <> c.submission_feature_id
+          AND EXISTS (
+            SELECT 1 FROM reachable r
+            WHERE r.origin = c.referenced_submission_feature_id
+              AND r.node = c.submission_feature_id
+          )
+      ),
+      grouped_errors AS (
+        SELECT
+          c.submission_upload_id,
+          c.property_name,
+          c.feature_type_property_id,
+          'CIRCULAR_FEATURE_REFERENCE'::text AS error_code,
+          'Feature property references form a circular dependency'::text AS error_message,
+          COUNT(*)::integer AS count
+        FROM cyclic c
+        GROUP BY c.submission_upload_id, c.property_name, c.feature_type_property_id
+      )
+      INSERT INTO submission_feature_error (
+        submission_upload_id,
+        property_name,
+        feature_type_property_id,
+        error_code,
+        error_message,
+        count,
+        details
+      )
+      SELECT
+        submission_upload_id,
+        property_name,
+        feature_type_property_id,
+        error_code,
+        error_message,
+        count,
+        NULL::jsonb
+      FROM grouped_errors
+      ON CONFLICT (
+        submission_upload_id,
+        error_code,
+        feature_type_property_id,
+        property_name
+      )
+      DO UPDATE SET
+        count = submission_feature_error.count + EXCLUDED.count,
+        error_message = EXCLUDED.error_message,
+        details = COALESCE(EXCLUDED.details, submission_feature_error.details);
+    `;
+
+    await this.connection.sql(sql);
+  }
+
+  /**
    * Record unresolved taxon TSN values for taxon properties.
    *
    * Candidate rows where parsed TSN did not resolve to `taxon_id` are grouped by
@@ -1726,6 +1971,58 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
       WHERE c.submission_upload_id = ${submissionUploadId}::uuid
         AND c.is_format_valid
         AND c.contributor_codeset_code_id IS NOT NULL;
+    `;
+
+    await this.connection.sql(sql);
+  }
+
+  /**
+   * Insert valid resolved feature references into `submission_feature_property_feature`.
+   *
+   * Inserts only candidate rows with valid format whose reference resolved to a target feature of the
+   * type allowed by the property definition (`allowed_referenced_feature_type_id`).
+   *
+   * Feature-valued *properties* land only in `submission_feature_property_feature`; `data.content`
+   * relationships land only in `submission_feature_feature`. These are two distinct channels and must
+   * never cross-write into each other's table.
+   *
+   * A multi-valued property may submit the same reference more than once; the unique constraint plus
+   * `ON CONFLICT DO NOTHING` keeps exactly one canonical row per `(source feature, property, referenced
+   * feature)` so downstream traversal does not double-count.
+   *
+   * Self-references are also rejected upstream with an error so the upload is blocked, but they remain
+   * excluded here (`referenced_submission_feature_id <> submission_feature_id`) as a hard guard so a
+   * self-loop — which would corrupt downstream closure traversal — can never be written.
+   *
+   * @param {string} submissionUploadId Upload scope.
+   * @returns {Promise<void>}
+   */
+  async insertFeaturePropertiesBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+    const sql = SQL`
+      INSERT INTO submission_feature_property_feature (
+        submission_feature_id,
+        feature_type_property_id,
+        referenced_submission_feature_id
+      )
+      SELECT
+        c.submission_feature_id,
+        c.feature_type_property_id,
+        c.referenced_submission_feature_id
+      FROM submission_upload_staging_feature_candidate c
+      JOIN feature_type_property ftp
+        ON ftp.feature_type_property_id = c.feature_type_property_id
+       AND ftp.record_end_date IS NULL
+      WHERE c.submission_upload_id = ${submissionUploadId}::uuid
+        AND c.is_format_valid
+        AND c.referenced_submission_feature_id IS NOT NULL
+        AND c.referenced_feature_type_id = ftp.allowed_referenced_feature_type_id
+        AND c.referenced_submission_feature_id <> c.submission_feature_id
+      ON CONFLICT (
+        submission_feature_id,
+        feature_type_property_id,
+        referenced_submission_feature_id
+      )
+      DO NOTHING;
     `;
 
     await this.connection.sql(sql);

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -104,6 +104,12 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
         USING upload_features uf
         WHERE sfptx.submission_feature_id = uf.submission_feature_id
         RETURNING 1
+      ),
+      delete_feature AS (
+        DELETE FROM submission_feature_property_feature sfpf
+        USING upload_features uf
+        WHERE sfpf.submission_feature_id = uf.submission_feature_id
+        RETURNING 1
       )
       SELECT 1;
     `;
@@ -406,6 +412,23 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   }
 
   /**
+   * Clear upload-scoped feature candidate rows.
+   *
+   * Feature candidates store parsed feature::<source_id> references and the
+   * within-upload features they resolved to.
+   *
+   * @param {string} submissionUploadId Upload scope.
+   * @returns {Promise<void>}
+   */
+  async clearFeatureCandidateStagingBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+    const sql = SQL`
+      DELETE FROM submission_upload_staging_feature_candidate
+      WHERE submission_upload_id = ${submissionUploadId}::uuid;
+    `;
+    await this.connection.sql(sql);
+  }
+
+  /**
    * Clear upload property working-set staging tables in one SQL round trip.
    *
    * Removes both:
@@ -437,8 +460,8 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   /**
    * Clear all complex-type candidate staging tables in one SQL round trip.
    *
-   * Removes upload-scoped rows from datetime, spatial, code, taxon, and artifact
-   * candidate tables so candidate generation phases can rerun idempotently.
+   * Removes upload-scoped rows from datetime, spatial, code, taxon, artifact, and
+   * feature candidate tables so candidate generation phases can rerun idempotently.
    *
    * @param {string} submissionUploadId Upload scope.
    * @returns {Promise<void>}
@@ -467,6 +490,11 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
       ),
       clear_artifact AS (
         DELETE FROM submission_upload_staging_artifact_candidate
+        WHERE submission_upload_id = ${submissionUploadId}::uuid
+        RETURNING 1
+      ),
+      clear_feature AS (
+        DELETE FROM submission_upload_staging_feature_candidate
         WHERE submission_upload_id = ${submissionUploadId}::uuid
         RETURNING 1
       )
@@ -869,6 +897,68 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   }
 
   /**
+   * Create `submission_upload_staging_feature_candidate` with parsed feature references and resolved targets.
+   *
+   * Expected format is a strict two-part reference `feature::<source_id>`. Source ids
+   * never contain `::`, so any other shape (`feature::`, `features::x`, `feature::a::b`)
+   * is malformed and rejected.
+   *
+   * Feature references resolve only against active features in the same upload, matching
+   * by `source_id`; cross-upload references are intentionally not resolved even though the
+   * foreign key permits them. The resolved target feature and its type are captured so later
+   * phases can validate the allowed target type and insert canonical rows.
+   *
+   * Rows remain in candidate staging even when unresolved so later phases can emit
+   * aggregated resolution errors.
+   *
+   * @param {string} submissionUploadId Upload scope.
+   * @returns {Promise<void>}
+   */
+  async populateFeatureCandidateStagingBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+    const sql = SQL`
+      INSERT INTO submission_upload_staging_feature_candidate (
+        submission_upload_id, submission_feature_id, property_name, feature_type_property_id,
+        raw_value, is_format_valid, parsed_source_id,
+        referenced_submission_feature_id, referenced_feature_type_id
+      )
+      WITH valid_property_values AS (
+        SELECT v.submission_upload_id, v.submission_feature_id, v.property_name,
+               v.feature_type_property_id, v.property_type_name, v.logical_value
+        FROM submission_upload_staging_typed_property_value v
+        WHERE v.submission_upload_id = ${submissionUploadId}::uuid
+      ),
+      candidates AS (
+        SELECT v.submission_upload_id, v.submission_feature_id, v.property_name,
+               v.feature_type_property_id,
+               v.logical_value AS raw_value,
+               regexp_split_to_array(btrim(v.logical_value #>> '{}'), '::') AS parts
+        FROM valid_property_values v
+        WHERE v.property_type_name = 'feature'
+          AND jsonb_typeof(v.logical_value) = 'string'
+      ),
+      parsed AS (
+        SELECT c.*,
+          (cardinality(c.parts) = 2 AND c.parts[1] = 'feature' AND btrim(c.parts[2]) <> '') AS is_format_valid,
+          CASE WHEN cardinality(c.parts) = 2 AND c.parts[1] = 'feature' AND btrim(c.parts[2]) <> ''
+               THEN btrim(c.parts[2]) ELSE NULL END AS parsed_source_id
+        FROM candidates c
+      )
+      SELECT
+        p.submission_upload_id, p.submission_feature_id, p.property_name, p.feature_type_property_id,
+        p.raw_value, p.is_format_valid, p.parsed_source_id,
+        target.submission_feature_id AS referenced_submission_feature_id,
+        target.feature_type_id        AS referenced_feature_type_id
+      FROM parsed p
+      LEFT JOIN submission_feature target
+        ON p.is_format_valid
+       AND target.submission_upload_id = ${submissionUploadId}::uuid
+       AND target.record_end_date IS NULL
+       AND target.source_id = p.parsed_source_id;
+    `;
+    await this.connection.sql(sql);
+  }
+
+  /**
    * Record missing required-property errors for features in an upload.
    *
    * Requiredness is evaluated by feature type against active metadata. A required property is
@@ -1006,7 +1096,7 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
           v.submission_upload_id = ${submissionUploadId}::uuid
           AND (
           (
-            v.property_type_name IN ('string', 'datetime', 'code', 'artifact_key')
+            v.property_type_name IN ('string', 'datetime', 'code', 'artifact_key', 'feature')
             AND jsonb_typeof(v.logical_value) <> 'string'
           )
           OR (
@@ -1048,7 +1138,8 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
             'spatial',
             'artifact_key',
             'code',
-            'taxon'
+            'taxon',
+            'feature'
           )
       ),
       grouped_errors AS (

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -1441,9 +1441,11 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
    * the edge set here. The scope is the property-feature channel only; cycles routed through
    * `data.content` relationships or parent/child edges are not considered.
    *
-   * The recursive walk is bounded so it terminates and stays cheap: a simple-path guard
-   * (`NOT dst = ANY(path)`) prevents revisiting a node, and a depth cap stops runaway recursion on
-   * pathological graphs. The work is upload-scoped and runs off the HTTP request flow.
+   * Detection computes transitive reachability over the edge set with a set-based recursive CTE
+   * (`UNION`, not `UNION ALL`): each step adds only new `(origin, node)` reachability pairs, so the
+   * working set is bounded by the number of distinct pairs (<= N^2) and the recursion terminates with
+   * no depth cap — cycles of any length are detected, not just short ones. An edge `a -> b` is part of
+   * a cycle when `b` can reach `a`. The work is upload-scoped and runs off the HTTP request flow.
    *
    * Counts are aggregated and upserted into `submission_feature_error`.
    *
@@ -1463,14 +1465,12 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
           AND c.referenced_submission_feature_id <> c.submission_feature_id
       ),
       reachable AS (
-        SELECT e.src AS origin, e.dst AS node, ARRAY[e.src, e.dst] AS path, 1 AS depth
+        SELECT e.src AS origin, e.dst AS node
         FROM edges e
-        UNION ALL
-        SELECT r.origin, e.dst, r.path || e.dst, r.depth + 1
+        UNION
+        SELECT r.origin, e.dst
         FROM reachable r
         JOIN edges e ON e.src = r.node
-        WHERE NOT e.dst = ANY(r.path)
-          AND r.depth < 50
       ),
       cyclic AS (
         SELECT
@@ -1994,6 +1994,11 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
    * excluded here (`referenced_submission_feature_id <> submission_feature_id`) as a hard guard so a
    * self-loop — which would corrupt downstream closure traversal — can never be written.
    *
+   * Resolution happens once at staging time; this insert runs later in the job. As a staleness guard
+   * it rejoins `submission_feature` for both endpoints with `record_end_date IS NULL`, so if a source
+   * or target feature is soft-deleted between staging and insert, no canonical row pointing at (or
+   * from) an inactive feature can land.
+   *
    * @param {string} submissionUploadId Upload scope.
    * @returns {Promise<void>}
    */
@@ -2012,6 +2017,12 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
       JOIN feature_type_property ftp
         ON ftp.feature_type_property_id = c.feature_type_property_id
        AND ftp.record_end_date IS NULL
+      JOIN submission_feature src
+        ON src.submission_feature_id = c.submission_feature_id
+       AND src.record_end_date IS NULL
+      JOIN submission_feature tgt
+        ON tgt.submission_feature_id = c.referenced_submission_feature_id
+       AND tgt.record_end_date IS NULL
       WHERE c.submission_upload_id = ${submissionUploadId}::uuid
         AND c.is_format_valid
         AND c.referenced_submission_feature_id IS NOT NULL

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -1296,11 +1296,11 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
    * - `INVALID_FEATURE_REFERENCE_TYPE`: the reference resolved, but the target feature's type is not allowed for this property
    * - `INVALID_FEATURE_REFERENCE_SELF`: the reference resolved to the feature's own row
    *
-   * The allowed target feature type is read from the property definition
-   * (`allowed_referenced_feature_type_id`) — the `feature::<id>` value itself carries no type — so a
-   * reference that resolves to a feature of any other type is rejected. An `allowed_referenced_feature_type_id`
-   * of NULL means the property authored no permitted target, so every reference is rejected (a feature-typed
-   * property with no authored target accepts nothing).
+   * The allowed target feature types are read from `feature_type_property_feature` — the
+   * `feature::<id>` value itself carries no type — so a reference that resolves to a feature whose
+   * type is not in the property's allowed-target set is rejected. A property with no active
+   * `feature_type_property_feature` rows has no permitted targets, so every reference is rejected
+   * (a feature-typed property with no authored targets accepts nothing).
    *
    * A feature-valued property must not reference its own feature. A self-reference is recorded as
    * `INVALID_FEATURE_REFERENCE_SELF` so the fail-fast gate blocks the entire upload, mirroring how a
@@ -1353,9 +1353,12 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
           AND c.is_format_valid
           AND c.referenced_submission_feature_id IS NOT NULL
           AND c.referenced_submission_feature_id <> c.submission_feature_id
-          AND (
-            ftp.allowed_referenced_feature_type_id IS NULL
-            OR c.referenced_feature_type_id <> ftp.allowed_referenced_feature_type_id
+          AND NOT EXISTS (
+            SELECT 1
+            FROM feature_type_property_feature ftpf
+            WHERE ftpf.feature_type_property_id = c.feature_type_property_id
+              AND ftpf.target_feature_type_id = c.referenced_feature_type_id
+              AND ftpf.record_end_date IS NULL
           )
       ),
       self_reference AS (
@@ -1979,8 +1982,8 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   /**
    * Insert valid resolved feature references into `submission_feature_property_feature`.
    *
-   * Inserts only candidate rows with valid format whose reference resolved to a target feature of the
-   * type allowed by the property definition (`allowed_referenced_feature_type_id`).
+   * Inserts only candidate rows with valid format whose reference resolved to a target feature
+   * whose type is in the property's allowed-target set (`feature_type_property_feature`).
    *
    * Feature-valued *properties* land only in `submission_feature_property_feature`; `data.content`
    * relationships land only in `submission_feature_feature`. These are two distinct channels and must
@@ -2026,8 +2029,14 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
       WHERE c.submission_upload_id = ${submissionUploadId}::uuid
         AND c.is_format_valid
         AND c.referenced_submission_feature_id IS NOT NULL
-        AND c.referenced_feature_type_id = ftp.allowed_referenced_feature_type_id
         AND c.referenced_submission_feature_id <> c.submission_feature_id
+        AND EXISTS (
+          SELECT 1
+          FROM feature_type_property_feature ftpf
+          WHERE ftpf.feature_type_property_id = c.feature_type_property_id
+            AND ftpf.target_feature_type_id = c.referenced_feature_type_id
+            AND ftpf.record_end_date IS NULL
+        )
       ON CONFLICT (
         submission_feature_id,
         feature_type_property_id,

--- a/api/src/services/ingestion/submission-feature-property-ingestion-service.ts
+++ b/api/src/services/ingestion/submission-feature-property-ingestion-service.ts
@@ -143,7 +143,7 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
       );
 
       // Phase 6: FK reference validation/resolution diagnostics.
-      currentPhase = 'record code, taxon, and artifact resolution errors';
+      currentPhase = 'record code, taxon, artifact, and feature resolution errors';
       defaultLog.debug({
         label: 'indexSubmissionPropertiesBySubmissionUploadId',
         message: 'phase start',
@@ -158,6 +158,12 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
         submissionUploadId
       );
       await this.submissionFeaturePropertyIngestionRepository.recordArtifactPropertyResolutionErrorsBySubmissionUploadId(
+        submissionUploadId
+      );
+      await this.submissionFeaturePropertyIngestionRepository.recordFeaturePropertyResolutionErrorsBySubmissionUploadId(
+        submissionUploadId
+      );
+      await this.submissionFeaturePropertyIngestionRepository.recordCircularFeatureReferenceErrorsBySubmissionUploadId(
         submissionUploadId
       );
 
@@ -275,6 +281,9 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
       await this.submissionFeaturePropertyIngestionRepository.insertCodePropertiesBySubmissionUploadId(
         submissionUploadId
       );
+      await this.submissionFeaturePropertyIngestionRepository.insertFeaturePropertiesBySubmissionUploadId(
+        submissionUploadId
+      );
       await this.submissionFeaturePropertyIngestionRepository.insertTaxonPropertiesBySubmissionUploadId(
         submissionUploadId
       );
@@ -389,6 +398,9 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
       submissionUploadId
     );
     await this.submissionFeaturePropertyIngestionRepository.populateArtifactCandidateStagingBySubmissionUploadId(
+      submissionUploadId
+    );
+    await this.submissionFeaturePropertyIngestionRepository.populateFeatureCandidateStagingBySubmissionUploadId(
       submissionUploadId
     );
   }

--- a/database/src/migrations/20260521000000_feature_property_indexing_engine.ts
+++ b/database/src/migrations/20260521000000_feature_property_indexing_engine.ts
@@ -75,7 +75,7 @@ export async function up(knex: Knex): Promise<void> {
     COMMENT ON COLUMN submission_upload_staging_feature_candidate.parsed_source_id IS
       'The <source_id> extracted from a well-formed reference; null when malformed.';
     COMMENT ON COLUMN submission_upload_staging_feature_candidate.referenced_submission_feature_id IS
-      'The within-upload feature the source_id resolved to; null when unresolved.';
+      'The within-upload feature the source_id resolved to; null when unresolved. Resolution is intentionally upload-scoped — cross-upload references are not resolved even though the canonical FK permits them.';
     COMMENT ON COLUMN submission_upload_staging_feature_candidate.referenced_feature_type_id IS
       'The resolved target feature type, used to validate against the property allowed target type.';
   `);

--- a/database/src/migrations/20260521000000_feature_property_indexing_engine.ts
+++ b/database/src/migrations/20260521000000_feature_property_indexing_engine.ts
@@ -1,0 +1,106 @@
+import type { Knex } from 'knex';
+
+/**
+ * Schema support for the feature-reference property indexing engine:
+ *
+ * 1. Adds `feature_type_property.allowed_referenced_feature_type_id` so feature-valued
+ *    properties declare the single feature type their `feature::<id>` references may resolve to.
+ * 2. Adds a uniqueness guarantee on the canonical `submission_feature_property_feature` table.
+ * 3. Adds the UNLOGGED upload-scoped `submission_upload_staging_feature_candidate` staging table
+ *    mirroring the sibling code/taxon candidate tables.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Allowed-target type for feature-valued properties.
+    --------------------------------------------------------------------------------
+    ALTER TABLE feature_type_property
+      ADD COLUMN allowed_referenced_feature_type_id integer;
+
+    ALTER TABLE feature_type_property
+      ADD CONSTRAINT feature_type_property_fk3
+      FOREIGN KEY (allowed_referenced_feature_type_id)
+      REFERENCES feature_type(feature_type_id);
+
+    COMMENT ON COLUMN feature_type_property.allowed_referenced_feature_type_id IS
+      'For feature-valued properties, the single feature type a reference is allowed to resolve to. The feature::<id> reference syntax carries no type, so the allowed target type is read from here. Null for non-feature properties.';
+
+    --------------------------------------------------------------------------------
+    -- Uniqueness on canonical feature-reference property values (table is empty).
+    --------------------------------------------------------------------------------
+    ALTER TABLE submission_feature_property_feature
+      ADD CONSTRAINT submission_feature_property_feature_uk1
+      UNIQUE (submission_feature_id, feature_type_property_id, referenced_submission_feature_id);
+
+    --------------------------------------------------------------------------------
+    -- UNLOGGED upload-scoped feature-reference candidate staging.
+    --------------------------------------------------------------------------------
+    CREATE UNLOGGED TABLE IF NOT EXISTS submission_upload_staging_feature_candidate (
+      submission_upload_id uuid NOT NULL,
+      submission_feature_id integer NOT NULL,
+      property_name text NOT NULL,
+      feature_type_property_id integer NOT NULL,
+      raw_value jsonb NOT NULL,
+      is_format_valid boolean NOT NULL,
+      parsed_source_id text,
+      referenced_submission_feature_id integer,
+      referenced_feature_type_id integer
+    );
+
+    CREATE INDEX IF NOT EXISTS sf_feature_candidate_work_idx1
+      ON submission_upload_staging_feature_candidate (submission_upload_id, is_format_valid);
+    CREATE INDEX IF NOT EXISTS sf_feature_candidate_work_idx2
+      ON submission_upload_staging_feature_candidate (submission_upload_id, feature_type_property_id);
+
+    COMMENT ON TABLE submission_upload_staging_feature_candidate IS
+      'UNLOGGED upload-scoped parsed feature-reference candidates and within-upload resolution outputs.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.submission_upload_id IS
+      'Upload scope this feature-reference candidate belongs to.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.submission_feature_id IS
+      'Source submission feature carrying the feature-valued property.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.property_name IS
+      'Property name as submitted, retained for error grouping.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.feature_type_property_id IS
+      'Resolved feature_type_property definition for the source feature type.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.raw_value IS
+      'Original jsonb property value before parsing.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.is_format_valid IS
+      'True when the value parsed as a strict feature::<source_id> reference.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.parsed_source_id IS
+      'The <source_id> extracted from a well-formed reference; null when malformed.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.referenced_submission_feature_id IS
+      'The within-upload feature the source_id resolved to; null when unresolved.';
+    COMMENT ON COLUMN submission_upload_staging_feature_candidate.referenced_feature_type_id IS
+      'The resolved target feature type, used to validate against the property allowed target type.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- Drop UNLOGGED feature-reference candidate staging.
+    --------------------------------------------------------------------------------
+    DROP TABLE IF EXISTS submission_upload_staging_feature_candidate;
+
+    --------------------------------------------------------------------------------
+    -- Drop uniqueness on canonical feature-reference property values.
+    --------------------------------------------------------------------------------
+    ALTER TABLE submission_feature_property_feature
+      DROP CONSTRAINT IF EXISTS submission_feature_property_feature_uk1;
+
+    --------------------------------------------------------------------------------
+    -- Drop allowed-target type for feature-valued properties.
+    --------------------------------------------------------------------------------
+    ALTER TABLE feature_type_property
+      DROP CONSTRAINT IF EXISTS feature_type_property_fk3,
+      DROP COLUMN IF EXISTS allowed_referenced_feature_type_id;
+  `);
+}

--- a/database/src/migrations/20260521000000_feature_property_indexing_engine.ts
+++ b/database/src/migrations/20260521000000_feature_property_indexing_engine.ts
@@ -3,8 +3,9 @@ import type { Knex } from 'knex';
 /**
  * Schema support for the feature-reference property indexing engine:
  *
- * 1. Adds `feature_type_property.allowed_referenced_feature_type_id` so feature-valued
- *    properties declare the single feature type their `feature::<id>` references may resolve to.
+ * 1. Adds the `feature_type_property_feature` join table so feature-valued properties may declare
+ *    one or more allowed target feature types. The `feature::<id>` reference syntax carries no
+ *    type, so the allowed targets are read from this table.
  * 2. Adds a uniqueness guarantee on the canonical `submission_feature_property_feature` table.
  * 3. Adds the UNLOGGED upload-scoped `submission_upload_staging_feature_candidate` staging table
  *    mirroring the sibling code/taxon candidate tables.
@@ -18,18 +19,53 @@ export async function up(knex: Knex): Promise<void> {
     SET SEARCH_PATH = biohub, public;
 
     --------------------------------------------------------------------------------
-    -- Allowed-target type for feature-valued properties.
+    -- Allowed target feature types for feature-valued properties.
     --------------------------------------------------------------------------------
-    ALTER TABLE feature_type_property
-      ADD COLUMN allowed_referenced_feature_type_id integer;
+    CREATE TABLE feature_type_property_feature (
+      feature_type_property_feature_id uuid DEFAULT gen_random_uuid() NOT NULL,
+      feature_type_property_id integer NOT NULL,
+      target_feature_type_id integer NOT NULL,
+      record_end_date timestamptz(6),
+      create_date timestamptz(6) DEFAULT now() NOT NULL,
+      create_user integer NOT NULL,
+      update_date timestamptz(6),
+      update_user integer,
+      revision_count integer DEFAULT 0 NOT NULL,
+      CONSTRAINT feature_type_property_feature_pk PRIMARY KEY (feature_type_property_feature_id),
+      CONSTRAINT feature_type_property_feature_fk1
+        FOREIGN KEY (feature_type_property_id) REFERENCES feature_type_property(feature_type_property_id),
+      CONSTRAINT feature_type_property_feature_fk2
+        FOREIGN KEY (target_feature_type_id) REFERENCES feature_type(feature_type_id)
+    );
 
-    ALTER TABLE feature_type_property
-      ADD CONSTRAINT feature_type_property_fk3
-      FOREIGN KEY (allowed_referenced_feature_type_id)
-      REFERENCES feature_type(feature_type_id);
+    -- Disallow duplicate (property, target) rows while a record is active.
+    CREATE UNIQUE INDEX feature_type_property_feature_nuk1
+      ON feature_type_property_feature(feature_type_property_id, target_feature_type_id)
+      WHERE record_end_date IS NULL;
+    CREATE INDEX feature_type_property_feature_idx1
+      ON feature_type_property_feature(feature_type_property_id)
+      WHERE record_end_date IS NULL;
+    CREATE INDEX feature_type_property_feature_idx2
+      ON feature_type_property_feature(target_feature_type_id)
+      WHERE record_end_date IS NULL;
 
-    COMMENT ON COLUMN feature_type_property.allowed_referenced_feature_type_id IS
-      'For feature-valued properties, the single feature type a reference is allowed to resolve to. The feature::<id> reference syntax carries no type, so the allowed target type is read from here. Null for non-feature properties.';
+    COMMENT ON TABLE  feature_type_property_feature IS 'For a feature-valued feature_type_property, the set of feature types a feature::<id> reference is allowed to resolve to. A property with no active rows here permits no targets.';
+    COMMENT ON COLUMN feature_type_property_feature.feature_type_property_feature_id IS 'System generated surrogate primary key identifier.';
+    COMMENT ON COLUMN feature_type_property_feature.feature_type_property_id IS 'Foreign key to the feature_type_property table — the feature-valued property whose allowed target type is being declared.';
+    COMMENT ON COLUMN feature_type_property_feature.target_feature_type_id IS 'Foreign key to the feature_type table — a feature type that a feature::<id> reference is allowed to resolve to.';
+    COMMENT ON COLUMN feature_type_property_feature.record_end_date IS 'Date/time when this allowed-target association was ended (soft delete).';
+    COMMENT ON COLUMN feature_type_property_feature.create_date IS 'The datetime the record was created.';
+    COMMENT ON COLUMN feature_type_property_feature.create_user IS 'The id of the user who created the record.';
+    COMMENT ON COLUMN feature_type_property_feature.update_date IS 'The datetime the record was last updated.';
+    COMMENT ON COLUMN feature_type_property_feature.update_user IS 'The id of the user who last updated the record.';
+    COMMENT ON COLUMN feature_type_property_feature.revision_count IS 'Revision count used for concurrency control.';
+
+    CREATE TRIGGER audit_feature_type_property_feature
+      BEFORE INSERT OR UPDATE OR DELETE ON feature_type_property_feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_audit_trigger();
+    CREATE TRIGGER journal_feature_type_property_feature
+      AFTER INSERT OR UPDATE OR DELETE ON feature_type_property_feature
+      FOR EACH ROW EXECUTE PROCEDURE biohub.tr_journal_trigger();
 
     --------------------------------------------------------------------------------
     -- Uniqueness on canonical feature-reference property values (table is empty).
@@ -77,7 +113,7 @@ export async function up(knex: Knex): Promise<void> {
     COMMENT ON COLUMN submission_upload_staging_feature_candidate.referenced_submission_feature_id IS
       'The within-upload feature the source_id resolved to; null when unresolved. Resolution is intentionally upload-scoped — cross-upload references are not resolved even though the canonical FK permits them.';
     COMMENT ON COLUMN submission_upload_staging_feature_candidate.referenced_feature_type_id IS
-      'The resolved target feature type, used to validate against the property allowed target type.';
+      'The resolved target feature type, used to validate against the property allowed target types.';
   `);
 }
 
@@ -97,10 +133,8 @@ export async function down(knex: Knex): Promise<void> {
       DROP CONSTRAINT IF EXISTS submission_feature_property_feature_uk1;
 
     --------------------------------------------------------------------------------
-    -- Drop allowed-target type for feature-valued properties.
+    -- Drop allowed-target feature type join table.
     --------------------------------------------------------------------------------
-    ALTER TABLE feature_type_property
-      DROP CONSTRAINT IF EXISTS feature_type_property_fk3,
-      DROP COLUMN IF EXISTS allowed_referenced_feature_type_id;
+    DROP TABLE IF EXISTS feature_type_property_feature;
   `);
 }


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-1015](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1015)[SIMSBIOHUB-1015](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1015)

As a system administrator, I want the property indexing job to resolve feature-backed properties into `submission_feature_property_feature`, so that feature references become canonical typed property rows.

Background

The previous ticket added:

the `feature` property type;
the `submission_feature_property_feature` table;
support for storing submitted feature-backed property values in `submission_feature.data`.

This ticket updates the property indexing job.

Feature-backed properties use this submitted syntax:

feature::<id>


Where `<id>` is the submitted feature id / `source_id` of another active feature in the same upload.

Example submitted property:

"sampling_site": "feature::site-1"


During indexing, this value should resolve to the internal `submission_feature_id` for the feature with:

source_id = 'site-1'


The resolved value should be inserted into:

submission_feature_property_feature.referenced_submission_feature_id

Scope

This ticket includes:

Add feature-reference candidate staging.
Parse `feature::<id>` values from staged typed property values.
Resolve parsed ids against active features in the same upload.
Record grouped feature-reference indexing errors.
Insert valid resolved rows into `submission_feature_property_feature`.
Include `submission_feature_property_feature` in upload-scoped property cleanup/reindexing.

This ticket does not include:

Search changes.
Closure table generation.
Download expansion.
Expanding feature-backed properties into `submission_feature_feature`.
Changing `data.content` relationship behaviour.
Acceptance Criteria

1. Clear Feature Reference Candidate Staging

WHEN the property indexing job starts or reruns for an upload
THEN upload-scoped feature-reference candidate rows should be cleared
AND rerunning the indexing job should be idempotent

2. Delete Existing Feature Property Rows on Reindex

WHEN `deletePropertyRecordsBySubmissionUploadId` runs for an upload
THEN existing `submission_feature_property_feature` rows for active features in that upload should be deleted
AND the indexing job should be able to reinsert the current resolved values

3. Stage Feature Reference Candidates

WHEN `submission_upload_staging_typed_property_value` contains a row with `property_type_name = 'feature'`
AND the logical value is a JSON string
THEN the indexing job should stage the value as a feature-reference candidate
AND the candidate should retain:
`submission_upload_id`
`submission_feature_id`
`property_name`
`feature_type_property_id`
raw value
parsed target source id, when valid
format validity flag

4. Parse Feature Reference Syntax

WHEN a feature-valued property value matches `feature::<id>`
THEN the candidate should be marked as format-valid
AND the parsed target source id should be the value after `feature::`

Example:

feature::site-1


parses to:

site-1


5. Record Invalid Feature Reference Format

WHEN a feature-valued property value does not match `feature::<id>`
THEN the indexing job should record `INVALID_FEATURE_REFERENCE_FORMAT`
AND the error should be grouped by `submission_upload_id`, `property_name`, and `feature_type_property_id`
AND no canonical row should be inserted for that candidate

Invalid examples:

site-1
feature:
feature::
features::site-1
code::sites::site-1


6. Resolve Feature Reference Within the Same Upload

WHEN a feature-reference candidate has valid syntax
THEN the indexing job should resolve the parsed target source id against active features in the same `submission_upload_id`

Resolution rule:

target.submission_upload_id = :submissionUploadId
target.record_end_date IS NULL
target.source_id = parsed_feature_source_id

WHEN the parsed target source id matches an active feature in the same upload
THEN the candidate should store the resolved target `submission_feature_id`

7. Record Unresolved Feature Reference

WHEN a feature-reference candidate has valid syntax
AND no active feature in the same upload has the parsed target source id
THEN the indexing job should record `UNRESOLVED_FEATURE_REFERENCE`
AND no canonical row should be inserted for that candidate

8. Validate Referenced Feature Type

WHEN a feature-reference candidate resolves to a target feature
THEN the indexing job should validate that the target feature type is allowed for the configured `feature_type_property_id`

Example valid case:

observation.sampling_site expects sampling_site
feature::site-1 resolves to sampling_site


Example invalid case:

observation.sampling_site expects sampling_site
feature::animal-1 resolves to individual

WHEN the resolved target feature type is not allowed
THEN the indexing job should record `INVALID_FEATURE_REFERENCE_TYPE`
AND no canonical row should be inserted for that candidate

9. Insert Valid Feature-Valued Properties

WHEN a feature-reference candidate has valid syntax
AND the referenced feature resolves within the same upload
AND the referenced feature type is allowed for the property
THEN the indexing job should insert a row into `submission_feature_property_feature`
AND `submission_feature_id` should be the source feature
AND `feature_type_property_id` should be the configured property assignment
AND `referenced_submission_feature_id` should be the resolved target feature

10. Support Multiple Feature References

WHEN a feature-valued property allows multiple values
AND the submitted property value is an array of valid `feature::<id>` strings
THEN typed property value staging should expand the array
AND each valid reference should be resolved independently
AND each valid reference should create one row in `submission_feature_property_feature`

11. Respect Single-Value Cardinality

WHEN a feature-valued property does not allow multiple values
AND the submitted property value is an array
THEN indexing should record `MULTIPLE_VALUES_NOT_ALLOWED`
AND no canonical feature-property rows should be inserted for that property value

12. Update Primitive Validation Type List

WHEN primitive validation checks supported property types
THEN `feature` should be included as a supported property type
AND feature-valued properties should require JSON string values before candidate resolution

13. Keep Content Relationships Separate

WHEN a feature has references in `data.content`
THEN the indexing job should continue inserting those relationships into `submission_feature_feature`
WHEN a feature has a feature-valued property in `data.properties`
THEN the indexing job should insert the resolved property value into `submission_feature_property_feature`
AND this ticket should not insert feature-valued property references into `submission_feature_feature`

14. Expose Aggregated Error Counts

WHEN feature-reference indexing errors are recorded
THEN existing ingestion error summary/count methods should include:
`INVALID_FEATURE_REFERENCE_FORMAT`
`UNRESOLVED_FEATURE_REFERENCE`
`INVALID_FEATURE_REFERENCE_TYPE`
Implementation Notes

Add feature-reference indexing methods to `SubmissionFeaturePropertyIngestionRepository`.

Expected new methods may include:

clearFeatureCandidateStagingBySubmissionUploadId
populateFeatureCandidateStagingBySubmissionUploadId
recordFeaturePropertyResolutionErrorsBySubmissionUploadId
insertFeaturePropertiesBySubmissionUploadId


Update existing indexing/reset paths as needed:

deletePropertyRecordsBySubmissionUploadId
recordPrimitiveValidationErrorsBySubmissionUploadId
clearComplexPropertyCandidateStagingBySubmissionUploadId


The canonical insert should only insert candidates that:

have valid feature::<id> syntax
resolve to an active target feature in the same upload
pass allowed target feature type validation

Out of Scope / Direction

`submission_feature_feature` remains scoped to `data.content` references.

A later ticket should add `submission_feature_closure`.

That closure table can expand relationships from:

parent relationships
content relationships from submission_feature_feature
feature-valued property relationships from submission_feature_property_feature

The closure layer will support traversal, search projection, and download expansion.


## Testing Notes

**Backend only — no UI, no API route, no production behavior change.**

```bash
make test       # unit (both layers)
make test-db    # ← the one that matters: proves the feature:: engine end-to-end
make test-sys   # broader ingestion regression (slower; skip if test-db is green)
```

`make test-db` is the verification — the `*-feature*` suites prove the engine against synthetic fixtures. No manual app driving needed.
