### PR TITLE
SIMSBIOHUB-1022: Prevent duplicate `source_id` in tarballs

### DIFF
--- a/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
@@ -1,7 +1,7 @@
-// Integration tests for SubmissionFeaturePropertyIngestionRepository — drives three methods that
-// read ALREADY-RESOLVED candidate rows from the UNLOGGED staging table
-// (submission_upload_staging_feature_candidate) directly, so each branch/gate is observable in
-// isolation (no service, no populate/resolve step, no Phase 9 gate):
+// Integration tests for SubmissionFeaturePropertyIngestionRepository — drives several error-recording
+// and property-insertion methods so each branch/gate is observable in isolation (no service, no
+// populate/resolve step, no Phase 9 gate). The first three read ALREADY-RESOLVED candidate rows from
+// the UNLOGGED staging table (submission_upload_staging_feature_candidate) directly:
 //
 //   - recordFeaturePropertyResolutionErrorsBySubmissionUploadId — groups four error categories into
 //     submission_feature_error: INVALID_FEATURE_REFERENCE_FORMAT, UNRESOLVED_FEATURE_REFERENCE,
@@ -11,7 +11,12 @@
 //   - insertFeaturePropertiesBySubmissionUploadId — gated INSERT…SELECT into
 //     submission_feature_property_feature with ON CONFLICT DO NOTHING.
 //
-// Fixtures hand-populate the staging table directly: the candidate's submission_upload_id is just a
+// The last method instead reads canonical submission_feature rows directly (not the staging table):
+//
+//   - recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId — flags source_id collisions within an
+//     upload, recording one DUPLICATE_FEATURE_SOURCE_ID row per duplicated source_id.
+//
+// Fixtures for the staging-driven methods hand-populate the staging table directly: the candidate's submission_upload_id is just a
 // filter key (the UNLOGGED staging table has no FK), so each test mints its own uuid. The canonical
 // tables DO have FKs, so real submission_feature rows and a feature_type_property config row are
 // created per test.
@@ -34,7 +39,11 @@ import {
   getPropertyFeatureRows as fetchPropertyFeatureRows,
   getSubmissionFeatureErrors
 } from '../helpers/test-feature-property-helpers';
-import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
+import {
+  createTestFeature,
+  createTestSubmission,
+  getOrCreateIntegrationTicketId
+} from '../helpers/test-submission-helpers';
 
 describe('SubmissionFeaturePropertyIngestionRepository (integration)', function () {
   this.timeout(15000);
@@ -162,6 +171,112 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     sourceFeatureId: number
   ): Promise<{ referenced_submission_feature_id: number; feature_type_property_id: number }[]> {
     return fetchPropertyFeatureRows(connection, sourceFeatureId);
+  }
+
+  /**
+   * Seed one `submission_upload` plus N `submission_feature` rows under it, each row
+   * parameterized by `(source_id, record_end_date)`.
+   *
+   * The helper exists so duplicate-detection scenarios can be expressed as a flat list
+   * of feature shapes — every test needs exactly one upload with a handful of feature
+   * rows, and inlining the FK chain (submission → upload → submission_upload →
+   * submission_feature plus the ticket lookup) in every test would obscure the
+   * scenario under test.
+   *
+   * Inserts run directly via `connection.sql` to bypass any logic in the repository
+   * under test.
+   */
+  async function seedUploadWithFeatures(
+    connection: IDBConnection,
+    features: Array<{ source_id: string | null; record_end_date?: string | null }>
+  ): Promise<{ submissionUploadId: string }> {
+    const systemUserId = connection.systemUserId();
+
+    const submissionId = await createTestSubmission(connection);
+
+    const uploadResult = await connection.sql(SQL`
+      INSERT INTO upload (upload_status, record_end_date, create_user)
+      VALUES ('completed', now(), ${systemUserId})
+      RETURNING upload_id;
+    `);
+    const uploadId = uploadResult.rows[0].upload_id;
+
+    const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
+
+    const bridgeResult = await connection.sql(SQL`
+      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+      VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
+      RETURNING submission_upload_id;
+    `);
+    const submissionUploadId = bridgeResult.rows[0].submission_upload_id as string;
+
+    if (features.length === 0) {
+      return { submissionUploadId };
+    }
+
+    const featureTypeResult = await connection.sql(SQL`
+      SELECT feature_type_id FROM feature_type WHERE name = 'dataset' LIMIT 1;
+    `);
+    const featureTypeId = featureTypeResult.rows[0].feature_type_id;
+
+    for (const feature of features) {
+      const dataJson = JSON.stringify({ source_id: feature.source_id });
+      await connection.sql(SQL`
+        INSERT INTO submission_feature (
+          submission_id,
+          submission_upload_id,
+          feature_type_id,
+          source_id,
+          record_end_date,
+          data,
+          data_byte_size,
+          create_user
+        )
+        VALUES (
+          ${submissionId},
+          ${submissionUploadId},
+          ${featureTypeId},
+          ${feature.source_id},
+          ${feature.record_end_date ?? null},
+          ${dataJson}::jsonb,
+          octet_length(${dataJson}::jsonb::text) + 500,
+          ${systemUserId}
+        );
+      `);
+    }
+
+    return { submissionUploadId };
+  }
+
+  /**
+   * Read back DUPLICATE_FEATURE_SOURCE_ID rows for an upload, ordered by source_id
+   * (NULLs last) for deterministic assertion order.
+   */
+  async function getDuplicateErrors(submissionUploadId: string): Promise<
+    Array<{
+      count: number;
+      property_name: string | null;
+      feature_type_property_id: number | null;
+      source_id: string | null;
+    }>
+  > {
+    const result = await connection.sql<{
+      count: number;
+      property_name: string | null;
+      feature_type_property_id: number | null;
+      source_id: string | null;
+    }>(SQL`
+      SELECT
+        count,
+        property_name,
+        feature_type_property_id,
+        details->>'source_id' AS source_id
+      FROM submission_feature_error
+      WHERE submission_upload_id = ${submissionUploadId}::uuid
+        AND error_code = 'DUPLICATE_FEATURE_SOURCE_ID'
+      ORDER BY details->>'source_id';
+    `);
+    return result.rows;
   }
 
   // --- recordFeaturePropertyResolutionErrorsBySubmissionUploadId -----------
@@ -806,6 +921,98 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
       await repo.insertFeaturePropertiesBySubmissionUploadId(uploadId);
 
       expect(await getPropertyFeatureRows(sourceFeatureId)).to.have.lengthOf(0);
+    });
+  });
+
+  // --- recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId ------------
+
+  describe('recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId', () => {
+    it('records one error row with count=3 when three active rows share one source_id', async () => {
+      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+        { source_id: 'A' },
+        { source_id: 'A' },
+        { source_id: 'A' }
+      ]);
+
+      await repo.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId);
+
+      const errors = await getDuplicateErrors(submissionUploadId);
+      expect(errors).to.have.length(1);
+      expect(errors[0].count).to.equal(3);
+      expect(errors[0].source_id).to.equal('A');
+      expect(errors[0].property_name).to.equal(null);
+      expect(errors[0].feature_type_property_id).to.equal(null);
+    });
+
+    it('records one row per distinct duplicated source_id with correct counts', async () => {
+      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+        { source_id: 'A' },
+        { source_id: 'A' },
+        { source_id: 'B' },
+        { source_id: 'B' },
+        { source_id: 'B' }
+      ]);
+
+      await repo.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId);
+
+      const errors = await getDuplicateErrors(submissionUploadId);
+      expect(errors).to.have.length(2);
+
+      expect(errors[0].source_id).to.equal('A');
+      expect(errors[0].count).to.equal(2);
+      expect(errors[0].property_name).to.equal(null);
+      expect(errors[0].feature_type_property_id).to.equal(null);
+
+      expect(errors[1].source_id).to.equal('B');
+      expect(errors[1].count).to.equal(3);
+      expect(errors[1].property_name).to.equal(null);
+      expect(errors[1].feature_type_property_id).to.equal(null);
+    });
+
+    it('records zero rows when every source_id is unique', async () => {
+      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+        { source_id: 'A' },
+        { source_id: 'B' },
+        { source_id: 'C' }
+      ]);
+
+      await repo.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId);
+
+      const errors = await getDuplicateErrors(submissionUploadId);
+      expect(errors).to.have.length(0);
+    });
+
+    it('treats NULL source_ids as non-duplicates and records no error rows', async () => {
+      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+        { source_id: null },
+        { source_id: null }
+      ]);
+
+      await repo.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId);
+
+      const errors = await getDuplicateErrors(submissionUploadId);
+      expect(errors).to.have.length(0);
+    });
+
+    it('ignores soft-deleted rows when checking for duplicates', async () => {
+      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+        { source_id: 'A' },
+        { source_id: 'A', record_end_date: '2026-01-01' }
+      ]);
+
+      await repo.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId);
+
+      const errors = await getDuplicateErrors(submissionUploadId);
+      expect(errors).to.have.length(0);
+    });
+
+    it('records zero rows and does not throw for an empty upload', async () => {
+      const { submissionUploadId } = await seedUploadWithFeatures(connection, []);
+
+      await repo.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId);
+
+      const errors = await getDuplicateErrors(submissionUploadId);
+      expect(errors).to.have.length(0);
     });
   });
 });

--- a/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
+++ b/api/src/__integration__/db/submission-feature-property-ingestion-repository.integration.ts
@@ -42,7 +42,7 @@ import {
 import {
   createTestFeature,
   createTestSubmission,
-  getOrCreateIntegrationTicketId
+  createTestUploadWithFeatures
 } from '../helpers/test-submission-helpers';
 
 describe('SubmissionFeaturePropertyIngestionRepository (integration)', function () {
@@ -174,83 +174,8 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
   }
 
   /**
-   * Seed one `submission_upload` plus N `submission_feature` rows under it, each row
-   * parameterized by `(source_id, record_end_date)`.
-   *
-   * The helper exists so duplicate-detection scenarios can be expressed as a flat list
-   * of feature shapes — every test needs exactly one upload with a handful of feature
-   * rows, and inlining the FK chain (submission → upload → submission_upload →
-   * submission_feature plus the ticket lookup) in every test would obscure the
-   * scenario under test.
-   *
-   * Inserts run directly via `connection.sql` to bypass any logic in the repository
-   * under test.
-   */
-  async function seedUploadWithFeatures(
-    connection: IDBConnection,
-    features: Array<{ source_id: string | null; record_end_date?: string | null }>
-  ): Promise<{ submissionUploadId: string }> {
-    const systemUserId = connection.systemUserId();
-
-    const submissionId = await createTestSubmission(connection);
-
-    const uploadResult = await connection.sql(SQL`
-      INSERT INTO upload (upload_status, record_end_date, create_user)
-      VALUES ('completed', now(), ${systemUserId})
-      RETURNING upload_id;
-    `);
-    const uploadId = uploadResult.rows[0].upload_id;
-
-    const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
-
-    const bridgeResult = await connection.sql(SQL`
-      INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
-      VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
-      RETURNING submission_upload_id;
-    `);
-    const submissionUploadId = bridgeResult.rows[0].submission_upload_id as string;
-
-    if (features.length === 0) {
-      return { submissionUploadId };
-    }
-
-    const featureTypeResult = await connection.sql(SQL`
-      SELECT feature_type_id FROM feature_type WHERE name = 'dataset' LIMIT 1;
-    `);
-    const featureTypeId = featureTypeResult.rows[0].feature_type_id;
-
-    for (const feature of features) {
-      const dataJson = JSON.stringify({ source_id: feature.source_id });
-      await connection.sql(SQL`
-        INSERT INTO submission_feature (
-          submission_id,
-          submission_upload_id,
-          feature_type_id,
-          source_id,
-          record_end_date,
-          data,
-          data_byte_size,
-          create_user
-        )
-        VALUES (
-          ${submissionId},
-          ${submissionUploadId},
-          ${featureTypeId},
-          ${feature.source_id},
-          ${feature.record_end_date ?? null},
-          ${dataJson}::jsonb,
-          octet_length(${dataJson}::jsonb::text) + 500,
-          ${systemUserId}
-        );
-      `);
-    }
-
-    return { submissionUploadId };
-  }
-
-  /**
    * Read back DUPLICATE_FEATURE_SOURCE_ID rows for an upload, ordered by source_id
-   * (NULLs last) for deterministic assertion order.
+   * for deterministic assertion order.
    */
   async function getDuplicateErrors(submissionUploadId: string): Promise<
     Array<{
@@ -928,7 +853,8 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
 
   describe('recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId', () => {
     it('records one error row with count=3 when three active rows share one source_id', async () => {
-      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+      const submissionId = await createTestSubmission(connection);
+      const submissionUploadId = await createTestUploadWithFeatures(connection, submissionId, 'dataset', [
         { source_id: 'A' },
         { source_id: 'A' },
         { source_id: 'A' }
@@ -945,7 +871,8 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('records one row per distinct duplicated source_id with correct counts', async () => {
-      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+      const submissionId = await createTestSubmission(connection);
+      const submissionUploadId = await createTestUploadWithFeatures(connection, submissionId, 'dataset', [
         { source_id: 'A' },
         { source_id: 'A' },
         { source_id: 'B' },
@@ -970,7 +897,8 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('records zero rows when every source_id is unique', async () => {
-      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+      const submissionId = await createTestSubmission(connection);
+      const submissionUploadId = await createTestUploadWithFeatures(connection, submissionId, 'dataset', [
         { source_id: 'A' },
         { source_id: 'B' },
         { source_id: 'C' }
@@ -983,7 +911,8 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('treats NULL source_ids as non-duplicates and records no error rows', async () => {
-      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+      const submissionId = await createTestSubmission(connection);
+      const submissionUploadId = await createTestUploadWithFeatures(connection, submissionId, 'dataset', [
         { source_id: null },
         { source_id: null }
       ]);
@@ -995,7 +924,8 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('ignores soft-deleted rows when checking for duplicates', async () => {
-      const { submissionUploadId } = await seedUploadWithFeatures(connection, [
+      const submissionId = await createTestSubmission(connection);
+      const submissionUploadId = await createTestUploadWithFeatures(connection, submissionId, 'dataset', [
         { source_id: 'A' },
         { source_id: 'A', record_end_date: '2026-01-01' }
       ]);
@@ -1007,7 +937,8 @@ describe('SubmissionFeaturePropertyIngestionRepository (integration)', function 
     });
 
     it('records zero rows and does not throw for an empty upload', async () => {
-      const { submissionUploadId } = await seedUploadWithFeatures(connection, []);
+      const submissionId = await createTestSubmission(connection);
+      const submissionUploadId = await createTestUploadWithFeatures(connection, submissionId, 'dataset', []);
 
       await repo.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId);
 

--- a/api/src/__integration__/helpers/test-submission-helpers.ts
+++ b/api/src/__integration__/helpers/test-submission-helpers.ts
@@ -165,6 +165,88 @@ export async function createTestFeaturesInBulk(
 }
 
 /**
+ * Insert one `submission_upload` plus N `submission_feature` rows under it, each row
+ * parameterized by `(source_id, record_end_date, data?)`.
+ *
+ * Unlike `createTestFeaturesInBulk` — which inserts homogeneous features via
+ * `generate_series` and is tuned for large counts — this helper supports
+ * heterogeneous per-row data. Use it for tests that need control over
+ * `source_id` and `record_end_date` to exercise NULL handling, soft-delete
+ * semantics, or other per-row variation.
+ *
+ * @param connection Active database connection (transaction-scoped).
+ * @param submissionId Submission to attach the upload and features to.
+ * @param featureTypeName Feature type name (must exist in seed data).
+ * @param features Per-row feature shapes. Empty array creates the upload with no features.
+ * @returns The created `submission_upload_id`.
+ */
+export async function createTestUploadWithFeatures(
+  connection: IDBConnection,
+  submissionId: number,
+  featureTypeName: string,
+  features: Array<{
+    source_id: string | null;
+    record_end_date?: string | null;
+    data?: Record<string, unknown>;
+  }>
+): Promise<string> {
+  const systemUserId = connection.systemUserId();
+
+  const uploadResult = await connection.sql(SQL`
+    INSERT INTO upload (upload_status, record_end_date, create_user)
+    VALUES ('completed', now(), ${systemUserId})
+    RETURNING upload_id;
+  `);
+  const uploadId = uploadResult.rows[0].upload_id;
+
+  const ticketId = await getOrCreateIntegrationTicketId(connection, submissionId, uploadId, systemUserId);
+
+  const bridgeResult = await connection.sql(SQL`
+    INSERT INTO submission_upload (submission_id, upload_id, ticket_id, create_user)
+    VALUES (${submissionId}, ${uploadId}, ${ticketId}, ${systemUserId})
+    RETURNING submission_upload_id;
+  `);
+  const submissionUploadId = bridgeResult.rows[0].submission_upload_id as string;
+
+  if (features.length === 0) {
+    return submissionUploadId;
+  }
+
+  const featureTypeResult = await connection.sql(SQL`
+    SELECT feature_type_id FROM feature_type WHERE name = ${featureTypeName} LIMIT 1;
+  `);
+  const featureTypeId = featureTypeResult.rows[0].feature_type_id;
+
+  for (const feature of features) {
+    const dataJson = JSON.stringify(feature.data ?? {});
+    await connection.sql(SQL`
+      INSERT INTO submission_feature (
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        source_id,
+        record_end_date,
+        data,
+        data_byte_size,
+        create_user
+      )
+      VALUES (
+        ${submissionId},
+        ${submissionUploadId},
+        ${featureTypeId},
+        ${feature.source_id},
+        ${feature.record_end_date ?? null},
+        ${dataJson}::jsonb,
+        octet_length(${dataJson}::jsonb::text) + 500,
+        ${systemUserId}
+      );
+    `);
+  }
+
+  return submissionUploadId;
+}
+
+/**
  * Get an existing integration ticket for a submission or create one if missing.
  *
  * This helper supports integration tests that insert into `submission_upload` directly now that

--- a/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
@@ -270,7 +270,7 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
   });
 
   describe('recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId', () => {
-    it('records one duplicate-source-id error per colliding source_id, excluding NULLs', async () => {
+    async function runAndGetSqlText(): Promise<string> {
       const sqlStub = sinon.stub().resolves(mockQueryResult([]));
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
       const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
@@ -278,18 +278,38 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
       await repository.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
 
       expect(sqlStub.calledOnce).to.equal(true);
-      const sqlText = sqlStub.firstCall.args[0].text as string;
+      return sqlStub.firstCall.args[0].text as string;
+    }
+
+    it('groups by source_id and emits one error row per collision', async () => {
+      const sqlText = await runAndGetSqlText();
+
       expect(sqlText).to.include('grouped_errors AS');
-      expect(sqlText).to.include("'DUPLICATE_FEATURE_SOURCE_ID'");
       expect(sqlText).to.include('HAVING COUNT(*) > 1');
+    });
+
+    it('excludes NULL source_ids and soft-deleted feature rows from the grouping', async () => {
+      const sqlText = await runAndGetSqlText();
+
       expect(sqlText).to.include('source_id IS NOT NULL');
       expect(sqlText).to.include('record_end_date IS NULL');
+      expect(sqlText).to.not.include('NULLIF');
+    });
+
+    it('labels rows DUPLICATE_FEATURE_SOURCE_ID and stores source_id in details jsonb', async () => {
+      const sqlText = await runAndGetSqlText();
+
+      expect(sqlText).to.include("'DUPLICATE_FEATURE_SOURCE_ID'");
       expect(sqlText).to.include("jsonb_build_object('source_id', source_id)");
+    });
+
+    it('upserts on the property-keyed unique index without writing submission_feature_id', async () => {
+      const sqlText = await runAndGetSqlText();
+
       expect(sqlText).to.include('ON CONFLICT');
       expect(sqlText).to.match(
         /ON CONFLICT\s*\(\s*submission_upload_id,\s*error_code,\s*feature_type_property_id,\s*property_name\s*\)/
       );
-      expect(sqlText).to.not.include('NULLIF');
       expect(sqlText).to.not.include('submission_feature_id');
     });
   });

--- a/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
@@ -269,6 +269,31 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
     });
   });
 
+  describe('recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId', () => {
+    it('records one duplicate-source-id error per colliding source_id, excluding NULLs', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([]));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
+
+      await repository.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      expect(sqlStub.calledOnce).to.equal(true);
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      expect(sqlText).to.include('grouped_errors AS');
+      expect(sqlText).to.include("'DUPLICATE_FEATURE_SOURCE_ID'");
+      expect(sqlText).to.include('HAVING COUNT(*) > 1');
+      expect(sqlText).to.include('source_id IS NOT NULL');
+      expect(sqlText).to.include('record_end_date IS NULL');
+      expect(sqlText).to.include("jsonb_build_object('source_id', source_id)");
+      expect(sqlText).to.include('ON CONFLICT');
+      expect(sqlText).to.match(
+        /ON CONFLICT\s*\(\s*submission_upload_id,\s*error_code,\s*feature_type_property_id,\s*property_name\s*\)/
+      );
+      expect(sqlText).to.not.include('NULLIF');
+      expect(sqlText).to.not.include('submission_feature_id');
+    });
+  });
+
   describe('recordMissingRequiredPropertyErrorsBySubmissionUploadId', () => {
     it('uses an indexable raw-property anti-lookup for present required properties', async () => {
       const sqlStub = sinon.stub().resolves(mockQueryResult([]));

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -2311,6 +2311,71 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   }
 
   /**
+   * Record duplicate `source_id` errors for the upload.
+   *
+   * A duplicate-source-id error is recorded once per `source_id` value that appears in
+   * two or more active rows of `submission_feature` within the same upload. NULL
+   * `source_id` rows are excluded — Postgres NULL semantics make them non-equal, and
+   * the downstream `feature::<source_id>` resolver cannot match NULLs either, so they
+   * cannot produce the resolution ambiguity this check prevents.
+   *
+   * One row per distinct duplicated `source_id` is written so that the colliding
+   * identifier is recoverable from `details->>'source_id'`. `count` is the literal
+   * duplicate-row count (e.g., three colliding rows → `count = 3`), matching the
+   * semantics of the sibling `recordUnresolvedParentErrors` method.
+   *
+   * @param {string} submissionUploadId Upload scope.
+   * @returns {Promise<void>}
+   */
+  async recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+    const sql = SQL`
+      WITH grouped_errors AS (
+        SELECT
+          submission_upload_id,
+          source_id,
+          COUNT(*)::integer AS count
+        FROM submission_feature
+        -- source_id IS NOT NULL is defensive — parser already rejects empty strings at parse time.
+        WHERE submission_upload_id = ${submissionUploadId}::uuid
+          AND record_end_date IS NULL
+          AND source_id IS NOT NULL
+        GROUP BY submission_upload_id, source_id
+        HAVING COUNT(*) > 1
+      )
+      INSERT INTO submission_feature_error (
+        submission_upload_id,
+        property_name,
+        feature_type_property_id,
+        error_code,
+        error_message,
+        count,
+        details
+      )
+      SELECT
+        submission_upload_id,
+        NULL::text,
+        NULL::integer,
+        'DUPLICATE_FEATURE_SOURCE_ID',
+        'Multiple active submission_feature rows share the same source_id within this upload',
+        count,
+        jsonb_build_object('source_id', source_id)
+      FROM grouped_errors
+      ON CONFLICT (
+        submission_upload_id,
+        error_code,
+        feature_type_property_id,
+        property_name
+      )
+      DO UPDATE SET
+        count = submission_feature_error.count + EXCLUDED.count,
+        error_message = EXCLUDED.error_message,
+        details = COALESCE(EXCLUDED.details, submission_feature_error.details);
+    `;
+
+    await this.connection.sql(sql);
+  }
+
+  /**
    * Get total number of ingestion error rows for one upload.
    *
    * Returns the aggregated sum of `submission_feature_error.count` rather than row

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -2321,11 +2321,11 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
    *
    * One row per distinct duplicated `source_id` is written so that the colliding
    * identifier is recoverable from `details->>'source_id'`. `count` is the literal
-   * duplicate-row count (e.g., three colliding rows → `count = 3`), matching the
-   * semantics of the sibling `recordUnresolvedParentErrors` method.
+   * duplicate-row count (e.g., three colliding rows → `count = 3`).
    *
    * @param {string} submissionUploadId Upload scope.
    * @returns {Promise<void>}
+   * @memberof SubmissionFeaturePropertyIngestionRepository
    */
   async recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(submissionUploadId: string): Promise<void> {
     const sql = SQL`
@@ -2335,9 +2335,11 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
           source_id,
           COUNT(*)::integer AS count
         FROM submission_feature
-        -- source_id IS NOT NULL is defensive — parser already rejects empty strings at parse time.
         WHERE submission_upload_id = ${submissionUploadId}::uuid
           AND record_end_date IS NULL
+          -- Load-bearing, not defensive: GROUP BY collapses all NULL source_id rows into a
+          -- single group, so omitting this would make HAVING COUNT(*) > 1 report distinct
+          -- NULL-source_id features as a false duplicate collision.
           AND source_id IS NOT NULL
         GROUP BY submission_upload_id, source_id
         HAVING COUNT(*) > 1

--- a/api/src/services/ingestion/submission-feature-property-ingestion-service.test.ts
+++ b/api/src/services/ingestion/submission-feature-property-ingestion-service.test.ts
@@ -145,6 +145,12 @@ describe('SubmissionFeaturePropertyIngestionService', () => {
     const parentErrorsStub = sinon
       .stub(SubmissionFeaturePropertyIngestionRepository.prototype, 'recordUnresolvedParentErrorsBySubmissionUploadId')
       .resolves();
+    const duplicateSourceIdErrorsStub = sinon
+      .stub(
+        SubmissionFeaturePropertyIngestionRepository.prototype,
+        'recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId'
+      )
+      .resolves();
 
     const errorCountStub = sinon
       .stub(SubmissionFeaturePropertyIngestionRepository.prototype, 'getIngestionErrorCountBySubmissionUploadId')
@@ -162,6 +168,7 @@ describe('SubmissionFeaturePropertyIngestionService', () => {
     expect(requestDefaultReviewsStub.calledOnceWith(99, '550e8400-e29b-41d4-a716-446655440000', 11)).to.equal(true);
     expect(referenceErrorsStub.calledOnce).to.equal(true);
     expect(parentErrorsStub.calledOnce).to.equal(true);
+    expect(duplicateSourceIdErrorsStub.calledOnce).to.equal(true);
     expect(outcome).to.eql({ status: 'ok' });
 
     sinon.assert.callOrder(
@@ -174,6 +181,7 @@ describe('SubmissionFeaturePropertyIngestionService', () => {
       codeErrorsStub,
       taxonErrorsStub,
       artifactErrorsStub,
+      duplicateSourceIdErrorsStub,
       parentErrorsStub,
       referenceErrorsStub,
       datetimeErrorsStub,
@@ -310,6 +318,12 @@ describe('SubmissionFeaturePropertyIngestionService', () => {
     sinon.stub(FeatureIngestionRepository.prototype, 'updateSubmissionFeatureParentsBySubmissionUploadId').resolves();
     sinon
       .stub(SubmissionFeaturePropertyIngestionRepository.prototype, 'recordUnresolvedParentErrorsBySubmissionUploadId')
+      .resolves();
+    sinon
+      .stub(
+        SubmissionFeaturePropertyIngestionRepository.prototype,
+        'recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId'
+      )
       .resolves();
 
     sinon

--- a/api/src/services/ingestion/submission-feature-property-ingestion-service.ts
+++ b/api/src/services/ingestion/submission-feature-property-ingestion-service.ts
@@ -176,6 +176,9 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
         submissionUploadId,
         phase: currentPhase
       });
+      await this.submissionFeaturePropertyIngestionRepository.recordDuplicateFeatureSourceIdErrorsBySubmissionUploadId(
+        submissionUploadId
+      );
       await this.submissionFeaturePropertyIngestionRepository.recordUnresolvedParentErrorsBySubmissionUploadId(
         submissionUploadId
       );


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-1022](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1022)

## Description of Changes

As a BioHub user, I want duplicate submitted feature IDs to be reported as upload validation errors after feature insertion, so that feature-backed properties can resolve only against unique feature references.

Acceptance Criteria

1. Validate Inserted Feature IDs

WHEN BioHub inserts features into `submission_feature` for an upload,
THEN BioHub should run duplicate-ID validation from inserted active rows using grouped `(submission_upload_id, source_id)` counts.

2. Report Duplicate Submitted Feature IDs

WHEN active rows for the same upload contain duplicate `source_id` values,
THEN BioHub should write validation errors using the existing upload validation flow and identify the duplicated submitted feature ID.

3. Gate Feature Reference Resolution

WHEN duplicate submitted feature ID validation errors exist for an upload,
THEN BioHub should not resolve feature-backed properties for that upload.

4. Resolve Only Unique Feature References

WHEN feature-reference resolution runs,
THEN `feature::<source_id>` should only resolve against unique active `(submission_upload_id, source_id)` values.

5. Regression Coverage

WHEN validation tests run,
THEN they should confirm duplicate inserted `source_id` values are reported before feature-reference resolution runs.

## Testing Notes

**Backend only — no UI, no API route. Pipeline-internal behavior change: duplicate `source_id`s record `DUPLICATE_FEATURE_SOURCE_ID` errors and gate indexing.**

`make test-db` is the verification — the repo-integration suite proves detection across happy / multi-dup / unique / NULL / soft-deleted / empty cases against the real DB.

