### PR TITLE
SIMSBIOHUB-1018: CRUD APIs for Feature Types and Properties

### DIFF
--- a/api/src/models/feature-property.ts
+++ b/api/src/models/feature-property.ts
@@ -61,7 +61,6 @@ export interface CreateFeatureProperty {
 
 /** Partial fields accepted when updating a feature property. */
 export interface UpdateFeatureProperty {
-  feature_property_type_id?: number;
   name?: string;
   display_name?: string;
   description?: string | null;

--- a/api/src/models/feature-property.ts
+++ b/api/src/models/feature-property.ts
@@ -29,3 +29,42 @@ export const SubmissionFeatureProperty = z.object({
 });
 
 export type SubmissionFeatureProperty = z.infer<typeof SubmissionFeatureProperty>;
+
+/**
+ * Schema for a feature property record (includes resolved type_name from feature_property_type).
+ */
+export const FeatureProperty = z.object({
+  feature_property_id: z.number(),
+  feature_property_type_id: z.number(),
+  name: z.string(),
+  display_name: z.string(),
+  description: z.string().nullable(),
+  type_name: z.string(),
+  calculated_value: z.boolean()
+});
+
+export type FeatureProperty = z.infer<typeof FeatureProperty>;
+
+/** Fields required to create a feature property. */
+export interface CreateFeatureProperty {
+  /** Foreign key to feature_property_type. */
+  feature_property_type_id: number;
+  /** Canonical property name. */
+  name: string;
+  /** Human-readable display name. */
+  display_name: string;
+  /** Optional description. */
+  description?: string | null;
+  /** Whether values are calculated rather than supplied. */
+  calculated_value?: boolean;
+}
+
+/** Partial fields accepted when updating a feature property. */
+export interface UpdateFeatureProperty {
+  feature_property_type_id?: number;
+  name?: string;
+  display_name?: string;
+  description?: string | null;
+  calculated_value?: boolean;
+  record_end_date?: string;
+}

--- a/api/src/models/feature-type-property.ts
+++ b/api/src/models/feature-type-property.ts
@@ -11,7 +11,7 @@ export const FeatureTypeProperty = z.object({
   feature_property_type_id: z.number().optional(),
   name: z.string(),
   display_name: z.string(),
-  description: z.string(),
+  description: z.string().nullable(),
   type_name: z.string(),
   required_value: z.boolean(),
   calculated_value: z.boolean(),
@@ -37,3 +37,36 @@ export const ExpressionPredicatePropertyMetadata = z.object({
 });
 
 export type ExpressionPredicatePropertyMetadata = z.infer<typeof ExpressionPredicatePropertyMetadata>;
+
+/**
+ * Schema for a raw feature_type_property record used by admin CRUD endpoints.
+ * Distinct from FeatureTypeProperty which is a denormalized view with joined property metadata.
+ */
+export const AdminFeatureTypeProperty = z.object({
+  feature_type_property_id: z.number(),
+  feature_type_id: z.number(),
+  feature_property_id: z.number(),
+  required_value: z.boolean(),
+  sort: z.number().int().nullable()
+});
+
+export type AdminFeatureTypeProperty = z.infer<typeof AdminFeatureTypeProperty>;
+
+/** Fields required to assign a feature property to a feature type. */
+export interface CreateFeatureTypePropertyRecord {
+  /** Parent feature type identifier. */
+  feature_type_id: number;
+  /** Feature property to assign. */
+  feature_property_id: number;
+  /** Whether the property is required for this feature type. */
+  required_value?: boolean;
+  /** Optional display sort order. */
+  sort?: number | null;
+}
+
+/** Partial metadata fields accepted when updating a feature type property assignment. */
+export interface UpdateFeatureTypePropertyRecord {
+  required_value?: boolean;
+  sort?: number | null;
+  record_end_date?: string;
+}

--- a/api/src/models/feature-type.ts
+++ b/api/src/models/feature-type.ts
@@ -7,7 +7,8 @@ import { FeatureTypeProperty } from './feature-type-property';
 export const FeatureType = z.object({
   feature_type_id: z.number(),
   name: z.string(),
-  display_name: z.string()
+  display_name: z.string(),
+  description: z.string().nullable()
 });
 
 export type FeatureType = z.infer<typeof FeatureType>;
@@ -21,3 +22,21 @@ export const FeatureTypeWithProperties = z.object({
 });
 
 export type FeatureTypeWithProperties = z.infer<typeof FeatureTypeWithProperties>;
+
+/** Fields required to create a feature type. */
+export interface CreateFeatureType {
+  /** Canonical name of the feature type. */
+  name: string;
+  /** Human-readable display name. */
+  display_name: string;
+  /** Optional description. */
+  description?: string | null;
+}
+
+/** Partial fields accepted when updating a feature type. */
+export interface UpdateFeatureType {
+  name?: string;
+  display_name?: string;
+  description?: string | null;
+  record_end_date?: string;
+}

--- a/api/src/openapi/schemas/feature-property.ts
+++ b/api/src/openapi/schemas/feature-property.ts
@@ -1,0 +1,149 @@
+/**
+ * OpenAPI schemas for Feature Property endpoints.
+ *
+ * These schemas define the API contract for feature property management operations.
+ */
+
+import { OpenAPIV3 } from 'openapi-types';
+import { paginationResponseSchema } from './pagination';
+
+/**
+ * Schema for a feature property.
+ */
+export const FeaturePropertySchema: OpenAPIV3.SchemaObject = {
+  title: 'FeatureProperty',
+  type: 'object',
+  required: [
+    'feature_property_id',
+    'feature_property_type_id',
+    'name',
+    'display_name',
+    'description',
+    'type_name',
+    'calculated_value'
+  ],
+  properties: {
+    feature_property_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'System generated surrogate primary key identifier'
+    },
+    feature_property_type_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Foreign key to the feature_property_type table'
+    },
+    name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Canonical name of the feature property'
+    },
+    display_name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Human-readable name of the feature property'
+    },
+    description: {
+      type: 'string',
+      maxLength: 500,
+      nullable: true,
+      description: 'Description of the feature property'
+    },
+    type_name: {
+      type: 'string',
+      description: 'The resolved name of the feature property type'
+    },
+    calculated_value: {
+      type: 'boolean',
+      description: 'Whether the property value is calculated rather than supplied'
+    }
+  }
+};
+
+/**
+ * Schema for paginated feature properties list response.
+ */
+export const FeaturePropertiesListResponseSchema: OpenAPIV3.SchemaObject = {
+  title: 'FeaturePropertiesListResponse',
+  type: 'object',
+  required: ['feature_properties', 'pagination'],
+  properties: {
+    feature_properties: {
+      type: 'array',
+      items: FeaturePropertySchema,
+      description: 'List of feature properties'
+    },
+    pagination: paginationResponseSchema
+  }
+};
+
+/**
+ * Schema for create feature property request body.
+ */
+export const CreateFeaturePropertyRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'CreateFeaturePropertyRequest',
+  type: 'object',
+  required: ['feature_property_type_id', 'name', 'display_name'],
+  properties: {
+    feature_property_type_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Foreign key to the feature_property_type table'
+    },
+    name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Canonical name of the feature property'
+    },
+    display_name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Human-readable name of the feature property'
+    },
+    description: {
+      type: 'string',
+      maxLength: 500,
+      nullable: true,
+      description: 'Description of the feature property'
+    },
+    calculated_value: {
+      type: 'boolean',
+      description: 'Whether the property value is calculated rather than supplied'
+    }
+  }
+};
+
+/**
+ * Schema for update feature property request body.
+ */
+export const UpdateFeaturePropertyRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'UpdateFeaturePropertyRequest',
+  type: 'object',
+  properties: {
+    feature_property_type_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Foreign key to the feature_property_type table'
+    },
+    name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Canonical name of the feature property'
+    },
+    display_name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Human-readable name of the feature property'
+    },
+    description: {
+      type: 'string',
+      maxLength: 500,
+      nullable: true,
+      description: 'Description of the feature property'
+    },
+    calculated_value: {
+      type: 'boolean',
+      description: 'Whether the property value is calculated rather than supplied'
+    }
+  }
+};

--- a/api/src/openapi/schemas/feature-property.ts
+++ b/api/src/openapi/schemas/feature-property.ts
@@ -120,11 +120,6 @@ export const UpdateFeaturePropertyRequestSchema: OpenAPIV3.SchemaObject = {
   title: 'UpdateFeaturePropertyRequest',
   type: 'object',
   properties: {
-    feature_property_type_id: {
-      type: 'integer',
-      minimum: 1,
-      description: 'Foreign key to the feature_property_type table'
-    },
     name: {
       type: 'string',
       maxLength: 100,

--- a/api/src/openapi/schemas/feature-type-property.ts
+++ b/api/src/openapi/schemas/feature-type-property.ts
@@ -1,0 +1,106 @@
+/**
+ * OpenAPI schemas for Feature Type Property endpoints.
+ *
+ * These schemas define the API contract for feature type property management operations.
+ */
+
+import { OpenAPIV3 } from 'openapi-types';
+import { paginationResponseSchema } from './pagination';
+
+/**
+ * Schema for a raw feature type property record (admin view).
+ */
+export const AdminFeatureTypePropertySchema: OpenAPIV3.SchemaObject = {
+  title: 'AdminFeatureTypeProperty',
+  type: 'object',
+  required: ['feature_type_property_id', 'feature_type_id', 'feature_property_id', 'required_value', 'sort'],
+  properties: {
+    feature_type_property_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'System generated surrogate primary key identifier'
+    },
+    feature_type_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Foreign key to the feature_type table'
+    },
+    feature_property_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Foreign key to the feature_property table'
+    },
+    required_value: {
+      type: 'boolean',
+      description: 'Whether the property is required for this feature type'
+    },
+    sort: {
+      type: 'integer',
+      nullable: true,
+      description: 'Custom sort order for display purposes'
+    }
+  }
+};
+
+/**
+ * Schema for paginated feature type properties list response.
+ */
+export const FeatureTypePropertiesListResponseSchema: OpenAPIV3.SchemaObject = {
+  title: 'FeatureTypePropertiesListResponse',
+  type: 'object',
+  required: ['feature_type_properties', 'pagination'],
+  properties: {
+    feature_type_properties: {
+      type: 'array',
+      items: AdminFeatureTypePropertySchema,
+      description: 'List of feature type properties'
+    },
+    pagination: paginationResponseSchema
+  }
+};
+
+/**
+ * Schema for create feature type property request body.
+ * feature_type_id is taken from the path param, not the body.
+ */
+export const CreateFeatureTypePropertyRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'CreateFeatureTypePropertyRequest',
+  type: 'object',
+  required: ['feature_property_id'],
+  properties: {
+    feature_property_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Foreign key to the feature_property table'
+    },
+    required_value: {
+      type: 'boolean',
+      description: 'Whether the property is required for this feature type'
+    },
+    sort: {
+      type: 'integer',
+      nullable: true,
+      description: 'Custom sort order for display purposes'
+    }
+  }
+};
+
+/**
+ * Schema for update feature type property request body.
+ * Only metadata fields are updatable; feature_type_id and feature_property_id cannot change.
+ */
+export const UpdateFeatureTypePropertyRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'UpdateFeatureTypePropertyRequest',
+  type: 'object',
+  properties: {
+    required_value: {
+      type: 'boolean',
+      description: 'Whether the property is required for this feature type'
+    },
+    sort: {
+      type: 'integer',
+      nullable: true,
+      description: 'Custom sort order for display purposes'
+    }
+  }
+};

--- a/api/src/openapi/schemas/feature-type.ts
+++ b/api/src/openapi/schemas/feature-type.ts
@@ -1,0 +1,110 @@
+/**
+ * OpenAPI schemas for Feature Type endpoints.
+ *
+ * These schemas define the API contract for feature type management operations.
+ */
+
+import { OpenAPIV3 } from 'openapi-types';
+import { paginationResponseSchema } from './pagination';
+
+/**
+ * Schema for a feature type.
+ */
+export const FeatureTypeSchema: OpenAPIV3.SchemaObject = {
+  title: 'FeatureType',
+  type: 'object',
+  required: ['feature_type_id', 'name', 'display_name', 'description'],
+  properties: {
+    feature_type_id: {
+      type: 'integer',
+      minimum: 1,
+      description: 'System generated surrogate primary key identifier'
+    },
+    name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Canonical name of the feature type'
+    },
+    display_name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Human-readable name of the feature type'
+    },
+    description: {
+      type: 'string',
+      maxLength: 500,
+      nullable: true,
+      description: 'Description of the feature type'
+    }
+  }
+};
+
+/**
+ * Schema for paginated feature types list response.
+ */
+export const FeatureTypesListResponseSchema: OpenAPIV3.SchemaObject = {
+  title: 'FeatureTypesListResponse',
+  type: 'object',
+  required: ['feature_types', 'pagination'],
+  properties: {
+    feature_types: {
+      type: 'array',
+      items: FeatureTypeSchema,
+      description: 'List of feature types'
+    },
+    pagination: paginationResponseSchema
+  }
+};
+
+/**
+ * Schema for create feature type request body.
+ */
+export const CreateFeatureTypeRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'CreateFeatureTypeRequest',
+  type: 'object',
+  required: ['name', 'display_name'],
+  properties: {
+    name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Canonical name of the feature type'
+    },
+    display_name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Human-readable name of the feature type'
+    },
+    description: {
+      type: 'string',
+      maxLength: 500,
+      nullable: true,
+      description: 'Description of the feature type'
+    }
+  }
+};
+
+/**
+ * Schema for update feature type request body.
+ */
+export const UpdateFeatureTypeRequestSchema: OpenAPIV3.SchemaObject = {
+  title: 'UpdateFeatureTypeRequest',
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Canonical name of the feature type'
+    },
+    display_name: {
+      type: 'string',
+      maxLength: 100,
+      description: 'Human-readable name of the feature type'
+    },
+    description: {
+      type: 'string',
+      maxLength: 500,
+      nullable: true,
+      description: 'Description of the feature type'
+    }
+  }
+};

--- a/api/src/paths/administrative/feature-properties/index.test.ts
+++ b/api/src/paths/administrative/feature-properties/index.test.ts
@@ -1,0 +1,179 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
+import * as db from '../../../database/db';
+import { FeatureProperty } from '../../../models/feature-property';
+import { FeaturePropertyService } from '../../../services/feature-property-service';
+import { createFeatureProperty, getFeatureProperties } from './index';
+
+chai.use(sinonChai);
+
+const mockFeatureProperty: FeatureProperty = {
+  feature_property_id: 1,
+  feature_property_type_id: 2,
+  name: 'guid',
+  display_name: 'GUID',
+  description: 'The globally unique identifier for the record.',
+  type_name: 'string',
+  calculated_value: false
+};
+
+describe('getFeatureProperties', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getFeatureProperties();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with paginated feature properties', async () => {
+    const mockFeatureProperties = [mockFeatureProperty];
+    const mockResponse = {
+      feature_properties: mockFeatureProperties,
+      pagination: { total: 1, per_page: 50, current_page: 1, last_page: 1, sort: undefined, order: undefined }
+    };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    sinon.stub(FeaturePropertyService.prototype, 'getFeatureProperties').resolves(mockFeatureProperties);
+    sinon.stub(FeaturePropertyService.prototype, 'getFeaturePropertiesCount').resolves(1);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getFeatureProperties();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockResponse);
+  });
+
+  it('should filter by search parameter', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const getStub = sinon.stub(FeaturePropertyService.prototype, 'getFeatureProperties').resolves([]);
+    const countStub = sinon.stub(FeaturePropertyService.prototype, 'getFeaturePropertiesCount').resolves(0);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.query = { page: '1', limit: '50', search: 'guid' };
+
+    const requestHandler = getFeatureProperties();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getStub).to.have.been.calledWith(
+      { search: 'guid' },
+      { page: 1, limit: 50, sort: undefined, order: undefined }
+    );
+    expect(countStub).to.have.been.calledWith({ search: 'guid' });
+  });
+});
+
+describe('createFeatureProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.body = { feature_property_type_id: 2, name: 'guid', display_name: 'GUID' };
+
+    const requestHandler = createFeatureProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 201 with created feature property', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const createStub = sinon
+      .stub(FeaturePropertyService.prototype, 'createFeatureProperty')
+      .resolves(mockFeatureProperty);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.body = {
+      feature_property_type_id: 2,
+      name: 'guid',
+      display_name: 'GUID',
+      description: 'The globally unique identifier for the record.',
+      calculated_value: false
+    };
+
+    const requestHandler = createFeatureProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledWith({
+      feature_property_type_id: 2,
+      name: 'guid',
+      display_name: 'GUID',
+      description: 'The globally unique identifier for the record.',
+      calculated_value: false
+    });
+    expect(mockRes.statusValue).to.equal(201);
+    expect(mockRes.jsonValue).to.eql(mockFeatureProperty);
+  });
+
+  it('should create feature property with minimal fields', async () => {
+    const mockMinimal: FeatureProperty = {
+      feature_property_id: 2,
+      feature_property_type_id: 3,
+      name: 'geometry',
+      display_name: 'Geometry',
+      description: null,
+      type_name: 'spatial',
+      calculated_value: false
+    };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const createStub = sinon.stub(FeaturePropertyService.prototype, 'createFeatureProperty').resolves(mockMinimal);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.body = { feature_property_type_id: 3, name: 'geometry', display_name: 'Geometry' };
+
+    const requestHandler = createFeatureProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledWith({
+      feature_property_type_id: 3,
+      name: 'geometry',
+      display_name: 'Geometry',
+      description: undefined,
+      calculated_value: undefined
+    });
+    expect(mockRes.statusValue).to.equal(201);
+  });
+});

--- a/api/src/paths/administrative/feature-properties/index.ts
+++ b/api/src/paths/administrative/feature-properties/index.ts
@@ -1,0 +1,165 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../constants/roles';
+import { getDBConnection } from '../../../database/db';
+import { CreateFeatureProperty } from '../../../models/feature-property';
+import {
+  CreateFeaturePropertyRequestSchema,
+  FeaturePropertiesListResponseSchema,
+  FeaturePropertySchema
+} from '../../../openapi/schemas/feature-property';
+import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
+import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
+import { FeaturePropertyService } from '../../../services/feature-property-service';
+import { getLogger } from '../../../utils/logger';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../utils/pagination';
+
+const defaultLog = getLogger('paths/administrative/feature-properties');
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  getFeatureProperties()
+];
+
+GET.apiDoc = {
+  description: 'Get all active feature properties with optional pagination and search.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    ...paginationRequestQueryParamSchema,
+    {
+      in: 'query',
+      name: 'search',
+      required: false,
+      schema: { type: 'string' },
+      description: 'Search by feature property name'
+    }
+  ],
+  responses: {
+    200: {
+      description: 'List of active feature properties',
+      content: {
+        'application/json': {
+          schema: FeaturePropertiesListResponseSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get all active feature properties with pagination.
+ *
+ * @returns {RequestHandler}
+ */
+export function getFeatureProperties(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const search = req.query.search as string | undefined;
+
+    try {
+      await connection.open();
+
+      const featurePropertyService = new FeaturePropertyService(connection);
+      const filters = { search };
+      const pagination = makePaginationOptionsFromRequest(req);
+
+      const [feature_properties, count] = await Promise.all([
+        featurePropertyService.getFeatureProperties(filters, pagination),
+        featurePropertyService.getFeaturePropertiesCount(filters)
+      ]);
+
+      await connection.commit();
+
+      return res.status(200).json({ feature_properties, pagination: makePaginationResponse(count, pagination) });
+    } catch (error) {
+      defaultLog.error({ label: 'getFeatureProperties', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const POST: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  createFeatureProperty()
+];
+
+POST.apiDoc = {
+  description: 'Create a new feature property.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: CreateFeaturePropertyRequestSchema
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Feature property created',
+      content: {
+        'application/json': {
+          schema: FeaturePropertySchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Create a new feature property.
+ *
+ * @returns {RequestHandler}
+ */
+export function createFeatureProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const { feature_property_type_id, name, display_name, description, calculated_value } =
+      req.body as CreateFeatureProperty;
+
+    try {
+      await connection.open();
+
+      const featurePropertyService = new FeaturePropertyService(connection);
+      const result = await featurePropertyService.createFeatureProperty({
+        feature_property_type_id,
+        name,
+        display_name,
+        description,
+        calculated_value
+      });
+
+      await connection.commit();
+
+      return res.status(201).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'createFeatureProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/feature-properties/{featurePropertyId}/index.test.ts
+++ b/api/src/paths/administrative/feature-properties/{featurePropertyId}/index.test.ts
@@ -1,0 +1,156 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
+import * as db from '../../../../database/db';
+import { FeatureProperty } from '../../../../models/feature-property';
+import { FeaturePropertyService } from '../../../../services/feature-property-service';
+import { deleteFeatureProperty, getFeatureProperty, updateFeatureProperty } from './index';
+
+chai.use(sinonChai);
+
+const mockFeatureProperty: FeatureProperty = {
+  feature_property_id: 1,
+  feature_property_type_id: 2,
+  name: 'guid',
+  display_name: 'GUID',
+  description: 'The globally unique identifier for the record.',
+  type_name: 'string',
+  calculated_value: false
+};
+
+describe('getFeatureProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featurePropertyId: '1' };
+
+    const requestHandler = getFeatureProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with feature property details', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    sinon.stub(FeaturePropertyService.prototype, 'getFeatureProperty').resolves(mockFeatureProperty);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featurePropertyId: '1' };
+
+    const requestHandler = getFeatureProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockFeatureProperty);
+  });
+});
+
+describe('updateFeatureProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featurePropertyId: '1' };
+    mockReq.body = { display_name: 'Updated GUID' };
+
+    const requestHandler = updateFeatureProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail('Expected error to be thrown');
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with updated feature property', async () => {
+    const updatedMock: FeatureProperty = { ...mockFeatureProperty, display_name: 'Updated GUID' };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const updateStub = sinon.stub(FeaturePropertyService.prototype, 'updateFeatureProperty').resolves(updatedMock);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featurePropertyId: '1' };
+    mockReq.body = { display_name: 'Updated GUID' };
+
+    const requestHandler = updateFeatureProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(updateStub).to.have.been.calledWith(1, { display_name: 'Updated GUID' });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(updatedMock);
+  });
+});
+
+describe('deleteFeatureProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featurePropertyId: '1' };
+
+    const requestHandler = deleteFeatureProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 on successful delete', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const deleteStub = sinon.stub(FeaturePropertyService.prototype, 'deleteFeatureProperty').resolves();
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featurePropertyId: '1' };
+
+    const requestHandler = deleteFeatureProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(deleteStub).to.have.been.calledWith(1);
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql({ message: 'Feature property deleted successfully' });
+  });
+});

--- a/api/src/paths/administrative/feature-properties/{featurePropertyId}/index.ts
+++ b/api/src/paths/administrative/feature-properties/{featurePropertyId}/index.ts
@@ -1,0 +1,214 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../constants/roles';
+import { getDBConnection } from '../../../../database/db';
+import { UpdateFeatureProperty } from '../../../../models/feature-property';
+import {
+  FeaturePropertySchema,
+  UpdateFeaturePropertyRequestSchema
+} from '../../../../openapi/schemas/feature-property';
+import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
+import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
+import { FeaturePropertyService } from '../../../../services/feature-property-service';
+import { getLogger } from '../../../../utils/logger';
+
+const defaultLog = getLogger('paths/administrative/feature-properties/{featurePropertyId}');
+
+const featurePropertyIdParam = {
+  in: 'path',
+  name: 'featurePropertyId',
+  required: true,
+  schema: { type: 'integer', minimum: 1 },
+  description: 'Feature property ID'
+} as const;
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  getFeatureProperty()
+];
+
+GET.apiDoc = {
+  description: 'Get a feature property by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featurePropertyIdParam],
+  responses: {
+    200: {
+      description: 'Feature property',
+      content: {
+        'application/json': {
+          schema: FeaturePropertySchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get a feature property by ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function getFeatureProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featurePropertyId = Number(req.params.featurePropertyId);
+
+    try {
+      await connection.open();
+
+      const featurePropertyService = new FeaturePropertyService(connection);
+      const result = await featurePropertyService.getFeatureProperty(featurePropertyId);
+
+      await connection.commit();
+
+      return res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'getFeatureProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const PUT: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  updateFeatureProperty()
+];
+
+PUT.apiDoc = {
+  description: 'Update an existing feature property.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featurePropertyIdParam],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: UpdateFeaturePropertyRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Feature property updated',
+      content: {
+        'application/json': {
+          schema: FeaturePropertySchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Update an existing feature property.
+ *
+ * @returns {RequestHandler}
+ */
+export function updateFeatureProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featurePropertyId = Number(req.params.featurePropertyId);
+    const payload = req.body as UpdateFeatureProperty;
+
+    try {
+      await connection.open();
+
+      const featurePropertyService = new FeaturePropertyService(connection);
+      const result = await featurePropertyService.updateFeatureProperty(featurePropertyId, payload);
+
+      await connection.commit();
+
+      return res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'updateFeatureProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const DELETE: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  deleteFeatureProperty()
+];
+
+DELETE.apiDoc = {
+  description: 'Soft delete a feature property by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featurePropertyIdParam],
+  responses: {
+    200: {
+      description: 'Feature property deleted',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' }
+            }
+          }
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Soft delete a feature property by ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function deleteFeatureProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featurePropertyId = Number(req.params.featurePropertyId);
+
+    try {
+      await connection.open();
+
+      const featurePropertyService = new FeaturePropertyService(connection);
+      await featurePropertyService.deleteFeatureProperty(featurePropertyId);
+
+      await connection.commit();
+
+      return res.status(200).json({ message: 'Feature property deleted successfully' });
+    } catch (error) {
+      defaultLog.error({ label: 'deleteFeatureProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/feature-types/index.test.ts
+++ b/api/src/paths/administrative/feature-types/index.test.ts
@@ -1,0 +1,166 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../__mocks__/db';
+import * as db from '../../../database/db';
+import { FeatureType } from '../../../models/feature-type';
+import { FeatureTypeService } from '../../../services/feature-type-service';
+import { createFeatureType, getFeatureTypes } from './index';
+
+chai.use(sinonChai);
+
+const mockFeatureType: FeatureType = {
+  feature_type_id: 1,
+  name: 'dataset',
+  display_name: 'Dataset',
+  description: 'A dataset feature type'
+};
+
+describe('getFeatureTypes', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getFeatureTypes();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with paginated feature types', async () => {
+    const mockFeatureTypes = [mockFeatureType];
+    const mockResponse = {
+      feature_types: mockFeatureTypes,
+      pagination: { total: 1, per_page: 50, current_page: 1, last_page: 1, sort: undefined, order: undefined }
+    };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    sinon.stub(FeatureTypeService.prototype, 'getFeatureTypes').resolves(mockFeatureTypes);
+    sinon.stub(FeatureTypeService.prototype, 'getFeatureTypesCount').resolves(1);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getFeatureTypes();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockResponse);
+  });
+
+  it('should filter by search parameter', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const getFeatureTypesStub = sinon.stub(FeatureTypeService.prototype, 'getFeatureTypes').resolves([]);
+    const getFeatureTypesCountStub = sinon.stub(FeatureTypeService.prototype, 'getFeatureTypesCount').resolves(0);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.query = { page: '1', limit: '50', search: 'dataset' };
+
+    const requestHandler = getFeatureTypes();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getFeatureTypesStub).to.have.been.calledWith(
+      { search: 'dataset' },
+      {
+        page: 1,
+        limit: 50,
+        sort: undefined,
+        order: undefined
+      }
+    );
+    expect(getFeatureTypesCountStub).to.have.been.calledWith({ search: 'dataset' });
+  });
+});
+
+describe('createFeatureType', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.body = { name: 'dataset', display_name: 'Dataset' };
+
+    const requestHandler = createFeatureType();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 201 with created feature type', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const createStub = sinon.stub(FeatureTypeService.prototype, 'createFeatureType').resolves(mockFeatureType);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.body = { name: 'dataset', display_name: 'Dataset', description: 'A dataset feature type' };
+
+    const requestHandler = createFeatureType();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledWith({
+      name: 'dataset',
+      display_name: 'Dataset',
+      description: 'A dataset feature type'
+    });
+    expect(mockRes.statusValue).to.equal(201);
+    expect(mockRes.jsonValue).to.eql(mockFeatureType);
+  });
+
+  it('should create feature type with minimal fields', async () => {
+    const mockMinimal: FeatureType = {
+      feature_type_id: 2,
+      name: 'observation',
+      display_name: 'Observation',
+      description: null
+    };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const createStub = sinon.stub(FeatureTypeService.prototype, 'createFeatureType').resolves(mockMinimal);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.body = { name: 'observation', display_name: 'Observation' };
+
+    const requestHandler = createFeatureType();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledWith({
+      name: 'observation',
+      display_name: 'Observation',
+      description: undefined
+    });
+    expect(mockRes.statusValue).to.equal(201);
+  });
+});

--- a/api/src/paths/administrative/feature-types/index.ts
+++ b/api/src/paths/administrative/feature-types/index.ts
@@ -1,0 +1,158 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../constants/roles';
+import { getDBConnection } from '../../../database/db';
+import { CreateFeatureType } from '../../../models/feature-type';
+import {
+  CreateFeatureTypeRequestSchema,
+  FeatureTypeSchema,
+  FeatureTypesListResponseSchema
+} from '../../../openapi/schemas/feature-type';
+import { defaultErrorResponses } from '../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema } from '../../../openapi/schemas/pagination';
+import { authorizeRequestHandler } from '../../../request-handlers/security/authorization';
+import { FeatureTypeService } from '../../../services/feature-type-service';
+import { getLogger } from '../../../utils/logger';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../utils/pagination';
+
+const defaultLog = getLogger('paths/administrative/feature-types');
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  getFeatureTypes()
+];
+
+GET.apiDoc = {
+  description: 'Get all active feature types with optional pagination and search.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [
+    ...paginationRequestQueryParamSchema,
+    {
+      in: 'query',
+      name: 'search',
+      required: false,
+      schema: { type: 'string' },
+      description: 'Search by feature type name'
+    }
+  ],
+  responses: {
+    200: {
+      description: 'List of active feature types',
+      content: {
+        'application/json': {
+          schema: FeatureTypesListResponseSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get all active feature types with pagination.
+ *
+ * @returns {RequestHandler}
+ */
+export function getFeatureTypes(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const search = req.query.search as string | undefined;
+
+    try {
+      await connection.open();
+
+      const featureTypeService = new FeatureTypeService(connection);
+      const filters = { search };
+      const pagination = makePaginationOptionsFromRequest(req);
+
+      const [feature_types, count] = await Promise.all([
+        featureTypeService.getFeatureTypes(filters, pagination),
+        featureTypeService.getFeatureTypesCount(filters)
+      ]);
+
+      await connection.commit();
+
+      return res.status(200).json({ feature_types, pagination: makePaginationResponse(count, pagination) });
+    } catch (error) {
+      defaultLog.error({ label: 'getFeatureTypes', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const POST: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  createFeatureType()
+];
+
+POST.apiDoc = {
+  description: 'Create a new feature type.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: CreateFeatureTypeRequestSchema
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Feature type created',
+      content: {
+        'application/json': {
+          schema: FeatureTypeSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Create a new feature type.
+ *
+ * @returns {RequestHandler}
+ */
+export function createFeatureType(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const { name, display_name, description } = req.body as CreateFeatureType;
+
+    try {
+      await connection.open();
+
+      const featureTypeService = new FeatureTypeService(connection);
+      const result = await featureTypeService.createFeatureType({ name, display_name, description });
+
+      await connection.commit();
+
+      return res.status(201).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'createFeatureType', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/feature-types/{featureTypeId}/index.test.ts
+++ b/api/src/paths/administrative/feature-types/{featureTypeId}/index.test.ts
@@ -1,0 +1,153 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../__mocks__/db';
+import * as db from '../../../../database/db';
+import { FeatureType } from '../../../../models/feature-type';
+import { FeatureTypeService } from '../../../../services/feature-type-service';
+import { deleteFeatureType, getFeatureType, updateFeatureType } from './index';
+
+chai.use(sinonChai);
+
+const mockFeatureType: FeatureType = {
+  feature_type_id: 1,
+  name: 'dataset',
+  display_name: 'Dataset',
+  description: 'A dataset feature type'
+};
+
+describe('getFeatureType', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '1' };
+
+    const requestHandler = getFeatureType();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with feature type details', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    sinon.stub(FeatureTypeService.prototype, 'getFeatureType').resolves(mockFeatureType);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '1' };
+
+    const requestHandler = getFeatureType();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockFeatureType);
+  });
+});
+
+describe('updateFeatureType', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '1' };
+    mockReq.body = { display_name: 'Updated Dataset' };
+
+    const requestHandler = updateFeatureType();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail('Expected error to be thrown');
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with updated feature type', async () => {
+    const updatedMock: FeatureType = { ...mockFeatureType, display_name: 'Updated Dataset' };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const updateStub = sinon.stub(FeatureTypeService.prototype, 'updateFeatureType').resolves(updatedMock);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '1' };
+    mockReq.body = { display_name: 'Updated Dataset' };
+
+    const requestHandler = updateFeatureType();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(updateStub).to.have.been.calledWith(1, { display_name: 'Updated Dataset' });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(updatedMock);
+  });
+});
+
+describe('deleteFeatureType', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '1' };
+
+    const requestHandler = deleteFeatureType();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 on successful delete', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const deleteStub = sinon.stub(FeatureTypeService.prototype, 'deleteFeatureType').resolves();
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '1' };
+
+    const requestHandler = deleteFeatureType();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(deleteStub).to.have.been.calledWith(1);
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql({ message: 'Feature type deleted successfully' });
+  });
+});

--- a/api/src/paths/administrative/feature-types/{featureTypeId}/index.ts
+++ b/api/src/paths/administrative/feature-types/{featureTypeId}/index.ts
@@ -1,0 +1,211 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../constants/roles';
+import { getDBConnection } from '../../../../database/db';
+import { UpdateFeatureType } from '../../../../models/feature-type';
+import { FeatureTypeSchema, UpdateFeatureTypeRequestSchema } from '../../../../openapi/schemas/feature-type';
+import { defaultErrorResponses } from '../../../../openapi/schemas/http-responses';
+import { authorizeRequestHandler } from '../../../../request-handlers/security/authorization';
+import { FeatureTypeService } from '../../../../services/feature-type-service';
+import { getLogger } from '../../../../utils/logger';
+
+const defaultLog = getLogger('paths/administrative/feature-types/{featureTypeId}');
+
+const featureTypeIdParam = {
+  in: 'path',
+  name: 'featureTypeId',
+  required: true,
+  schema: { type: 'integer', minimum: 1 },
+  description: 'Feature type ID'
+} as const;
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  getFeatureType()
+];
+
+GET.apiDoc = {
+  description: 'Get a feature type by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featureTypeIdParam],
+  responses: {
+    200: {
+      description: 'Feature type',
+      content: {
+        'application/json': {
+          schema: FeatureTypeSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get a feature type by ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function getFeatureType(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+
+    try {
+      await connection.open();
+
+      const featureTypeService = new FeatureTypeService(connection);
+      const result = await featureTypeService.getFeatureType(featureTypeId);
+
+      await connection.commit();
+
+      return res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'getFeatureType', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const PUT: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  updateFeatureType()
+];
+
+PUT.apiDoc = {
+  description: 'Update an existing feature type.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featureTypeIdParam],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: UpdateFeatureTypeRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Feature type updated',
+      content: {
+        'application/json': {
+          schema: FeatureTypeSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Update an existing feature type.
+ *
+ * @returns {RequestHandler}
+ */
+export function updateFeatureType(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+    const payload = req.body as UpdateFeatureType;
+
+    try {
+      await connection.open();
+
+      const featureTypeService = new FeatureTypeService(connection);
+      const result = await featureTypeService.updateFeatureType(featureTypeId, payload);
+
+      await connection.commit();
+
+      return res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'updateFeatureType', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const DELETE: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  deleteFeatureType()
+];
+
+DELETE.apiDoc = {
+  description: 'Soft delete a feature type by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featureTypeIdParam],
+  responses: {
+    200: {
+      description: 'Feature type deleted',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' }
+            }
+          }
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Soft delete a feature type by ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function deleteFeatureType(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+
+    try {
+      await connection.open();
+
+      const featureTypeService = new FeatureTypeService(connection);
+      await featureTypeService.deleteFeatureType(featureTypeId);
+
+      await connection.commit();
+
+      return res.status(200).json({ message: 'Feature type deleted successfully' });
+    } catch (error) {
+      defaultLog.error({ label: 'deleteFeatureType', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/feature-types/{featureTypeId}/properties/index.test.ts
+++ b/api/src/paths/administrative/feature-types/{featureTypeId}/properties/index.test.ts
@@ -1,0 +1,155 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
+import * as db from '../../../../../database/db';
+import { AdminFeatureTypeProperty } from '../../../../../models/feature-type-property';
+import { FeatureTypePropertyService } from '../../../../../services/feature-type-property-service';
+import { createFeatureTypeProperty, getFeatureTypeProperties } from './index';
+
+chai.use(sinonChai);
+
+const mockAdminFeatureTypeProperty: AdminFeatureTypeProperty = {
+  feature_type_property_id: 1,
+  feature_type_id: 10,
+  feature_property_id: 20,
+  required_value: false,
+  sort: null
+};
+
+describe('getFeatureTypeProperties', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10' };
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getFeatureTypeProperties();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with paginated feature type properties', async () => {
+    const mockProperties = [mockAdminFeatureTypeProperty];
+    const mockResponse = {
+      feature_type_properties: mockProperties,
+      pagination: { total: 1, per_page: 50, current_page: 1, last_page: 1, sort: undefined, order: undefined }
+    };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    sinon.stub(FeatureTypePropertyService.prototype, 'getAdminFeatureTypeProperties').resolves(mockProperties);
+    sinon.stub(FeatureTypePropertyService.prototype, 'getAdminFeatureTypePropertiesCount').resolves(1);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10' };
+    mockReq.query = { page: '1', limit: '50' };
+
+    const requestHandler = getFeatureTypeProperties();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockResponse);
+  });
+});
+
+describe('createFeatureTypeProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10' };
+    mockReq.body = { feature_property_id: 20 };
+
+    const requestHandler = createFeatureTypeProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 201 with created feature type property', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const createStub = sinon
+      .stub(FeatureTypePropertyService.prototype, 'createFeatureTypeProperty')
+      .resolves(mockAdminFeatureTypeProperty);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10' };
+    mockReq.body = { feature_property_id: 20, required_value: false, sort: null };
+
+    const requestHandler = createFeatureTypeProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledWith({
+      feature_type_id: 10,
+      feature_property_id: 20,
+      required_value: false,
+      sort: null
+    });
+    expect(mockRes.statusValue).to.equal(201);
+    expect(mockRes.jsonValue).to.eql(mockAdminFeatureTypeProperty);
+  });
+
+  it('should create feature type property with minimal fields', async () => {
+    const mockMinimal: AdminFeatureTypeProperty = {
+      feature_type_property_id: 2,
+      feature_type_id: 10,
+      feature_property_id: 30,
+      required_value: false,
+      sort: null
+    };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const createStub = sinon
+      .stub(FeatureTypePropertyService.prototype, 'createFeatureTypeProperty')
+      .resolves(mockMinimal);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10' };
+    mockReq.body = { feature_property_id: 30 };
+
+    const requestHandler = createFeatureTypeProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(createStub).to.have.been.calledWith({
+      feature_type_id: 10,
+      feature_property_id: 30,
+      required_value: undefined,
+      sort: undefined
+    });
+    expect(mockRes.statusValue).to.equal(201);
+  });
+});

--- a/api/src/paths/administrative/feature-types/{featureTypeId}/properties/index.ts
+++ b/api/src/paths/administrative/feature-types/{featureTypeId}/properties/index.ts
@@ -1,0 +1,162 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../../constants/roles';
+import { getDBConnection } from '../../../../../database/db';
+import {
+  AdminFeatureTypePropertySchema,
+  CreateFeatureTypePropertyRequestSchema,
+  FeatureTypePropertiesListResponseSchema
+} from '../../../../../openapi/schemas/feature-type-property';
+import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema } from '../../../../../openapi/schemas/pagination';
+import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
+import { FeatureTypePropertyService } from '../../../../../services/feature-type-property-service';
+import { getLogger } from '../../../../../utils/logger';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../../../utils/pagination';
+
+const defaultLog = getLogger('paths/administrative/feature-types/{featureTypeId}/properties');
+
+const featureTypeIdParam = {
+  in: 'path',
+  name: 'featureTypeId',
+  required: true,
+  schema: { type: 'integer', minimum: 1 },
+  description: 'Feature type ID'
+} as const;
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  getFeatureTypeProperties()
+];
+
+GET.apiDoc = {
+  description: 'Get all active feature type properties for a given feature type.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featureTypeIdParam, ...paginationRequestQueryParamSchema],
+  responses: {
+    200: {
+      description: 'List of active feature type properties',
+      content: {
+        'application/json': {
+          schema: FeatureTypePropertiesListResponseSchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get all active feature type properties for a feature type.
+ *
+ * @returns {RequestHandler}
+ */
+export function getFeatureTypeProperties(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+
+    try {
+      await connection.open();
+
+      const featureTypePropertyService = new FeatureTypePropertyService(connection);
+      const pagination = makePaginationOptionsFromRequest(req);
+
+      const [feature_type_properties, count] = await Promise.all([
+        featureTypePropertyService.getAdminFeatureTypeProperties(featureTypeId, pagination),
+        featureTypePropertyService.getAdminFeatureTypePropertiesCount(featureTypeId)
+      ]);
+
+      await connection.commit();
+
+      return res.status(200).json({ feature_type_properties, pagination: makePaginationResponse(count, pagination) });
+    } catch (error) {
+      defaultLog.error({ label: 'getFeatureTypeProperties', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const POST: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  createFeatureTypeProperty()
+];
+
+POST.apiDoc = {
+  description: 'Assign a feature property to a feature type.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [featureTypeIdParam],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: CreateFeatureTypePropertyRequestSchema
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Feature type property created',
+      content: {
+        'application/json': {
+          schema: AdminFeatureTypePropertySchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Assign a feature property to a feature type.
+ *
+ * @returns {RequestHandler}
+ */
+export function createFeatureTypeProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+    const { feature_property_id, required_value, sort } = req.body;
+
+    try {
+      await connection.open();
+
+      const featureTypePropertyService = new FeatureTypePropertyService(connection);
+      const result = await featureTypePropertyService.createFeatureTypeProperty({
+        feature_type_id: featureTypeId,
+        feature_property_id,
+        required_value,
+        sort
+      });
+
+      await connection.commit();
+
+      return res.status(201).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'createFeatureTypeProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/administrative/feature-types/{featureTypeId}/properties/{featureTypePropertyId}/index.test.ts
+++ b/api/src/paths/administrative/feature-types/{featureTypeId}/properties/{featureTypePropertyId}/index.test.ts
@@ -1,0 +1,157 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
+import * as db from '../../../../../../database/db';
+import { AdminFeatureTypeProperty } from '../../../../../../models/feature-type-property';
+import { FeatureTypePropertyService } from '../../../../../../services/feature-type-property-service';
+import { deleteFeatureTypeProperty, getFeatureTypeProperty, updateFeatureTypeProperty } from './index';
+
+chai.use(sinonChai);
+
+const mockAdminFeatureTypeProperty: AdminFeatureTypeProperty = {
+  feature_type_property_id: 1,
+  feature_type_id: 10,
+  feature_property_id: 20,
+  required_value: false,
+  sort: null
+};
+
+describe('getFeatureTypeProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10', featureTypePropertyId: '1' };
+
+    const requestHandler = getFeatureTypeProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with feature type property', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const getStub = sinon
+      .stub(FeatureTypePropertyService.prototype, 'getAdminFeatureTypeProperty')
+      .resolves(mockAdminFeatureTypeProperty);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10', featureTypePropertyId: '1' };
+
+    const requestHandler = getFeatureTypeProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(getStub).to.have.been.calledWith(1, 10);
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(mockAdminFeatureTypeProperty);
+  });
+});
+
+describe('updateFeatureTypeProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10', featureTypePropertyId: '1' };
+    mockReq.body = { required_value: true };
+
+    const requestHandler = updateFeatureTypeProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with updated feature type property', async () => {
+    const updated: AdminFeatureTypeProperty = { ...mockAdminFeatureTypeProperty, required_value: true };
+
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const updateStub = sinon.stub(FeatureTypePropertyService.prototype, 'updateFeatureTypeProperty').resolves(updated);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10', featureTypePropertyId: '1' };
+    mockReq.body = { required_value: true };
+
+    const requestHandler = updateFeatureTypeProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(updateStub).to.have.been.calledWith(1, 10, { required_value: true });
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql(updated);
+  });
+});
+
+describe('deleteFeatureTypeProperty', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('re-throws any error that is thrown', async () => {
+    const mockDBConnection = getMockDBConnection({
+      open: () => {
+        throw new Error('test error');
+      }
+    });
+
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10', featureTypePropertyId: '1' };
+
+    const requestHandler = deleteFeatureTypeProperty();
+
+    try {
+      await requestHandler(mockReq, mockRes, mockNext);
+      expect.fail();
+    } catch (actualError) {
+      expect((actualError as Error).message).to.equal('test error');
+    }
+  });
+
+  it('should return 200 with success message', async () => {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
+    const deleteStub = sinon.stub(FeatureTypePropertyService.prototype, 'deleteFeatureTypeProperty').resolves();
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { featureTypeId: '10', featureTypePropertyId: '1' };
+
+    const requestHandler = deleteFeatureTypeProperty();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(deleteStub).to.have.been.calledWith(1, 10);
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue).to.eql({ message: 'Feature type property deleted successfully' });
+  });
+});

--- a/api/src/paths/administrative/feature-types/{featureTypeId}/properties/{featureTypePropertyId}/index.ts
+++ b/api/src/paths/administrative/feature-types/{featureTypeId}/properties/{featureTypePropertyId}/index.ts
@@ -1,0 +1,230 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SYSTEM_ROLE } from '../../../../../../constants/roles';
+import { getDBConnection } from '../../../../../../database/db';
+import { UpdateFeatureTypePropertyRecord } from '../../../../../../models/feature-type-property';
+import {
+  AdminFeatureTypePropertySchema,
+  UpdateFeatureTypePropertyRequestSchema
+} from '../../../../../../openapi/schemas/feature-type-property';
+import { defaultErrorResponses } from '../../../../../../openapi/schemas/http-responses';
+import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
+import { FeatureTypePropertyService } from '../../../../../../services/feature-type-property-service';
+import { getLogger } from '../../../../../../utils/logger';
+
+const defaultLog = getLogger('paths/administrative/feature-types/{featureTypeId}/properties/{featureTypePropertyId}');
+
+const pathParams = [
+  {
+    in: 'path',
+    name: 'featureTypeId',
+    required: true,
+    schema: { type: 'integer', minimum: 1 },
+    description: 'Feature type ID'
+  },
+  {
+    in: 'path',
+    name: 'featureTypePropertyId',
+    required: true,
+    schema: { type: 'integer', minimum: 1 },
+    description: 'Feature type property ID'
+  }
+] as const;
+
+export const GET: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  getFeatureTypeProperty()
+];
+
+GET.apiDoc = {
+  description: 'Get a feature type property by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [...pathParams],
+  responses: {
+    200: {
+      description: 'Feature type property',
+      content: {
+        'application/json': {
+          schema: AdminFeatureTypePropertySchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get a feature type property by ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function getFeatureTypeProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+    const featureTypePropertyId = Number(req.params.featureTypePropertyId);
+
+    try {
+      await connection.open();
+
+      const featureTypePropertyService = new FeatureTypePropertyService(connection);
+      const result = await featureTypePropertyService.getAdminFeatureTypeProperty(featureTypePropertyId, featureTypeId);
+
+      await connection.commit();
+
+      return res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'getFeatureTypeProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const PUT: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  updateFeatureTypeProperty()
+];
+
+PUT.apiDoc = {
+  description: 'Update an existing feature type property.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [...pathParams],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: UpdateFeatureTypePropertyRequestSchema
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Feature type property updated',
+      content: {
+        'application/json': {
+          schema: AdminFeatureTypePropertySchema
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Update an existing feature type property.
+ *
+ * @returns {RequestHandler}
+ */
+export function updateFeatureTypeProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+    const featureTypePropertyId = Number(req.params.featureTypePropertyId);
+    const payload = req.body as UpdateFeatureTypePropertyRecord;
+
+    try {
+      await connection.open();
+
+      const featureTypePropertyService = new FeatureTypePropertyService(connection);
+      const result = await featureTypePropertyService.updateFeatureTypeProperty(
+        featureTypePropertyId,
+        featureTypeId,
+        payload
+      );
+
+      await connection.commit();
+
+      return res.status(200).json(result);
+    } catch (error) {
+      defaultLog.error({ label: 'updateFeatureTypeProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}
+
+export const DELETE: Operation = [
+  authorizeRequestHandler(() => ({
+    and: [
+      {
+        validSystemRoles: [SYSTEM_ROLE.SYSTEM_ADMIN],
+        discriminator: 'SystemRole'
+      }
+    ]
+  })),
+  deleteFeatureTypeProperty()
+];
+
+DELETE.apiDoc = {
+  description: 'Soft delete a feature type property by ID.',
+  tags: ['admin'],
+  security: [{ Bearer: [] }],
+  parameters: [...pathParams],
+  responses: {
+    200: {
+      description: 'Feature type property deleted',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' }
+            }
+          }
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Soft delete a feature type property by ID.
+ *
+ * @returns {RequestHandler}
+ */
+export function deleteFeatureTypeProperty(): RequestHandler {
+  return async (req, res) => {
+    const connection = getDBConnection(req.keycloak_token);
+    const featureTypeId = Number(req.params.featureTypeId);
+    const featureTypePropertyId = Number(req.params.featureTypePropertyId);
+
+    try {
+      await connection.open();
+
+      const featureTypePropertyService = new FeatureTypePropertyService(connection);
+      await featureTypePropertyService.deleteFeatureTypeProperty(featureTypePropertyId, featureTypeId);
+
+      await connection.commit();
+
+      return res.status(200).json({ message: 'Feature type property deleted successfully' });
+    } catch (error) {
+      defaultLog.error({ label: 'deleteFeatureTypeProperty', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/codes.ts
+++ b/api/src/paths/codes.ts
@@ -29,7 +29,7 @@ GET.apiDoc = {
                   properties: {
                     feature_type: {
                       type: 'object',
-                      required: ['feature_type_id', 'name', 'display_name'],
+                      required: ['feature_type_id', 'name', 'display_name', 'description'],
                       properties: {
                         feature_type_id: {
                           type: 'integer',
@@ -45,6 +45,11 @@ GET.apiDoc = {
                           type: 'string',
                           description: 'The feature type display name.',
                           example: 'Dataset'
+                        },
+                        description: {
+                          type: 'string',
+                          nullable: true,
+                          description: 'The feature type description.'
                         }
                       },
                       additionalProperties: false
@@ -57,7 +62,6 @@ GET.apiDoc = {
                           'feature_type_property_id',
                           'name',
                           'display_name',
-                          'description',
                           'type_name',
                           'required_value',
                           'calculated_value',
@@ -81,6 +85,7 @@ GET.apiDoc = {
                           },
                           description: {
                             type: 'string',
+                            nullable: true,
                             description: 'The feature property description.',
                             example: 'Description text'
                           },

--- a/api/src/repositories/code-repository.test.ts
+++ b/api/src/repositories/code-repository.test.ts
@@ -22,7 +22,8 @@ describe('CodeRepository', () => {
       const mockRow: FeatureType = {
         feature_type_id: 1,
         name: 'dataset',
-        display_name: 'Dataset'
+        display_name: 'Dataset',
+        description: null
       };
 
       const mockQueryResponse = {
@@ -52,7 +53,8 @@ describe('CodeRepository', () => {
         feature_type: {
           feature_type_id: 1,
           name: 'dataset',
-          display_name: 'Dataset'
+          display_name: 'Dataset',
+          description: null
         },
         properties: [
           {

--- a/api/src/repositories/code-repository.ts
+++ b/api/src/repositories/code-repository.ts
@@ -23,7 +23,8 @@ export class CodeRepository extends BaseRepository {
       SELECT 
         feature_type_id, 
         name,
-        display_name
+        display_name,
+        description
       FROM 
         feature_type
       WHERE
@@ -47,7 +48,8 @@ export class CodeRepository extends BaseRepository {
         JSON_BUILD_OBJECT(
           'feature_type_id', ft.feature_type_id,
           'name', ft.name,
-          'display_name', ft.display_name
+          'display_name', ft.display_name,
+          'description', ft.description
         ) AS "feature_type",
         COALESCE(
           JSON_AGG(

--- a/api/src/repositories/feature-property-repository.test.ts
+++ b/api/src/repositories/feature-property-repository.test.ts
@@ -25,6 +25,33 @@ describe('FeaturePropertyRepository', () => {
     sinon.restore();
   });
 
+  describe('getFeaturePropertyTypeById', () => {
+    it('returns the feature property type record when found', async () => {
+      const mockResponse = {
+        rowCount: 1,
+        rows: [{ feature_property_type_id: 2 }]
+      } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeaturePropertyRepository(mockConnection);
+
+      const result = await repository.getFeaturePropertyTypeById(2);
+      expect(result).to.eql({ feature_property_type_id: 2 });
+    });
+
+    it('throws ApiNotFoundError when no active type exists for the given ID', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeaturePropertyRepository(mockConnection);
+
+      try {
+        await repository.getFeaturePropertyTypeById(999);
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+  });
+
   describe('insertFeatureProperty', () => {
     it('returns the new feature_property_id', async () => {
       const mockResponse = { rowCount: 1, rows: [{ feature_property_id: 1 }] } as unknown as Promise<QueryResult<any>>;

--- a/api/src/repositories/feature-property-repository.test.ts
+++ b/api/src/repositories/feature-property-repository.test.ts
@@ -1,0 +1,82 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import { QueryResult } from 'pg';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
+import { FeatureProperty } from '../models/feature-property';
+import { FeaturePropertyRepository } from './feature-property-repository';
+
+chai.use(sinonChai);
+
+const mockFeatureProperty: FeatureProperty = {
+  feature_property_id: 1,
+  feature_property_type_id: 2,
+  name: 'guid',
+  display_name: 'GUID',
+  description: null,
+  type_name: 'string',
+  calculated_value: false
+};
+
+describe('FeaturePropertyRepository', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('insertFeatureProperty', () => {
+    it('returns the new feature_property_id', async () => {
+      const mockResponse = { rowCount: 1, rows: [{ feature_property_id: 1 }] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeaturePropertyRepository(mockConnection);
+
+      const result = await repository.insertFeatureProperty({
+        feature_property_type_id: 2,
+        name: 'guid',
+        display_name: 'GUID'
+      });
+
+      expect(result).to.equal(1);
+    });
+  });
+
+  describe('getFeatureProperty', () => {
+    it('returns a feature property by ID', async () => {
+      const mockResponse = { rowCount: 1, rows: [mockFeatureProperty] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeaturePropertyRepository(mockConnection);
+
+      const result = await repository.getFeatureProperty(1);
+      expect(result).to.eql(mockFeatureProperty);
+    });
+
+    it('throws ApiNotFoundError when not found', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeaturePropertyRepository(mockConnection);
+
+      try {
+        await repository.getFeatureProperty(999);
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+  });
+
+  describe('updateFeatureProperty', () => {
+    it('throws when no active row is updated', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeaturePropertyRepository(mockConnection);
+
+      try {
+        await repository.updateFeatureProperty(999, { display_name: 'Updated' });
+        expect.fail();
+      } catch (error) {
+        expect((error as ApiExecuteSQLError).message).to.equal('Failed to update feature property');
+      }
+    });
+  });
+});

--- a/api/src/repositories/feature-property-repository.ts
+++ b/api/src/repositories/feature-property-repository.ts
@@ -41,6 +41,42 @@ export class FeaturePropertyRepository extends BaseRepository {
   }
 
   /**
+   * Get a single active feature property type record by ID.
+   *
+   * @param {number} featurePropertyTypeId - The ID of the feature property type to retrieve.
+   * @return {Promise<{ feature_property_type_id: number }>} The active feature property type record.
+   * @throws {ApiNotFoundError} If no active feature property type exists for the given ID.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeaturePropertyRepository
+   */
+  async getFeaturePropertyTypeById(featurePropertyTypeId: number): Promise<{ feature_property_type_id: number }> {
+    const knex = getKnex();
+    const query = knex
+      .from('feature_property_type')
+      .select('feature_property_type_id')
+      .whereNull('record_end_date')
+      .where('feature_property_type_id', featurePropertyTypeId);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Feature property type not found', [
+        'FeaturePropertyRepository->getFeaturePropertyTypeById',
+        { featurePropertyTypeId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'FeaturePropertyRepository->getFeaturePropertyTypeById',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
    * Insert a new feature property record.
    *
    * @param {CreateFeatureProperty} data - The data for the feature property to insert.
@@ -159,7 +195,6 @@ export class FeaturePropertyRepository extends BaseRepository {
     const query = knex
       .table('feature_property')
       .update({
-        feature_property_type_id: data.feature_property_type_id,
         name: data.name,
         display_name: data.display_name,
         description: data.description,

--- a/api/src/repositories/feature-property-repository.ts
+++ b/api/src/repositories/feature-property-repository.ts
@@ -1,0 +1,229 @@
+import { Knex } from 'knex';
+import { getKnex } from '../database/db';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
+import { CountResult } from '../models/count';
+import { CreateFeatureProperty, FeatureProperty, UpdateFeatureProperty } from '../models/feature-property';
+import { FeaturePropertyFilters } from '../services/feature-property-service.interface';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
+import { BaseRepository } from './base-repository';
+
+/**
+ * A repository class for accessing feature property data.
+ *
+ * @export
+ * @class FeaturePropertyRepository
+ * @extends {BaseRepository}
+ */
+export class FeaturePropertyRepository extends BaseRepository {
+  /**
+   * Build the base SELECT query that joins feature_property_type for type_name.
+   *
+   * @returns {Knex.QueryBuilder}
+   * @private
+   * @memberof FeaturePropertyRepository
+   */
+  private baseQuery(): Knex.QueryBuilder {
+    const knex = getKnex();
+    return knex
+      .from('feature_property as fp')
+      .innerJoin('feature_property_type as fpt', function () {
+        this.on('fpt.feature_property_type_id', '=', 'fp.feature_property_type_id').andOnNull('fpt.record_end_date');
+      })
+      .select([
+        'fp.feature_property_id',
+        'fp.feature_property_type_id',
+        'fp.name',
+        'fp.display_name',
+        'fp.description',
+        knex.ref('fpt.name').as('type_name'),
+        'fp.calculated_value'
+      ]);
+  }
+
+  /**
+   * Insert a new feature property record.
+   *
+   * @param {CreateFeatureProperty} data - The data for the feature property to insert.
+   * @return {Promise<number>} The new feature_property_id.
+   * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
+   * @memberof FeaturePropertyRepository
+   */
+  async insertFeatureProperty(data: CreateFeatureProperty): Promise<number> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_property')
+      .insert({
+        feature_property_type_id: data.feature_property_type_id,
+        name: data.name,
+        display_name: data.display_name,
+        description: data.description ?? null,
+        calculated_value: data.calculated_value ?? false
+      })
+      .returning(['feature_property_id']);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to insert feature property', [
+        'FeaturePropertyRepository->insertFeatureProperty',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+
+    return response.rows[0].feature_property_id;
+  }
+
+  /**
+   * Get a single active feature property by ID.
+   *
+   * @param {number} featurePropertyId - The ID of the feature property to retrieve.
+   * @return {Promise<FeatureProperty>} The feature property record.
+   * @throws {ApiNotFoundError} If no active feature property exists for the id.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeaturePropertyRepository
+   */
+  async getFeatureProperty(featurePropertyId: number): Promise<FeatureProperty> {
+    const query = this.baseQuery().whereNull('fp.record_end_date').where('fp.feature_property_id', featurePropertyId);
+
+    const response = await this.connection.knex(query, FeatureProperty);
+
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Feature property not found', [
+        'FeaturePropertyRepository->getFeatureProperty',
+        { featurePropertyId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'FeaturePropertyRepository->getFeatureProperty',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Get active feature properties with optional search and pagination.
+   *
+   * @param {FeaturePropertyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<FeatureProperty[]>}
+   * @memberof FeaturePropertyRepository
+   */
+  async getFeatureProperties(
+    filters?: FeaturePropertyFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FeatureProperty[]> {
+    const query = this.applyFilters(this.baseQuery().whereNull('fp.record_end_date'), filters);
+
+    query.orderBy('fp.name', 'asc');
+
+    if (pagination) {
+      this.applyPagination(query, pagination);
+    }
+
+    const response = await this.connection.knex(query, FeatureProperty);
+
+    return response.rows;
+  }
+
+  /**
+   * Get count of active feature properties matching optional filters.
+   *
+   * @param {FeaturePropertyFilters} [filters] - Optional filter set.
+   * @return {Promise<number>}
+   * @memberof FeaturePropertyRepository
+   */
+  async getFeaturePropertiesCount(filters?: FeaturePropertyFilters): Promise<number> {
+    const knex = getKnex();
+    const baseQuery = this.applyFilters(knex.from('feature_property as fp').whereNull('fp.record_end_date'), filters);
+
+    const countQuery = baseQuery.clone().select(knex.raw('coalesce(count(*), 0)::integer as count')).first();
+    const countResult = await this.connection.knex(countQuery, CountResult);
+    return countResult.rows[0].count;
+  }
+
+  /**
+   * Update an existing feature property record.
+   *
+   * @param {number} featurePropertyId - The ID of the feature property to update.
+   * @param {UpdateFeatureProperty} data - The data to update.
+   * @return {Promise<void>}
+   * @throws {ApiExecuteSQLError} If the update does not affect exactly one row.
+   * @memberof FeaturePropertyRepository
+   */
+  async updateFeatureProperty(featurePropertyId: number, data: UpdateFeatureProperty): Promise<void> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_property')
+      .update({
+        feature_property_type_id: data.feature_property_type_id,
+        name: data.name,
+        display_name: data.display_name,
+        description: data.description,
+        calculated_value: data.calculated_value,
+        record_end_date: data.record_end_date
+      })
+      .whereNull('record_end_date')
+      .where('feature_property_id', featurePropertyId);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to update feature property', [
+        'FeaturePropertyRepository->updateFeatureProperty',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+  }
+
+  /**
+   * Soft delete a feature property record by ID.
+   *
+   * @param {number} featurePropertyId - The ID of the feature property to delete.
+   * @return {Promise<void>}
+   * @throws {ApiExecuteSQLError} If the delete does not affect exactly one row.
+   * @memberof FeaturePropertyRepository
+   */
+  async deleteFeatureProperty(featurePropertyId: number): Promise<void> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_property')
+      .update({ record_end_date: knex.fn.now() })
+      .whereNull('record_end_date')
+      .where('feature_property_id', featurePropertyId)
+      .returning(['feature_property_id']);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to delete feature property', [
+        'FeaturePropertyRepository->deleteFeatureProperty',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+  }
+
+  /**
+   * Apply feature property list filters to the provided query.
+   *
+   * @param {Knex.QueryBuilder} query - Base query to filter.
+   * @param {FeaturePropertyFilters} [filters] - Optional filter set.
+   * @return {Knex.QueryBuilder} Filtered query.
+   * @private
+   * @memberof FeaturePropertyRepository
+   */
+  private applyFilters(query: Knex.QueryBuilder, filters?: FeaturePropertyFilters): Knex.QueryBuilder {
+    if (!filters) {
+      return query;
+    }
+
+    if (filters.search) {
+      query.whereILike('fp.name', `%${filters.search}%`);
+    }
+
+    return query;
+  }
+}

--- a/api/src/repositories/feature-type-property-repository.test.ts
+++ b/api/src/repositories/feature-type-property-repository.test.ts
@@ -1,0 +1,124 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import { QueryResult } from 'pg';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
+import { ApiConflictError, ApiNotFoundError } from '../errors/api-error';
+import { AdminFeatureTypeProperty } from '../models/feature-type-property';
+import { FeatureTypePropertyRepository } from './feature-type-property-repository';
+
+chai.use(sinonChai);
+
+const mockAdminFeatureTypeProperty: AdminFeatureTypeProperty = {
+  feature_type_property_id: 1,
+  feature_type_id: 10,
+  feature_property_id: 20,
+  required_value: false,
+  sort: null
+};
+
+describe('FeatureTypePropertyRepository admin CRUD', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('insertFeatureTypeProperty', () => {
+    it('returns the new feature_type_property_id', async () => {
+      let callCount = 0;
+      const mockConnection = getMockDBConnection({
+        knex: async () => {
+          callCount += 1;
+          if (callCount === 1) {
+            return { rowCount: 0, rows: [] } as unknown as QueryResult<any>;
+          }
+          return { rowCount: 1, rows: [{ feature_type_property_id: 1 }] } as unknown as QueryResult<any>;
+        }
+      });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      const result = await repository.insertFeatureTypeProperty({
+        feature_type_id: 10,
+        feature_property_id: 20
+      });
+
+      expect(result).to.equal(1);
+    });
+
+    it('throws ApiConflictError when assignment already exists', async () => {
+      const mockConnection = getMockDBConnection({
+        knex: async () => ({ rowCount: 1, rows: [{ feature_type_property_id: 99 }] } as unknown as QueryResult<any>)
+      });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      try {
+        await repository.insertFeatureTypeProperty({
+          feature_type_id: 10,
+          feature_property_id: 20
+        });
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiConflictError);
+        expect((error as ApiConflictError).message).to.equal(
+          'Feature property is already assigned to this feature type'
+        );
+      }
+    });
+  });
+
+  describe('getAdminFeatureTypeProperty', () => {
+    it('returns a scoped feature type property', async () => {
+      const mockResponse = { rowCount: 1, rows: [mockAdminFeatureTypeProperty] } as unknown as Promise<
+        QueryResult<any>
+      >;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      const result = await repository.getAdminFeatureTypeProperty(1, 10);
+      expect(result).to.eql(mockAdminFeatureTypeProperty);
+    });
+
+    it('throws ApiNotFoundError when scoped record is not found', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      try {
+        await repository.getAdminFeatureTypeProperty(1, 99);
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+  });
+
+  describe('updateFeatureTypeProperty', () => {
+    it('throws ApiNotFoundError when scoped update affects no rows', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      try {
+        await repository.updateFeatureTypeProperty(1, 99, { required_value: true });
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+  });
+
+  describe('deleteFeatureTypeProperty', () => {
+    it('throws ApiNotFoundError when scoped delete affects no rows', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      try {
+        await repository.deleteFeatureTypeProperty(1, 99);
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+  });
+});

--- a/api/src/repositories/feature-type-property-repository.test.ts
+++ b/api/src/repositories/feature-type-property-repository.test.ts
@@ -4,7 +4,7 @@ import { QueryResult } from 'pg';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../__mocks__/db';
-import { ApiConflictError, ApiNotFoundError } from '../errors/api-error';
+import { ApiNotFoundError } from '../errors/api-error';
 import { AdminFeatureTypeProperty } from '../models/feature-type-property';
 import { FeatureTypePropertyRepository } from './feature-type-property-repository';
 
@@ -23,17 +23,32 @@ describe('FeatureTypePropertyRepository admin CRUD', () => {
     sinon.restore();
   });
 
+  describe('findActiveFeatureTypePropertyByFeatureTypeAndProperty', () => {
+    it('returns the record when an active assignment exists', async () => {
+      const mockConnection = getMockDBConnection({
+        knex: async () => ({ rowCount: 1, rows: [{ feature_type_property_id: 99 }] } as unknown as QueryResult<any>)
+      });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      const result = await repository.findActiveFeatureTypePropertyByFeatureTypeAndProperty(10, 20);
+      expect(result).to.eql({ feature_type_property_id: 99 });
+    });
+
+    it('returns null when no active assignment exists', async () => {
+      const mockConnection = getMockDBConnection({
+        knex: async () => ({ rowCount: 0, rows: [] } as unknown as QueryResult<any>)
+      });
+      const repository = new FeatureTypePropertyRepository(mockConnection);
+
+      const result = await repository.findActiveFeatureTypePropertyByFeatureTypeAndProperty(10, 20);
+      expect(result).to.be.null;
+    });
+  });
+
   describe('insertFeatureTypeProperty', () => {
     it('returns the new feature_type_property_id', async () => {
-      let callCount = 0;
       const mockConnection = getMockDBConnection({
-        knex: async () => {
-          callCount += 1;
-          if (callCount === 1) {
-            return { rowCount: 0, rows: [] } as unknown as QueryResult<any>;
-          }
-          return { rowCount: 1, rows: [{ feature_type_property_id: 1 }] } as unknown as QueryResult<any>;
-        }
+        knex: async () => ({ rowCount: 1, rows: [{ feature_type_property_id: 1 }] } as unknown as QueryResult<any>)
       });
       const repository = new FeatureTypePropertyRepository(mockConnection);
 
@@ -43,26 +58,6 @@ describe('FeatureTypePropertyRepository admin CRUD', () => {
       });
 
       expect(result).to.equal(1);
-    });
-
-    it('throws ApiConflictError when assignment already exists', async () => {
-      const mockConnection = getMockDBConnection({
-        knex: async () => ({ rowCount: 1, rows: [{ feature_type_property_id: 99 }] } as unknown as QueryResult<any>)
-      });
-      const repository = new FeatureTypePropertyRepository(mockConnection);
-
-      try {
-        await repository.insertFeatureTypeProperty({
-          feature_type_id: 10,
-          feature_property_id: 20
-        });
-        expect.fail();
-      } catch (error) {
-        expect(error).to.be.instanceOf(ApiConflictError);
-        expect((error as ApiConflictError).message).to.equal(
-          'Feature property is already assigned to this feature type'
-        );
-      }
     });
   });
 

--- a/api/src/repositories/feature-type-property-repository.ts
+++ b/api/src/repositories/feature-type-property-repository.ts
@@ -1,8 +1,33 @@
 import SQL from 'sql-template-strings';
-import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
-import { ExpressionPredicatePropertyMetadata, FeatureTypeProperty } from '../models/feature-type-property';
+import { getKnex } from '../database/db';
+import { ApiConflictError, ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
+import { CountResult } from '../models/count';
+import {
+  AdminFeatureTypeProperty,
+  CreateFeatureTypePropertyRecord,
+  ExpressionPredicatePropertyMetadata,
+  FeatureTypeProperty,
+  UpdateFeatureTypePropertyRecord
+} from '../models/feature-type-property';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 
+/** Columns selected for admin CRUD responses (raw feature_type_property row). */
+const ADMIN_FEATURE_TYPE_PROPERTY_COLUMNS = [
+  'feature_type_property_id',
+  'feature_type_id',
+  'feature_property_id',
+  'required_value',
+  'sort'
+] as const;
+
+/**
+ * A repository class for accessing feature type property data.
+ *
+ * @export
+ * @class FeatureTypePropertyRepository
+ * @extends {BaseRepository}
+ */
 export class FeatureTypePropertyRepository extends BaseRepository {
   /**
    * Get a feature property record by canonical feature-property name.
@@ -11,6 +36,7 @@ export class FeatureTypePropertyRepository extends BaseRepository {
    * @return {Promise<FeatureTypeProperty>} Matching feature-type-property row.
    * @throws {ApiNotFoundError} If no active feature property matches the name.
    * @throws {ApiExecuteSQLError} If more than one active row is returned.
+   * @memberof FeatureTypePropertyRepository
    */
   async getFeaturePropertyByName(featurePropertyName: string): Promise<FeatureTypeProperty> {
     const sqlStatement = SQL`
@@ -66,6 +92,7 @@ export class FeatureTypePropertyRepository extends BaseRepository {
    * @return {Promise<FeatureTypeProperty>} Matching feature-type-property row.
    * @throws {ApiNotFoundError} If no active row exists for the id.
    * @throws {ApiExecuteSQLError} If more than one active row is returned.
+   * @memberof FeatureTypePropertyRepository
    */
   async getFeaturePropertyByFeatureTypePropertyId(featureTypePropertyId: number): Promise<FeatureTypeProperty> {
     const sqlStatement = SQL`
@@ -122,6 +149,9 @@ export class FeatureTypePropertyRepository extends BaseRepository {
    * @param {number} featurePropertyId - Shared feature property id.
    * @param {number | null} featureTypePropertyId - Optional concrete feature type property id.
    * @return {Promise<ExpressionPredicatePropertyMetadata>} Resolved metadata.
+   * @throws {ApiNotFoundError} If no matching active property metadata exists.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypePropertyRepository
    */
   async getExpressionPredicatePropertyMetadata(
     featurePropertyId: number,
@@ -179,5 +209,222 @@ export class FeatureTypePropertyRepository extends BaseRepository {
     }
 
     return response.rows[0];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Admin CRUD methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Insert a new feature type property record.
+   *
+   * @param {CreateFeatureTypePropertyRecord} data - Data for the record to insert.
+   * @return {Promise<number>} The new feature_type_property_id.
+   * @throws {ApiConflictError} If the feature property is already assigned to the feature type.
+   * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
+   * @memberof FeatureTypePropertyRepository
+   */
+  async insertFeatureTypeProperty(data: CreateFeatureTypePropertyRecord): Promise<number> {
+    const knex = getKnex();
+
+    const existingQuery = knex
+      .from('feature_type_property')
+      .select('feature_type_property_id')
+      .whereNull('record_end_date')
+      .where({
+        feature_type_id: data.feature_type_id,
+        feature_property_id: data.feature_property_id
+      })
+      .first();
+
+    const existingResult = await this.connection.knex(existingQuery);
+
+    if ((existingResult.rowCount ?? 0) > 0) {
+      throw new ApiConflictError('Feature property is already assigned to this feature type', [
+        'FeatureTypePropertyRepository->insertFeatureTypeProperty',
+        { feature_type_id: data.feature_type_id, feature_property_id: data.feature_property_id }
+      ]);
+    }
+
+    const query = knex
+      .table('feature_type_property')
+      .insert({
+        feature_type_id: data.feature_type_id,
+        feature_property_id: data.feature_property_id,
+        required_value: data.required_value ?? false,
+        sort: data.sort ?? null
+      })
+      .returning(['feature_type_property_id']);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to insert feature type property', [
+        'FeatureTypePropertyRepository->insertFeatureTypeProperty',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+
+    return response.rows[0].feature_type_property_id;
+  }
+
+  /**
+   * Get a single active feature type property record by ID (admin raw row, no joins).
+   *
+   * When `featureTypeId` is supplied the query additionally filters by that column,
+   * ensuring the record belongs to the expected parent feature type. This enforces
+   * the nested route hierarchy and prevents cross-feature-type mutations.
+   *
+   * @param {number} featureTypePropertyId - Feature type property identifier.
+   * @param {number} featureTypeId - Parent feature type identifier used to scope the lookup.
+   * @return {Promise<AdminFeatureTypeProperty>} The raw feature type property record.
+   * @throws {ApiNotFoundError} If no active record exists for the id within the parent feature type.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypePropertyRepository
+   */
+  async getAdminFeatureTypeProperty(
+    featureTypePropertyId: number,
+    featureTypeId: number
+  ): Promise<AdminFeatureTypeProperty> {
+    const knex = getKnex();
+    const query = knex
+      .from('feature_type_property')
+      .select(ADMIN_FEATURE_TYPE_PROPERTY_COLUMNS)
+      .whereNull('record_end_date')
+      .where('feature_type_property_id', featureTypePropertyId)
+      .where('feature_type_id', featureTypeId);
+
+    const response = await this.connection.knex(query, AdminFeatureTypeProperty);
+
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Feature type property not found', [
+        'FeatureTypePropertyRepository->getAdminFeatureTypeProperty',
+        { featureTypePropertyId, featureTypeId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'FeatureTypePropertyRepository->getAdminFeatureTypeProperty',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Get active feature type property records for a given feature type.
+   *
+   * @param {number} featureTypeId - Feature type identifier to scope results.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<AdminFeatureTypeProperty[]>}
+   * @memberof FeatureTypePropertyRepository
+   */
+  async getAdminFeatureTypeProperties(
+    featureTypeId: number,
+    pagination?: ApiPaginationOptions
+  ): Promise<AdminFeatureTypeProperty[]> {
+    const knex = getKnex();
+    const query = knex
+      .from('feature_type_property')
+      .select(ADMIN_FEATURE_TYPE_PROPERTY_COLUMNS)
+      .whereNull('record_end_date')
+      .where('feature_type_id', featureTypeId)
+      .orderBy('sort', 'asc');
+
+    if (pagination) {
+      this.applyPagination(query, pagination);
+    }
+
+    const response = await this.connection.knex(query, AdminFeatureTypeProperty);
+
+    return response.rows;
+  }
+
+  /**
+   * Get count of active feature type property records for a given feature type.
+   *
+   * @param {number} featureTypeId - Feature type identifier to scope the count.
+   * @return {Promise<number>}
+   * @memberof FeatureTypePropertyRepository
+   */
+  async getAdminFeatureTypePropertiesCount(featureTypeId: number): Promise<number> {
+    const knex = getKnex();
+    const countQuery = knex
+      .from('feature_type_property')
+      .whereNull('record_end_date')
+      .where('feature_type_id', featureTypeId)
+      .select(knex.raw('coalesce(count(*), 0)::integer as count'))
+      .first();
+
+    const countResult = await this.connection.knex(countQuery, CountResult);
+    return countResult.rows[0].count;
+  }
+
+  /**
+   * Update an existing feature type property record.
+   *
+   * @param {number} featureTypePropertyId - Feature type property identifier.
+   * @param {number} featureTypeId - Parent feature type identifier used to scope the update.
+   * @param {UpdateFeatureTypePropertyRecord} data - The data to update.
+   * @return {Promise<void>}
+   * @throws {ApiNotFoundError} If no active record exists for the id within the parent feature type.
+   * @memberof FeatureTypePropertyRepository
+   */
+  async updateFeatureTypeProperty(
+    featureTypePropertyId: number,
+    featureTypeId: number,
+    data: UpdateFeatureTypePropertyRecord
+  ): Promise<void> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_type_property')
+      .update({
+        required_value: data.required_value,
+        sort: data.sort,
+        record_end_date: data.record_end_date
+      })
+      .whereNull('record_end_date')
+      .where('feature_type_property_id', featureTypePropertyId)
+      .where('feature_type_id', featureTypeId);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiNotFoundError('Feature type property not found', [
+        'FeatureTypePropertyRepository->updateFeatureTypeProperty',
+        { featureTypePropertyId, featureTypeId }
+      ]);
+    }
+  }
+
+  /**
+   * Soft delete a feature type property record scoped to a parent feature type.
+   *
+   * @param {number} featureTypePropertyId - Feature type property identifier.
+   * @param {number} featureTypeId - Parent feature type identifier used to scope the delete.
+   * @return {Promise<void>}
+   * @throws {ApiNotFoundError} If no active record exists for the id within the parent feature type.
+   * @memberof FeatureTypePropertyRepository
+   */
+  async deleteFeatureTypeProperty(featureTypePropertyId: number, featureTypeId: number): Promise<void> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_type_property')
+      .update({ record_end_date: knex.fn.now() })
+      .whereNull('record_end_date')
+      .where('feature_type_property_id', featureTypePropertyId)
+      .where('feature_type_id', featureTypeId)
+      .returning(['feature_type_property_id']);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiNotFoundError('Feature type property not found', [
+        'FeatureTypePropertyRepository->deleteFeatureTypeProperty',
+        { featureTypePropertyId, featureTypeId }
+      ]);
+    }
   }
 }

--- a/api/src/repositories/feature-type-property-repository.ts
+++ b/api/src/repositories/feature-type-property-repository.ts
@@ -1,6 +1,6 @@
 import SQL from 'sql-template-strings';
 import { getKnex } from '../database/db';
-import { ApiConflictError, ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
 import { CountResult } from '../models/count';
 import {
   AdminFeatureTypeProperty,
@@ -216,35 +216,43 @@ export class FeatureTypePropertyRepository extends BaseRepository {
   // ---------------------------------------------------------------------------
 
   /**
+   * Find an active feature type property record matching the given feature type and feature property.
+   *
+   * Returns `null` when no active assignment exists; callers are responsible for deciding whether
+   * that constitutes a conflict.
+   *
+   * @param {number} featureTypeId - The feature type identifier.
+   * @param {number} featurePropertyId - The feature property identifier.
+   * @return {Promise<{ feature_type_property_id: number } | null>} The matching record, or `null` if none exists.
+   * @memberof FeatureTypePropertyRepository
+   */
+  async findActiveFeatureTypePropertyByFeatureTypeAndProperty(
+    featureTypeId: number,
+    featurePropertyId: number
+  ): Promise<{ feature_type_property_id: number } | null> {
+    const knex = getKnex();
+    const query = knex
+      .from('feature_type_property')
+      .select('feature_type_property_id')
+      .whereNull('record_end_date')
+      .where({ feature_type_id: featureTypeId, feature_property_id: featurePropertyId })
+      .first();
+
+    const response = await this.connection.knex(query);
+
+    return response.rows[0] ?? null;
+  }
+
+  /**
    * Insert a new feature type property record.
    *
    * @param {CreateFeatureTypePropertyRecord} data - Data for the record to insert.
    * @return {Promise<number>} The new feature_type_property_id.
-   * @throws {ApiConflictError} If the feature property is already assigned to the feature type.
    * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
    * @memberof FeatureTypePropertyRepository
    */
   async insertFeatureTypeProperty(data: CreateFeatureTypePropertyRecord): Promise<number> {
     const knex = getKnex();
-
-    const existingQuery = knex
-      .from('feature_type_property')
-      .select('feature_type_property_id')
-      .whereNull('record_end_date')
-      .where({
-        feature_type_id: data.feature_type_id,
-        feature_property_id: data.feature_property_id
-      })
-      .first();
-
-    const existingResult = await this.connection.knex(existingQuery);
-
-    if ((existingResult.rowCount ?? 0) > 0) {
-      throw new ApiConflictError('Feature property is already assigned to this feature type', [
-        'FeatureTypePropertyRepository->insertFeatureTypeProperty',
-        { feature_type_id: data.feature_type_id, feature_property_id: data.feature_property_id }
-      ]);
-    }
 
     const query = knex
       .table('feature_type_property')

--- a/api/src/repositories/feature-type-repository.test.ts
+++ b/api/src/repositories/feature-type-repository.test.ts
@@ -1,0 +1,102 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import { QueryResult } from 'pg';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
+import { FeatureType } from '../models/feature-type';
+import { FeatureTypeRepository } from './feature-type-repository';
+
+chai.use(sinonChai);
+
+const mockFeatureType: FeatureType = {
+  feature_type_id: 1,
+  name: 'dataset',
+  display_name: 'Dataset',
+  description: null
+};
+
+describe('FeatureTypeRepository', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('insertFeatureType', () => {
+    it('returns the inserted feature type', async () => {
+      const mockResponse = { rowCount: 1, rows: [mockFeatureType] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypeRepository(mockConnection);
+
+      const result = await repository.insertFeatureType({
+        name: 'dataset',
+        display_name: 'Dataset'
+      });
+
+      expect(result).to.eql(mockFeatureType);
+    });
+
+    it('throws when insert fails', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypeRepository(mockConnection);
+
+      try {
+        await repository.insertFeatureType({ name: 'dataset', display_name: 'Dataset' });
+        expect.fail();
+      } catch (error) {
+        expect((error as ApiExecuteSQLError).message).to.equal('Failed to insert feature type');
+      }
+    });
+  });
+
+  describe('getFeatureType', () => {
+    it('returns a feature type by ID', async () => {
+      const mockResponse = { rowCount: 1, rows: [mockFeatureType] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypeRepository(mockConnection);
+
+      const result = await repository.getFeatureType(1);
+      expect(result).to.eql(mockFeatureType);
+    });
+
+    it('throws ApiNotFoundError when not found', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypeRepository(mockConnection);
+
+      try {
+        await repository.getFeatureType(999);
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+  });
+
+  describe('getFeatureTypesCount', () => {
+    it('returns the count of active feature types', async () => {
+      const mockResponse = { rowCount: 1, rows: [{ count: 3 }] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypeRepository(mockConnection);
+
+      const result = await repository.getFeatureTypesCount();
+      expect(result).to.equal(3);
+    });
+  });
+
+  describe('deleteFeatureType', () => {
+    it('throws when no active row is deleted', async () => {
+      const mockResponse = { rowCount: 0, rows: [] } as unknown as Promise<QueryResult<any>>;
+      const mockConnection = getMockDBConnection({ knex: async () => mockResponse });
+      const repository = new FeatureTypeRepository(mockConnection);
+
+      try {
+        await repository.deleteFeatureType(999);
+        expect.fail();
+      } catch (error) {
+        expect((error as ApiExecuteSQLError).message).to.equal('Failed to delete feature type');
+      }
+    });
+  });
+});

--- a/api/src/repositories/feature-type-repository.ts
+++ b/api/src/repositories/feature-type-repository.ts
@@ -1,0 +1,209 @@
+import { Knex } from 'knex';
+import { getKnex } from '../database/db';
+import { ApiExecuteSQLError, ApiNotFoundError } from '../errors/api-error';
+import { CountResult } from '../models/count';
+import { CreateFeatureType, FeatureType, UpdateFeatureType } from '../models/feature-type';
+import { FeatureTypeFilters } from '../services/feature-type-service.interface';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
+import { BaseRepository } from './base-repository';
+
+/**
+ * A repository class for accessing feature type data.
+ *
+ * @export
+ * @class FeatureTypeRepository
+ * @extends {BaseRepository}
+ */
+export class FeatureTypeRepository extends BaseRepository {
+  /**
+   * Insert a new feature type record.
+   *
+   * @param {CreateFeatureType} data - The data for the feature type to insert.
+   * @return {Promise<FeatureType>} The created feature type record.
+   * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
+   * @memberof FeatureTypeRepository
+   */
+  async insertFeatureType(data: CreateFeatureType): Promise<FeatureType> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_type')
+      .insert({
+        name: data.name,
+        display_name: data.display_name,
+        description: data.description ?? null
+      })
+      .returning(['feature_type_id', 'name', 'display_name', 'description']);
+
+    const response = await this.connection.knex(query, FeatureType);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to insert feature type', [
+        'FeatureTypeRepository->insertFeatureType',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Get a single active feature type by ID.
+   *
+   * @param {number} featureTypeId - The ID of the feature type to retrieve.
+   * @return {Promise<FeatureType>} The feature type record.
+   * @throws {ApiNotFoundError} If no active feature type exists for the id.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypeRepository
+   */
+  async getFeatureType(featureTypeId: number): Promise<FeatureType> {
+    const knex = getKnex();
+    const query = knex
+      .from('feature_type')
+      .select(['feature_type_id', 'name', 'display_name', 'description'])
+      .whereNull('record_end_date')
+      .where('feature_type_id', featureTypeId);
+
+    const response = await this.connection.knex(query, FeatureType);
+
+    if (response.rowCount === 0) {
+      throw new ApiNotFoundError('Feature type not found', [
+        'FeatureTypeRepository->getFeatureType',
+        { featureTypeId }
+      ]);
+    }
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Unexpected row count', [
+        'FeatureTypeRepository->getFeatureType',
+        `expected rowCount=1, actual rowCount=${response.rowCount}`
+      ]);
+    }
+
+    return response.rows[0];
+  }
+
+  /**
+   * Get active feature types with optional search and pagination.
+   *
+   * @param {FeatureTypeFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<FeatureType[]>}
+   * @memberof FeatureTypeRepository
+   */
+  async getFeatureTypes(filters?: FeatureTypeFilters, pagination?: ApiPaginationOptions): Promise<FeatureType[]> {
+    const knex = getKnex();
+    const baseQuery = this.applyFilters(
+      knex
+        .from('feature_type')
+        .select(['feature_type_id', 'name', 'display_name', 'description'])
+        .whereNull('record_end_date'),
+      filters
+    );
+
+    baseQuery.orderBy('sort', 'asc');
+
+    if (pagination) {
+      this.applyPagination(baseQuery, pagination);
+    }
+
+    const response = await this.connection.knex(baseQuery, FeatureType);
+
+    return response.rows;
+  }
+
+  /**
+   * Get count of active feature types matching optional filters.
+   *
+   * @param {FeatureTypeFilters} [filters] - Optional filter set.
+   * @return {Promise<number>}
+   * @memberof FeatureTypeRepository
+   */
+  async getFeatureTypesCount(filters?: FeatureTypeFilters): Promise<number> {
+    const knex = getKnex();
+    const baseQuery = this.applyFilters(knex.from('feature_type').whereNull('record_end_date'), filters);
+
+    const countQuery = baseQuery.clone().select(knex.raw('coalesce(count(*), 0)::integer as count')).first();
+    const countResult = await this.connection.knex(countQuery, CountResult);
+    return countResult.rows[0].count;
+  }
+
+  /**
+   * Update an existing feature type record.
+   *
+   * @param {number} featureTypeId - The ID of the feature type to update.
+   * @param {UpdateFeatureType} data - The data to update.
+   * @return {Promise<void>}
+   * @throws {ApiExecuteSQLError} If the update does not affect exactly one row.
+   * @memberof FeatureTypeRepository
+   */
+  async updateFeatureType(featureTypeId: number, data: UpdateFeatureType): Promise<void> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_type')
+      .update({
+        name: data.name,
+        display_name: data.display_name,
+        description: data.description,
+        record_end_date: data.record_end_date
+      })
+      .whereNull('record_end_date')
+      .where('feature_type_id', featureTypeId);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to update feature type', [
+        'FeatureTypeRepository->updateFeatureType',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+  }
+
+  /**
+   * Soft delete a feature type record by ID.
+   *
+   * @param {number} featureTypeId - The ID of the feature type to delete.
+   * @return {Promise<void>}
+   * @throws {ApiExecuteSQLError} If the delete does not affect exactly one row.
+   * @memberof FeatureTypeRepository
+   */
+  async deleteFeatureType(featureTypeId: number): Promise<void> {
+    const knex = getKnex();
+    const query = knex
+      .table('feature_type')
+      .update({ record_end_date: knex.fn.now() })
+      .whereNull('record_end_date')
+      .where('feature_type_id', featureTypeId)
+      .returning(['feature_type_id']);
+
+    const response = await this.connection.knex(query);
+
+    if (response.rowCount !== 1) {
+      throw new ApiExecuteSQLError('Failed to delete feature type', [
+        'FeatureTypeRepository->deleteFeatureType',
+        'rowCount was null or undefined, expected rowCount = 1'
+      ]);
+    }
+  }
+
+  /**
+   * Apply feature type list filters to the provided query.
+   *
+   * @param {Knex.QueryBuilder} query - Base query to filter.
+   * @param {FeatureTypeFilters} [filters] - Optional filter set.
+   * @return {Knex.QueryBuilder} Filtered query.
+   * @private
+   * @memberof FeatureTypeRepository
+   */
+  private applyFilters(query: Knex.QueryBuilder, filters?: FeatureTypeFilters): Knex.QueryBuilder {
+    if (!filters) {
+      return query;
+    }
+
+    if (filters.search) {
+      query.whereILike('name', `%${filters.search}%`);
+    }
+
+    return query;
+  }
+}

--- a/api/src/services/code-service.test.ts
+++ b/api/src/services/code-service.test.ts
@@ -24,7 +24,8 @@ describe('codeService', () => {
           feature_type: {
             feature_type_id: 1,
             name: 'dataset',
-            display_name: 'Dataset'
+            display_name: 'Dataset',
+            description: null
           },
           properties: [
             {
@@ -94,7 +95,8 @@ describe('codeService', () => {
           feature_type: {
             feature_type_id: 1,
             name: 'dataset',
-            display_name: 'Dataset'
+            display_name: 'Dataset',
+            description: null
           },
           properties: [
             {
@@ -123,7 +125,8 @@ describe('codeService', () => {
           feature_type: {
             feature_type_id: 2,
             name: 'artifact',
-            display_name: 'Artifact'
+            display_name: 'Artifact',
+            description: null
           },
           properties: [
             {

--- a/api/src/services/download/download-export-pipeline-service.test.ts
+++ b/api/src/services/download/download-export-pipeline-service.test.ts
@@ -191,7 +191,12 @@ describe('DownloadExportPipelineService', () => {
   describe('runExport', () => {
     const mockCodes: FeatureTypeWithProperties[] = [
       {
-        feature_type: { feature_type_id: 1, name: 'observation', display_name: 'Observation' },
+        feature_type: {
+          feature_type_id: 1,
+          name: 'observation',
+          display_name: 'Observation',
+          description: null
+        },
         properties: [
           {
             feature_type_property_id: 1,
@@ -766,7 +771,12 @@ describe('DownloadExportPipelineService', () => {
   describe('runExport per-part file refs', () => {
     const mockCodes: FeatureTypeWithProperties[] = [
       {
-        feature_type: { feature_type_id: 1, name: 'observation', display_name: 'Observation' },
+        feature_type: {
+          feature_type_id: 1,
+          name: 'observation',
+          display_name: 'Observation',
+          description: null
+        },
         properties: [
           {
             feature_type_property_id: 1,

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -156,7 +156,7 @@ describe('DownloadPipelineService', () => {
   describe('resolveParquetSchema', () => {
     const mockCodes: FeatureTypeWithProperties[] = [
       {
-        feature_type: { feature_type_id: 1, name: 'dataset', display_name: 'Dataset' },
+        feature_type: { feature_type_id: 1, name: 'dataset', display_name: 'Dataset', description: null },
         properties: [
           {
             feature_type_property_id: 1,
@@ -171,7 +171,12 @@ describe('DownloadPipelineService', () => {
         ]
       },
       {
-        feature_type: { feature_type_id: 2, name: 'observation', display_name: 'Observation' },
+        feature_type: {
+          feature_type_id: 2,
+          name: 'observation',
+          display_name: 'Observation',
+          description: null
+        },
         properties: [
           {
             feature_type_property_id: 2,

--- a/api/src/services/feature-property-service.interface.ts
+++ b/api/src/services/feature-property-service.interface.ts
@@ -1,0 +1,9 @@
+/**
+ * Optional filters when querying feature properties.
+ */
+export interface FeaturePropertyFilters {
+  /**
+   * Optional feature property name search term.
+   */
+  search?: string;
+}

--- a/api/src/services/feature-property-service.test.ts
+++ b/api/src/services/feature-property-service.test.ts
@@ -1,0 +1,86 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
+import { ApiNotFoundError } from '../errors/api-error';
+import { FeatureProperty } from '../models/feature-property';
+import { FeaturePropertyService } from './feature-property-service';
+
+chai.use(sinonChai);
+
+const mockFeatureProperty: FeatureProperty = {
+  feature_property_id: 1,
+  feature_property_type_id: 2,
+  name: 'guid',
+  display_name: 'GUID',
+  description: null,
+  type_name: 'string',
+  calculated_value: false
+};
+
+describe('FeaturePropertyService', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('createFeatureProperty', () => {
+    it('validates the feature_property_type_id and returns the created property', async () => {
+      const mockConnection = getMockDBConnection();
+      const service = new FeaturePropertyService(mockConnection);
+
+      sinon
+        .stub(service.featurePropertyRepository, 'getFeaturePropertyTypeById')
+        .resolves({ feature_property_type_id: 2 });
+      sinon.stub(service.featurePropertyRepository, 'insertFeatureProperty').resolves(1);
+      sinon.stub(service.featurePropertyRepository, 'getFeatureProperty').resolves(mockFeatureProperty);
+
+      const result = await service.createFeatureProperty({
+        feature_property_type_id: 2,
+        name: 'guid',
+        display_name: 'GUID'
+      });
+
+      expect(result).to.eql(mockFeatureProperty);
+      expect(service.featurePropertyRepository.getFeaturePropertyTypeById).to.have.been.calledOnceWith(2);
+    });
+
+    it('throws ApiNotFoundError when the feature_property_type_id does not exist', async () => {
+      const mockConnection = getMockDBConnection();
+      const service = new FeaturePropertyService(mockConnection);
+
+      sinon
+        .stub(service.featurePropertyRepository, 'getFeaturePropertyTypeById')
+        .rejects(new ApiNotFoundError('Feature property type not found', []));
+
+      try {
+        await service.createFeatureProperty({
+          feature_property_type_id: 999,
+          name: 'guid',
+          display_name: 'GUID'
+        });
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+  });
+
+  describe('updateFeatureProperty', () => {
+    it('updates the property and returns the refreshed record (without changing type)', async () => {
+      const mockConnection = getMockDBConnection();
+      const service = new FeaturePropertyService(mockConnection);
+
+      const updatedProperty: FeatureProperty = { ...mockFeatureProperty, display_name: 'Updated GUID' };
+      sinon.stub(service.featurePropertyRepository, 'updateFeatureProperty').resolves();
+      sinon.stub(service.featurePropertyRepository, 'getFeatureProperty').resolves(updatedProperty);
+
+      const result = await service.updateFeatureProperty(1, { display_name: 'Updated GUID' });
+
+      expect(result).to.eql(updatedProperty);
+      expect(service.featurePropertyRepository.updateFeatureProperty).to.have.been.calledOnceWith(1, {
+        display_name: 'Updated GUID'
+      });
+    });
+  });
+});

--- a/api/src/services/feature-property-service.ts
+++ b/api/src/services/feature-property-service.ts
@@ -1,0 +1,107 @@
+import { IDBConnection } from '../database/db';
+import { CreateFeatureProperty, FeatureProperty, UpdateFeatureProperty } from '../models/feature-property';
+import { FeaturePropertyRepository } from '../repositories/feature-property-repository';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
+import { DBService } from './db-service';
+import { FeaturePropertyFilters } from './feature-property-service.interface';
+
+/**
+ * Service for feature property admin CRUD operations.
+ *
+ * @export
+ * @class FeaturePropertyService
+ * @extends {DBService}
+ */
+export class FeaturePropertyService extends DBService {
+  featurePropertyRepository: FeaturePropertyRepository;
+
+  /**
+   * Creates a FeaturePropertyService instance.
+   *
+   * @param {IDBConnection} connection - The active database connection.
+   * @memberof FeaturePropertyService
+   */
+  constructor(connection: IDBConnection) {
+    super(connection);
+    this.featurePropertyRepository = new FeaturePropertyRepository(connection);
+  }
+
+  /**
+   * Create a feature property record.
+   *
+   * @param {CreateFeatureProperty} data - Feature property fields required to create the record.
+   * @return {Promise<FeatureProperty>} The created feature property (with resolved type_name).
+   * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
+   * @memberof FeaturePropertyService
+   */
+  async createFeatureProperty(data: CreateFeatureProperty): Promise<FeatureProperty> {
+    const featurePropertyId = await this.featurePropertyRepository.insertFeatureProperty(data);
+    return this.featurePropertyRepository.getFeatureProperty(featurePropertyId);
+  }
+
+  /**
+   * Get a single active feature property by ID.
+   *
+   * @param {number} featurePropertyId - Feature property identifier.
+   * @return {Promise<FeatureProperty>} Feature property record (with resolved type_name).
+   * @throws {ApiNotFoundError} If no active feature property exists for the id.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeaturePropertyService
+   */
+  getFeatureProperty(featurePropertyId: number): Promise<FeatureProperty> {
+    return this.featurePropertyRepository.getFeatureProperty(featurePropertyId);
+  }
+
+  /**
+   * Get active feature properties with optional search and pagination.
+   *
+   * @param {FeaturePropertyFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<FeatureProperty[]>} Feature property list.
+   * @memberof FeaturePropertyService
+   */
+  getFeatureProperties(
+    filters?: FeaturePropertyFilters,
+    pagination?: ApiPaginationOptions
+  ): Promise<FeatureProperty[]> {
+    return this.featurePropertyRepository.getFeatureProperties(filters, pagination);
+  }
+
+  /**
+   * Get total count of active feature properties matching optional filters.
+   *
+   * @param {FeaturePropertyFilters} [filters] - Optional filter set.
+   * @return {Promise<number>} Count of matching feature properties.
+   * @memberof FeaturePropertyService
+   */
+  getFeaturePropertiesCount(filters?: FeaturePropertyFilters): Promise<number> {
+    return this.featurePropertyRepository.getFeaturePropertiesCount(filters);
+  }
+
+  /**
+   * Update a feature property record by ID.
+   *
+   * @param {number} featurePropertyId - Feature property identifier.
+   * @param {UpdateFeatureProperty} data - Partial feature property fields to update.
+   * @return {Promise<FeatureProperty>} Updated feature property (with resolved type_name).
+   * @throws {ApiExecuteSQLError} If the update does not affect exactly one row.
+   * @throws {ApiNotFoundError} If no active feature property exists for the id.
+   * @memberof FeaturePropertyService
+   */
+  async updateFeatureProperty(featurePropertyId: number, data: UpdateFeatureProperty): Promise<FeatureProperty> {
+    await this.featurePropertyRepository.updateFeatureProperty(featurePropertyId, data);
+    return this.featurePropertyRepository.getFeatureProperty(featurePropertyId);
+  }
+
+  /**
+   * Soft-delete a feature property by ID.
+   *
+   * @param {number} featurePropertyId - Feature property identifier.
+   * @return {Promise<void>}
+   * @throws {ApiExecuteSQLError} If the delete does not affect exactly one row.
+   * @memberof FeaturePropertyService
+   */
+  async deleteFeatureProperty(featurePropertyId: number): Promise<void> {
+    await this.featurePropertyRepository.deleteFeatureProperty(featurePropertyId);
+  }
+}

--- a/api/src/services/feature-property-service.ts
+++ b/api/src/services/feature-property-service.ts
@@ -31,10 +31,12 @@ export class FeaturePropertyService extends DBService {
    *
    * @param {CreateFeatureProperty} data - Feature property fields required to create the record.
    * @return {Promise<FeatureProperty>} The created feature property (with resolved type_name).
+   * @throws {ApiNotFoundError} If the referenced feature_property_type_id does not exist.
    * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
    * @memberof FeaturePropertyService
    */
   async createFeatureProperty(data: CreateFeatureProperty): Promise<FeatureProperty> {
+    await this.featurePropertyRepository.getFeaturePropertyTypeById(data.feature_property_type_id);
     const featurePropertyId = await this.featurePropertyRepository.insertFeatureProperty(data);
     return this.featurePropertyRepository.getFeatureProperty(featurePropertyId);
   }

--- a/api/src/services/feature-type-property-service.test.ts
+++ b/api/src/services/feature-type-property-service.test.ts
@@ -1,0 +1,112 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
+import { ApiConflictError, ApiNotFoundError } from '../errors/api-error';
+import { AdminFeatureTypeProperty } from '../models/feature-type-property';
+import { FeaturePropertyRepository } from '../repositories/feature-property-repository';
+import { FeatureTypePropertyRepository } from '../repositories/feature-type-property-repository';
+import { FeatureTypeRepository } from '../repositories/feature-type-repository';
+import { FeatureTypePropertyService } from './feature-type-property-service';
+
+chai.use(sinonChai);
+
+const mockAdminFeatureTypeProperty: AdminFeatureTypeProperty = {
+  feature_type_property_id: 1,
+  feature_type_id: 10,
+  feature_property_id: 20,
+  required_value: false,
+  sort: null
+};
+
+describe('FeatureTypePropertyService', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('instantiates repository fields in the constructor', () => {
+    const mockConnection = getMockDBConnection();
+    const service = new FeatureTypePropertyService(mockConnection);
+
+    expect(service.featureTypePropertyRepository).to.be.instanceof(FeatureTypePropertyRepository);
+    expect(service.featureTypeRepository).to.be.instanceof(FeatureTypeRepository);
+    expect(service.featurePropertyRepository).to.be.instanceof(FeaturePropertyRepository);
+  });
+
+  describe('createFeatureTypeProperty', () => {
+    it('creates and returns the new record when FK references exist and no conflict', async () => {
+      const mockConnection = getMockDBConnection();
+      const service = new FeatureTypePropertyService(mockConnection);
+
+      sinon.stub(service.featureTypeRepository, 'getFeatureType').resolves({ feature_type_id: 10 } as any);
+      sinon.stub(service.featurePropertyRepository, 'getFeatureProperty').resolves({ feature_property_id: 20 } as any);
+      sinon
+        .stub(service.featureTypePropertyRepository, 'findActiveFeatureTypePropertyByFeatureTypeAndProperty')
+        .resolves(null);
+      sinon.stub(service.featureTypePropertyRepository, 'insertFeatureTypeProperty').resolves(1);
+      sinon
+        .stub(service.featureTypePropertyRepository, 'getAdminFeatureTypeProperty')
+        .resolves(mockAdminFeatureTypeProperty);
+
+      const result = await service.createFeatureTypeProperty({ feature_type_id: 10, feature_property_id: 20 });
+
+      expect(result).to.eql(mockAdminFeatureTypeProperty);
+    });
+
+    it('throws ApiNotFoundError when the parent feature type does not exist', async () => {
+      const mockConnection = getMockDBConnection();
+      const service = new FeatureTypePropertyService(mockConnection);
+
+      sinon
+        .stub(service.featureTypeRepository, 'getFeatureType')
+        .rejects(new ApiNotFoundError('Feature type not found', []));
+      sinon.stub(service.featurePropertyRepository, 'getFeatureProperty').resolves({ feature_property_id: 20 } as any);
+
+      try {
+        await service.createFeatureTypeProperty({ feature_type_id: 999, feature_property_id: 20 });
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+
+    it('throws ApiNotFoundError when the feature property does not exist', async () => {
+      const mockConnection = getMockDBConnection();
+      const service = new FeatureTypePropertyService(mockConnection);
+
+      sinon.stub(service.featureTypeRepository, 'getFeatureType').resolves({ feature_type_id: 10 } as any);
+      sinon
+        .stub(service.featurePropertyRepository, 'getFeatureProperty')
+        .rejects(new ApiNotFoundError('Feature property not found', []));
+
+      try {
+        await service.createFeatureTypeProperty({ feature_type_id: 10, feature_property_id: 999 });
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiNotFoundError);
+      }
+    });
+
+    it('throws ApiConflictError when the feature property is already assigned to the feature type', async () => {
+      const mockConnection = getMockDBConnection();
+      const service = new FeatureTypePropertyService(mockConnection);
+
+      sinon.stub(service.featureTypeRepository, 'getFeatureType').resolves({ feature_type_id: 10 } as any);
+      sinon.stub(service.featurePropertyRepository, 'getFeatureProperty').resolves({ feature_property_id: 20 } as any);
+      sinon
+        .stub(service.featureTypePropertyRepository, 'findActiveFeatureTypePropertyByFeatureTypeAndProperty')
+        .resolves({ feature_type_property_id: 99 });
+
+      try {
+        await service.createFeatureTypeProperty({ feature_type_id: 10, feature_property_id: 20 });
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiConflictError);
+        expect((error as ApiConflictError).message).to.equal(
+          'Feature property is already assigned to this feature type'
+        );
+      }
+    });
+  });
+});

--- a/api/src/services/feature-type-property-service.ts
+++ b/api/src/services/feature-type-property-service.ts
@@ -1,4 +1,5 @@
 import { IDBConnection } from '../database/db';
+import { ApiConflictError } from '../errors/api-error';
 import {
   AdminFeatureTypeProperty,
   CreateFeatureTypePropertyRecord,
@@ -20,6 +21,8 @@ import { DBService } from './db-service';
  */
 export class FeatureTypePropertyService extends DBService {
   featureTypePropertyRepository: FeatureTypePropertyRepository;
+  featureTypeRepository: FeatureTypeRepository;
+  featurePropertyRepository: FeaturePropertyRepository;
 
   /**
    * Build a feature-type-property service.
@@ -30,6 +33,8 @@ export class FeatureTypePropertyService extends DBService {
   constructor(connection: IDBConnection) {
     super(connection);
     this.featureTypePropertyRepository = new FeatureTypePropertyRepository(connection);
+    this.featureTypeRepository = new FeatureTypeRepository(connection);
+    this.featurePropertyRepository = new FeaturePropertyRepository(connection);
   }
 
   /**
@@ -73,11 +78,22 @@ export class FeatureTypePropertyService extends DBService {
    * @memberof FeatureTypePropertyService
    */
   async createFeatureTypeProperty(data: CreateFeatureTypePropertyRecord): Promise<AdminFeatureTypeProperty> {
-    const featureTypeRepository = new FeatureTypeRepository(this.connection);
-    const featurePropertyRepository = new FeaturePropertyRepository(this.connection);
+    await Promise.all([
+      this.featureTypeRepository.getFeatureType(data.feature_type_id),
+      this.featurePropertyRepository.getFeatureProperty(data.feature_property_id)
+    ]);
 
-    await featureTypeRepository.getFeatureType(data.feature_type_id);
-    await featurePropertyRepository.getFeatureProperty(data.feature_property_id);
+    const existing = await this.featureTypePropertyRepository.findActiveFeatureTypePropertyByFeatureTypeAndProperty(
+      data.feature_type_id,
+      data.feature_property_id
+    );
+
+    if (existing) {
+      throw new ApiConflictError('Feature property is already assigned to this feature type', [
+        'FeatureTypePropertyService->createFeatureTypeProperty',
+        { feature_type_id: data.feature_type_id, feature_property_id: data.feature_property_id }
+      ]);
+    }
 
     const featureTypePropertyId = await this.featureTypePropertyRepository.insertFeatureTypeProperty(data);
     return this.featureTypePropertyRepository.getAdminFeatureTypeProperty(featureTypePropertyId, data.feature_type_id);

--- a/api/src/services/feature-type-property-service.ts
+++ b/api/src/services/feature-type-property-service.ts
@@ -1,8 +1,23 @@
 import { IDBConnection } from '../database/db';
-import { FeatureTypeProperty } from '../models/feature-type-property';
+import {
+  AdminFeatureTypeProperty,
+  CreateFeatureTypePropertyRecord,
+  FeatureTypeProperty,
+  UpdateFeatureTypePropertyRecord
+} from '../models/feature-type-property';
+import { FeaturePropertyRepository } from '../repositories/feature-property-repository';
 import { FeatureTypePropertyRepository } from '../repositories/feature-type-property-repository';
+import { FeatureTypeRepository } from '../repositories/feature-type-repository';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { DBService } from './db-service';
 
+/**
+ * Service for feature type property reads and admin CRUD operations.
+ *
+ * @export
+ * @class FeatureTypePropertyService
+ * @extends {DBService}
+ */
 export class FeatureTypePropertyService extends DBService {
   featureTypePropertyRepository: FeatureTypePropertyRepository;
 
@@ -10,6 +25,7 @@ export class FeatureTypePropertyService extends DBService {
    * Build a feature-type-property service.
    *
    * @param {IDBConnection} connection - Active database connection.
+   * @memberof FeatureTypePropertyService
    */
   constructor(connection: IDBConnection) {
     super(connection);
@@ -21,6 +37,9 @@ export class FeatureTypePropertyService extends DBService {
    *
    * @param {string} featurePropertyName - Canonical feature-property name.
    * @return {Promise<FeatureTypeProperty>} Matched feature-type-property row.
+   * @throws {ApiNotFoundError} If no active feature property matches the name.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypePropertyService
    */
   async getFeaturePropertyByName(featurePropertyName: string): Promise<FeatureTypeProperty> {
     return this.featureTypePropertyRepository.getFeaturePropertyByName(featurePropertyName);
@@ -31,8 +50,109 @@ export class FeatureTypePropertyService extends DBService {
    *
    * @param {number} featureTypePropertyId - Feature type property identifier.
    * @return {Promise<FeatureTypeProperty>} Matched feature-type-property row.
+   * @throws {ApiNotFoundError} If no active row exists for the id.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypePropertyService
    */
   async getFeaturePropertyByFeatureTypePropertyId(featureTypePropertyId: number): Promise<FeatureTypeProperty> {
     return this.featureTypePropertyRepository.getFeaturePropertyByFeatureTypePropertyId(featureTypePropertyId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Admin CRUD methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a feature type property record after validating parent FK references.
+   *
+   * @param {CreateFeatureTypePropertyRecord} data - Fields to insert.
+   * @return {Promise<AdminFeatureTypeProperty>} The created record.
+   * @throws {ApiNotFoundError} If the parent feature type or feature property does not exist.
+   * @throws {ApiConflictError} If the feature property is already assigned to the feature type.
+   * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
+   * @memberof FeatureTypePropertyService
+   */
+  async createFeatureTypeProperty(data: CreateFeatureTypePropertyRecord): Promise<AdminFeatureTypeProperty> {
+    const featureTypeRepository = new FeatureTypeRepository(this.connection);
+    const featurePropertyRepository = new FeaturePropertyRepository(this.connection);
+
+    await featureTypeRepository.getFeatureType(data.feature_type_id);
+    await featurePropertyRepository.getFeatureProperty(data.feature_property_id);
+
+    const featureTypePropertyId = await this.featureTypePropertyRepository.insertFeatureTypeProperty(data);
+    return this.featureTypePropertyRepository.getAdminFeatureTypeProperty(featureTypePropertyId, data.feature_type_id);
+  }
+
+  /**
+   * Get a single active feature type property record by ID, scoped to a parent feature type.
+   *
+   * @param {number} featureTypePropertyId - Feature type property identifier.
+   * @param {number} featureTypeId - Parent feature type identifier.
+   * @return {Promise<AdminFeatureTypeProperty>} The raw record.
+   * @throws {ApiNotFoundError} If no active record exists for the id within the parent feature type.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypePropertyService
+   */
+  getAdminFeatureTypeProperty(featureTypePropertyId: number, featureTypeId: number): Promise<AdminFeatureTypeProperty> {
+    return this.featureTypePropertyRepository.getAdminFeatureTypeProperty(featureTypePropertyId, featureTypeId);
+  }
+
+  /**
+   * Get active feature type property records for a feature type, with optional pagination.
+   *
+   * @param {number} featureTypeId - Feature type identifier to scope results.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<AdminFeatureTypeProperty[]>}
+   * @memberof FeatureTypePropertyService
+   */
+  getAdminFeatureTypeProperties(
+    featureTypeId: number,
+    pagination?: ApiPaginationOptions
+  ): Promise<AdminFeatureTypeProperty[]> {
+    return this.featureTypePropertyRepository.getAdminFeatureTypeProperties(featureTypeId, pagination);
+  }
+
+  /**
+   * Get count of active feature type property records for a feature type.
+   *
+   * @param {number} featureTypeId - Feature type identifier.
+   * @return {Promise<number>}
+   * @memberof FeatureTypePropertyService
+   */
+  getAdminFeatureTypePropertiesCount(featureTypeId: number): Promise<number> {
+    return this.featureTypePropertyRepository.getAdminFeatureTypePropertiesCount(featureTypeId);
+  }
+
+  /**
+   * Update a feature type property record by ID, scoped to a parent feature type.
+   *
+   * @param {number} featureTypePropertyId - Feature type property identifier.
+   * @param {number} featureTypeId - Parent feature type identifier.
+   * @param {UpdateFeatureTypePropertyRecord} data - Partial fields to update.
+   * @return {Promise<AdminFeatureTypeProperty>} The updated record.
+   * @throws {ApiNotFoundError} If no active record exists for the id within the parent feature type.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypePropertyService
+   */
+  async updateFeatureTypeProperty(
+    featureTypePropertyId: number,
+    featureTypeId: number,
+    data: UpdateFeatureTypePropertyRecord
+  ): Promise<AdminFeatureTypeProperty> {
+    await this.featureTypePropertyRepository.updateFeatureTypeProperty(featureTypePropertyId, featureTypeId, data);
+    return this.featureTypePropertyRepository.getAdminFeatureTypeProperty(featureTypePropertyId, featureTypeId);
+  }
+
+  /**
+   * Soft-delete a feature type property scoped to a parent feature type.
+   *
+   * @param {number} featureTypePropertyId - Feature type property identifier.
+   * @param {number} featureTypeId - Parent feature type identifier.
+   * @return {Promise<void>}
+   * @throws {ApiNotFoundError} If no active record exists for the id within the parent feature type.
+   * @memberof FeatureTypePropertyService
+   */
+  async deleteFeatureTypeProperty(featureTypePropertyId: number, featureTypeId: number): Promise<void> {
+    await this.featureTypePropertyRepository.deleteFeatureTypeProperty(featureTypePropertyId, featureTypeId);
   }
 }

--- a/api/src/services/feature-type-service.interface.ts
+++ b/api/src/services/feature-type-service.interface.ts
@@ -1,0 +1,9 @@
+/**
+ * Optional filters when querying feature types.
+ */
+export interface FeatureTypeFilters {
+  /**
+   * Optional feature type name search term.
+   */
+  search?: string;
+}

--- a/api/src/services/feature-type-service.ts
+++ b/api/src/services/feature-type-service.ts
@@ -1,0 +1,103 @@
+import { IDBConnection } from '../database/db';
+import { CreateFeatureType, FeatureType, UpdateFeatureType } from '../models/feature-type';
+import { FeatureTypeRepository } from '../repositories/feature-type-repository';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
+import { DBService } from './db-service';
+import { FeatureTypeFilters } from './feature-type-service.interface';
+
+/**
+ * Service for feature type admin CRUD operations.
+ *
+ * @export
+ * @class FeatureTypeService
+ * @extends {DBService}
+ */
+export class FeatureTypeService extends DBService {
+  featureTypeRepository: FeatureTypeRepository;
+
+  /**
+   * Creates a FeatureTypeService instance.
+   *
+   * @param {IDBConnection} connection - The active database connection.
+   * @memberof FeatureTypeService
+   */
+  constructor(connection: IDBConnection) {
+    super(connection);
+    this.featureTypeRepository = new FeatureTypeRepository(connection);
+  }
+
+  /**
+   * Create a feature type record.
+   *
+   * @param {CreateFeatureType} data - Feature type fields required to create the record.
+   * @return {Promise<FeatureType>} The created feature type.
+   * @throws {ApiExecuteSQLError} If the insert does not affect exactly one row.
+   * @memberof FeatureTypeService
+   */
+  async createFeatureType(data: CreateFeatureType): Promise<FeatureType> {
+    return this.featureTypeRepository.insertFeatureType(data);
+  }
+
+  /**
+   * Get a single active feature type by ID.
+   *
+   * @param {number} featureTypeId - Feature type identifier.
+   * @return {Promise<FeatureType>} Feature type record.
+   * @throws {ApiNotFoundError} If no active feature type exists for the id.
+   * @throws {ApiExecuteSQLError} If an unexpected row count is returned.
+   * @memberof FeatureTypeService
+   */
+  getFeatureType(featureTypeId: number): Promise<FeatureType> {
+    return this.featureTypeRepository.getFeatureType(featureTypeId);
+  }
+
+  /**
+   * Get active feature types with optional search and pagination.
+   *
+   * @param {FeatureTypeFilters} [filters] - Optional filter set.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<FeatureType[]>} Feature type list.
+   * @memberof FeatureTypeService
+   */
+  getFeatureTypes(filters?: FeatureTypeFilters, pagination?: ApiPaginationOptions): Promise<FeatureType[]> {
+    return this.featureTypeRepository.getFeatureTypes(filters, pagination);
+  }
+
+  /**
+   * Get total count of active feature types matching optional filters.
+   *
+   * @param {FeatureTypeFilters} [filters] - Optional filter set.
+   * @return {Promise<number>} Count of matching feature types.
+   * @memberof FeatureTypeService
+   */
+  getFeatureTypesCount(filters?: FeatureTypeFilters): Promise<number> {
+    return this.featureTypeRepository.getFeatureTypesCount(filters);
+  }
+
+  /**
+   * Update a feature type record by ID.
+   *
+   * @param {number} featureTypeId - Feature type identifier.
+   * @param {UpdateFeatureType} data - Partial feature type fields to update.
+   * @return {Promise<FeatureType>} Updated feature type.
+   * @throws {ApiExecuteSQLError} If the update does not affect exactly one row.
+   * @throws {ApiNotFoundError} If no active feature type exists for the id.
+   * @memberof FeatureTypeService
+   */
+  async updateFeatureType(featureTypeId: number, data: UpdateFeatureType): Promise<FeatureType> {
+    await this.featureTypeRepository.updateFeatureType(featureTypeId, data);
+    return this.featureTypeRepository.getFeatureType(featureTypeId);
+  }
+
+  /**
+   * Soft-delete a feature type by ID.
+   *
+   * @param {number} featureTypeId - Feature type identifier.
+   * @return {Promise<void>}
+   * @throws {ApiExecuteSQLError} If the delete does not affect exactly one row.
+   * @memberof FeatureTypeService
+   */
+  async deleteFeatureType(featureTypeId: number): Promise<void> {
+    await this.featureTypeRepository.deleteFeatureType(featureTypeId);
+  }
+}

--- a/app/src/features/admin/policies/utils/policyValidator.test.ts
+++ b/app/src/features/admin/policies/utils/policyValidator.test.ts
@@ -49,7 +49,8 @@ const createMockFeatureType = (): FeatureTypeWithProperties => ({
   feature_type: {
     feature_type_id: 1,
     name: 'animal',
-    display_name: 'Animal'
+    display_name: 'Animal',
+    description: null
   },
   properties: [
     {

--- a/app/src/interfaces/useCodesApi.interface.ts
+++ b/app/src/interfaces/useCodesApi.interface.ts
@@ -2,6 +2,7 @@ export type FeatureType = {
   feature_type_id: number;
   name: string;
   display_name: string;
+  description: string | null;
 };
 
 export type FeatureTypeWithProperties = {
@@ -13,7 +14,7 @@ export type FeatureTypeProperty = {
   feature_type_property_id: number;
   name: string;
   display_name: string;
-  description: string;
+  description: string | null;
   type_name: string;
   required_value: boolean;
   calculated_value: boolean;


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1018](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1018)
- [SIMSBIOHUB-1019](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1019)
- [SIMSBIOHUB-1020](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1020)

## Description of Changes

Adds system-admin CRUD APIs for feature types, feature properties, and feature-type-property assignments. Backend-only — no admin UI in this PR.

**New admin endpoints** (all require System Admin Bearer auth):

| Resource | Routes |
|----------|--------|
| Feature types | `GET/POST /api/administrative/feature-types`, `GET/PUT/DELETE /api/administrative/feature-types/{featureTypeId}` |
| Feature properties | `GET/POST /api/administrative/feature-properties`, `GET/PUT/DELETE /api/administrative/feature-properties/{featurePropertyId}` |
| Assignments | `GET/POST /api/administrative/feature-types/{featureTypeId}/properties`, `GET/PUT/DELETE .../properties/{featureTypePropertyId}` |

List endpoints support pagination and search (feature types/properties). Assignments are scoped to the parent feature type on nested routes. Deletes are soft deletes via `record_end_date`.

**Supporting changes**

- New repositories, services, models, and OpenAPI schemas for the above resources.
- `/api/codes` now includes `description` on feature types and nullable `description` on properties.
- `feature_type.sort` and admin CRUD `allow_multiple` are **not** exposed in the API (DB columns unchanged; inserts rely on DB defaults). List ordering still uses `sort` internally.

## Testing Notes

- Authenticate as a system admin and exercise full CRUD for each resource (create → get → list → update → delete).
- For feature property create, use a valid `feature_property_type_id` from the database.
- For assignment create, verify parent feature type and feature property must exist; duplicate assignments return 409.
- Confirm nested assignment routes reject cross–feature-type access (wrong `featureTypeId` → 404).
- Run API tests: `npm test -- --grep "FeatureType|FeatureProperty|createFeatureType|CodeRepository"`.
- Confirm `/api/codes` still returns expected feature type/property metadata.
