### PR TITLE
SIMSBIOHUB-1021: Export `feature` properties

### DIFF
--- a/api/src/__integration__/db/data-request-service.integration.ts
+++ b/api/src/__integration__/db/data-request-service.integration.ts
@@ -333,7 +333,7 @@ describe('DataRequestService (integration)', function () {
       expect(policyTeamRows.rowCount).to.equal(1);
       const policyTeamId = policyTeamRows.rows[0].team_id as string;
 
-      const expectedMembers = [collaborator];
+      const expectedMembers = [requester, collaborator].sort((a, b) => a - b);
       expect(await teamMemberIds(dataRequestTeamId)).to.deep.equal(expectedMembers);
       expect(await teamMemberIds(policyTeamId)).to.deep.equal(expectedMembers);
     });

--- a/api/src/__integration__/db/download-parquet-pipeline.integration.ts
+++ b/api/src/__integration__/db/download-parquet-pipeline.integration.ts
@@ -33,6 +33,10 @@ import { DownloadPolicyService } from '../../services/download/download-policy-s
 import { DownloadService } from '../../services/download/download-service';
 import { ObjectStorageService } from '../../services/object-storage/object-storage-service';
 import { CsvPropertyDefinition } from '../../utils/csv-utils';
+import {
+  createFeatureTypeProperty,
+  insertSubmissionFeaturePropertyFeature
+} from '../helpers/test-feature-property-helpers';
 import { secureFeature, setupFullAccess } from '../helpers/test-rbac-helpers';
 import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
 
@@ -530,6 +534,163 @@ describe('Download Parquet pipeline (integration)', function () {
       expect(rows).to.have.length(1);
       expect(rows[0].data.species).to.be.a('string');
       expect(rows[0].data.species).to.include('Ursus arctos');
+    });
+
+    describe('feature properties', () => {
+      it('hydrates a single feature reference into a length-1 URN array', async () => {
+        const submissionId = await createTestSubmission(connection);
+        const sourceFeatureId = await createTestFeature(connection, submissionId, 'capture', { comment: 'src' });
+        const referencedFeatureId = await createTestFeature(connection, submissionId, 'observation_subcount', {
+          name: 'ref-1'
+        });
+
+        const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty(
+          connection,
+          'capture',
+          'observation_subcount',
+          true
+        );
+
+        await insertSubmissionFeaturePropertyFeature(
+          connection,
+          sourceFeatureId,
+          featureTypePropertyId,
+          referencedFeatureId
+        );
+
+        const refRow = await connection.sql(SQL`
+          SELECT urn FROM submission_feature WHERE submission_feature_id = ${referencedFeatureId};
+        `);
+        const urnR1 = refRow.rows[0].urn;
+
+        const properties: CsvPropertyDefinition[] = [
+          { feature_property_name: propertyName, feature_property_type_name: 'feature' }
+        ];
+
+        const rows = await streamAndHydrateBySubmission(submissionId, 'capture', properties, 'pq-feature-single');
+        const sourceRow = rows.find((r) => r.submission_feature_id === sourceFeatureId);
+        expect(sourceRow).to.exist;
+        expect(sourceRow!.data[propertyName]).to.deep.equal([urnR1]);
+      });
+
+      it('orders multiple feature references ASC by referenced_submission_feature_id', async () => {
+        const submissionId = await createTestSubmission(connection);
+        const sourceFeatureId = await createTestFeature(connection, submissionId, 'capture', { comment: 'src' });
+        const referencedFeatureId1 = await createTestFeature(connection, submissionId, 'observation_subcount', {
+          name: 'ref-1'
+        });
+        const referencedFeatureId2 = await createTestFeature(connection, submissionId, 'observation_subcount', {
+          name: 'ref-2'
+        });
+        // Sanity: ids are inserted in ascending order
+        expect(referencedFeatureId1).to.be.lessThan(referencedFeatureId2);
+
+        const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty(
+          connection,
+          'capture',
+          'observation_subcount',
+          true
+        );
+
+        // Insert link rows in REVERSE order to prove the SQL's ORDER BY does the work
+        await insertSubmissionFeaturePropertyFeature(
+          connection,
+          sourceFeatureId,
+          featureTypePropertyId,
+          referencedFeatureId2
+        );
+        await insertSubmissionFeaturePropertyFeature(
+          connection,
+          sourceFeatureId,
+          featureTypePropertyId,
+          referencedFeatureId1
+        );
+
+        const refRows = await connection.sql(SQL`
+          SELECT submission_feature_id, urn FROM submission_feature
+          WHERE submission_feature_id = ANY(${[referencedFeatureId1, referencedFeatureId2]})
+          ORDER BY submission_feature_id ASC;
+        `);
+        const urnR1 = refRows.rows[0].urn;
+        const urnR2 = refRows.rows[1].urn;
+
+        const properties: CsvPropertyDefinition[] = [
+          { feature_property_name: propertyName, feature_property_type_name: 'feature' }
+        ];
+
+        const rows = await streamAndHydrateBySubmission(submissionId, 'capture', properties, 'pq-feature-multi');
+        const sourceRow = rows.find((r) => r.submission_feature_id === sourceFeatureId);
+        expect(sourceRow).to.exist;
+        expect(sourceRow!.data[propertyName]).to.deep.equal([urnR1, urnR2]);
+      });
+
+      it('returns null when a feature property is requested but no link rows exist', async () => {
+        const submissionId = await createTestSubmission(connection);
+        const sourceFeatureId = await createTestFeature(connection, submissionId, 'capture', { comment: 'src' });
+
+        const { propertyName } = await createFeatureTypeProperty(connection, 'capture', 'observation_subcount', true);
+
+        const properties: CsvPropertyDefinition[] = [
+          { feature_property_name: propertyName, feature_property_type_name: 'feature' }
+        ];
+
+        const rows = await streamAndHydrateBySubmission(submissionId, 'capture', properties, 'pq-feature-none');
+        const sourceRow = rows.find((r) => r.submission_feature_id === sourceFeatureId);
+        expect(sourceRow).to.exist;
+        expect(sourceRow!.data[propertyName]).to.be.null;
+      });
+
+      it('excludes soft-deleted referenced features from the URN array', async () => {
+        const submissionId = await createTestSubmission(connection);
+        const sourceFeatureId = await createTestFeature(connection, submissionId, 'capture', { comment: 'src' });
+        const referencedFeatureLiveId = await createTestFeature(connection, submissionId, 'observation_subcount', {
+          name: 'live'
+        });
+        const referencedFeatureDeletedId = await createTestFeature(connection, submissionId, 'observation_subcount', {
+          name: 'soft-deleted'
+        });
+
+        const { featureTypePropertyId, propertyName } = await createFeatureTypeProperty(
+          connection,
+          'capture',
+          'observation_subcount',
+          true
+        );
+
+        await insertSubmissionFeaturePropertyFeature(
+          connection,
+          sourceFeatureId,
+          featureTypePropertyId,
+          referencedFeatureLiveId
+        );
+        await insertSubmissionFeaturePropertyFeature(
+          connection,
+          sourceFeatureId,
+          featureTypePropertyId,
+          referencedFeatureDeletedId
+        );
+
+        // Soft-delete one referenced feature
+        await connection.sql(SQL`
+          UPDATE submission_feature
+          SET record_end_date = now()
+          WHERE submission_feature_id = ${referencedFeatureDeletedId};
+        `);
+
+        const liveRow = await connection.sql(SQL`
+          SELECT urn FROM submission_feature WHERE submission_feature_id = ${referencedFeatureLiveId};
+        `);
+        const urnLive = liveRow.rows[0].urn;
+
+        const properties: CsvPropertyDefinition[] = [
+          { feature_property_name: propertyName, feature_property_type_name: 'feature' }
+        ];
+
+        const rows = await streamAndHydrateBySubmission(submissionId, 'capture', properties, 'pq-feature-soft-deleted');
+        const sourceRow = rows.find((r) => r.submission_feature_id === sourceFeatureId);
+        expect(sourceRow).to.exist;
+        expect(sourceRow!.data[propertyName]).to.deep.equal([urnLive]);
+      });
     });
 
     it('returns geometry as GeoJSON object', async () => {

--- a/api/src/__integration__/helpers/test-feature-property-helpers.ts
+++ b/api/src/__integration__/helpers/test-feature-property-helpers.ts
@@ -156,6 +156,40 @@ export async function getSubmissionFeatureErrors(
   return result.rows;
 }
 
+/**
+ * Insert a single link row into `submission_feature_property_feature`, tying a source
+ * feature to one referenced feature via a `feature`-typed feature_type_property.
+ *
+ * The link table has no `value` column — the "value" of a feature-typed property is
+ * the set of referenced submission_feature_ids carried by these rows. FK semantics:
+ * both `submission_feature_id` (source) and `referenced_submission_feature_id` point
+ * at `biohub.submission_feature`, and `feature_type_property_id` must be a property
+ * declared on the source feature's type.
+ */
+export async function insertSubmissionFeaturePropertyFeature(
+  connection: IDBConnection,
+  sourceSubmissionFeatureId: number,
+  featureTypePropertyId: number,
+  referencedSubmissionFeatureId: number
+): Promise<void> {
+  const systemUserId = connection.systemUserId();
+
+  await connection.sql(SQL`
+    INSERT INTO submission_feature_property_feature (
+      submission_feature_id,
+      feature_type_property_id,
+      referenced_submission_feature_id,
+      create_user
+    )
+    VALUES (
+      ${sourceSubmissionFeatureId},
+      ${featureTypePropertyId},
+      ${referencedSubmissionFeatureId},
+      ${systemUserId}
+    );
+  `);
+}
+
 /** Fetch canonical property-feature rows for a source feature, ordered by referenced feature. */
 export async function getPropertyFeatureRows(
   connection: IDBConnection,

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -614,6 +614,65 @@ describe('DownloadRepository', () => {
       expect(queryTexts.some((t) => t.includes('submission_feature_property_string'))).to.be.true;
       expect(queryTexts.some((t) => t.includes('submission_feature_property_number'))).to.be.true;
       expect(queryTexts.some((t) => t.includes('submission_feature_property_code'))).to.be.false;
+      // When `feature` is absent from the requested property types, the feature-arm SQL must not run.
+      expect(queryTexts.some((t) => t.includes('submission_feature_property_feature'))).to.be.false;
+
+      // When `feature` is present, the feature-arm SQL is included.
+      queryStub.resetHistory();
+      await repo.fetchTypedPropertyRows([1], ['string', 'feature']);
+      const featureQueryTexts = queryStub.getCalls().map((c) => String(c.args[0]));
+      expect(featureQueryTexts.some((t) => t.includes('submission_feature_property_feature'))).to.be.true;
+    });
+
+    it('returns a single-element string array for a feature property with one referenced feature', async () => {
+      const queryStub = sinon.stub();
+      queryStub.resolves({
+        rows: [{ submission_feature_id: 100, name: 'related_feature', value: ['urn:1:obs:42'] }]
+      });
+
+      const mockDBConnection = getMockDBConnection({ query: queryStub });
+      const repo = new DownloadRepository(mockDBConnection);
+
+      const result = await repo.fetchTypedPropertyRows([100], ['feature']);
+
+      expect(result).to.deep.include({
+        submission_feature_id: 100,
+        name: 'related_feature',
+        value: ['urn:1:obs:42']
+      });
+
+      const sqlText = String(queryStub.getCall(0).args[0]);
+      expect(sqlText).to.include('jsonb_agg');
+      expect(sqlText).to.include('submission_feature_property_feature');
+      expect(sqlText).to.include('ORDER BY sf.submission_feature_id');
+    });
+
+    it('returns an ordered multi-element string array for a feature property with multiple referenced features', async () => {
+      const queryStub = sinon.stub();
+      queryStub.resolves({
+        rows: [{ submission_feature_id: 100, name: 'related_feature', value: ['urn:1:obs:42', 'urn:1:obs:43'] }]
+      });
+
+      const mockDBConnection = getMockDBConnection({ query: queryStub });
+      const repo = new DownloadRepository(mockDBConnection);
+
+      const result = await repo.fetchTypedPropertyRows([100], ['feature']);
+
+      expect(result[0].value).to.deep.equal(['urn:1:obs:42', 'urn:1:obs:43']);
+    });
+
+    it('includes the sf.record_end_date IS NULL filter', async () => {
+      const queryStub = sinon.stub();
+      queryStub.resolves({ rows: [] });
+
+      const mockDBConnection = getMockDBConnection({ query: queryStub });
+      const repo = new DownloadRepository(mockDBConnection);
+
+      await repo.fetchTypedPropertyRows([100], ['feature']);
+
+      const sqlText = String(queryStub.getCall(0).args[0]);
+      expect(sqlText).to.include('sf.record_end_date IS NULL');
+      expect(sqlText).to.include('referenced_submission_feature_id');
     });
 
     it('skips unknown property type names', async () => {

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -611,17 +611,17 @@ export class DownloadRepository extends BaseRepository {
        * - `submission_feature_property_feature` has no soft-delete column, so no `p`-side filter is needed.
        */
       feature: `SELECT
-  p.submission_feature_id,
-  fp.name,
-  jsonb_agg(sf.urn ORDER BY sf.submission_feature_id) AS value
- FROM submission_feature_property_feature p
- INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id
- INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
- INNER JOIN submission_feature sf
-   ON sf.submission_feature_id = p.referenced_submission_feature_id
-  AND sf.record_end_date IS NULL
- WHERE p.submission_feature_id = ANY($1)
- GROUP BY p.submission_feature_id, fp.name`
+        p.submission_feature_id,
+        fp.name,
+        jsonb_agg(sf.urn ORDER BY sf.submission_feature_id) AS value
+      FROM submission_feature_property_feature p
+      INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id
+      INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
+      INNER JOIN submission_feature sf
+        ON sf.submission_feature_id = p.referenced_submission_feature_id
+        AND sf.record_end_date IS NULL
+      WHERE p.submission_feature_id = ANY($1)
+      GROUP BY p.submission_feature_id, fp.name`
     };
 
     // Query only the typed tables for property types present in this batch

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -600,7 +600,28 @@ export class DownloadRepository extends BaseRepository {
                 FROM submission_feature_property_geometry p
                 INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id
                 INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
-                WHERE p.submission_feature_id = ANY($1)`
+                WHERE p.submission_feature_id = ANY($1)`,
+      /**
+       * - `jsonb_agg` (not `array_agg`) so pg's JSONB deserializer yields a native `string[]`,
+       *   matching the same-file `spatial` precedent's use of `::jsonb`.
+       * - `ORDER BY sf.submission_feature_id` is mandatory: export reruns must be byte-identical
+       *   for the same data so downstream hash-based diff tooling stays valid.
+       * - The `sf.record_end_date IS NULL` filter is defense-in-depth — ingestion already excludes
+       *   inactive features, but soft-delete-on-read is the codebase convention.
+       * - `submission_feature_property_feature` has no soft-delete column, so no `p`-side filter is needed.
+       */
+      feature: `SELECT
+  p.submission_feature_id,
+  fp.name,
+  jsonb_agg(sf.urn ORDER BY sf.submission_feature_id) AS value
+ FROM submission_feature_property_feature p
+ INNER JOIN feature_type_property ftp ON p.feature_type_property_id = ftp.feature_type_property_id
+ INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
+ INNER JOIN submission_feature sf
+   ON sf.submission_feature_id = p.referenced_submission_feature_id
+  AND sf.record_end_date IS NULL
+ WHERE p.submission_feature_id = ANY($1)
+ GROUP BY p.submission_feature_id, fp.name`
     };
 
     // Query only the typed tables for property types present in this batch

--- a/api/src/utils/csv-utils.test.ts
+++ b/api/src/utils/csv-utils.test.ts
@@ -569,6 +569,47 @@ describe('csv-utils', () => {
       expect(result).to.deep.equal({ metadata: '{"key":"value"}' });
     });
 
+    it('should JSON-stringify a feature array of URN strings', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const data = { child_features: ['urn:1', 'urn:2'] };
+
+      const result = flattenFeatureBySchema(data, properties, 100);
+
+      expect(result).to.deep.equal({ child_features: '["urn:1","urn:2"]' });
+    });
+
+    it('should emit empty string for a null feature value', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+
+      const result = flattenFeatureBySchema({ child_features: null }, properties, 100);
+
+      expect(result).to.deep.equal({ child_features: '' });
+    });
+
+    it('should emit empty string for an undefined feature value', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+
+      const result = flattenFeatureBySchema({}, properties, 100);
+
+      expect(result).to.deep.equal({ child_features: '' });
+    });
+
+    it('should JSON-stringify an empty feature array as "[]"', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+
+      const result = flattenFeatureBySchema({ child_features: [] }, properties, 100);
+
+      expect(result).to.deep.equal({ child_features: '[]' });
+    });
+
     it('should return empty strings for null/undefined values', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'name', feature_property_type_name: 'string' },

--- a/api/src/utils/csv-utils.test.ts
+++ b/api/src/utils/csv-utils.test.ts
@@ -580,6 +580,17 @@ describe('csv-utils', () => {
       expect(result).to.deep.equal({ child_features: '["urn:1","urn:2"]' });
     });
 
+    it('should pass a scalar feature value through unquoted', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const data = { child_features: 'urn:1' };
+
+      const result = flattenFeatureBySchema(data, properties, 100);
+
+      expect(result).to.deep.equal({ child_features: 'urn:1' });
+    });
+
     it('should emit empty string for a null feature value', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'child_features', feature_property_type_name: 'feature' }

--- a/api/src/utils/csv-utils.ts
+++ b/api/src/utils/csv-utils.ts
@@ -125,6 +125,7 @@ export function flattenFeatureWithParent(
  * - array → delegate to flattenArray()
  * - artifact_key → files/{submissionFeatureId}_{filename}
  * - object → JSON.stringify(value)
+ * - feature → JSON.stringify(value), '' for null/undefined
  * - null/undefined → empty string
  *
  * @param data - The feature's JSONB data.
@@ -171,6 +172,9 @@ export function flattenFeatureBySchema(
         result[prop.feature_property_name] = Array.isArray(value) ? flattenArray(value) : toStringOrEmpty(value);
         break;
       case 'object':
+        result[prop.feature_property_name] = value == null ? '' : JSON.stringify(value);
+        break;
+      case 'feature':
         result[prop.feature_property_name] = value == null ? '' : JSON.stringify(value);
         break;
       default:

--- a/api/src/utils/csv-utils.ts
+++ b/api/src/utils/csv-utils.ts
@@ -172,8 +172,6 @@ export function flattenFeatureBySchema(
         result[prop.feature_property_name] = Array.isArray(value) ? flattenArray(value) : toStringOrEmpty(value);
         break;
       case 'object':
-        result[prop.feature_property_name] = value == null ? '' : JSON.stringify(value);
-        break;
       case 'feature':
         result[prop.feature_property_name] = value == null ? '' : JSON.stringify(value);
         break;

--- a/api/src/utils/csv-utils.ts
+++ b/api/src/utils/csv-utils.ts
@@ -125,7 +125,8 @@ export function flattenFeatureWithParent(
  * - array → delegate to flattenArray()
  * - artifact_key → files/{submissionFeatureId}_{filename}
  * - object → JSON.stringify(value)
- * - feature → JSON.stringify(value), '' for null/undefined
+ * - feature → JSON.stringify(value) for the URN array, toStringOrEmpty(value)
+ *   for a scalar, '' for null/undefined
  * - null/undefined → empty string
  *
  * @param data - The feature's JSONB data.
@@ -172,8 +173,17 @@ export function flattenFeatureBySchema(
         result[prop.feature_property_name] = Array.isArray(value) ? flattenArray(value) : toStringOrEmpty(value);
         break;
       case 'object':
-      case 'feature':
         result[prop.feature_property_name] = value == null ? '' : JSON.stringify(value);
+        break;
+      case 'feature':
+        if (value == null) {
+          result[prop.feature_property_name] = '';
+          break;
+        }
+        // A feature property hydrates into a URN array; JSON-stringify it so the
+        // cell carries the full list. A scalar value passes through unquoted —
+        // JSON.stringify would otherwise wrap a lone string in literal quotes.
+        result[prop.feature_property_name] = Array.isArray(value) ? JSON.stringify(value) : toStringOrEmpty(value);
         break;
       default:
         result[prop.feature_property_name] = toStringOrEmpty(value);

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -1,4 +1,8 @@
+import parquetjs from '@dsnp/parquetjs';
 import { expect } from 'chai';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, it } from 'mocha';
 import wkx from 'wkx';
 
@@ -51,14 +55,16 @@ describe('parquet-utils', () => {
       expect(propertyTypeToParquetType('spatial')).to.equal('BYTE_ARRAY');
     });
 
-    it('should map array to JSON LogicalType (BYTE_ARRAY + originalType=JSON)', () => {
-      // Physical bytes are identical to UTF8 — readers that honour the annotation
-      // (DuckDB, pyarrow, Spark) auto-deserialize; others see the same string.
-      expect(propertyTypeToParquetType('array')).to.equal('JSON');
+    it('should map array to UTF8 (JSON-encoded string)', () => {
+      // The Parquet `JSON` LogicalType is incompatible with arrays in @dsnp/parquetjs:
+      // the shredder unwraps `Array.isArray(value)` regardless of annotation, so a
+      // raw array on a non-REPEATED JSON cell throws "too many values for field".
+      // UTF8 + caller-side `JSON.stringify` sidesteps the mismatch.
+      expect(propertyTypeToParquetType('array')).to.equal('UTF8');
     });
 
-    it('should map object to JSON LogicalType (BYTE_ARRAY + originalType=JSON)', () => {
-      expect(propertyTypeToParquetType('object')).to.equal('JSON');
+    it('should map object to UTF8 (JSON-encoded string)', () => {
+      expect(propertyTypeToParquetType('object')).to.equal('UTF8');
     });
 
     it('should map artifact_key to UTF8 (file path string)', () => {
@@ -266,19 +272,16 @@ describe('parquet-utils', () => {
       expect(field.originalType).to.equal('UTF8');
     });
 
-    it('should annotate object and array columns with the JSON LogicalType', () => {
-      // JSON LogicalType is BYTE_ARRAY with originalType=JSON. Physical bytes
-      // are identical to UTF8 (the encoder still JSON.stringify's), but the
-      // annotation lets honouring readers auto-deserialize the cell.
+    it('should emit object and array columns as UTF8 (JSON-encoded strings)', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'tags', feature_property_type_name: 'array' },
         { feature_property_name: 'meta', feature_property_type_name: 'object' }
       ];
       const schema = buildParquetSchema(properties);
 
-      expect(schema.fields['tags'].originalType).to.equal('JSON');
+      expect(schema.fields['tags'].originalType).to.equal('UTF8');
       expect(schema.fields['tags'].primitiveType).to.equal('BYTE_ARRAY');
-      expect(schema.fields['meta'].originalType).to.equal('JSON');
+      expect(schema.fields['meta'].originalType).to.equal('UTF8');
       expect(schema.fields['meta'].primitiveType).to.equal('BYTE_ARRAY');
     });
 
@@ -423,7 +426,7 @@ describe('parquet-utils', () => {
       expect(row['file']).to.equal('uploads/photo.jpg');
     });
 
-    it('should JSON-stringify array values', () => {
+    it('should JSON-stringify array values for the UTF8 cell', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'tags', feature_property_type_name: 'array' }
       ];
@@ -432,7 +435,7 @@ describe('parquet-utils', () => {
       expect(row['tags']).to.equal('[1,2,3]');
     });
 
-    it('should JSON-stringify object values', () => {
+    it('should JSON-stringify object values for the UTF8 cell', () => {
       const properties: CsvPropertyDefinition[] = [
         { feature_property_name: 'meta', feature_property_type_name: 'object' }
       ];
@@ -1036,6 +1039,111 @@ describe('parquet-utils', () => {
 
       expect(result.type).to.equal('Point');
       expect(result.coordinates).to.deep.equal([5, 10]);
+    });
+  });
+
+  // End-to-end round-trip: write real Parquet bytes via @dsnp/parquetjs, read
+  // them back via ParquetReader, assert the decoded cell shape matches input.
+  //
+  // The earlier `featureToRow`-output tests asserted what the writer received
+  // (the intermediate object), not what the columnar layer did with it. When
+  // `array`/`object` columns moved from `'UTF8'` to `'JSON'` (logical type),
+  // parquetjs began running its own `JSON.stringify` in `toPrimitive_JSON` on
+  // top of any pre-stringify the encoder did — silently double-encoding the
+  // cell. The pre-existing tests passed because they stopped one layer above
+  // the bug. This suite exercises that seam.
+  describe('Parquet round-trip via @dsnp/parquetjs', () => {
+    async function roundTrip(
+      properties: CsvPropertyDefinition[],
+      featureData: Record<string, unknown>
+    ): Promise<Record<string, unknown>> {
+      const tmpFile = path.join(os.tmpdir(), `parquet-utils-roundtrip-${Date.now()}-${Math.random()}.parquet`);
+      try {
+        const schema = buildParquetSchema(properties);
+        const writer = await parquetjs.ParquetWriter.openFile(schema, tmpFile);
+        await writer.appendRow(
+          featureToRow({ uuid: 'u-1', parent_uuid: null, submission_feature_id: 1, data: featureData }, properties)
+        );
+        await writer.close();
+
+        const reader = await parquetjs.ParquetReader.openFile(tmpFile);
+        const cursor = reader.getCursor();
+        const row = (await cursor.next()) as Record<string, unknown> | null;
+        await reader.close();
+        if (!row) {
+          throw new Error('round-trip read returned no rows');
+        }
+        return row;
+      } finally {
+        await fs.unlink(tmpFile).catch(() => undefined);
+      }
+    }
+
+    it('array column round-trips as a JSON-encoded UTF8 string (no double-encoding)', async () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'tags', feature_property_type_name: 'array' }
+      ];
+      const row = await roundTrip(properties, { tags: [1, 2, 3] });
+
+      // Cell is a UTF8 string that single-`JSON.parse`s back to the original
+      // array. If the writer double-encoded, the cell would be `'"[1,2,3]"'`
+      // (quoted) and `JSON.parse` would return the string `'[1,2,3]'` instead.
+      expect(row['tags']).to.equal('[1,2,3]');
+      expect(JSON.parse(row['tags'] as string)).to.deep.equal([1, 2, 3]);
+    });
+
+    it('object column round-trips as a JSON-encoded UTF8 string (no double-encoding)', async () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'meta', feature_property_type_name: 'object' }
+      ];
+      const row = await roundTrip(properties, { meta: { key: 'value', n: 42 } });
+
+      expect(row['meta']).to.equal('{"key":"value","n":42}');
+      expect(JSON.parse(row['meta'] as string)).to.deep.equal({ key: 'value', n: 42 });
+    });
+
+    it('feature column round-trips to the original URN array (native LIST<UTF8>)', async () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = await roundTrip(properties, {
+        child_features: ['urn:1:observation:42', 'urn:1:observation:43']
+      });
+      expect(row['child_features']).to.deep.equal(['urn:1:observation:42', 'urn:1:observation:43']);
+    });
+
+    it('feature column with one referenced row round-trips as a length-1 array (uniform shape)', async () => {
+      // Spec UO-3 / EC-3: `allow_multiple = false` cells must still surface as
+      // an array, not a bare string — downstream parsers should not have to
+      // branch on schema metadata to decode the cell.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = await roundTrip(properties, { child_features: ['urn:1:observation:42'] });
+      expect(row['child_features']).to.deep.equal(['urn:1:observation:42']);
+    });
+
+    it('feature column with no value round-trips as null (spec EC-1)', async () => {
+      // Spec EC-1: a feature-typed property with zero referenced rows exports
+      // as `null` (Parquet). `featureToRow` maps a missing key to `null`, and
+      // parquetjs preserves that on read for the REPEATED column.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = await roundTrip(properties, {});
+      expect(row['child_features']).to.be.null;
+    });
+
+    it('feature column defensively normalizes a scalar from upstream drift to a one-element array', async () => {
+      // The encoder's `Array.isArray(value) ? value : [String(value)]` fallback
+      // exists for contract drift — the hydrator guarantees arrays today, but a
+      // malformed cell should land as a valid one-element list rather than
+      // crash the writer mid-file. This pins that escape hatch end-to-end.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = await roundTrip(properties, { child_features: 'urn:1:observation:42' });
+      expect(row['child_features']).to.deep.equal(['urn:1:observation:42']);
     });
   });
 });

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -109,6 +109,16 @@ describe('parquet-utils', () => {
       expect(result).to.have.length(1);
       expect(result[0]).to.deep.equal({ name: 'geometry', parquetType: 'BYTE_ARRAY' });
     });
+
+    it('should return a UTF8 column flagged as repeated for a feature property (native Parquet LIST)', () => {
+      const result = expandPropertyToColumns({
+        feature_property_name: 'child_features',
+        feature_property_type_name: 'feature'
+      });
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.deep.equal({ name: 'child_features', parquetType: 'UTF8', repeated: true });
+    });
   });
 
   describe('dateStringToParquet', () => {
@@ -238,6 +248,20 @@ describe('parquet-utils', () => {
       expect(sfid.primitiveType).to.equal('INT64');
       // optional=false in @dsnp/parquetjs surfaces as REQUIRED on the schema field.
       expect(sfid.repetitionType).to.equal('REQUIRED');
+    });
+
+    it('should mark a feature-typed column as REPEATED in the Parquet schema (native LIST)', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const schema = buildParquetSchema(properties);
+
+      const field = schema.fields['child_features'];
+      expect(field).to.exist;
+      // `repeated: true` in @dsnp/parquetjs surfaces as REPEATED on the schema field.
+      expect(field.repetitionType).to.equal('REPEATED');
+      // UTF8 elements — downstream readers UNNEST into a string column.
+      expect(field.originalType).to.equal('UTF8');
     });
 
     it('should throw when a datetime expansion collides with a sibling property name', () => {
@@ -435,6 +459,54 @@ describe('parquet-utils', () => {
       expect(row['centroid']).to.be.instanceOf(Buffer);
       // Different geometries should produce different WKB
       expect(Buffer.compare(row['geometry'] as Buffer, row['centroid'] as Buffer)).to.not.equal(0);
+    });
+
+    it('should pass through a single-element feature array unchanged for the Parquet LIST writer', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = featureToRow(makeFeature({ child_features: ['urn:1'] }), properties);
+
+      expect(row['child_features']).to.deep.equal(['urn:1']);
+    });
+
+    it('should preserve order in a multi-element feature array', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = featureToRow(makeFeature({ child_features: ['urn:1', 'urn:2'] }), properties);
+
+      expect(row['child_features']).to.deep.equal(['urn:1', 'urn:2']);
+    });
+
+    it('should pass through an empty feature array as [] (not null) so the LIST writer emits an empty list', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = featureToRow(makeFeature({ child_features: [] }), properties);
+
+      expect(row['child_features']).to.deep.equal([]);
+    });
+
+    it('should defensively wrap a non-array feature scalar in a single-element array', () => {
+      // Contract drift defense: the hydrator guarantees arrays of URN strings,
+      // but a malformed cell from upstream should land in Parquet as a valid
+      // one-element list rather than crash the LIST writer mid-file.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = featureToRow(makeFeature({ child_features: 'urn:x' }), properties);
+
+      expect(row['child_features']).to.deep.equal(['urn:x']);
+    });
+
+    it('should set null for a missing feature property key (the shared null guard runs before encoding)', () => {
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'child_features', feature_property_type_name: 'feature' }
+      ];
+      const row = featureToRow(makeFeature({}), properties);
+
+      expect(row['child_features']).to.be.null;
     });
 
     it('should set null for null property values', () => {

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -1,9 +1,9 @@
 import parquetjs from '@dsnp/parquetjs';
 import { expect } from 'chai';
+import { describe, it } from 'mocha';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, it } from 'mocha';
 import wkx from 'wkx';
 
 import { ParquetFeatureData } from '../models/download';

--- a/api/src/utils/parquet-utils.test.ts
+++ b/api/src/utils/parquet-utils.test.ts
@@ -51,12 +51,14 @@ describe('parquet-utils', () => {
       expect(propertyTypeToParquetType('spatial')).to.equal('BYTE_ARRAY');
     });
 
-    it('should map array to UTF8 (JSON-stringified fallback)', () => {
-      expect(propertyTypeToParquetType('array')).to.equal('UTF8');
+    it('should map array to JSON LogicalType (BYTE_ARRAY + originalType=JSON)', () => {
+      // Physical bytes are identical to UTF8 — readers that honour the annotation
+      // (DuckDB, pyarrow, Spark) auto-deserialize; others see the same string.
+      expect(propertyTypeToParquetType('array')).to.equal('JSON');
     });
 
-    it('should map object to UTF8 (JSON-stringified fallback)', () => {
-      expect(propertyTypeToParquetType('object')).to.equal('UTF8');
+    it('should map object to JSON LogicalType (BYTE_ARRAY + originalType=JSON)', () => {
+      expect(propertyTypeToParquetType('object')).to.equal('JSON');
     });
 
     it('should map artifact_key to UTF8 (file path string)', () => {
@@ -262,6 +264,22 @@ describe('parquet-utils', () => {
       expect(field.repetitionType).to.equal('REPEATED');
       // UTF8 elements — downstream readers UNNEST into a string column.
       expect(field.originalType).to.equal('UTF8');
+    });
+
+    it('should annotate object and array columns with the JSON LogicalType', () => {
+      // JSON LogicalType is BYTE_ARRAY with originalType=JSON. Physical bytes
+      // are identical to UTF8 (the encoder still JSON.stringify's), but the
+      // annotation lets honouring readers auto-deserialize the cell.
+      const properties: CsvPropertyDefinition[] = [
+        { feature_property_name: 'tags', feature_property_type_name: 'array' },
+        { feature_property_name: 'meta', feature_property_type_name: 'object' }
+      ];
+      const schema = buildParquetSchema(properties);
+
+      expect(schema.fields['tags'].originalType).to.equal('JSON');
+      expect(schema.fields['tags'].primitiveType).to.equal('BYTE_ARRAY');
+      expect(schema.fields['meta'].originalType).to.equal('JSON');
+      expect(schema.fields['meta'].primitiveType).to.equal('BYTE_ARRAY');
     });
 
     it('should throw when a datetime expansion collides with a sibling property name', () => {

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -22,10 +22,15 @@ import type { CsvPropertyDefinition } from './csv-utils';
  *
  * Most property types map 1:1 (one property -> one column). `datetime`
  * expands to two — see {@link expandPropertyToColumns}.
+ *
+ * `repeated` marks the column as a native Parquet LIST (the schema field gets
+ * `repetitionType === 'REPEATED'`), used by `feature` properties so downstream
+ * readers see an array column they can UNNEST without JSON parsing.
  */
 export interface FeatureColumnSpec {
   name: string;
   parquetType: FieldDefinition['type'];
+  repeated?: boolean;
 }
 
 /**
@@ -60,6 +65,20 @@ export interface FeatureColumnSpec {
  *   two-element (`<name>_date`, `<name>_time`) for datetime.
  */
 export function expandPropertyToColumns(prop: CsvPropertyDefinition): FeatureColumnSpec[] {
+  if (prop.feature_property_type_name === 'feature') {
+    // Native Parquet LIST<UTF8> preserves the columnar shape of cross-feature
+    // references so downstream readers (DuckDB, pyarrow, Spark) can UNNEST
+    // directly — no per-row JSON.parse on a stringified array, no loss of
+    // per-element predicate pushdown. The `repeated` flag becomes
+    // `repetitionType: 'REPEATED'` on the Parquet schema field.
+    //
+    // The defensive normalization in `encodePropertyValue` (scalar → single-
+    // element array) handles contract drift from upstream: the hydrator
+    // guarantees arrays of URN strings today, but a malformed cell should
+    // land in Parquet as a valid one-element list rather than crash the
+    // writer mid-file.
+    return [{ name: prop.feature_property_name, parquetType: 'UTF8', repeated: true }];
+  }
   if (prop.feature_property_type_name === 'datetime') {
     // Native Parquet logical types — DATE (INT32 days-since-epoch) and TIME_MILLIS
     // (INT32 ms-since-midnight). DuckDB / pandas / arrow read these as native
@@ -209,7 +228,9 @@ export function buildParquetSchema(properties: CsvPropertyDefinition[]): Parquet
 
   for (const prop of properties) {
     for (const col of expandPropertyToColumns(prop)) {
-      fields[col.name] = { type: col.parquetType, optional: true };
+      fields[col.name] = col.repeated
+        ? { type: col.parquetType, repeated: true }
+        : { type: col.parquetType, optional: true };
     }
   }
 
@@ -273,6 +294,11 @@ function encodePropertyValue(prop: CsvPropertyDefinition, value: unknown): unkno
     case 'array':
     case 'object':
       return JSON.stringify(value);
+    case 'feature':
+      // `feature` columns are native Parquet LIST<UTF8>; the writer expects an
+      // array. Defensive normalization: a scalar from upstream contract drift
+      // lands as a one-element list rather than crashing the writer mid-file.
+      return Array.isArray(value) ? value : [String(value)];
     default:
       // string, number, boolean, code, taxon, artifact_key — pass through directly
       return value;

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -144,9 +144,11 @@ export function timeStringToMillis(s: string): number {
  * downstream consumers (DuckDB, QGIS, pandas) get native typed columns instead of strings.
  *
  * `array` and `object` types have dynamic internal structure (arrays of objects, nested
- * JSON). They serialize as Parquet's JSON LogicalType — `BYTE_ARRAY` annotated with
- * `originalType=JSON` so readers that honour the annotation auto-deserialize. `artifact_key`
- * is a file path string and stays UTF8. `spatial` maps to `BYTE_ARRAY` for WKB encoding.
+ * JSON). They serialize as UTF8 — the caller JSON-stringifies and consumers `JSON.parse`
+ * the cell. The Parquet JSON LogicalType was tempting (DuckDB/pyarrow auto-deserialize)
+ * but @dsnp/parquetjs's shredder unwraps `Array.isArray(value)` regardless of annotation,
+ * so a raw array on a non-REPEATED JSON cell throws at write time. `artifact_key` is a
+ * file path string and stays UTF8. `spatial` maps to `BYTE_ARRAY` for WKB encoding.
  *
  * @param typeName - The feature property type name from `feature_type_property`.
  * @returns The Parquet type string.
@@ -187,13 +189,14 @@ export function propertyTypeToParquetType(typeName: string): FieldDefinition['ty
       return 'BYTE_ARRAY';
     case 'array':
     case 'object':
-      // Dynamic internal structure — JSON-stringified for Parquet output. The
-      // JSON LogicalType (BYTE_ARRAY with originalType=JSON) is physically
-      // identical to UTF8 on the wire, but readers that honour the annotation
-      // (DuckDB, pyarrow, Spark) auto-deserialize the cell instead of leaving
-      // it as a string. Readers that ignore the annotation see the same bytes
-      // as before.
-      return 'JSON';
+      // JSON-encoded UTF8 string. The Parquet `JSON` LogicalType was tempting
+      // here (DuckDB/pyarrow auto-deserialize), but @dsnp/parquetjs's shredder
+      // unconditionally unwraps `Array.isArray(value)` into multiple per-row
+      // values regardless of column annotation — passing a raw array to a
+      // non-REPEATED JSON cell throws "too many values for field" at write
+      // time. UTF8 + caller-side `JSON.stringify` sidesteps the shred-layer
+      // mismatch; consumers `JSON.parse` the cell themselves.
+      return 'UTF8';
     case 'artifact_key':
       // File path string — no special encoding needed
       return 'UTF8';

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -168,6 +168,14 @@ export function propertyTypeToParquetType(typeName: string): FieldDefinition['ty
       throw new Error(
         `propertyTypeToParquetType: 'datetime' has no single Parquet type — use expandPropertyToColumns to get DATE + TIME_MILLIS`
       );
+    case 'feature':
+      // `feature` cannot map to a single primitive — it emits a native LIST<UTF8>
+      // (UTF8 with `repeated: true`) via `expandPropertyToColumns`. Reaching this
+      // case means a caller bypassed the helper and asked for a scalar type;
+      // silently returning UTF8 would erase the list shape from the Parquet footer.
+      throw new Error(
+        `propertyTypeToParquetType: 'feature' has no single Parquet type — use expandPropertyToColumns to get a repeated UTF8 column`
+      );
     case 'code':
       // Code properties arrive pre-resolved: the cursor JOIN resolves FK -> display label
       return 'UTF8';

--- a/api/src/utils/parquet-utils.ts
+++ b/api/src/utils/parquet-utils.ts
@@ -143,9 +143,10 @@ export function timeStringToMillis(s: string): number {
  * `_number`, etc.). This function bridges those type names to Parquet column types so
  * downstream consumers (DuckDB, QGIS, pandas) get native typed columns instead of strings.
  *
- * `array`, `object`, and `artifact_key` types have dynamic internal structure (arrays of
- * objects, nested JSON, file paths). No typed table exists for them — they fall back to
- * UTF8 (JSON-stringified) for Parquet output. `spatial` maps to BYTE_ARRAY for WKB encoding.
+ * `array` and `object` types have dynamic internal structure (arrays of objects, nested
+ * JSON). They serialize as Parquet's JSON LogicalType — `BYTE_ARRAY` annotated with
+ * `originalType=JSON` so readers that honour the annotation auto-deserialize. `artifact_key`
+ * is a file path string and stays UTF8. `spatial` maps to `BYTE_ARRAY` for WKB encoding.
  *
  * @param typeName - The feature property type name from `feature_type_property`.
  * @returns The Parquet type string.
@@ -177,11 +178,14 @@ export function propertyTypeToParquetType(typeName: string): FieldDefinition['ty
       // GeoParquet WKB-encoded geometry — each spatial property gets its own BYTE_ARRAY column
       return 'BYTE_ARRAY';
     case 'array':
-      // Dynamic internal structure — JSON-stringified for Parquet output
-      return 'UTF8';
     case 'object':
-      // Dynamic internal structure — JSON-stringified for Parquet output
-      return 'UTF8';
+      // Dynamic internal structure — JSON-stringified for Parquet output. The
+      // JSON LogicalType (BYTE_ARRAY with originalType=JSON) is physically
+      // identical to UTF8 on the wire, but readers that honour the annotation
+      // (DuckDB, pyarrow, Spark) auto-deserialize the cell instead of leaving
+      // it as a string. Readers that ignore the annotation see the same bytes
+      // as before.
+      return 'JSON';
     case 'artifact_key':
       // File path string — no special encoding needed
       return 'UTF8';


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-1021](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1021)

## Description of Changes

As a BioHub user, I want feature-backed properties to export as referenced feature URNs, so that downloaded CSV and Parquet files contain durable feature references.

Acceptance Criteria

1. Feature Property Export

WHEN a feature-backed property is included in a download/export,
THEN BioHub should export the referenced feature’s URN as the property value.

2. Feature Property Hydration

WHEN export hydration fetches typed property rows,
THEN BioHub should include `feature` properties from `submission_feature_property_feature`.
WHEN a feature-backed property row is hydrated,
THEN BioHub should join to the referenced `submission_feature` to resolve its URN.

3. CSV and Parquet Output

WHEN a CSV export includes a feature-backed property,
THEN the exported value should be the referenced feature’s URN.
WHEN a Parquet export includes a feature-backed property,
THEN the exported value should be the referenced feature’s URN.

4. Null Handling

WHEN the referenced feature does not exist or is inactive,
THEN the exported property value should be `null`.
Note: This should never happen

## Testing Notes

**Backend only — `feature`-typed property columns become populated in dataset CSV + Parquet exports.**

```bash
make test       # unit (both layers); parquet round-trip suite catches the array/object double-encode regression
make test-db    # ← the one that matters: download-parquet-pipeline integration proves the new `feature` SELECT end-to-end
make test-sys   # broader regression (slower; skip if test-db is green)
```
