### PR TITLE
SIMSBIOHUB-1012: API access to parquet downloads

### DIFF
--- a/api/src/constants/download.ts
+++ b/api/src/constants/download.ts
@@ -3,6 +3,12 @@ import { getNumberEnv } from '../utils/env-utils';
 export const SIGNED_URL_EXPIRY_DOWNLOAD = 432000; // 5 days
 
 /**
+ * Presigned URL expiry for the API-key presigned-URL endpoint (30 minutes).
+ * Short-lived by design — scripts should re-request a fresh URL per download attempt.
+ */
+export const SIGNED_URL_EXPIRY_PARQUET_DOWNLOAD = 60 * 30; // 30 minutes
+
+/**
  * Default `download_export.max_part_size_bytes` (500 MB). Applied by the service
  * when a client omits `max_part_size_bytes` on export creation.
  */

--- a/api/src/models/download.ts
+++ b/api/src/models/download.ts
@@ -147,6 +147,21 @@ export const DownloadArtifactInfo = z.object({
 export type DownloadArtifactInfo = z.infer<typeof DownloadArtifactInfo>;
 
 /**
+ * A single entry in the presigned-URL endpoint's `parts[]` response.
+ *
+ * - `feature_type` — feature type name for the Parquet file, parsed from the S3
+ *   object key shape `downloads/{downloadId}/{featureTypeName}/data.parquet`.
+ * - `url` — presigned S3 URL minted at request time; clients must not cache it.
+ * - `expires_at` — ISO timestamp when the URL expires (30 minutes from request time).
+ */
+export const DownloadParquetPart = z.object({
+  feature_type: z.string(),
+  url: z.string(),
+  expires_at: z.string()
+});
+export type DownloadParquetPart = z.infer<typeof DownloadParquetPart>;
+
+/**
  * Row shape for the Parquet download pipeline.
  *
  * Mirrors DownloadFeatureData but uses `parent_uuid` instead of full parent denormalization.

--- a/api/src/openapi/schemas/download.ts
+++ b/api/src/openapi/schemas/download.ts
@@ -1,0 +1,50 @@
+import { OpenAPIV3 } from 'openapi-types';
+
+/**
+ * A single Parquet artifact entry in the presigned-URL endpoint's `parts[]` array.
+ */
+export const DownloadPresignedUrlPartSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: ['feature_type', 'url', 'expires_at'],
+  additionalProperties: false,
+  properties: {
+    feature_type: {
+      type: 'string',
+      description: 'Feature type name for the Parquet file (parsed from the S3 object key).'
+    },
+    url: {
+      type: 'string',
+      format: 'uri',
+      description: 'Presigned S3 URL for the Parquet artifact. Regenerated per request — do not cache.'
+    },
+    expires_at: {
+      type: 'string',
+      format: 'date-time',
+      description: 'ISO timestamp when the presigned URL expires (30 minutes from request time).'
+    }
+  }
+};
+
+/**
+ * Response schema for `GET /api/download/{downloadId}/presigned-url`.
+ *
+ * Returns one presigned URL per Parquet feature type when the download status
+ * is `ready` or `downloaded`.
+ */
+export const DownloadPresignedUrlResponseSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  required: ['download_id', 'status', 'parts'],
+  additionalProperties: false,
+  properties: {
+    download_id: { type: 'string', format: 'uuid' },
+    status: {
+      type: 'string',
+      enum: ['ready', 'downloaded'],
+      description: 'Current download status. Only `ready` and `downloaded` downloads return presigned URLs.'
+    },
+    parts: {
+      type: 'array',
+      items: DownloadPresignedUrlPartSchema
+    }
+  }
+};

--- a/api/src/paths/download/index.ts
+++ b/api/src/paths/download/index.ts
@@ -141,6 +141,8 @@ GET.apiDoc = {
  * download_id (UUID), not through this listing endpoint. Without a user identity there
  * is no way to scope "my downloads", so allowing unauthenticated access would return
  * every anonymous download in the system.
+ *
+ * @returns {RequestHandler}
  */
 export function getDownloads(): RequestHandler {
   return async (req, res) => {

--- a/api/src/paths/download/{downloadId}/presigned-url/index.test.ts
+++ b/api/src/paths/download/{downloadId}/presigned-url/index.test.ts
@@ -1,0 +1,189 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getDownloadPresignedUrl } from '.';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
+import * as db from '../../../../database/db';
+import { HTTP403, HTTP404, HTTP409 } from '../../../../errors/http-error';
+import { DownloadRecord } from '../../../../models/download';
+import { DownloadStatusEnum } from '../../../../models/download-status';
+import { DownloadService } from '../../../../services/download/download-service';
+
+chai.use(sinonChai);
+
+const makeDownloadRecord = (overrides: Partial<DownloadRecord> = {}): DownloadRecord => ({
+  download_id: 'aaaa0000-0000-0000-0000-000000000001',
+  download_version_id: 'dddd0000-0000-0000-0000-000000000002',
+  download_status: DownloadStatusEnum.READY,
+  format: 'parquet',
+  metadata: null,
+  started_at: '2026-01-01T00:00:00Z',
+  completed_at: '2026-01-01T00:01:00Z',
+  downloaded_at: null,
+  create_date: '2026-01-01T00:00:00Z',
+  ...overrides
+});
+
+const makeParts = () => [
+  {
+    feature_type: 'Animal',
+    url: 'https://s3.example.com/downloads/dl-1/Animal/data.parquet?sig=x',
+    expires_at: '2026-01-01T00:30:00Z'
+  }
+];
+
+describe('paths/download/{downloadId}/presigned-url', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getDownloadPresignedUrl', () => {
+    it('returns 200 with parts for a READY download', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon.stub(DownloadService.prototype, 'getAuthorizedDownload').resolves(makeDownloadRecord());
+      sinon.stub(DownloadService.prototype, 'listDownloadParquetUrls').resolves(makeParts());
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.keycloak_token = 'token';
+      mockReq.params = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
+
+      const handler = getDownloadPresignedUrl();
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.statusValue).to.equal(200);
+      expect(mockRes.jsonValue).to.deep.equal({
+        download_id: 'aaaa0000-0000-0000-0000-000000000001',
+        status: DownloadStatusEnum.READY,
+        parts: makeParts()
+      });
+    });
+
+    it('returns 200 with parts for a DOWNLOADED download', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon
+        .stub(DownloadService.prototype, 'getAuthorizedDownload')
+        .resolves(makeDownloadRecord({ download_status: DownloadStatusEnum.DOWNLOADED }));
+      sinon.stub(DownloadService.prototype, 'listDownloadParquetUrls').resolves(makeParts());
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.keycloak_token = 'token';
+      mockReq.params = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
+
+      const handler = getDownloadPresignedUrl();
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.statusValue).to.equal(200);
+    });
+
+    it('throws HTTP409 when download status is PENDING', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon
+        .stub(DownloadService.prototype, 'getAuthorizedDownload')
+        .resolves(makeDownloadRecord({ download_status: DownloadStatusEnum.PENDING }));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.keycloak_token = 'token';
+      mockReq.params = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
+
+      const handler = getDownloadPresignedUrl();
+
+      try {
+        await handler(mockReq, mockRes, mockNext);
+        expect.fail('Expected HTTP409 to be thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP409);
+      }
+    });
+
+    it('throws HTTP409 when download status is PROCESSING', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon
+        .stub(DownloadService.prototype, 'getAuthorizedDownload')
+        .resolves(makeDownloadRecord({ download_status: DownloadStatusEnum.PROCESSING }));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.keycloak_token = 'token';
+      mockReq.params = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
+
+      const handler = getDownloadPresignedUrl();
+
+      try {
+        await handler(mockReq, mockRes, mockNext);
+        expect.fail('Expected HTTP409 to be thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP409);
+      }
+    });
+
+    it('throws HTTP409 when download status is FAILED', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon
+        .stub(DownloadService.prototype, 'getAuthorizedDownload')
+        .resolves(makeDownloadRecord({ download_status: DownloadStatusEnum.FAILED }));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.keycloak_token = 'token';
+      mockReq.params = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
+
+      const handler = getDownloadPresignedUrl();
+
+      try {
+        await handler(mockReq, mockRes, mockNext);
+        expect.fail('Expected HTTP409 to be thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP409);
+      }
+    });
+
+    it('propagates HTTP403 from getAuthorizedDownload when user is not a team member', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon.stub(DownloadService.prototype, 'getAuthorizedDownload').rejects(new HTTP403('Access denied'));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.keycloak_token = 'token';
+      mockReq.params = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
+
+      const handler = getDownloadPresignedUrl();
+
+      try {
+        await handler(mockReq, mockRes, mockNext);
+        expect.fail('Expected HTTP403 to be thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP403);
+      }
+    });
+
+    it('propagates HTTP404 from getAuthorizedDownload when download is missing', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon.stub(DownloadService.prototype, 'getAuthorizedDownload').rejects(new HTTP404('Download not found'));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.keycloak_token = 'token';
+      mockReq.params = { downloadId: 'aaaa0000-0000-0000-0000-000000000001' };
+
+      const handler = getDownloadPresignedUrl();
+
+      try {
+        await handler(mockReq, mockRes, mockNext);
+        expect.fail('Expected HTTP404 to be thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP404);
+      }
+    });
+  });
+});

--- a/api/src/paths/download/{downloadId}/presigned-url/index.ts
+++ b/api/src/paths/download/{downloadId}/presigned-url/index.ts
@@ -1,0 +1,97 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { getDBConnection } from '../../../../database/db';
+import { HTTP409 } from '../../../../errors/http-error';
+import { DownloadStatusEnum } from '../../../../models/download-status';
+import { DownloadPresignedUrlResponseSchema } from '../../../../openapi/schemas/download';
+import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
+import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
+import { DownloadService } from '../../../../services/download/download-service';
+import { getLogger } from '../../../../utils/logger';
+
+const defaultLog = getLogger('paths/download/{downloadId}/presigned-url');
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({ and: [{ discriminator: 'SystemUser' }] })),
+  getDownloadPresignedUrl()
+];
+
+GET.apiDoc = {
+  description:
+    'Generate presigned S3 URLs for the Parquet artifacts of a completed download. Authenticated via an API key. URLs expire after 30 minutes.',
+  tags: ['download'],
+  security: [{ ApiKey: [] }],
+  parameters: [
+    {
+      in: 'path',
+      name: 'downloadId',
+      required: true,
+      schema: { type: 'string', format: 'uuid' },
+      description: 'UUID of the download to fetch presigned URLs for.'
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Presigned URLs for all Parquet artifacts of the download.',
+      content: {
+        'application/json': {
+          schema: DownloadPresignedUrlResponseSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Generate presigned S3 URLs for the Parquet artifacts of a download.
+ *
+ * Enforces the same team-membership authorization used by JWT download routes
+ * via `DownloadService.getAuthorizedDownload`. The API key only authenticates
+ * the caller — it does not bypass normal access control.
+ *
+ * Only `ready` and `downloaded` downloads may return URLs; any other status
+ * produces a 409 Conflict so scripts can distinguish "not ready yet" from
+ * access errors.
+ *
+ * @returns {RequestHandler}
+ */
+export function getDownloadPresignedUrl(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+
+    try {
+      await connection.open();
+
+      const systemUserId = connection.systemUserId();
+      const { downloadId } = req.params;
+
+      const downloadService = new DownloadService(connection);
+
+      const download = await downloadService.getAuthorizedDownload(downloadId, systemUserId);
+
+      const readyStatuses: string[] = [DownloadStatusEnum.READY, DownloadStatusEnum.DOWNLOADED];
+      if (!readyStatuses.includes(download.download_status)) {
+        throw new HTTP409(
+          'Download is not ready — presigned URLs are only available for ready or downloaded downloads'
+        );
+      }
+
+      const parts = await downloadService.listDownloadParquetUrls(downloadId, download.download_version_id);
+
+      await connection.commit();
+
+      return res.status(200).json({
+        download_id: download.download_id,
+        status: download.download_status,
+        parts
+      });
+    } catch (error) {
+      defaultLog.error({ label: 'getDownloadPresignedUrl', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/services/download/download-service.test.ts
+++ b/api/src/services/download/download-service.test.ts
@@ -16,6 +16,7 @@ import { DownloadVersionExportRepository } from '../../repositories/download/dow
 import { DownloadVersionRepository } from '../../repositories/download/download-version-repository';
 import { TeamService } from '../access-policy/team-service';
 import { ExpressionTreeService } from '../expression-tree-service';
+import { ObjectStorageService } from '../object-storage/object-storage-service';
 import { DownloadPolicyService } from './download-policy-service';
 import { DownloadService, groupExportsByDownloadId } from './download-service';
 
@@ -641,6 +642,102 @@ describe('DownloadService', () => {
       } catch (error) {
         expect(error).to.be.instanceOf(HTTP409);
       }
+    });
+  });
+
+  describe('listDownloadParquetUrls', () => {
+    const DOWNLOAD_ID = 'dl-1';
+    const VERSION_ID = 'ver-1';
+
+    it('returns feature_type, url, and expires_at per Parquet artifact', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadService(mockDBConnection);
+
+      const artifacts = [
+        {
+          artifact_id: 'art-1',
+          object_key: `downloads/${DOWNLOAD_ID}/versions/${VERSION_ID}/Animal/data.parquet`
+        },
+        {
+          artifact_id: 'art-2',
+          object_key: `downloads/${DOWNLOAD_ID}/versions/${VERSION_ID}/Observation/data.parquet`
+        }
+      ];
+
+      sinon
+        .stub(DownloadVersionRepository.prototype, 'listDownloadVersionArtifactsByDownloadVersionId')
+        .resolves(artifacts);
+      const signedUrlStub = sinon
+        .stub(ObjectStorageService.prototype, 'getSignedUrl')
+        .callsFake(async (_bucket, key) => `https://s3.example.com/${key}?sig=x`);
+
+      const result = await service.listDownloadParquetUrls(DOWNLOAD_ID, VERSION_ID);
+
+      expect(signedUrlStub).to.have.been.calledTwice;
+      expect(result).to.have.length(2);
+      expect(result[0].feature_type).to.equal('Animal');
+      expect(result[0].url).to.equal(
+        `https://s3.example.com/downloads/${DOWNLOAD_ID}/versions/${VERSION_ID}/Animal/data.parquet?sig=x`
+      );
+      expect(result[0].expires_at).to.be.a('string');
+      expect(result[1].feature_type).to.equal('Observation');
+    });
+
+    it('passes 1800 seconds as the expiry to getSignedUrl', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadService(mockDBConnection);
+
+      sinon.stub(DownloadVersionRepository.prototype, 'listDownloadVersionArtifactsByDownloadVersionId').resolves([
+        {
+          artifact_id: 'art-1',
+          object_key: `downloads/${DOWNLOAD_ID}/versions/${VERSION_ID}/Animal/data.parquet`
+        }
+      ]);
+
+      const signedUrlStub = sinon
+        .stub(ObjectStorageService.prototype, 'getSignedUrl')
+        .resolves('https://s3.example.com/signed');
+
+      await service.listDownloadParquetUrls(DOWNLOAD_ID, VERSION_ID);
+
+      expect(signedUrlStub.firstCall.args[2]).to.equal(1800);
+    });
+
+    it('filters out artifacts whose key does not match the Parquet shape', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadService(mockDBConnection);
+
+      const artifacts = [
+        {
+          artifact_id: 'art-1',
+          object_key: `downloads/${DOWNLOAD_ID}/versions/${VERSION_ID}/Animal/data.parquet`
+        },
+        {
+          artifact_id: 'art-zip',
+          object_key: `downloads/${DOWNLOAD_ID}/versions/${VERSION_ID}/exports/exp-1/biohub-exp-1-part-1.zip`
+        }
+      ];
+
+      sinon
+        .stub(DownloadVersionRepository.prototype, 'listDownloadVersionArtifactsByDownloadVersionId')
+        .resolves(artifacts);
+      sinon.stub(ObjectStorageService.prototype, 'getSignedUrl').resolves('https://s3.example.com/signed');
+
+      const result = await service.listDownloadParquetUrls(DOWNLOAD_ID, VERSION_ID);
+
+      expect(result).to.have.length(1);
+      expect(result[0].feature_type).to.equal('Animal');
+    });
+
+    it('returns an empty array when the download has no artifacts', async () => {
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadService(mockDBConnection);
+
+      sinon.stub(DownloadVersionRepository.prototype, 'listDownloadVersionArtifactsByDownloadVersionId').resolves([]);
+
+      const result = await service.listDownloadParquetUrls(DOWNLOAD_ID, VERSION_ID);
+
+      expect(result).to.deep.equal([]);
     });
   });
 });

--- a/api/src/services/download/download-service.ts
+++ b/api/src/services/download/download-service.ts
@@ -1,6 +1,13 @@
+import { SIGNED_URL_EXPIRY_PARQUET_DOWNLOAD } from '../../constants/download';
 import { IDBConnection } from '../../database/db';
 import { HTTP403, HTTP404, HTTP409 } from '../../errors/http-error';
-import { CreateDownload, DownloadDetailRecord, DownloadId, DownloadListRecord } from '../../models/download';
+import {
+  CreateDownload,
+  DownloadDetailRecord,
+  DownloadId,
+  DownloadListRecord,
+  DownloadParquetPart
+} from '../../models/download';
 import { DownloadVersionRecord } from '../../models/download-version';
 import { DownloadVersionExportListRow } from '../../models/download-version-export';
 import { ExpressionTree } from '../../models/expression-tree';
@@ -8,10 +15,12 @@ import { publishProcessDownloadJob } from '../../queue/publisher';
 import { DownloadRepository } from '../../repositories/download/download-repository';
 import { DownloadVersionExportRepository } from '../../repositories/download/download-version-export-repository';
 import { DownloadVersionRepository } from '../../repositories/download/download-version-repository';
+import { parseFeatureTypeFromParquetKey } from '../../utils/export-utils';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { TeamService } from '../access-policy/team-service';
 import { DBService } from '../db-service';
 import { ExpressionTreeService } from '../expression-tree-service';
+import { BucketType, ObjectStorageService } from '../object-storage/object-storage-service';
 import { DownloadPolicyService } from './download-policy-service';
 
 export interface CreateDownloadRequestPayload {
@@ -333,6 +342,51 @@ export class DownloadService extends DBService {
       system_user_ids: [systemUserId]
     });
     await this.downloadRepository.createDownloadTeam(downloadId, team.team_id);
+  }
+
+  /**
+   * Build the presigned-URL list for a Parquet download.
+   *
+   * Returns one entry per Parquet artifact — typically one per feature type
+   * (e.g. Animal, Observation). The `feature_type` is parsed from the S3 key
+   * shape `downloads/{downloadId}/versions/{downloadVersionId}/{featureTypeName}/data.parquet`.
+   * Artifacts that do not match this shape (e.g. export zips) are filtered out.
+   *
+   * URLs expire after 30 minutes and should not be cached.
+   *
+   * Does not enforce authorization — callers must first call `getAuthorizedDownload`
+   * to confirm access before calling this method.
+   *
+   * @param {string} downloadId - The download ID.
+   * @param {string} downloadVersionId - The version whose Parquet artifacts to sign.
+   * @return {Promise<DownloadParquetPart[]>}
+   * @memberof DownloadService
+   */
+  async listDownloadParquetUrls(downloadId: string, downloadVersionId: string): Promise<DownloadParquetPart[]> {
+    const artifacts = await this.downloadVersionRepository.listDownloadVersionArtifactsByDownloadVersionId(
+      downloadVersionId
+    );
+    const objectStorageService = new ObjectStorageService();
+
+    const parts: DownloadParquetPart[] = [];
+
+    for (const artifact of artifacts) {
+      const featureType = parseFeatureTypeFromParquetKey(artifact.object_key, downloadId, downloadVersionId);
+      if (featureType === null) {
+        continue;
+      }
+
+      const expiresAt = new Date(Date.now() + SIGNED_URL_EXPIRY_PARQUET_DOWNLOAD * 1000).toISOString();
+      const url = await objectStorageService.getSignedUrl(
+        BucketType.MAIN,
+        artifact.object_key,
+        SIGNED_URL_EXPIRY_PARQUET_DOWNLOAD
+      );
+
+      parts.push({ feature_type: featureType, url, expires_at: expiresAt });
+    }
+
+    return parts;
   }
 
   /**


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1012](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1012)

## Description of Changes

Adds a presigned-URL endpoint for Parquet downloads, accessible via API key.

**New endpoint: `GET /api/download/{downloadId}/presigned-url`**

- Authenticated via `X-API-Key` header (API key security scheme).
- Runs the same team-membership authorization check used by JWT download routes — the API key does not bypass access control.
- Returns presigned S3 URLs (30-minute expiry) for each Parquet artifact belonging to the download, one per feature type.
- Only returns URLs when the download status is `ready` or `downloaded`; all other statuses produce a 409 so scripts can distinguish "not ready yet" from access errors.
- Response shape per part: `{ feature_type, url, expires_at }`.

**Removed**

- `GET /api/script/download-export/{exportId}` — script route for CSV exports. The JWT-protected `GET /api/download-export/{exportId}` is unchanged.

## Testing Notes

- Create an API key via the portal API Keys tab, copy the plaintext key, and call `GET /api/download/{downloadId}/presigned-url` with `X-API-Key: <key>`. Confirm parts are returned with valid presigned URLs and a 30-minute expiry.
- Confirm a 409 is returned for a download in `pending` or `processing` status.
- Confirm a 403 is returned when the API key owner is not on the download's team.
- Confirm a 404 is returned for a non-existent download ID.
- Confirm the existing `GET /api/download-export/{exportId}` (Bearer-secured) is unaffected.
