### PR TITLE
SIMSBIOHUB-1026: Toggle Security Rules for Automatic Screening

### DIFF
--- a/api/src/models/security-rule.ts
+++ b/api/src/models/security-rule.ts
@@ -5,6 +5,7 @@ export const SecurityRuleRecord = z.object({
   policy_id: z.string().uuid().nullable(),
   name: z.string(),
   description: z.string(),
+  is_active: z.boolean(),
   record_effective_date: z.string(),
   record_end_date: z.string().nullable(),
   create_date: z.string(),
@@ -21,6 +22,7 @@ export const SecurityRuleAndCategory = z.object({
   policy_id: z.string().uuid().nullable(),
   name: z.string(),
   description: z.string(),
+  is_active: z.boolean(),
   record_effective_date: z.string(),
   record_end_date: z.string().nullable(),
   security_category_id: z.number(),
@@ -38,6 +40,7 @@ export const SecurityRuleWithFeatureCount = z.object({
   category_name: z.string(),
   name: z.string(),
   description: z.string().nullable(),
+  is_active: z.boolean(),
   feature_count: z.number()
 });
 
@@ -47,7 +50,8 @@ export const SecurityRule = z.object({
   security_rule_id: z.number(),
   security_category_id: z.number(),
   name: z.string(),
-  description: z.string().nullable()
+  description: z.string().nullable(),
+  is_active: z.boolean()
 });
 
 export type SecurityRule = z.infer<typeof SecurityRule>;
@@ -56,12 +60,14 @@ export interface CreateSecurityRule {
   name: string;
   description: string;
   security_category_id: number;
+  is_active: boolean;
 }
 
 export interface UpdateSecurityRule {
   name: string;
   description: string;
   security_category_id: number;
+  is_active: boolean;
 }
 
 export interface SecuritySearchFilters {

--- a/api/src/openapi/schemas/security.ts
+++ b/api/src/openapi/schemas/security.ts
@@ -151,7 +151,15 @@ export const UpdateSecurityCategoryRequestSchema: OpenAPIV3.SchemaObject = {
 export const SecurityRuleWithFeatureCountSchema: OpenAPIV3.SchemaObject = {
   title: 'SecurityRuleWithFeatureCount',
   type: 'object',
-  required: ['security_rule_id', 'security_category_id', 'category_name', 'name', 'description', 'feature_count'],
+  required: [
+    'security_rule_id',
+    'security_category_id',
+    'category_name',
+    'name',
+    'description',
+    'is_active',
+    'feature_count'
+  ],
   properties: {
     security_rule_id: {
       type: 'integer',
@@ -177,6 +185,10 @@ export const SecurityRuleWithFeatureCountSchema: OpenAPIV3.SchemaObject = {
       nullable: true,
       description: 'Description of the security rule'
     },
+    is_active: {
+      type: 'boolean',
+      description: 'Whether the rule is enabled for automatic security screening'
+    },
     feature_count: {
       type: 'integer',
       description: 'Number of submission features secured by this rule'
@@ -190,7 +202,7 @@ export const SecurityRuleWithFeatureCountSchema: OpenAPIV3.SchemaObject = {
 export const SecurityReasonSchema: OpenAPIV3.SchemaObject = {
   title: 'SecurityReason',
   type: 'object',
-  required: ['security_rule_id', 'security_category_id', 'name', 'description'],
+  required: ['security_rule_id', 'security_category_id', 'name', 'description', 'is_active'],
   properties: {
     security_rule_id: {
       type: 'integer',
@@ -210,6 +222,10 @@ export const SecurityReasonSchema: OpenAPIV3.SchemaObject = {
       maxLength: 500,
       nullable: true,
       description: 'Description of the security rule'
+    },
+    is_active: {
+      type: 'boolean',
+      description: 'Whether the rule is enabled for automatic security screening'
     }
   }
 };
@@ -236,6 +252,10 @@ export const CreateSecurityReasonRequestSchema: OpenAPIV3.SchemaObject = {
       type: 'integer',
       minimum: 1,
       description: 'ID of the security category this reason belongs to'
+    },
+    is_active: {
+      type: 'boolean',
+      description: 'Whether the rule is enabled for automatic security screening (defaults to true)'
     }
   }
 };
@@ -246,7 +266,7 @@ export const CreateSecurityReasonRequestSchema: OpenAPIV3.SchemaObject = {
 export const UpdateSecurityReasonRequestSchema: OpenAPIV3.SchemaObject = {
   title: 'UpdateSecurityReasonRequest',
   type: 'object',
-  required: ['name', 'description', 'security_category_id'],
+  required: ['name', 'description', 'security_category_id', 'is_active'],
   properties: {
     name: {
       type: 'string',
@@ -262,6 +282,10 @@ export const UpdateSecurityReasonRequestSchema: OpenAPIV3.SchemaObject = {
       type: 'integer',
       minimum: 1,
       description: 'ID of the security category this reason belongs to'
+    },
+    is_active: {
+      type: 'boolean',
+      description: 'Whether the rule is enabled for automatic security screening'
     }
   }
 };

--- a/api/src/paths/administrative/security/reasons/index.test.ts
+++ b/api/src/paths/administrative/security/reasons/index.test.ts
@@ -140,7 +140,8 @@ describe('administrative/security/reasons', () => {
         security_rule_id: 1,
         security_category_id: 2,
         name: 'New Reason',
-        description: 'A new reason'
+        description: 'A new reason',
+        is_active: true
       };
 
       const mockDBConnection = getMockDBConnection({
@@ -162,7 +163,8 @@ describe('administrative/security/reasons', () => {
       expect(SecurityRuleService.prototype.createSecurityRule).to.have.been.calledOnceWith({
         name: 'New Reason',
         description: 'A new reason',
-        security_category_id: 2
+        security_category_id: 2,
+        is_active: undefined
       });
       expect(mockRes.statusValue).to.equal(201);
       expect(mockRes.jsonValue).to.eql(mockReason);

--- a/api/src/paths/administrative/security/reasons/index.ts
+++ b/api/src/paths/administrative/security/reasons/index.ts
@@ -130,13 +130,18 @@ POST.apiDoc = {
 export function createSecurityReason(): RequestHandler {
   return async (req, res) => {
     const connection = getDBConnection(req.keycloak_token);
-    const { name, description, security_category_id } = req.body as CreateSecurityRule;
+    const { name, description, security_category_id, is_active } = req.body as CreateSecurityRule;
 
     try {
       await connection.open();
 
       const securityRuleService = new SecurityRuleService(connection);
-      const result = await securityRuleService.createSecurityRule({ name, description, security_category_id });
+      const result = await securityRuleService.createSecurityRule({
+        name,
+        description,
+        security_category_id,
+        is_active
+      });
 
       await connection.commit();
 

--- a/api/src/paths/administrative/security/reasons/{securityRuleId}/index.test.ts
+++ b/api/src/paths/administrative/security/reasons/{securityRuleId}/index.test.ts
@@ -19,7 +19,8 @@ describe('administrative/security/reasons/{securityRuleId}', () => {
     security_rule_id: 1,
     security_category_id: 2,
     name: 'Research',
-    description: 'Research reason'
+    description: 'Research reason',
+    is_active: true
   };
 
   describe('GET/getSecurityReason', () => {
@@ -47,14 +48,15 @@ describe('administrative/security/reasons/{securityRuleId}', () => {
 
       const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
       mockReq.params = { securityRuleId: '1' };
-      mockReq.body = { name: 'Updated', description: 'Research reason', security_category_id: 2 };
+      mockReq.body = { name: 'Updated', description: 'Research reason', security_category_id: 2, is_active: false };
 
       await updateSecurityReason()(mockReq, mockRes, mockNext);
 
       expect(SecurityRuleService.prototype.updateSecurityRule).to.have.been.calledOnceWith(1, {
         name: 'Updated',
         description: 'Research reason',
-        security_category_id: 2
+        security_category_id: 2,
+        is_active: false
       });
       expect(mockRes.statusValue).to.equal(200);
       expect(mockRes.jsonValue).to.eql(updatedReason);

--- a/api/src/paths/administrative/security/rules.test.ts
+++ b/api/src/paths/administrative/security/rules.test.ts
@@ -54,6 +54,7 @@ describe('administrative/security/rules', () => {
           policy_id: 'f4b2f372-98b2-4faa-b98e-91ea2296e370',
           name: 'Caribou',
           description: 'Sensitive data',
+          is_active: true,
           record_effective_date: '2026-01-01',
           record_end_date: null,
           security_category_id: 1,

--- a/api/src/paths/administrative/security/rules.ts
+++ b/api/src/paths/administrative/security/rules.ts
@@ -44,6 +44,7 @@ GET.apiDoc = {
                 'security_rule_id',
                 'name',
                 'description',
+                'is_active',
                 'record_effective_date',
                 'record_end_date',
                 'security_category_id',
@@ -66,6 +67,9 @@ GET.apiDoc = {
                 },
                 description: {
                   type: 'string'
+                },
+                is_active: {
+                  type: 'boolean'
                 },
                 record_effective_date: {
                   type: 'string'

--- a/api/src/repositories/security-rule-repository.ts
+++ b/api/src/repositories/security-rule-repository.ts
@@ -35,6 +35,7 @@ export class SecurityRuleRepository extends BaseRepository {
         policy_id,
         name,
         description,
+        is_active,
         record_effective_date,
         record_end_date,
         create_date,
@@ -44,6 +45,38 @@ export class SecurityRuleRepository extends BaseRepository {
         revision_count
       FROM security_rule
       WHERE record_end_date IS NULL;
+    `;
+    const response = await this.connection.sql(sql, SecurityRuleRecord);
+    return response.rows;
+  }
+
+  /**
+   * Gets security rules eligible for automatic screening.
+   * A rule is screenable when it is not soft-deleted and is_active is true.
+   *
+   * Future automatic screening must use this method (not getActiveSecurityRules).
+   *
+   * @return {Promise<SecurityRuleRecord[]>}
+   * @memberof SecurityRuleRepository
+   */
+  async getScreenableSecurityRules(): Promise<SecurityRuleRecord[]> {
+    const sql = SQL`
+      SELECT
+        security_rule_id,
+        policy_id,
+        name,
+        description,
+        is_active,
+        record_effective_date,
+        record_end_date,
+        create_date,
+        create_user,
+        update_date,
+        update_user,
+        revision_count
+      FROM security_rule
+      WHERE record_end_date IS NULL
+        AND is_active = true;
     `;
     const response = await this.connection.sql(sql, SecurityRuleRecord);
     return response.rows;
@@ -62,6 +95,7 @@ export class SecurityRuleRepository extends BaseRepository {
         sr.policy_id,
         sr.name,
         sr.description,
+        sr.is_active,
         sr.record_effective_date,
         sr.record_end_date,
         sc.security_category_id,
@@ -99,6 +133,7 @@ export class SecurityRuleRepository extends BaseRepository {
         'sc.name as category_name',
         'sr.name',
         'sr.description',
+        'sr.is_active',
         knex.raw('COUNT(sfs.submission_feature_security_id)::integer AS feature_count')
       )
       .from('security_rule as sr')
@@ -109,7 +144,14 @@ export class SecurityRuleRepository extends BaseRepository {
         this.on('sfs.security_rule_id', '=', 'sr.security_rule_id').andOnNull('sfs.record_end_date');
       })
       .whereNull('sr.record_end_date')
-      .groupBy('sr.security_rule_id', 'sr.security_category_id', 'sc.name', 'sr.name', 'sr.description');
+      .groupBy(
+        'sr.security_rule_id',
+        'sr.security_category_id',
+        'sc.name',
+        'sr.name',
+        'sr.description',
+        'sr.is_active'
+      );
 
     if (filters?.search) {
       query.whereILike('sr.name', `%${filters.search}%`);
@@ -160,15 +202,18 @@ export class SecurityRuleRepository extends BaseRepository {
    */
   async insertSecurityRule(data: CreateSecurityRule): Promise<SecurityRule> {
     const knex = getKnex();
+    const insertData = {
+      security_category_id: data.security_category_id,
+      name: data.name,
+      description: data.description,
+      is_active: data.is_active,
+      policy_id: null
+    };
+
     const query = knex
       .table('security_rule')
-      .insert({
-        security_category_id: data.security_category_id,
-        name: data.name,
-        description: data.description,
-        policy_id: null
-      })
-      .returning(['security_rule_id', 'security_category_id', 'name', 'description']);
+      .insert(insertData)
+      .returning(['security_rule_id', 'security_category_id', 'name', 'description', 'is_active']);
 
     const response = await this.connection.knex(query, SecurityRule);
 
@@ -195,7 +240,7 @@ export class SecurityRuleRepository extends BaseRepository {
     const knex = getKnex();
     const query = knex
       .from('security_rule')
-      .select(['security_rule_id', 'security_category_id', 'name', 'description'])
+      .select(['security_rule_id', 'security_category_id', 'name', 'description', 'is_active'])
       .whereNull('record_end_date')
       .where('security_rule_id', securityRuleId);
 
@@ -234,7 +279,8 @@ export class SecurityRuleRepository extends BaseRepository {
       .update({
         security_category_id: data.security_category_id,
         name: data.name,
-        description: data.description
+        description: data.description,
+        is_active: data.is_active
       })
       .whereNull('record_end_date')
       .where('security_rule_id', securityRuleId);

--- a/api/src/services/security-rule-service.test.ts
+++ b/api/src/services/security-rule-service.test.ts
@@ -31,7 +31,8 @@ describe('SecurityRuleService', () => {
       const result = await service.createSecurityRule({
         name: 'rule-a',
         description: 'desc',
-        security_category_id: 2
+        security_category_id: 2,
+        is_active: true
       });
 
       expect(getCategoryStub).to.have.been.calledOnceWith(2);
@@ -49,7 +50,12 @@ describe('SecurityRuleService', () => {
       const insertStub = sinon.stub(SecurityRuleRepository.prototype, 'insertSecurityRule').resolves();
 
       try {
-        await service.createSecurityRule({ name: 'rule-a', description: 'desc', security_category_id: 999 });
+        await service.createSecurityRule({
+          name: 'rule-a',
+          description: 'desc',
+          security_category_id: 999,
+          is_active: true
+        });
         expect.fail();
       } catch (error) {
         expect((error as Error).message).to.equal('Security category not found');

--- a/app/src/features/admin/security/components/AddReasonForm.tsx
+++ b/app/src/features/admin/security/components/AddReasonForm.tsx
@@ -1,7 +1,10 @@
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
 import CustomAutocompleteFormik from 'components/fields/CustomAutocompleteFormik';
 import { ICustomAutocompleteOption } from 'components/fields/CustomAutocomplete';
 import CustomTextFieldFormik from 'components/fields/CustomTextFieldFormik';
+import { useFormikContext } from 'formik';
 import yup from 'utils/YupSchema';
 
 /**
@@ -14,6 +17,8 @@ export interface IAddReasonFormValues {
   description: string;
   /** Selected security category ID */
   security_category_id: number | undefined;
+  /** Whether the rule is enabled for automatic security screening */
+  is_active: boolean;
 }
 
 /**
@@ -22,7 +27,8 @@ export interface IAddReasonFormValues {
 export const AddReasonFormInitialValues: IAddReasonFormValues = {
   name: '',
   description: '',
-  security_category_id: undefined
+  security_category_id: undefined,
+  is_active: true
 };
 
 /**
@@ -31,7 +37,8 @@ export const AddReasonFormInitialValues: IAddReasonFormValues = {
 export const AddReasonFormYupSchema = yup.object().shape({
   name: yup.string().required('Name is required').max(100, 'Name must be 100 characters or less'),
   description: yup.string().required('Description is required').max(500, 'Description must be 500 characters or less'),
-  security_category_id: yup.number().required('Category is required')
+  security_category_id: yup.number().required('Category is required'),
+  is_active: yup.boolean()
 });
 
 interface IAddReasonFormProps {
@@ -49,6 +56,7 @@ interface IAddReasonFormProps {
  */
 export const AddReasonForm = (props: IAddReasonFormProps) => {
   const { categoryOptions } = props;
+  const { values, setFieldValue } = useFormikContext<IAddReasonFormValues>();
 
   return (
     <Stack gap={2} sx={{ pt: 1, minWidth: { xs: 300, sm: 520 } }}>
@@ -67,6 +75,16 @@ export const AddReasonForm = (props: IAddReasonFormProps) => {
         label="Category"
         required
         options={categoryOptions}
+      />
+      <FormControlLabel
+        control={
+          <Switch
+            checked={values.is_active}
+            onChange={(_, checked) => setFieldValue('is_active', checked)}
+            color="primary"
+          />
+        }
+        label={values.is_active ? 'Active' : 'Inactive'}
       />
     </Stack>
   );

--- a/app/src/features/admin/security/components/ReasonsContainer.test.tsx
+++ b/app/src/features/admin/security/components/ReasonsContainer.test.tsx
@@ -25,6 +25,7 @@ vi.mock('@mui/x-data-grid', () => ({
             <span>{row.description}</span>
             <span>{row.category_name}</span>
             <span>{row.feature_count}</span>
+            {columns.find((c) => c.field === 'is_active')?.renderCell?.({ row, value: row.is_active } as never)}
             {columns.find((c) => c.field === 'actions')?.renderCell?.({ row } as never)}
           </div>
         ))
@@ -43,7 +44,17 @@ const mockReasons: ISecurityReasonWithFeatureCount[] = [
     category_name: 'Health',
     name: 'Research',
     description: 'Research reason',
+    is_active: true,
     feature_count: 4
+  },
+  {
+    security_rule_id: 2,
+    security_category_id: 2,
+    category_name: 'Health',
+    name: 'Inactive Rule',
+    description: 'Disabled reason',
+    is_active: false,
+    feature_count: 0
   }
 ];
 
@@ -98,6 +109,13 @@ describe('ReasonsContainer', () => {
     vi.clearAllMocks();
   });
 
+  it('renders Active and Inactive status chips', () => {
+    const { getByText } = renderComponent({ reasons: mockReasons, rowCount: 2 });
+
+    expect(getByText('Active')).toBeVisible();
+    expect(getByText('Inactive')).toBeVisible();
+  });
+
   it('opens add dialog when Add button is clicked', async () => {
     const { getByRole, getByText } = renderComponent();
 
@@ -136,7 +154,8 @@ describe('ReasonsContainer', () => {
       expect(mockCreateSecurityReason).toHaveBeenCalledWith({
         name: 'New Reason',
         description: 'A new reason',
-        security_category_id: 2
+        security_category_id: 2,
+        is_active: true
       });
     });
 

--- a/app/src/features/admin/security/components/ReasonsContainer.tsx
+++ b/app/src/features/admin/security/components/ReasonsContainer.tsx
@@ -1,5 +1,6 @@
 import { mdiDotsVertical, mdiMagnify, mdiPencilOutline, mdiTrashCanOutline } from '@mdi/js';
 import Icon from '@mdi/react';
+import Chip from '@mui/material/Chip';
 import Container from '@mui/material/Container';
 import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
@@ -173,7 +174,8 @@ export const ReasonsContainer = (props: IReasonsContainerProps) => {
       await biohubApi.security.createSecurityReason({
         name: values.name,
         description: values.description,
-        security_category_id: values.security_category_id
+        security_category_id: values.security_category_id,
+        is_active: values.is_active
       });
 
       setOpenAddReasonDialog(false);
@@ -212,7 +214,8 @@ export const ReasonsContainer = (props: IReasonsContainerProps) => {
       await biohubApi.security.updateSecurityReason(editingReason.security_rule_id, {
         name: values.name,
         description: values.description,
-        security_category_id: values.security_category_id
+        security_category_id: values.security_category_id,
+        is_active: values.is_active
       });
 
       setOpenEditReasonDialog(false);
@@ -248,7 +251,8 @@ export const ReasonsContainer = (props: IReasonsContainerProps) => {
     return {
       name: editingReason.name,
       description: editingReason.description || '',
-      security_category_id: editingReason.security_category_id
+      security_category_id: editingReason.security_category_id,
+      is_active: editingReason.is_active
     };
   };
 
@@ -270,6 +274,21 @@ export const ReasonsContainer = (props: IReasonsContainerProps) => {
       headerName: 'Category',
       flex: 1,
       minWidth: 150
+    },
+    {
+      field: 'is_active',
+      headerName: 'Status',
+      width: 120,
+      align: 'center',
+      headerAlign: 'center',
+      renderCell: (params) => (
+        <Chip
+          label={params.value ? 'Active' : 'Inactive'}
+          size="small"
+          color={params.value ? 'success' : 'default'}
+          sx={{ fontWeight: 700 }}
+        />
+      )
     },
     {
       field: 'feature_count',

--- a/app/src/hooks/api/useSecurityApi.test.ts
+++ b/app/src/hooks/api/useSecurityApi.test.ts
@@ -146,7 +146,7 @@ describe('useSecurityApi', () => {
 
   describe('createSecurityReason', () => {
     it('posts a new security reason', async () => {
-      const body = { name: 'New Reason', description: 'Description', security_category_id: 2 };
+      const body = { name: 'New Reason', description: 'Description', security_category_id: 2, is_active: true };
       const response = { security_rule_id: 1, ...body };
 
       mock.onPost('/api/administrative/security/reasons').reply(201, response);
@@ -158,7 +158,7 @@ describe('useSecurityApi', () => {
 
   describe('updateSecurityReason', () => {
     it('puts an updated security reason', async () => {
-      const body = { name: 'Updated', description: 'Updated desc', security_category_id: 2 };
+      const body = { name: 'Updated', description: 'Updated desc', security_category_id: 2, is_active: false };
       const response = { security_rule_id: 1, ...body };
 
       mock.onPut('/api/administrative/security/reasons/1').reply(200, response);

--- a/app/src/hooks/api/useSecurityApi.ts
+++ b/app/src/hooks/api/useSecurityApi.ts
@@ -34,6 +34,7 @@ export interface ISecurityRuleAndCategory {
   security_rule_id: number;
   name: string;
   description: string;
+  is_active: boolean;
   record_effective_date: string;
   record_end_date: string;
   security_category_id: number;

--- a/app/src/interfaces/useSecurityApi.interface.ts
+++ b/app/src/interfaces/useSecurityApi.interface.ts
@@ -106,6 +106,7 @@ export interface ISecurityReasonWithFeatureCount {
   category_name: string;
   name: string;
   description: string | null;
+  is_active: boolean;
   feature_count: number;
 }
 
@@ -114,18 +115,21 @@ export interface ISecurityReason {
   security_category_id: number;
   name: string;
   description: string | null;
+  is_active: boolean;
 }
 
 export interface ICreateSecurityReasonRequest {
   name: string;
   description: string;
   security_category_id: number;
+  is_active: boolean;
 }
 
 export interface IUpdateSecurityReasonRequest {
   name: string;
   description: string;
   security_category_id: number;
+  is_active: boolean;
 }
 
 export interface ISecurityReasonsResponse {

--- a/database/src/migrations/20260527120000_security_rule_is_active.ts
+++ b/database/src/migrations/20260527120000_security_rule_is_active.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+/**
+ * Adds is_active flag to security_rule for enable/disable without soft-delete.
+ *
+ * Notes:
+ * - DEFAULT true backfills existing rules as active.
+ * - Inactive rules are excluded from automatic security screening.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE security_rule
+      ADD COLUMN is_active boolean NOT NULL DEFAULT true;
+
+    COMMENT ON COLUMN security_rule.is_active IS
+      'When false, the rule is excluded from automatic security screening.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE security_rule
+      DROP COLUMN IF EXISTS is_active;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1026](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1026)
- [SIMSBIOHUB-948](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-948) - Dependency

## Description of Changes

Adds `is_active` to `security_rule` so admins can enable or disable rules without soft-deleting them. Inactive rules stay visible in admin and remain available for manual application; they are excluded from automatic screening.

**Database**

- Migration adds `is_active boolean NOT NULL DEFAULT true` (existing rules backfilled as active).

**API**

- Reasons CRUD and `GET /api/administrative/security/rules` include `is_active`.
- Create defaults to active; update persists `is_active`.
- New `getScreenableSecurityRules()` returns non-deleted rules with `is_active = true` for future automatic screening (no screening pipeline in this PR).

**UI** (`/admin/security` Reasons table)

- Status column with Active/Inactive chips.
- Active toggle on create/edit reason dialogs.

## Testing Notes

- Run migration, then `make test`.
- As system admin on `/admin/security`: confirm Status column; create a reason (defaults Active); edit and set Inactive; verify `GET` reasons returns `is_active`.
- Confirm manual rule application on submissions still lists inactive rules; screening hook is repository/service only until automatic screening is implemented.
