### PR TITLE
SIMSBIOHUB-1025: Improve Search Performance

### DIFF
--- a/api/src/__integration__/db/cart-submission-feature-service.integration.ts
+++ b/api/src/__integration__/db/cart-submission-feature-service.integration.ts
@@ -1,14 +1,33 @@
-// Integration test for cart submission feature security — verifies the auth-aware walk-up CTE
-// correctly gates secured features at insert time, computes the `secured` flag on read,
-// and counts all features regardless of security status.
+// Integration test for cart submission feature security — verifies the read-paths-only security swap:
+// "is this feature secured / accessible" is resolved via the precomputed submission_feature_closure
+// (the `isEffectivelySecuredViaClosure` / `isAccessibleToUser` SQL fragments), NOT a live recursive
+// parent walk. The cart insert reads that closure to gate secured features, computes the `secured`
+// flag on read, and counts all features regardless of security status.
 //
-// Tests the full SQL execution path: recursive ancestor walk-up, security_scope_anchor →
-// team_security_scope → team_member join, and the bulk CTE for read-side `secured` computation.
+// CLOSURE SEEDING CONTRACT (the load-bearing detail these tests pin):
+//   The closure is UPLOAD-SCOPED and built by SubmissionFeatureClosureService.computeClosureForUpload.
+//   It MUST be populated BEFORE the cart insert, or the fragment finds nothing and every feature reads
+//   as unsecured.
+//     - A feature's "directly secured" check relies on its closure SELF-LOOP (source = target), which is
+//       only created for ACTIVE features (record_end_date IS NULL).
+//     - Inherited security relies on parent -> ancestor closure edges, which only exist when parent and
+//       child share ONE submission_upload_id (both endpoints must be active features of the same upload).
+//   createTestFeature mints a NEW upload per call, so parent/child land in different uploads and the
+//   closure cannot link them. The security tests therefore seed features directly under a SHARED upload
+//   via createTestUpload + insertFeatureRow, then rebuild the closure AFTER seeding + securing and BEFORE
+//   the cart insert (mirrors expression-evaluation.integration.ts, Phase 2).
+//
+// RISK 1 REGRESSION (the active-guard proof): the cart repo's w_valid_features CTE has a
+//   `JOIN submission_feature ... record_end_date IS NULL` guard. A soft-deleted feature has NO closure
+//   row (no self-loop), so without the guard the empty closure would read it as unsecured and ADD it.
+//   The two "inactive-secured id excluded" tests below secure a feature, soft-delete it, rebuild the
+//   closure (now no self-loop for it), and assert the id is NOT added — proving the guard.
 //
 // Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
 //
-// Run: make test-db
-// Requires: make web (database must be running with seed data)
+// Run: docker compose exec api npm run test:mocha -- --no-config --extension ts \
+//        'src/__integration__/db/cart-submission-feature-service.integration.ts'
+// Requires: database container running with seed data.
 
 import { expect } from 'chai';
 import SQL from 'sql-template-strings';
@@ -16,8 +35,10 @@ import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } 
 import { SecurityScopeRepository } from '../../repositories/authorization/security-scope-repository';
 import { CartRepository } from '../../repositories/cart-repository';
 import { CartSubmissionFeatureService } from '../../services/cart-submission-feature-service';
+import { SubmissionFeatureClosureService } from '../../services/submission-feature-closure-service';
+import { createTestUpload } from '../helpers/test-feature-property-helpers';
 import { secureFeature, setupFullAccess } from '../helpers/test-rbac-helpers';
-import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
+import { createTestSubmission } from '../helpers/test-submission-helpers';
 
 describe('Cart submission feature security (integration)', function () {
   this.timeout(15000);
@@ -71,27 +92,64 @@ describe('Cart submission feature security (integration)', function () {
   }
 
   /**
-   * Create a submission with one unsecured and one secured feature, grant scope access to
-   * a new user, add both features to a cart, and return all IDs.
+   * Insert ONE submission_feature bound to a SPECIFIC upload, resolving feature_type_id by name.
+   *
+   * The closure recompute is upload-scoped and only links a parent and child when both share one
+   * submission_upload_id (both endpoints must be active features of the same upload). createTestFeature
+   * mints its OWN upload per call and cannot place a parent + child under one upload, so the closure-driven
+   * cart-security fixtures insert features directly here. `recordEndDate: true` soft-deletes the feature
+   * (drops it from the closure's active universe — no self-loop, no edges).
+   *
+   * @returns The new submission_feature_id.
    */
-  async function setupSecuredCart(teamName: string): Promise<{
-    cartId: string;
-    userId: number;
-    unsecuredId: number;
-    securedId: number;
-  }> {
-    const submissionId = await createTestSubmission(connection);
-    const unsecuredId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public' });
-    const securedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
-    await secureFeature(connection, securedId);
+  async function insertFeatureRow(params: {
+    submissionId: number;
+    submissionUploadId: string;
+    featureTypeName: string;
+    parentFeatureId?: number;
+    recordEndDate?: boolean;
+  }): Promise<number> {
+    const systemUserId = connection.systemUserId();
 
-    const userId = await createOtherUser();
-    await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, teamName);
+    const result = await connection.sql(SQL`
+      INSERT INTO submission_feature (
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        parent_submission_feature_id,
+        data,
+        data_byte_size,
+        record_effective_date,
+        record_end_date,
+        create_user
+      )
+      VALUES (
+        ${params.submissionId},
+        ${params.submissionUploadId}::uuid,
+        (SELECT feature_type_id FROM feature_type WHERE name = ${params.featureTypeName} LIMIT 1),
+        ${params.parentFeatureId ?? null},
+        '{}'::jsonb,
+        500,
+        now(),
+        ${params.recordEndDate ? 'now()' : null},
+        ${systemUserId}
+      )
+      RETURNING submission_feature_id;
+    `);
 
-    const cartId = await createActiveCart(userId);
-    await cartFeatureService.createCartSubmissionFeatures(cartId, [unsecuredId, securedId], userId);
+    return result.rows[0].submission_feature_id;
+  }
 
-    return { cartId, userId, unsecuredId, securedId };
+  /** Recompute the upload-scoped closure (self-loops + ancestry/property edges) for the given upload. */
+  async function rebuildClosure(uploadId: string): Promise<void> {
+    await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+  }
+
+  /** Soft-delete a feature so it drops out of the closure's active universe. */
+  async function softDeleteFeature(submissionFeatureId: number): Promise<void> {
+    await connection.sql(SQL`
+      UPDATE submission_feature SET record_end_date = now() WHERE submission_feature_id = ${submissionFeatureId};
+    `);
   }
 
   /**
@@ -107,12 +165,54 @@ describe('Cart submission feature security (integration)', function () {
     return result.rows.map((r: { submission_feature_id: number }) => r.submission_feature_id);
   }
 
+  /**
+   * Create a submission with one unsecured and one secured feature under a SHARED upload, rebuild the
+   * closure, grant scope access to a new user, add both features to a cart, and return all IDs.
+   */
+  async function setupSecuredCart(teamName: string): Promise<{
+    cartId: string;
+    userId: number;
+    unsecuredId: number;
+    securedId: number;
+  }> {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(connection, submissionId);
+    const unsecuredId = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'dataset'
+    });
+    const securedId = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'dataset'
+    });
+    await secureFeature(connection, securedId);
+
+    await rebuildClosure(uploadId);
+
+    const userId = await createOtherUser();
+    await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, teamName);
+
+    const cartId = await createActiveCart(userId);
+    await cartFeatureService.createCartSubmissionFeatures(cartId, [unsecuredId, securedId], userId);
+
+    return { cartId, userId, unsecuredId, securedId };
+  }
+
   // ── createCartSubmissionFeatures — anonymous ──────────────────────────
 
   describe('createCartSubmissionFeatures — anonymous', () => {
     it('should add an unsecured feature to cart', async () => {
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public Dataset' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+
+      await rebuildClosure(uploadId);
 
       const cartId = await createActiveCart(null);
       await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
@@ -122,9 +222,18 @@ describe('Cart submission feature security (integration)', function () {
     });
 
     it('should exclude a directly secured feature', async () => {
+      // Directly secured feature under a shared upload: rebuild the closure so the feature's SELF-LOOP
+      // exists, then isEffectivelySecuredViaClosure resolves its own security rule and excludes it.
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, featureId);
+
+      await rebuildClosure(uploadId);
 
       const cartId = await createActiveCart(null);
       await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
@@ -134,19 +243,86 @@ describe('Cart submission feature security (integration)', function () {
     });
 
     it('should exclude a feature with inherited security from a secured parent', async () => {
+      // Parent + child share ONE upload so the closure stores the child -> parent ancestor edge;
+      // securing the parent then makes the child read as effectively secured (inherited).
       const submissionId = await createTestSubmission(connection);
-      const parentId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Parent' });
-      const childId = await createTestFeature(
-        connection,
+      const uploadId = await createTestUpload(connection, submissionId);
+      const parentId = await insertFeatureRow({
         submissionId,
-        'species_observation',
-        { name: 'Child' },
-        parentId
-      );
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const childId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'species_observation',
+        parentFeatureId: parentId
+      });
       await secureFeature(connection, parentId);
+
+      await rebuildClosure(uploadId);
 
       const cartId = await createActiveCart(null);
       await cartFeatureService.createCartSubmissionFeatures(cartId, [childId], null);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([]);
+    });
+
+    it('should exclude an inactive (soft-deleted) secured id — anonymous (Risk 1 active-guard)', async () => {
+      // RISK 1 GUARD. Secure the feature, then soft-delete it. The closure rebuild now writes NO self-loop
+      // for it (inactive features are excluded from the active universe), so isEffectivelySecuredViaClosure
+      // finds nothing and would read it as UNSECURED. The cart repo's `JOIN submission_feature ...
+      // record_end_date IS NULL` active-guard is what excludes the id here — without that guard the empty
+      // closure would let the soft-deleted secured id slip into the cart.
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      await secureFeature(connection, featureId);
+      await softDeleteFeature(featureId);
+
+      await rebuildClosure(uploadId);
+
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([]);
+    });
+
+    it('should exclude a 3-level inherited-secured leaf (grandparent secured)', async () => {
+      // 3-level chain under ONE upload: grandparent <- parent <- leaf. Secure ONLY the grandparent. The
+      // closure stores the transitive leaf -> grandparent ancestor edge (2 hops), so the leaf reads as
+      // effectively secured — this is the multi-hop closure ancestry replacing the old recursive walk.
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+      const grandparentId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const parentId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'animal',
+        parentFeatureId: grandparentId
+      });
+      const leafId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'capture',
+        parentFeatureId: parentId
+      });
+      await secureFeature(connection, grandparentId);
+
+      await rebuildClosure(uploadId);
+
+      const cartId = await createActiveCart(null);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [leafId], null);
 
       const ids = await getCartFeatureIds(cartId);
       expect(ids).to.deep.equal([]);
@@ -157,9 +333,18 @@ describe('Cart submission feature security (integration)', function () {
 
   describe('createCartSubmissionFeatures — authenticated', () => {
     it('should add a secured feature when user has scope access', async () => {
+      // Closure rebuilt so isAccessibleToUser Branch 2 can resolve the anchor via closure ancestry
+      // (the feature's own self-loop is the anchor's closure source here).
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, featureId);
+
+      await rebuildClosure(uploadId);
 
       const userId = await createOtherUser();
       await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, 'scope-access-team');
@@ -173,8 +358,15 @@ describe('Cart submission feature security (integration)', function () {
 
     it('should exclude a secured feature when user has NO scope access', async () => {
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, featureId);
+
+      await rebuildClosure(uploadId);
 
       // User exists but is not a member of any team with scope access
       const userId = await createOtherUser();
@@ -188,7 +380,14 @@ describe('Cart submission feature security (integration)', function () {
 
     it('should add an unsecured feature with secured: false', async () => {
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public Dataset' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+
+      await rebuildClosure(uploadId);
 
       const userId = await createOtherUser();
       const cartId = await createActiveCart(userId);
@@ -200,35 +399,70 @@ describe('Cart submission feature security (integration)', function () {
       expect(features[0].secured).to.equal(false);
     });
 
-    it('should add only authorized features from a mixed batch', async () => {
+    it('should exclude an inactive (soft-deleted) secured id — authenticated (Risk 1 active-guard)', async () => {
+      // RISK 1 GUARD (authenticated path, createCartSubmissionFeaturesWithScopeCheck). Same as the anonymous
+      // variant: secure + soft-delete, rebuild the closure (no self-loop for the inactive id). With an empty
+      // closure isAccessibleToUser Branch 1 (NOT secured) would be TRUE and ADD the id — the active-guard
+      // JOIN on record_end_date IS NULL is what keeps the soft-deleted id out.
       const submissionId = await createTestSubmission(connection);
-
-      // Unsecured feature — always allowed
-      const unsecuredId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public' });
-
-      // Directly secured feature — user has scope access
-      const securedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
-      await secureFeature(connection, securedId);
-
-      // Inherited security — parent secured, child has no direct rule
-      const securedParentId = await createTestFeature(connection, submissionId, 'dataset', {
-        name: 'Secured Parent'
-      });
-      const inheritedChildId = await createTestFeature(
-        connection,
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
         submissionId,
-        'species_observation',
-        { name: 'Inherited Child' },
-        securedParentId
-      );
-      await secureFeature(connection, securedParentId);
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      await secureFeature(connection, featureId);
+      await softDeleteFeature(featureId);
 
-      // Note: securedId's scope access covers it directly; inheritedChildId's access
-      // comes via ancestor walk-up to securedParentId which is also in the same submission
+      await rebuildClosure(uploadId);
 
       const userId = await createOtherUser();
-      // Grant scope for the first secured feature's submission but NOT the second
-      // Use wildcard URN that covers the whole submission — all secured features accessible
+      const cartId = await createActiveCart(userId);
+      await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], userId);
+
+      const ids = await getCartFeatureIds(cartId);
+      expect(ids).to.deep.equal([]);
+    });
+
+    it('should add only authorized features from a mixed batch', async () => {
+      // All features share ONE upload so the closure links the inherited child to its secured parent and
+      // anchors each secured feature for the scope grant. Wildcard URN covers the whole submission.
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      // Unsecured feature — always allowed
+      const unsecuredId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+
+      // Directly secured feature — user has scope access
+      const securedId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      await secureFeature(connection, securedId);
+
+      // Inherited security — parent secured, child has no direct rule (resolved via closure ancestry)
+      const securedParentId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const inheritedChildId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'species_observation',
+        parentFeatureId: securedParentId
+      });
+      await secureFeature(connection, securedParentId);
+
+      await rebuildClosure(uploadId);
+
+      const userId = await createOtherUser();
+      // Wildcard URN covers the whole submission — all secured features accessible
       await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, 'mixed-batch-team');
 
       const cartId = await createActiveCart(userId);
@@ -241,15 +475,28 @@ describe('Cart submission feature security (integration)', function () {
     });
 
     it('should add only features from the scoped submission when user has partial authorization across submissions', async () => {
-      // Submission A — user has scope access
+      // Each submission gets its OWN shared upload + closure rebuild so each secured feature's self-loop
+      // (and any ancestry) exists. The scope grant covers submission A only.
       const submissionA = await createTestSubmission(connection);
-      const securedA = await createTestFeature(connection, submissionA, 'dataset', { name: 'Secured A' });
+      const uploadA = await createTestUpload(connection, submissionA);
+      const securedA = await insertFeatureRow({
+        submissionId: submissionA,
+        submissionUploadId: uploadA,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedA);
+      await rebuildClosure(uploadA);
 
       // Submission B — user has NO scope access
       const submissionB = await createTestSubmission(connection);
-      const securedB = await createTestFeature(connection, submissionB, 'dataset', { name: 'Secured B' });
+      const uploadB = await createTestUpload(connection, submissionB);
+      const securedB = await insertFeatureRow({
+        submissionId: submissionB,
+        submissionUploadId: uploadB,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedB);
+      await rebuildClosure(uploadB);
 
       const userId = await createOtherUser();
       // Grant scope only for submission A
@@ -281,8 +528,18 @@ describe('Cart submission feature security (integration)', function () {
     });
 
     it('should reflect security changes after feature was added to cart', async () => {
+      // The read-side `secured` column uses isEffectivelySecuredViaClosure, so the closure must carry the
+      // feature's self-loop for the rule to be seen. The closure is rebuilt up front (the feature is active
+      // throughout); only the security ROW is added after the cart insert.
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Initially Public' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+
+      await rebuildClosure(uploadId);
 
       // Add while unsecured (anonymous can add it)
       const cartId = await createActiveCart(null);
@@ -292,18 +549,30 @@ describe('Cart submission feature security (integration)', function () {
       let features = await cartFeatureService.getCartSubmissionFeatures(cartId);
       expect(features[0].secured).to.equal(false);
 
-      // Apply security after the feature is already in the cart
+      // Apply security after the feature is already in the cart (no structural change — closure self-loop
+      // already exists, so no rebuild is needed for the read-side fragment to see the new rule).
       await secureFeature(connection, featureId);
 
-      // Read-side CTE should now compute secured: true
+      // Read-side fragment should now compute secured: true via the closure self-loop
       features = await cartFeatureService.getCartSubmissionFeatures(cartId);
       expect(features[0].secured).to.equal(true);
     });
 
     it('should filter by submissionFeatureId when provided', async () => {
       const submissionId = await createTestSubmission(connection);
-      const featureA = await createTestFeature(connection, submissionId, 'dataset', { name: 'A' });
-      const featureB = await createTestFeature(connection, submissionId, 'dataset', { name: 'B' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureA = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const featureB = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+
+      await rebuildClosure(uploadId);
 
       const cartId = await createActiveCart(null);
       await cartFeatureService.createCartSubmissionFeatures(cartId, [featureA, featureB], null);
@@ -330,7 +599,14 @@ describe('Cart submission feature security (integration)', function () {
   describe('edge cases', () => {
     it('should handle idempotent add (same feature twice) without error', async () => {
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+
+      await rebuildClosure(uploadId);
 
       const cartId = await createActiveCart(null);
       await cartFeatureService.createCartSubmissionFeatures(cartId, [featureId], null);
@@ -342,7 +618,14 @@ describe('Cart submission feature security (integration)', function () {
 
     it('should not add features to an inactive (checked-out) cart', async () => {
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Dataset' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+
+      await rebuildClosure(uploadId);
 
       const cartId = await createActiveCart(null);
 

--- a/api/src/__integration__/db/cart-submission-feature-service.integration.ts
+++ b/api/src/__integration__/db/cart-submission-feature-service.integration.ts
@@ -1,6 +1,6 @@
 // Integration test for cart submission feature security — verifies the read-paths-only security swap:
 // "is this feature secured / accessible" is resolved via the precomputed submission_feature_closure
-// (the `isEffectivelySecuredViaClosure` / `isAccessibleToUser` SQL fragments), NOT a live recursive
+// (the `isEffectivelySecured` / `isAccessibleToUser` SQL fragments), NOT a live recursive
 // parent walk. The cart insert reads that closure to gate secured features, computes the `secured`
 // flag on read, and counts all features regardless of security status.
 //
@@ -223,7 +223,7 @@ describe('Cart submission feature security (integration)', function () {
 
     it('should exclude a directly secured feature', async () => {
       // Directly secured feature under a shared upload: rebuild the closure so the feature's SELF-LOOP
-      // exists, then isEffectivelySecuredViaClosure resolves its own security rule and excludes it.
+      // exists, then isEffectivelySecured resolves its own security rule and excludes it.
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
       const featureId = await insertFeatureRow({
@@ -271,7 +271,7 @@ describe('Cart submission feature security (integration)', function () {
 
     it('should exclude an inactive (soft-deleted) secured id — anonymous (Risk 1 active-guard)', async () => {
       // RISK 1 GUARD. Secure the feature, then soft-delete it. The closure rebuild now writes NO self-loop
-      // for it (inactive features are excluded from the active universe), so isEffectivelySecuredViaClosure
+      // for it (inactive features are excluded from the active universe), so isEffectivelySecured
       // finds nothing and would read it as UNSECURED. The cart repo's `JOIN submission_feature ...
       // record_end_date IS NULL` active-guard is what excludes the id here — without that guard the empty
       // closure would let the soft-deleted secured id slip into the cart.
@@ -528,7 +528,7 @@ describe('Cart submission feature security (integration)', function () {
     });
 
     it('should reflect security changes after feature was added to cart', async () => {
-      // The read-side `secured` column uses isEffectivelySecuredViaClosure, so the closure must carry the
+      // The read-side `secured` column uses isEffectivelySecured, so the closure must carry the
       // feature's self-loop for the rule to be seen. The closure is rebuilt up front (the feature is active
       // throughout); only the security ROW is added after the cart insert.
       const submissionId = await createTestSubmission(connection);

--- a/api/src/__integration__/db/download-parquet-pipeline.integration.ts
+++ b/api/src/__integration__/db/download-parquet-pipeline.integration.ts
@@ -32,9 +32,11 @@ import { DownloadPipelineService } from '../../services/download/download-pipeli
 import { DownloadPolicyService } from '../../services/download/download-policy-service';
 import { DownloadService } from '../../services/download/download-service';
 import { ObjectStorageService } from '../../services/object-storage/object-storage-service';
+import { SubmissionFeatureClosureService } from '../../services/submission-feature-closure-service';
 import { CsvPropertyDefinition } from '../../utils/csv-utils';
 import {
   createFeatureTypeProperty,
+  createTestUpload,
   insertSubmissionFeaturePropertyFeature
 } from '../helpers/test-feature-property-helpers';
 import { secureFeature, setupFullAccess } from '../helpers/test-rbac-helpers';
@@ -164,6 +166,53 @@ describe('Download Parquet pipeline (integration)', function () {
       requestedBy: connection.systemUserId()
     });
     return download_id;
+  }
+
+  /**
+   * Insert ONE submission_feature bound to a SPECIFIC upload, resolving feature_type_id by name.
+   *
+   * The export security filter resolves "is this feature secured" via the precomputed closure
+   * (isEffectivelySecuredViaClosure), which needs the feature's closure SELF-LOOP. That self-loop only
+   * exists after computeClosureForUpload runs for the feature's upload. createTestFeature mints a NEW
+   * upload per call and never rebuilds the closure, so a feature secured that way reads as unsecured and
+   * is NOT stripped. The security tests therefore seed features directly under a SHARED upload via
+   * createTestUpload + this helper, then rebuild the closure AFTER securing and BEFORE the subquery.
+   *
+   * @returns The new submission_feature_id.
+   */
+  async function insertFeatureRow(params: {
+    submissionId: number;
+    submissionUploadId: string;
+    featureTypeName: string;
+    parentFeatureId?: number;
+  }): Promise<number> {
+    const systemUserId = connection.systemUserId();
+
+    const result = await connection.sql(SQL`
+      INSERT INTO submission_feature (
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        parent_submission_feature_id,
+        data,
+        data_byte_size,
+        record_effective_date,
+        create_user
+      )
+      VALUES (
+        ${params.submissionId},
+        ${params.submissionUploadId}::uuid,
+        (SELECT feature_type_id FROM feature_type WHERE name = ${params.featureTypeName} LIMIT 1),
+        ${params.parentFeatureId ?? null},
+        '{}'::jsonb,
+        500,
+        now(),
+        ${systemUserId}
+      )
+      RETURNING submission_feature_id;
+    `);
+
+    return result.rows[0].submission_feature_id;
   }
 
   /**
@@ -1038,10 +1087,26 @@ describe('Download Parquet pipeline (integration)', function () {
       // AC #4 — an anonymous download must never package secured data. Two same-type
       // features in one submission; one is secured. The anonymous identity used to
       // build the export must strip the secured id while keeping the unsecured one.
+      //
+      // The export security filter (isEffectivelySecuredViaClosure) reads the precomputed closure, so
+      // the secured feature is only recognised as secured once its closure self-loop exists. Seed both
+      // siblings under a SHARED upload and rebuild the closure AFTER securing — without the rebuild the
+      // empty closure reads securedId as unsecured and it would leak into the anonymous export.
       const submissionId = await createTestSubmission(connection);
-      const unsecuredId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public sibling' });
-      const securedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured sibling' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const unsecuredId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const securedId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedId);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
 
       const { policy_id } = await policyService.createDownloadPolicy({
         name: `pq-sec-anon-${Date.now()}-${randomUUID().slice(0, 8)}`,
@@ -1066,10 +1131,26 @@ describe('Download Parquet pipeline (integration)', function () {
       // AC #5 — a user with a scope grant to the secured feature still gets it in
       // their export. Same fixture as the anon case, but the export is built with the
       // granted user's id as requested_by.
+      //
+      // The closure rebuild is load-bearing here too: it makes isEffectivelySecuredViaClosure recognise
+      // securedId as secured (Branch 1 fails), so visibility now hinges on the scope grant (Branch 2's
+      // closure-anchor probe). WITHOUT the rebuild this test would pass spuriously — an empty closure
+      // reads securedId as unsecured, so it would be "visible" regardless of any grant.
       const submissionId = await createTestSubmission(connection);
-      const unsecuredId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public sibling' });
-      const securedId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured sibling' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const unsecuredId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const securedId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedId);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
 
       const userId = connection.systemUserId();
       await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, 'pq-export-access-team');

--- a/api/src/__integration__/db/download-parquet-pipeline.integration.ts
+++ b/api/src/__integration__/db/download-parquet-pipeline.integration.ts
@@ -172,7 +172,7 @@ describe('Download Parquet pipeline (integration)', function () {
    * Insert ONE submission_feature bound to a SPECIFIC upload, resolving feature_type_id by name.
    *
    * The export security filter resolves "is this feature secured" via the precomputed closure
-   * (isEffectivelySecuredViaClosure), which needs the feature's closure SELF-LOOP. That self-loop only
+   * (isEffectivelySecured), which needs the feature's closure SELF-LOOP. That self-loop only
    * exists after computeClosureForUpload runs for the feature's upload. createTestFeature mints a NEW
    * upload per call and never rebuilds the closure, so a feature secured that way reads as unsecured and
    * is NOT stripped. The security tests therefore seed features directly under a SHARED upload via
@@ -1088,7 +1088,7 @@ describe('Download Parquet pipeline (integration)', function () {
       // features in one submission; one is secured. The anonymous identity used to
       // build the export must strip the secured id while keeping the unsecured one.
       //
-      // The export security filter (isEffectivelySecuredViaClosure) reads the precomputed closure, so
+      // The export security filter (isEffectivelySecured) reads the precomputed closure, so
       // the secured feature is only recognised as secured once its closure self-loop exists. Seed both
       // siblings under a SHARED upload and rebuild the closure AFTER securing — without the rebuild the
       // empty closure reads securedId as unsecured and it would leak into the anonymous export.
@@ -1132,7 +1132,7 @@ describe('Download Parquet pipeline (integration)', function () {
       // their export. Same fixture as the anon case, but the export is built with the
       // granted user's id as requested_by.
       //
-      // The closure rebuild is load-bearing here too: it makes isEffectivelySecuredViaClosure recognise
+      // The closure rebuild is load-bearing here too: it makes isEffectivelySecured recognise
       // securedId as secured (Branch 1 fails), so visibility now hinges on the scope grant (Branch 2's
       // closure-anchor probe). WITHOUT the rebuild this test would pass spuriously — an empty closure
       // reads securedId as unsecured, so it would be "visible" regardless of any grant.

--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -6,10 +6,11 @@
 // The evaluator resolves a predicate's evidence features (security-filtered on the evidence side) and
 // then expands them to the anchor feature type through two reachability sources combined with UNION:
 //
-//   content_reach  = a bounded recursive walk SEEDED FROM the evidence (depth 0), following BIDIRECTIONAL
-//                    submission_feature_feature content edges (both endpoints active), cap depth < 6 in
-//                    the recursive step (deepest node reached is 6 edges from the seed), cycle-guarded by
-//                    the visited path. content_reach ALWAYS includes the evidence itself.
+//   content_reach  = a bounded recursive walk SEEDED FROM the evidence (depth 0), following the BIDIRECTIONAL
+//                    edges the closure omits — submission_feature_feature content edges AND synthetic
+//                    dataset↔same-submission membership edges (both endpoints active) — cap depth < 6 in the
+//                    recursive step (deepest node reached is 6 edges from the seed), cycle-guarded by the
+//                    visited path. content_reach ALWAYS includes the evidence itself.
 //   reachable      = content_reach
 //                    ∪ closureForward = { c.target : c.source ∈ content_reach }  (ancestors + referenced)
 //                    ∪ closureReverse = { c.source : c.target ∈ content_reach }  (descendants + referencing)
@@ -31,6 +32,8 @@
 //      because M ∈ content_reach and the closure is probed from content_reach.
 //   5. ACCEPTED, INTENTIONAL GAP: the reverse order (closure-ancestor of E, then THAT ancestor's content
 //      edge) is NOT recovered — the content walk seeds only from evidence, not from closure results.
+//   6. Dataset MEMBERSHIP reach (dataset ↔ every same-submission feature) is walked at read time like
+//      content — closure-independent, needing only a shared submission_id (not an upload or a rebuild).
 //
 // UO#5 / API-shape acceptance rows are exercised at the route layer and are out of scope for this
 // evaluator suite, which pins the emitted-SQL reachability semantics directly.
@@ -681,11 +684,11 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Dataset has no synthetic same-upload fan-out. D(dataset) with a real descendant Y(animal, parent=D)
-     * and an UNCONNECTED same-upload X(animal). Evidence=D reaches Y via closureReverse but NOT X — the old
-     * dataset→every-feature-in-submission synthetic edge is gone.
+     * Dataset membership fan-out is restored. D(dataset) with a real descendant Y(animal, parent=D) and an
+     * UNCONNECTED same-submission X(animal, no parent). Evidence=D reaches Y via closureReverse AND reaches X
+     * via the restored dataset→every-feature-in-submission membership edge.
      */
-    it('8: dataset evidence reaches real descendants only, not unconnected same-upload features', async () => {
+    it('8: dataset evidence reaches descendants and unconnected same-submission features via membership', async () => {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
 
@@ -709,26 +712,33 @@ describe('expression-evaluation (integration)', function () {
       const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId()));
 
       expect(ids.has(y)).to.equal(true);
-      expect(ids.has(x)).to.equal(false);
+      expect(ids.has(x)).to.equal(true);
     });
 
     /**
-     * Empty-closure behaviour, two halves. (a) Without computeClosureForUpload, ancestor reach is empty:
-     * P(dataset) ← E(sample_site), evidence=E, anchor=dataset → P ABSENT (the closure is what carries
-     * ancestor reach). (b) The content walk works WITHOUT a closure: E2(sample_site) ─content→ M(animal),
-     * evidence=E2, anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
+     * Empty-closure behaviour, two halves. (a) Without computeClosureForUpload, closure ancestor reach is
+     * empty: A(sample_site) ← E(sample_site), evidence=E, anchor=sample_site → A ABSENT (the closure is what
+     * carries ancestor reach). A NON-dataset ancestor is used deliberately — the dataset membership edge is
+     * closure-independent, so a dataset ancestor would be reachable here and mask the closure dependence.
+     * (b) The content walk works WITHOUT a closure: E2(sample_site) ─content→ M(animal), evidence=E2,
+     * anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
      */
-    it('9: empty closure — ancestor reach absent, content reach still works', async () => {
+    it('9: empty closure — closure ancestor reach absent, content reach still works', async () => {
       const submissionId = await createTestSubmission(connection);
 
-      // (a) ancestor reach needs the closure — do NOT rebuild it.
+      // (a) closure ancestor reach needs the closure — do NOT rebuild it. NON-dataset ancestor so the dataset
+      // membership edge (closure-independent) can't mask the closure dependence.
       const uploadA = await createTestUpload(connection, submissionId);
-      const p = await insertFeatureRow({ submissionId, submissionUploadId: uploadA, featureTypeName: 'dataset' });
+      const ancestorSite = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadA,
+        featureTypeName: 'sample_site'
+      });
       const e = await insertFeatureRow({
         submissionId,
         submissionUploadId: uploadA,
         featureTypeName: 'sample_site',
-        parentFeatureId: p
+        parentFeatureId: ancestorSite
       });
       await indexNameProperty(e, 'no-closure-ancestor', SAMPLE_SITE_NAME_FTP_ID);
 
@@ -738,9 +748,9 @@ describe('expression-evaluation (integration)', function () {
         clauses: [namePredicate('no-closure-ancestor', SAMPLE_SITE_NAME_FTP_ID)]
       };
       const ancestorIds = await runSubquery(
-        buildExpressionTreeFeatureIdsSubquery('dataset', ancestorTree, connection.systemUserId())
+        buildExpressionTreeFeatureIdsSubquery('sample_site', ancestorTree, connection.systemUserId())
       );
-      expect(ancestorIds.has(p)).to.equal(false);
+      expect(ancestorIds.has(ancestorSite)).to.equal(false);
 
       // (b) content reach does NOT need the closure — also do NOT rebuild it.
       const uploadB = await createTestUpload(connection, submissionId);
@@ -761,30 +771,38 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * AND/OR compose over closure-related features. Two datasets in separate uploads each have a child
-     * sample_site: D1 ← S1, D2 ← S2. An OR of [D1.name, D2.name] anchored at sample_site UNIONs the two
-     * descendant reaches (S1 and S2). An AND of [D1.name, D2.name] anchored at sample_site INTERSECTs them —
-     * no sample_site is a descendant of both datasets, so the intersection is empty. The raw combinator is
-     * already pinned by the self-match AND/OR tests; this guards that it composes correctly when leaves
-     * resolve THROUGH closure relatedness.
+     * AND/OR compose over closure-related features. Two datasets in separate SUBMISSIONS each have a child
+     * sample_site: D1 ← S1, D2 ← S2. Separate submissions (not just uploads) so the dataset membership edge —
+     * which keys on submission_id — cannot cross-link them. An OR of [D1.name, D2.name] anchored at sample_site
+     * UNIONs the two descendant reaches (S1 and S2). An AND INTERSECTs them — no sample_site is a descendant of
+     * both datasets, so the intersection is empty. The raw combinator is already pinned by the self-match AND/OR
+     * tests; this guards that it composes correctly when leaves resolve THROUGH closure relatedness.
      */
     it('10: AND/OR compose over closure-related features (union widens, intersect narrows)', async () => {
-      const submissionId = await createTestSubmission(connection);
-
-      const uploadOne = await createTestUpload(connection, submissionId);
-      const d1 = await insertFeatureRow({ submissionId, submissionUploadId: uploadOne, featureTypeName: 'dataset' });
+      const submissionOne = await createTestSubmission(connection);
+      const uploadOne = await createTestUpload(connection, submissionOne);
+      const d1 = await insertFeatureRow({
+        submissionId: submissionOne,
+        submissionUploadId: uploadOne,
+        featureTypeName: 'dataset'
+      });
       const s1 = await insertFeatureRow({
-        submissionId,
+        submissionId: submissionOne,
         submissionUploadId: uploadOne,
         featureTypeName: 'sample_site',
         parentFeatureId: d1
       });
       await indexNameProperty(d1, 'compose-d1', DATASET_NAME_FTP_ID);
 
-      const uploadTwo = await createTestUpload(connection, submissionId);
-      const d2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadTwo, featureTypeName: 'dataset' });
+      const submissionTwo = await createTestSubmission(connection);
+      const uploadTwo = await createTestUpload(connection, submissionTwo);
+      const d2 = await insertFeatureRow({
+        submissionId: submissionTwo,
+        submissionUploadId: uploadTwo,
+        featureTypeName: 'dataset'
+      });
       const s2 = await insertFeatureRow({
-        submissionId,
+        submissionId: submissionTwo,
         submissionUploadId: uploadTwo,
         featureTypeName: 'sample_site',
         parentFeatureId: d2

--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -7,10 +7,9 @@
 // then expands them to the anchor feature type through two reachability sources combined with UNION:
 //
 //   content_reach  = a bounded recursive walk SEEDED FROM the evidence (depth 0), following the BIDIRECTIONAL
-//                    edges the closure omits — submission_feature_feature content edges AND synthetic
-//                    dataset↔same-submission membership edges (both endpoints active) — cap depth < 6 in the
-//                    recursive step (deepest node reached is 6 edges from the seed), cycle-guarded by the
-//                    visited path. content_reach ALWAYS includes the evidence itself.
+//                    submission_feature_feature content edges the closure omits (both endpoints active) — cap
+//                    depth < 6 in the recursive step (deepest node reached is 6 edges from the seed),
+//                    cycle-guarded by the visited path. content_reach ALWAYS includes the evidence itself.
 //   reachable      = content_reach
 //                    ∪ closureForward = { c.target : c.source ∈ content_reach }  (ancestors + referenced)
 //                    ∪ closureReverse = { c.source : c.target ∈ content_reach }  (descendants + referencing)
@@ -32,8 +31,6 @@
 //      because M ∈ content_reach and the closure is probed from content_reach.
 //   5. ACCEPTED, INTENTIONAL GAP: the reverse order (closure-ancestor of E, then THAT ancestor's content
 //      edge) is NOT recovered — the content walk seeds only from evidence, not from closure results.
-//   6. Dataset MEMBERSHIP reach (dataset ↔ every same-submission feature) is walked at read time like
-//      content — closure-independent, needing only a shared submission_id (not an upload or a rebuild).
 //
 // UO#5 / API-shape acceptance rows are exercised at the route layer and are out of scope for this
 // evaluator suite, which pins the emitted-SQL reachability semantics directly.
@@ -329,7 +326,7 @@ describe('expression-evaluation (integration)', function () {
       // completes (one Parquet per statement, some empty) — "5 in, 5 files, 1 empty" is a
       // valid, deliberate outcome, not a failure.
       // The broad subquery's security filter resolves "is this feature secured" via the closure
-      // (isEffectivelySecuredViaClosure), so the secured `restricted` feature only reads as secured
+      // (isEffectivelySecured), so the secured `restricted` feature only reads as secured
       // once its closure self-loop exists. Seed it under a shared upload and rebuild the closure
       // BEFORE the subquery; otherwise an empty closure reads it as unsecured and it is NOT stripped.
       const submissionAccessible = await createTestSubmission(connection);
@@ -430,7 +427,7 @@ describe('expression-evaluation (integration)', function () {
     it('security filter excludes features the user cannot read', async () => {
       // Evidence-side security: a secured candidate is dropped before projection, so it never reaches
       // the result even as its own self-match. The drop is driven by the closure-based security filter
-      // (isEffectivelySecuredViaClosure), so each feature is seeded under its OWN upload and its closure
+      // (isEffectivelySecured), so each feature is seeded under its OWN upload and its closure
       // self-loop is rebuilt BEFORE the subquery — without the self-loop the secured feature reads as
       // unsecured and would NOT be stripped. Separate uploads keep the OR-tree reach narrow (each
       // feature only self-matches; no shared upload means no incidental closure relatedness between them).
@@ -718,11 +715,12 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Dataset membership fan-out is restored. D(dataset) with a real descendant Y(animal, parent=D) and an
-     * UNCONNECTED same-submission X(animal, no parent). Evidence=D reaches Y via closureReverse AND reaches X
-     * via the restored dataset→every-feature-in-submission membership edge.
+     * Dataset membership fan-out has been removed. D(dataset) with a real descendant Y(animal, parent=D) and an
+     * UNCONNECTED same-submission X(animal, no parent). Evidence=D reaches Y via closureReverse (Y is D's
+     * descendant) but no longer reaches X — the synthetic dataset→every-feature-in-submission membership edge is
+     * gone, so an unconnected same-submission feature is unreachable from dataset evidence.
      */
-    it('8: dataset evidence reaches descendants and unconnected same-submission features via membership', async () => {
+    it('8: dataset evidence reaches descendants via closure but not unconnected same-submission features', async () => {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
 
@@ -746,22 +744,19 @@ describe('expression-evaluation (integration)', function () {
       const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId()));
 
       expect(ids.has(y)).to.equal(true);
-      expect(ids.has(x)).to.equal(true);
+      expect(ids.has(x)).to.equal(false);
     });
 
     /**
      * Empty-closure behaviour, two halves. (a) Without computeClosureForUpload, closure ancestor reach is
      * empty: A(sample_site) ← E(sample_site), evidence=E, anchor=sample_site → A ABSENT (the closure is what
-     * carries ancestor reach). A NON-dataset ancestor is used deliberately — the dataset membership edge is
-     * closure-independent, so a dataset ancestor would be reachable here and mask the closure dependence.
-     * (b) The content walk works WITHOUT a closure: E2(sample_site) ─content→ M(animal), evidence=E2,
-     * anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
+     * carries ancestor reach). (b) The content walk works WITHOUT a closure: E2(sample_site) ─content→ M(animal),
+     * evidence=E2, anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
      */
     it('9: empty closure — closure ancestor reach absent, content reach still works', async () => {
       const submissionId = await createTestSubmission(connection);
 
-      // (a) closure ancestor reach needs the closure — do NOT rebuild it. NON-dataset ancestor so the dataset
-      // membership edge (closure-independent) can't mask the closure dependence.
+      // (a) closure ancestor reach needs the closure — do NOT rebuild it.
       const uploadA = await createTestUpload(connection, submissionId);
       const ancestorSite = await insertFeatureRow({
         submissionId,
@@ -805,12 +800,11 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * AND/OR compose over closure-related features. Two datasets in separate SUBMISSIONS each have a child
-     * sample_site: D1 ← S1, D2 ← S2. Separate submissions (not just uploads) so the dataset membership edge —
-     * which keys on submission_id — cannot cross-link them. An OR of [D1.name, D2.name] anchored at sample_site
-     * UNIONs the two descendant reaches (S1 and S2). An AND INTERSECTs them — no sample_site is a descendant of
-     * both datasets, so the intersection is empty. The raw combinator is already pinned by the self-match AND/OR
-     * tests; this guards that it composes correctly when leaves resolve THROUGH closure relatedness.
+     * AND/OR compose over closure-related features. Two datasets in separate submissions each have a child
+     * sample_site: D1 ← S1, D2 ← S2. An OR of [D1.name, D2.name] anchored at sample_site UNIONs the two
+     * descendant reaches (S1 and S2). An AND INTERSECTs them — no sample_site is a descendant of both datasets,
+     * so the intersection is empty. The raw combinator is already pinned by the self-match AND/OR tests; this
+     * guards that it composes correctly when leaves resolve THROUGH closure relatedness.
      */
     it('10: AND/OR compose over closure-related features (union widens, intersect narrows)', async () => {
       const submissionOne = await createTestSubmission(connection);

--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -1,19 +1,52 @@
-// Integration test for expression-evaluation — verifies that the
-// emitted SQL (recursive expression-tree evaluator + broad feature-type
-// projection) returns the expected submission_feature_id sets against a real
-// schema, including the security filter applied for an authenticated user.
+// Integration tests for expression-evaluation — verifies that the emitted SQL returns the expected
+// submission_feature_id sets against a real schema, including the security filter applied for an
+// authenticated user.
 //
-// Both the search wrapper (POST /api/search/feature) and the download pipeline
-// (POST /api/download) consume the same emitted SQL, so a single substrate
-// keeps semantics identical across both consumers — these tests pin that.
+// SEMANTICS UNDER TEST — closure + recursive content walk:
+// The evaluator resolves a predicate's evidence features (security-filtered on the evidence side) and
+// then expands them to the anchor feature type through two reachability sources combined with UNION:
+//
+//   content_reach  = a bounded recursive walk SEEDED FROM the evidence (depth 0), following BIDIRECTIONAL
+//                    submission_feature_feature content edges (both endpoints active), cap depth < 6 in
+//                    the recursive step (deepest node reached is 6 edges from the seed), cycle-guarded by
+//                    the visited path. content_reach ALWAYS includes the evidence itself.
+//   reachable      = content_reach
+//                    ∪ closureForward = { c.target : c.source ∈ content_reach }  (ancestors + referenced)
+//                    ∪ closureReverse = { c.source : c.target ∈ content_reach }  (descendants + referencing)
+//   result         = { sf ∈ reachable : sf is of anchorFeatureType, sf active, sf passes TARGET security }
+//
+// The closure (submission_feature_closure) is UPLOAD-SCOPED and precomputes parent-ancestry and
+// property-reference reach. A parent edge stores (source=child, target=parent); a property edge stores
+// (source=feature, target=referenced). It is built by SubmissionFeatureClosureService.computeClosureForUpload
+// AFTER seeding and BEFORE running the subquery. Closure relatedness therefore REQUIRES a shared upload.
+// Content edges are excluded from the closure and are walked at read time; they need neither a shared
+// upload nor a closure rebuild.
+//
+// Key consequences pinned by these tests:
+//   1. Evidence is always in content_reach, so a reflexive match (anchor = evidence's own type) returns
+//      the evidence even with an empty closure and no content edges.
+//   2. Ancestor / descendant / property reach REQUIRES a shared upload + computeClosureForUpload.
+//   3. Content reach is a RECURSIVE multi-hop walk (not one-hop).
+//   4. content→closure chains: a content neighbour M of E contributes M's closure ancestors/descendants,
+//      because M ∈ content_reach and the closure is probed from content_reach.
+//   5. ACCEPTED, INTENTIONAL GAP: the reverse order (closure-ancestor of E, then THAT ancestor's content
+//      edge) is NOT recovered — the content walk seeds only from evidence, not from closure results.
+//
+// UO#5 / API-shape acceptance rows are exercised at the route layer and are out of scope for this
+// evaluator suite, which pins the emitted-SQL reachability semantics directly.
+//
+// Both the search wrapper (POST /api/search/feature) and the download pipeline (POST /api/download)
+// consume the same emitted SQL, so a single substrate keeps semantics identical across both consumers.
 //
 // Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
 //
-// Run: make test-db
-// Requires: make web (database must be running with seed data)
+// Run: docker compose exec api npm run test:mocha -- --no-config --extension ts \
+//        'src/__integration__/db/expression-evaluation.integration.ts'
+// Requires: database container running with seed data.
 
 import { expect } from 'chai';
 import SQL from 'sql-template-strings';
+import { MAX_SEARCH_GRAPH_DEPTH } from '../../constants/expression';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
 import {
   NormalizedExpressionTreeExpression,
@@ -23,27 +56,34 @@ import {
   buildBroadFeatureTypeSubquery,
   buildExpressionTreeFeatureIdsSubquery
 } from '../../repositories/expression-evaluation';
+import { SubmissionFeatureClosureService } from '../../services/submission-feature-closure-service';
+import { createFeatureTypeProperty, createTestUpload } from '../helpers/test-feature-property-helpers';
 import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
 
+// Verified seed ids (checked against the live DB):
+//   feature_property name           = 31
+//   sample_site.name ftp            = 45
+//   dataset.name ftp                = 70
+const FEATURE_PROPERTY_NAME_ID = 31;
+const SAMPLE_SITE_NAME_FTP_ID = 45;
+const DATASET_NAME_FTP_ID = 70;
+
 /**
- * Build a normalized predicate clause that targets the `sample_site.name` string property.
+ * Build a normalized predicate clause that targets a string `name` property.
  *
- * Why sample_site rather than dataset: the evaluator's recursive graph projects evidence
- * through dataset → all-features-in-submission synthetic edges, which would pull in
- * decoy datasets when we want a clean target set. Anchoring on a non-dataset feature
- * type with its own `name` property keeps the target set tight, one feature per
- * submission per test.
- *
- * Both the predicate-evidence query and the typed-table JOIN need
- * (feature_property_id, feature_type_property_id, internal_predicate type/operator/value).
- *
- * Seed values: feature_property_id=31 (name, string), feature_type_property_id=45 (sample_site.name).
+ * `feature_property_id` stays 31 (the shared `name` feature_property); `featureTypePropertyId` selects
+ * the typed slot to filter on (45 = sample_site.name, 70 = dataset.name). The predicate is intentionally
+ * target-feature agnostic — it only identifies EVIDENCE features that carry the matching string row; the
+ * evaluator then projects that evidence to the anchor type through the closure + content walk.
  */
-function namePredicate(value: string): NormalizedExpressionTreePredicate {
+function namePredicate(
+  value: string,
+  featureTypePropertyId: number = SAMPLE_SITE_NAME_FTP_ID
+): NormalizedExpressionTreePredicate {
   return {
     type: 'predicate',
-    feature_property_id: 31,
-    feature_type_property_id: 45,
+    feature_property_id: FEATURE_PROPERTY_NAME_ID,
+    feature_type_property_id: featureTypePropertyId,
     operator: 'Equals',
     value,
     feature_property_type_id: 1,
@@ -71,33 +111,197 @@ describe('expression-evaluation (integration)', function () {
     connection.release();
   });
 
+  // --- local fixture helpers -----------------------------------------------
+
   /**
-   * Helper: write the typed string property row used by the predicate query.
-   * The expression-tree evaluator JOINs feature_type_property + reads from
-   * `submission_feature_property_string`; both have to be populated for a row
-   * to satisfy a string predicate.
+   * Insert one submission_feature bound to a SPECIFIC upload, resolving feature_type_id by NAME so the
+   * anchor filter can isolate a target type.
    *
-   * Uses sample_site.name (feature_type_property_id=45) — see `namePredicate` for why.
+   * The closure recompute is upload-scoped and only walks edges whose BOTH endpoints are active features
+   * of the same upload, so a parent and its children must share one submission_upload_id. createTestFeature
+   * mints its OWN upload per call and cannot place a parent + child under one upload, so the closure-driven
+   * fixtures insert features directly here. `recordEndDate` marks a feature inactive (excluded from the
+   * active universe, dropped from the closure and the content walk's active-endpoint guard).
+   *
+   * @returns The new submission_feature_id.
    */
-  async function indexNameProperty(submissionFeatureId: number, value: string): Promise<void> {
+  async function insertFeatureRow(params: {
+    submissionId: number;
+    submissionUploadId: string;
+    featureTypeName: string;
+    parentFeatureId?: number;
+    recordEndDate?: boolean;
+  }): Promise<number> {
+    const systemUserId = connection.systemUserId();
+
+    const result = await connection.sql(SQL`
+      INSERT INTO submission_feature (
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        parent_submission_feature_id,
+        data,
+        data_byte_size,
+        record_effective_date,
+        record_end_date,
+        create_user
+      )
+      VALUES (
+        ${params.submissionId},
+        ${params.submissionUploadId}::uuid,
+        (SELECT feature_type_id FROM feature_type WHERE name = ${params.featureTypeName} LIMIT 1),
+        ${params.parentFeatureId ?? null},
+        '{}'::jsonb,
+        500,
+        now(),
+        ${params.recordEndDate ? 'now()' : null},
+        ${systemUserId}
+      )
+      RETURNING submission_feature_id;
+    `);
+
+    return result.rows[0].submission_feature_id;
+  }
+
+  /**
+   * Index a string `name` value on a feature so a predicate can find it as evidence.
+   *
+   * The evaluator JOINs feature_type_property and reads from submission_feature_property_string; both must
+   * agree on the typed slot. `featureTypePropertyId` defaults to sample_site.name (45); pass 70 for
+   * dataset.name. The slot here MUST match the one in the matching `namePredicate(...)`.
+   */
+  async function indexNameProperty(
+    submissionFeatureId: number,
+    value: string,
+    featureTypePropertyId: number = SAMPLE_SITE_NAME_FTP_ID
+  ): Promise<void> {
     const systemUserId = connection.systemUserId();
     await connection.sql(SQL`
       INSERT INTO submission_feature_property_string
         (submission_feature_id, feature_type_property_id, value, create_user)
-      VALUES (${submissionFeatureId}, 45, ${value}, ${systemUserId});
+      VALUES (${submissionFeatureId}, ${featureTypePropertyId}, ${value}, ${systemUserId});
     `);
   }
 
   /**
-   * Helper: run an emitted Knex subquery and return the resulting set of
-   * submission_feature_id values. Strips ordering off the caller — set-equality
-   * is what every test cares about.
+   * Insert a single content edge (submission_feature_feature) source -> target.
+   *
+   * Content edges are walked at read time (bidirectionally) and are NOT part of the closure, so this
+   * helper drives the recursive-content-walk assertions. The table has a unique index on
+   * (LEAST(source, target), GREATEST(source, target)), so only ONE direction per unordered pair may be
+   * inserted — the evaluator makes the walk bidirectional regardless of stored direction.
+   */
+  async function insertContentEdge(sourceFeatureId: number, targetFeatureId: number): Promise<void> {
+    const systemUserId = connection.systemUserId();
+    await connection.sql(SQL`
+      INSERT INTO submission_feature_feature (source_feature_id, target_feature_id, create_user)
+      VALUES (${sourceFeatureId}, ${targetFeatureId}, ${systemUserId});
+    `);
+  }
+
+  /**
+   * Insert a property edge (submission_feature_property_feature) source -> referenced, using the supplied
+   * feature_type_property_id (mint one via createFeatureTypeProperty on the source type). In the closure
+   * this stores (source=feature, target=referenced): closureForward(feature) reaches the referenced
+   * feature; closureReverse(referenced) reaches the referencing feature.
+   */
+  async function insertPropertyEdge(
+    sourceFeatureId: number,
+    referencedFeatureId: number,
+    featureTypePropertyId: number
+  ): Promise<void> {
+    const systemUserId = connection.systemUserId();
+    await connection.sql(SQL`
+      INSERT INTO submission_feature_property_feature (
+        submission_feature_id,
+        feature_type_property_id,
+        referenced_submission_feature_id,
+        create_user
+      )
+      VALUES (${sourceFeatureId}, ${featureTypePropertyId}, ${referencedFeatureId}, ${systemUserId});
+    `);
+  }
+
+  /** Apply security rule 1 to a feature so anonymous callers (and ungranted users) cannot read it. */
+  async function secureFeature(submissionFeatureId: number): Promise<void> {
+    const systemUserId = connection.systemUserId();
+    await connection.sql(SQL`
+      INSERT INTO submission_feature_security (submission_feature_id, security_rule_id, create_user)
+      VALUES (${submissionFeatureId}, 1, ${systemUserId});
+    `);
+  }
+
+  /**
+   * Grant the current API user read access to a SECURED feature by standing up the scope-grant chain the
+   * security filter's Branch 2 walks: security_scope -> security_scope_anchor (on the feature) ->
+   * team_security_scope -> team -> team_member (for connection.systemUserId()). Without this chain a
+   * plain DATABASE-type API user is NOT effectively privileged over an arbitrary secured feature.
+   */
+  async function grantPrivilegedAccess(anchorSubmissionFeatureId: number): Promise<void> {
+    const systemUserId = connection.systemUserId();
+
+    const scope = await connection.sql(SQL`
+      INSERT INTO security_scope (scope_hash)
+      VALUES (${`test-scope-${anchorSubmissionFeatureId}`})
+      RETURNING security_scope_id;
+    `);
+    const securityScopeId = scope.rows[0].security_scope_id;
+
+    await connection.sql(SQL`
+      INSERT INTO security_scope_anchor (security_scope_id, anchor_submission_feature_id)
+      VALUES (${securityScopeId}, ${anchorSubmissionFeatureId});
+    `);
+
+    const team = await connection.sql(SQL`
+      INSERT INTO team (name, description, create_user)
+      VALUES (${`Privileged Test Team ${anchorSubmissionFeatureId}`}, 'integration', ${systemUserId})
+      RETURNING team_id;
+    `);
+    const teamId = team.rows[0].team_id;
+
+    await connection.sql(SQL`
+      INSERT INTO team_security_scope (team_id, security_scope_id)
+      VALUES (${teamId}, ${securityScopeId});
+    `);
+
+    await connection.sql(SQL`
+      INSERT INTO team_member (system_user_id, team_id, create_user)
+      VALUES (${systemUserId}, ${teamId}, ${systemUserId});
+    `);
+  }
+
+  /**
+   * Run an emitted Knex subquery and return the resulting SET of submission_feature_id values. Set
+   * equality is what every reachability test asserts on; ordering is irrelevant. NOTE: a Set hides
+   * duplicates — use runCount for the UNION-dedup assertion.
    */
   async function runSubquery(subquery: any): Promise<Set<number>> {
     const { sql, bindings } = subquery.toSQL().toNative();
     const result = await connection.query<{ submission_feature_id: number }>(sql, bindings as any[]);
     return new Set(result.rows.map((r) => r.submission_feature_id));
   }
+
+  /**
+   * Count the rows the emitted subquery returns by wrapping it as a derived table. Needed where a Set
+   * would collapse duplicates — the evaluator UNIONs (not UNION ALL) its reachability sources, so a
+   * feature reachable by more than one path must surface exactly once.
+   */
+  async function runCount(subquery: any): Promise<number> {
+    const { sql, bindings } = subquery.toSQL().toNative();
+    const result = await connection.query<{ count: number }>(
+      `SELECT count(*)::int AS count FROM (${sql}) t`,
+      bindings as any[]
+    );
+    return result.rows[0].count;
+  }
+
+  /** Mint a real feature_type_property usable as a property-edge label, from source type to target type. */
+  async function mintPropertyEdgeLabel(sourceFeatureType: string, targetFeatureType: string): Promise<number> {
+    const { featureTypePropertyId } = await createFeatureTypeProperty(connection, sourceFeatureType, targetFeatureType);
+    return featureTypePropertyId;
+  }
+
+  // === broad feature-type projection (no closure needed) ===================
 
   describe('buildBroadFeatureTypeSubquery', () => {
     it('returns every active submission_feature of the given type for an authenticated user', async () => {
@@ -130,11 +334,7 @@ describe('expression-evaluation (integration)', function () {
       // Apply a security rule. With systemUserId=null (anonymous), the security filter
       // strips any secured feature — the same mechanism that strips features from a
       // statement whose policy creator lacks the matching team grant.
-      const systemUserId = connection.systemUserId();
-      await connection.sql(SQL`
-        INSERT INTO submission_feature_security (submission_feature_id, security_rule_id, create_user)
-        VALUES (${restricted}, 1, ${systemUserId});
-      `);
+      await secureFeature(restricted);
 
       // Per-statement subquery for the type the user CAN see → returns the row.
       const accessibleIds = await runSubquery(buildBroadFeatureTypeSubquery('sample_site', null));
@@ -149,10 +349,13 @@ describe('expression-evaluation (integration)', function () {
     });
   });
 
-  describe('buildExpressionTreeFeatureIdsSubquery', () => {
+  // === self-match: evidence ∈ content_reach guards the set-op combinator and evidence security =========
+
+  describe('buildExpressionTreeFeatureIdsSubquery — self-match (evidence ∈ content_reach)', () => {
     it('AND tree returns only features matching every predicate', async () => {
-      // Use isolated submissions so the dataset → submission synthetic edge can't
-      // bridge target and decoy into the same connected component.
+      // Self-match: anchor type == evidence type, so the result is the evidence itself (content_reach
+      // always contains the evidence) with no closure or content edges needed. Isolated submissions keep
+      // the target and decoy from sharing any reach.
       const submissionTarget = await createTestSubmission(connection);
       const target = await createTestFeature(connection, submissionTarget, 'sample_site', { name: 'AND-target' });
       await indexNameProperty(target, 'AND-target');
@@ -175,7 +378,8 @@ describe('expression-evaluation (integration)', function () {
     });
 
     it('OR tree returns the union of predicate matches', async () => {
-      // Each candidate lives in its own submission to keep the bridge narrow.
+      // Self-match OR: the UNION combinator over two predicate branches; each candidate is its own
+      // evidence in content_reach. Each in its own submission to keep reach narrow.
       const submissionA = await createTestSubmission(connection);
       const a = await createTestFeature(connection, submissionA, 'sample_site', { name: 'OR-A' });
       await indexNameProperty(a, 'OR-A');
@@ -203,6 +407,8 @@ describe('expression-evaluation (integration)', function () {
     });
 
     it('security filter excludes features the user cannot read', async () => {
+      // Evidence-side security: a secured candidate is dropped before projection, so it never reaches
+      // the result even as its own self-match.
       const submissionOpen = await createTestSubmission(connection);
       const open = await createTestFeature(connection, submissionOpen, 'sample_site', { name: 'Open-secfilter' });
       await indexNameProperty(open, 'Open-secfilter');
@@ -213,12 +419,7 @@ describe('expression-evaluation (integration)', function () {
       });
       await indexNameProperty(secured, 'Secured-secfilter');
 
-      // Apply a security rule. Anonymous callers see only unsecured features.
-      const systemUserId = connection.systemUserId();
-      await connection.sql(SQL`
-        INSERT INTO submission_feature_security (submission_feature_id, security_rule_id, create_user)
-        VALUES (${secured}, 1, ${systemUserId});
-      `);
+      await secureFeature(secured);
 
       const tree: NormalizedExpressionTreeExpression = {
         type: 'expression',
@@ -231,47 +432,582 @@ describe('expression-evaluation (integration)', function () {
       expect(ids.has(open)).to.equal(true);
       expect(ids.has(secured)).to.equal(false);
     });
+  });
 
-    it('security filter excludes secured target features even when reached from unsecured evidence (defense in depth)', async () => {
-      // Regression test for the leak path the download pipeline previously had:
-      // evidence-side filtering let the predicate see an unsecured row, then graph traversal
-      // projected to a related SECURED target row. With only evidence-side filtering, the
-      // secured target id flowed out of the subquery to any consumer that bypassed the search
-      // wrapper's outer filter (e.g. the download cursor). The fix re-applies the security
-      // filter at the projected target level.
-      const submission = await createTestSubmission(connection);
+  // === closure + recursive content-walk reachability =====================================
 
-      // Evidence row — anonymous callers can read it; carries the predicate match.
-      const evidence = await createTestFeature(connection, submission, 'sample_site', { name: 'evidence-row' });
-      await indexNameProperty(evidence, 'evidence-row');
+  describe('buildExpressionTreeFeatureIdsSubquery — closure + content-walk reachability', () => {
+    /**
+     * Descendant reach (load-bearing reverse closure probe). D(dataset) ← A(animal) ← C(capture) under one
+     * upload; evidence = D (dataset.name). content_reach = {D}; closureReverse(D) = D's descendants = {A, C}.
+     * Anchor=capture isolates C. A FORWARD-ONLY probe would return EMPTY here — descendant reach exists only
+     * because the closure is probed in BOTH directions.
+     */
+    it('1: descendant reach — anchor below evidence is recovered via closureReverse', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
 
-      // Target row — same anchor type, parent of evidence so the parent-child graph edge
-      // bridges them. SECURED, so anonymous callers must NOT see it.
-      const securedTarget = await createTestFeature(
-        connection,
-        submission,
-        'sample_site',
-        { name: 'secured-target' },
-        evidence
-      );
-      const systemUserId = connection.systemUserId();
-      await connection.sql(SQL`
-        INSERT INTO submission_feature_security (submission_feature_id, security_rule_id, create_user)
-        VALUES (${securedTarget}, 1, ${systemUserId});
-      `);
+      const d = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const a = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'animal',
+        parentFeatureId: d
+      });
+      const c = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'capture',
+        parentFeatureId: a
+      });
+      await indexNameProperty(d, 'Caribou Study', DATASET_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
 
       const tree: NormalizedExpressionTreeExpression = {
         type: 'expression',
         operator: 'AND',
-        clauses: [namePredicate('evidence-row')]
+        clauses: [namePredicate('Caribou Study', DATASET_NAME_FTP_ID)]
       };
-      const subquery = buildExpressionTreeFeatureIdsSubquery('sample_site', tree, null);
-      const ids = await runSubquery(subquery);
+      const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('capture', tree, connection.systemUserId()));
 
-      // Evidence is unsecured and matches the predicate — keep it.
-      expect(ids.has(evidence)).to.equal(true);
-      // Secured target is reachable via the graph from `evidence` — must NOT leak through.
-      expect(ids.has(securedTarget)).to.equal(false);
+      expect(ids.has(c)).to.equal(true);
+    });
+
+    /**
+     * Ancestor reach (forward closure probe). D(dataset) ← S(sample_site) under one upload; evidence = S.
+     * content_reach = {S}; closureForward(S) = S's ancestors = {D}. Anchor=dataset isolates D.
+     */
+    it('2: ancestor reach — anchor above evidence is recovered via closureForward', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const d = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const s = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: d
+      });
+      await indexNameProperty(s, 'leaf', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('leaf', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('dataset', tree, connection.systemUserId()));
+
+      expect(ids.has(d)).to.equal(true);
+    });
+
+    /**
+     * Property-reference reach in BOTH directions. F(sample_site) → G(animal) via a property edge, NO parent
+     * link. Forward: evidence=F, closureForward(F)→G, anchor=animal returns G (the referenced feature).
+     * Reverse: evidence=G, closureReverse(G)→F, anchor=sample_site returns F (the referencing feature).
+     */
+    it('3: property-reference reach — referenced (forward) and referencing (reverse) both recovered', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const f = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'sample_site' });
+      const g = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'animal' });
+      const label = await mintPropertyEdgeLabel('sample_site', 'animal');
+      await insertPropertyEdge(f, g, label);
+      await indexNameProperty(f, 'ref', SAMPLE_SITE_NAME_FTP_ID);
+      // Index G with an animal-agnostic value reusing the sample_site slot only for evidence selection in
+      // the reverse sub-case; the predicate is type-agnostic and only needs a matching string row.
+      await indexNameProperty(g, 'ref-reverse', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      // (a) forward: filter F (referencing) -> anchor animal returns G (referenced).
+      const forwardTree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('ref', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const forwardIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('animal', forwardTree, connection.systemUserId())
+      );
+      expect(forwardIds.has(g)).to.equal(true);
+
+      // (b) reverse: filter G (referenced) -> anchor sample_site returns F (referencing).
+      const reverseTree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('ref-reverse', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const reverseIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('sample_site', reverseTree, connection.systemUserId())
+      );
+      expect(reverseIds.has(f)).to.equal(true);
+    });
+
+    /**
+     * Defense-in-depth: the security filter is re-applied to PROJECTED targets, not just evidence. evidence
+     * (sample_site, unsecured) and securedTarget (sample_site, parent=evidence) share one upload, so the
+     * closure connects them (parent edge securedTarget→evidence ⇒ closureReverse(evidence) reaches it). With
+     * systemUserId=null the secured target must NOT leak; with a privileged user (scope-granted) it appears.
+     */
+    it('4: secured projected target is filtered for anonymous and visible to a granted user', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const evidence = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site'
+      });
+      const securedTarget = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: evidence
+      });
+      await indexNameProperty(evidence, 'evidence-row', SAMPLE_SITE_NAME_FTP_ID);
+      await secureFeature(securedTarget);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('evidence-row', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+
+      // Anonymous: evidence (unsecured) is kept; the secured descendant must not leak.
+      const anonymousIds = await runSubquery(buildExpressionTreeFeatureIdsSubquery('sample_site', tree, null));
+      expect(anonymousIds.has(evidence)).to.equal(true);
+      expect(anonymousIds.has(securedTarget)).to.equal(false);
+
+      // Granted: stand up the scope-grant chain on the secured target, then the privileged user sees it.
+      await grantPrivilegedAccess(securedTarget);
+      const grantedIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('sample_site', tree, connection.systemUserId())
+      );
+      expect(grantedIds.has(securedTarget)).to.equal(true);
+    });
+
+    /**
+     * Reflexive reach. A single feature E(sample_site) with an empty closure and no content edges still
+     * returns itself, because content_reach is seeded from the evidence and always contains it.
+     */
+    it('5: reflexive — evidence returns itself with empty closure and no edges', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const e = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'sample_site' });
+      await indexNameProperty(e, 'self', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('self', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('sample_site', tree, connection.systemUserId())
+      );
+
+      expect(ids.has(e)).to.equal(true);
+    });
+
+    /**
+     * UNION dedup. F is reachable from evidence E both as a referenced feature (closureForward, via a
+     * property edge E→F) AND as a descendant (closureReverse, via parent F→E). UNION (not UNION ALL) must
+     * collapse the two paths so F appears EXACTLY ONCE — a downstream count(*) wrap must not double-count.
+     */
+    it('6: UNION dedup — a multi-path target appears exactly once', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const e = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'sample_site' });
+      // F is BOTH a descendant of E (parent edge F->E) and a referenced feature of E (property edge E->F).
+      const f = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'animal',
+        parentFeatureId: e
+      });
+      const label = await mintPropertyEdgeLabel('sample_site', 'animal');
+      await insertPropertyEdge(e, f, label);
+      await indexNameProperty(e, 'dedup', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('dedup', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const subquery = buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId());
+
+      expect(await runCount(subquery)).to.equal(1);
+      expect((await runSubquery(subquery)).has(f)).to.equal(true);
+    });
+
+    /**
+     * Content-only reach is preserved (no closure path). F(sample_site) ─content→ G(telemetry); G2(telemetry)
+     * has NO edge. The closure adds only self loops, so G is reached purely by the content walk; G2 (the
+     * control) proves it is the content edge doing the work, not incidental same-upload reach.
+     */
+    it('7: content-only — content neighbour reached, unconnected same-type decoy not', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const f = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'sample_site' });
+      const g = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'telemetry' });
+      const g2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'telemetry' });
+      await insertContentEdge(f, g);
+      await indexNameProperty(f, 'c', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('c', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('telemetry', tree, connection.systemUserId())
+      );
+
+      expect(ids.has(g)).to.equal(true);
+      expect(ids.has(g2)).to.equal(false);
+    });
+
+    /**
+     * Dataset has no synthetic same-upload fan-out. D(dataset) with a real descendant Y(animal, parent=D)
+     * and an UNCONNECTED same-upload X(animal). Evidence=D reaches Y via closureReverse but NOT X — the old
+     * dataset→every-feature-in-submission synthetic edge is gone.
+     */
+    it('8: dataset evidence reaches real descendants only, not unconnected same-upload features', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const d = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const y = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'animal',
+        parentFeatureId: d
+      });
+      const x = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'animal' });
+      await indexNameProperty(d, 'ds', DATASET_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('ds', DATASET_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId()));
+
+      expect(ids.has(y)).to.equal(true);
+      expect(ids.has(x)).to.equal(false);
+    });
+
+    /**
+     * Empty-closure behaviour, two halves. (a) Without computeClosureForUpload, ancestor reach is empty:
+     * P(dataset) ← E(sample_site), evidence=E, anchor=dataset → P ABSENT (the closure is what carries
+     * ancestor reach). (b) The content walk works WITHOUT a closure: E2(sample_site) ─content→ M(animal),
+     * evidence=E2, anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
+     */
+    it('9: empty closure — ancestor reach absent, content reach still works', async () => {
+      const submissionId = await createTestSubmission(connection);
+
+      // (a) ancestor reach needs the closure — do NOT rebuild it.
+      const uploadA = await createTestUpload(connection, submissionId);
+      const p = await insertFeatureRow({ submissionId, submissionUploadId: uploadA, featureTypeName: 'dataset' });
+      const e = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadA,
+        featureTypeName: 'sample_site',
+        parentFeatureId: p
+      });
+      await indexNameProperty(e, 'no-closure-ancestor', SAMPLE_SITE_NAME_FTP_ID);
+
+      const ancestorTree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('no-closure-ancestor', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ancestorIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('dataset', ancestorTree, connection.systemUserId())
+      );
+      expect(ancestorIds.has(p)).to.equal(false);
+
+      // (b) content reach does NOT need the closure — also do NOT rebuild it.
+      const uploadB = await createTestUpload(connection, submissionId);
+      const e2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadB, featureTypeName: 'sample_site' });
+      const m = await insertFeatureRow({ submissionId, submissionUploadId: uploadB, featureTypeName: 'animal' });
+      await insertContentEdge(e2, m);
+      await indexNameProperty(e2, 'no-closure-content', SAMPLE_SITE_NAME_FTP_ID);
+
+      const contentTree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('no-closure-content', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const contentIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('animal', contentTree, connection.systemUserId())
+      );
+      expect(contentIds.has(m)).to.equal(true);
+    });
+
+    /**
+     * AND/OR compose over closure-related features. Two datasets in separate uploads each have a child
+     * sample_site: D1 ← S1, D2 ← S2. An OR of [D1.name, D2.name] anchored at sample_site UNIONs the two
+     * descendant reaches (S1 and S2). An AND of [D1.name, D2.name] anchored at sample_site INTERSECTs them —
+     * no sample_site is a descendant of both datasets, so the intersection is empty. The raw combinator is
+     * already pinned by the self-match AND/OR tests; this guards that it composes correctly when leaves
+     * resolve THROUGH closure relatedness.
+     */
+    it('10: AND/OR compose over closure-related features (union widens, intersect narrows)', async () => {
+      const submissionId = await createTestSubmission(connection);
+
+      const uploadOne = await createTestUpload(connection, submissionId);
+      const d1 = await insertFeatureRow({ submissionId, submissionUploadId: uploadOne, featureTypeName: 'dataset' });
+      const s1 = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadOne,
+        featureTypeName: 'sample_site',
+        parentFeatureId: d1
+      });
+      await indexNameProperty(d1, 'compose-d1', DATASET_NAME_FTP_ID);
+
+      const uploadTwo = await createTestUpload(connection, submissionId);
+      const d2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadTwo, featureTypeName: 'dataset' });
+      const s2 = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadTwo,
+        featureTypeName: 'sample_site',
+        parentFeatureId: d2
+      });
+      await indexNameProperty(d2, 'compose-d2', DATASET_NAME_FTP_ID);
+
+      const closure = new SubmissionFeatureClosureService(connection);
+      await closure.computeClosureForUpload(uploadOne);
+      await closure.computeClosureForUpload(uploadTwo);
+
+      const orTree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'OR',
+        clauses: [namePredicate('compose-d1', DATASET_NAME_FTP_ID), namePredicate('compose-d2', DATASET_NAME_FTP_ID)]
+      };
+      const orIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('sample_site', orTree, connection.systemUserId())
+      );
+      expect(orIds.has(s1)).to.equal(true);
+      expect(orIds.has(s2)).to.equal(true);
+
+      const andTree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('compose-d1', DATASET_NAME_FTP_ID), namePredicate('compose-d2', DATASET_NAME_FTP_ID)]
+      };
+      const andIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('sample_site', andTree, connection.systemUserId())
+      );
+      // No sample_site descends from BOTH datasets, so the intersection of the two reaches is empty.
+      expect(andIds.has(s1)).to.equal(false);
+      expect(andIds.has(s2)).to.equal(false);
+    });
+
+    /**
+     * Cross-type anchor filter. D(dataset) ← A(animal) ← C(capture) under one upload; evidence=D reaches
+     * {A, C} via closureReverse plus D itself. Anchor=animal returns ONLY A — not C (capture), not D
+     * (dataset). The anchor type is the sole result filter over the reachable set.
+     */
+    it('11: anchor type filters the reachable set to one type', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const d = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const a = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'animal',
+        parentFeatureId: d
+      });
+      const c = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'capture',
+        parentFeatureId: a
+      });
+      await indexNameProperty(d, 'cross-type', DATASET_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('cross-type', DATASET_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId()));
+
+      expect(ids.has(a)).to.equal(true);
+      expect(ids.has(c)).to.equal(false);
+      expect(ids.has(d)).to.equal(false);
+    });
+
+    /**
+     * Multi-hop content chain (CRITICAL). Content edges A→B and B→C only (no A→C). Evidence=A; the recursive
+     * walk reaches C across TWO content hops (A→B→C). Anchor=telemetry returns C and not the unconnected
+     * decoy. This result would be EMPTY under a one-hop probe — that is the point of the recursive walk.
+     */
+    it('12: multi-hop content chain — target reached across two content hops', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const a = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'sample_site' });
+      const b = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'animal' });
+      const c = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'telemetry' });
+      const cDecoy = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'telemetry'
+      });
+      await insertContentEdge(a, b);
+      await insertContentEdge(b, c);
+      await indexNameProperty(a, 'chain', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('chain', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('telemetry', tree, connection.systemUserId())
+      );
+
+      expect(ids.has(c)).to.equal(true);
+      expect(ids.has(cDecoy)).to.equal(false);
+    });
+
+    /**
+     * content→closure chain. E ─content→ M, and M's parent is P (closure: M→P ancestor). Evidence=E;
+     * content_reach={E, M}; closureForward(M)→P. Anchor=capture returns P (and not the unconnected Pdecoy):
+     * a content neighbour contributes ITS closure ancestors because the closure is probed from content_reach.
+     */
+    it('13: content→closure chain — content neighbour contributes its closure ancestor', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const e = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'sample_site' });
+      const p = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'capture' });
+      const m = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'animal',
+        parentFeatureId: p
+      });
+      const pDecoy = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'capture'
+      });
+      await insertContentEdge(e, m);
+      await indexNameProperty(e, 'cc', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('cc', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('capture', tree, connection.systemUserId()));
+
+      expect(ids.has(p)).to.equal(true);
+      expect(ids.has(pDecoy)).to.equal(false);
+    });
+
+    /**
+     * ACCEPTED INTENTIONAL GAP (negative). A(capture) is rootless; E(sample_site, parent=A) so the closure
+     * gives E→A ancestor. A ─content→ Q (NOT E→Q). Evidence=E; content_reach={E} (E has no content edge).
+     * closureForward(E)→A, but A is reached via the CLOSURE, not content_reach, so A's content neighbour Q is
+     * never walked — the walk seeds only from evidence, not from closure results. Q must be ABSENT. This is a
+     * deliberate one-way design choice (closure-then-content is not recovered), not a bug.
+     */
+    it('14: accepted gap — closure-ancestor then ITS content edge is not recovered', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const a = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'capture' });
+      const e = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: a
+      });
+      const q = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'telemetry' });
+      await insertContentEdge(a, q);
+      await indexNameProperty(e, 'gap', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('gap', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('telemetry', tree, connection.systemUserId())
+      );
+
+      expect(ids.has(q)).to.equal(false);
+    });
+
+    /**
+     * Depth cap = MAX_SEARCH_GRAPH_DEPTH (6). A linear content chain n1→…→n8 (7 edges). n1 is depth 0; the
+     * deepest reachable node is 6 edges from the seed (depth 6 included, depth 7 excluded). n7 (animal) sits
+     * at depth 6 and is reachable; n8 (telemetry) sits at depth 7 and is truncated. n1..n6 are sample_site so
+     * the animal/telemetry anchors isolate n7 and n8.
+     */
+    it('15: depth cap — node at depth 6 reachable, node at depth 7 truncated', async () => {
+      expect(MAX_SEARCH_GRAPH_DEPTH).to.equal(6);
+
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const nodes: number[] = [];
+      for (let i = 0; i < 8; i++) {
+        const featureTypeName = i < 6 ? 'sample_site' : i === 6 ? 'animal' : 'telemetry';
+        nodes.push(await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName }));
+      }
+      for (let i = 0; i < nodes.length - 1; i++) {
+        await insertContentEdge(nodes[i], nodes[i + 1]);
+      }
+      await indexNameProperty(nodes[0], 'depth', SAMPLE_SITE_NAME_FTP_ID);
+
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('depth', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+
+      // n7 (index 6) is depth 6 — exactly at the cap — so it is reachable.
+      const animalIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId())
+      );
+      expect(animalIds.has(nodes[6])).to.equal(true);
+
+      // n8 (index 7) is depth 7 — one past the cap — so it is truncated.
+      const telemetryIds = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('telemetry', tree, connection.systemUserId())
+      );
+      expect(telemetryIds.has(nodes[7])).to.equal(false);
     });
   });
 });

--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -328,16 +328,34 @@ describe('expression-evaluation (integration)', function () {
       // the accessible type and an empty set for the inaccessible type. The pipeline still
       // completes (one Parquet per statement, some empty) — "5 in, 5 files, 1 empty" is a
       // valid, deliberate outcome, not a failure.
+      // The broad subquery's security filter resolves "is this feature secured" via the closure
+      // (isEffectivelySecuredViaClosure), so the secured `restricted` feature only reads as secured
+      // once its closure self-loop exists. Seed it under a shared upload and rebuild the closure
+      // BEFORE the subquery; otherwise an empty closure reads it as unsecured and it is NOT stripped.
       const submissionAccessible = await createTestSubmission(connection);
-      const accessible = await createTestFeature(connection, submissionAccessible, 'sample_site', { name: 'visible' });
+      const uploadAccessible = await createTestUpload(connection, submissionAccessible);
+      const accessible = await insertFeatureRow({
+        submissionId: submissionAccessible,
+        submissionUploadId: uploadAccessible,
+        featureTypeName: 'sample_site'
+      });
 
       const submissionRestricted = await createTestSubmission(connection);
-      const restricted = await createTestFeature(connection, submissionRestricted, 'capture', { comment: 'hidden' });
+      const uploadRestricted = await createTestUpload(connection, submissionRestricted);
+      const restricted = await insertFeatureRow({
+        submissionId: submissionRestricted,
+        submissionUploadId: uploadRestricted,
+        featureTypeName: 'capture'
+      });
 
       // Apply a security rule. With systemUserId=null (anonymous), the security filter
       // strips any secured feature — the same mechanism that strips features from a
       // statement whose policy creator lacks the matching team grant.
       await secureFeature(restricted);
+
+      const closure = new SubmissionFeatureClosureService(connection);
+      await closure.computeClosureForUpload(uploadAccessible);
+      await closure.computeClosureForUpload(uploadRestricted);
 
       // Per-statement subquery for the type the user CAN see → returns the row.
       const accessibleIds = await runSubquery(buildBroadFeatureTypeSubquery('sample_site', null));
@@ -411,18 +429,34 @@ describe('expression-evaluation (integration)', function () {
 
     it('security filter excludes features the user cannot read', async () => {
       // Evidence-side security: a secured candidate is dropped before projection, so it never reaches
-      // the result even as its own self-match.
+      // the result even as its own self-match. The drop is driven by the closure-based security filter
+      // (isEffectivelySecuredViaClosure), so each feature is seeded under its OWN upload and its closure
+      // self-loop is rebuilt BEFORE the subquery — without the self-loop the secured feature reads as
+      // unsecured and would NOT be stripped. Separate uploads keep the OR-tree reach narrow (each
+      // feature only self-matches; no shared upload means no incidental closure relatedness between them).
       const submissionOpen = await createTestSubmission(connection);
-      const open = await createTestFeature(connection, submissionOpen, 'sample_site', { name: 'Open-secfilter' });
+      const uploadOpen = await createTestUpload(connection, submissionOpen);
+      const open = await insertFeatureRow({
+        submissionId: submissionOpen,
+        submissionUploadId: uploadOpen,
+        featureTypeName: 'sample_site'
+      });
       await indexNameProperty(open, 'Open-secfilter');
 
       const submissionSecured = await createTestSubmission(connection);
-      const secured = await createTestFeature(connection, submissionSecured, 'sample_site', {
-        name: 'Secured-secfilter'
+      const uploadSecured = await createTestUpload(connection, submissionSecured);
+      const secured = await insertFeatureRow({
+        submissionId: submissionSecured,
+        submissionUploadId: uploadSecured,
+        featureTypeName: 'sample_site'
       });
       await indexNameProperty(secured, 'Secured-secfilter');
 
       await secureFeature(secured);
+
+      const closure = new SubmissionFeatureClosureService(connection);
+      await closure.computeClosureForUpload(uploadOpen);
+      await closure.computeClosureForUpload(uploadSecured);
 
       const tree: NormalizedExpressionTreeExpression = {
         type: 'expression',

--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -164,6 +164,26 @@ describe('expression-evaluation (integration)', function () {
   }
 
   /**
+   * Rebuild the closure for every upload holding an active feature of the submission.
+   *
+   * The security filter classifies a feature via `isEffectivelySecured`, which fails closed when the
+   * feature has no closure rows. `createTestFeature` mints a fresh upload per call and builds no closure,
+   * so its features need their self-loops rebuilt before the authenticated security filter reads them as
+   * active + unsecured rather than hidden-by-default.
+   */
+  async function rebuildClosureForSubmission(submissionId: number): Promise<void> {
+    const uploads = await connection.sql(SQL`
+      SELECT DISTINCT submission_upload_id
+      FROM submission_feature
+      WHERE submission_id = ${submissionId}
+        AND record_end_date IS NULL;
+    `);
+    for (const row of uploads.rows) {
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(row.submission_upload_id);
+    }
+  }
+
+  /**
    * Index a string `name` value on a feature so a predicate can find it as evidence.
    *
    * The evaluator JOINs feature_type_property and reads from submission_feature_property_string; both must
@@ -339,6 +359,10 @@ describe('expression-evaluation (integration)', function () {
       // Decoy of a different feature type — must not appear.
       const decoy = await createTestFeature(connection, submissionId, 'capture', { comment: 'cap' });
 
+      // Build the closure self-loops so the authenticated security filter reads these active features as
+      // unsecured, not hidden-by-default (isEffectivelySecured fails closed on missing closure rows).
+      await rebuildClosureForSubmission(submissionId);
+
       const subquery = buildBroadFeatureTypeSubquery('sample_site', connection.systemUserId());
       const ids = await runSubquery(subquery);
 
@@ -410,6 +434,10 @@ describe('expression-evaluation (integration)', function () {
       const other = await createTestFeature(connection, submissionOther, 'sample_site', { name: 'AND-other' });
       await indexNameProperty(other, 'AND-other');
 
+      // Self-loops so the authenticated security filter reads these as active + unsecured (fail-closed).
+      await rebuildClosureForSubmission(submissionTarget);
+      await rebuildClosureForSubmission(submissionOther);
+
       const tree: NormalizedExpressionTreeExpression = {
         type: 'expression',
         operator: 'AND',
@@ -437,6 +465,11 @@ describe('expression-evaluation (integration)', function () {
       const submissionDecoy = await createTestSubmission(connection);
       const decoy = await createTestFeature(connection, submissionDecoy, 'sample_site', { name: 'OR-decoy' });
       await indexNameProperty(decoy, 'OR-decoy');
+
+      // Self-loops so the authenticated security filter reads these as active + unsecured (fail-closed).
+      await rebuildClosureForSubmission(submissionA);
+      await rebuildClosureForSubmission(submissionB);
+      await rebuildClosureForSubmission(submissionDecoy);
 
       const tree: NormalizedExpressionTreeExpression = {
         type: 'expression',
@@ -758,10 +791,13 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Empty-closure behaviour, two halves. (a) Without computeClosureForUpload, closure ancestor reach is
-     * empty: A(sample_site) ← E(sample_site), evidence=E, anchor=sample_site → A ABSENT (the closure is what
-     * carries ancestor reach). (b) The content walk works WITHOUT a closure: E2(sample_site) ─content→ M(animal),
-     * evidence=E2, anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
+     * Empty-closure behaviour, two halves, evaluated on the authenticated path.
+     * (a) uploadA gets NO closure: A(sample_site) ← E(sample_site), evidence=E, anchor=sample_site → A
+     *     ABSENT. With no ancestry rows the parent A is unreachable from E, and (post fail-closed) E itself
+     *     reads as secured and is stripped — either way A does not appear.
+     * (b) uploadB's closure is rebuilt to self-loops only (no e2→m ancestor edge), so M stays reachable
+     *     SOLELY via the content walk while reading as a visible unsecured feature: E2(sample_site)
+     *     ─content→ M(animal), evidence=E2, anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
      */
     it('9: empty closure — closure ancestor reach absent, content reach still works', async () => {
       const submissionId = await createTestSubmission(connection);
@@ -791,12 +827,16 @@ describe('expression-evaluation (integration)', function () {
       );
       expect(ancestorIds.has(ancestorSite)).to.equal(false);
 
-      // (b) content reach does NOT need the closure — also do NOT rebuild it.
+      // (b) The content WALK still reaches m without any closure ancestry — but the security filter now
+      // fails closed on a feature with no closure rows, so rebuild uploadB's closure to give e2 and m their
+      // self-loops. m is NOT e2's child, so no e2→m ancestor edge is created: the content edge remains the
+      // ONLY thing that reaches m, while the self-loop lets the filter read m as a visible (unsecured) feature.
       const uploadB = await createTestUpload(connection, submissionId);
       const e2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadB, featureTypeName: 'sample_site' });
       const m = await insertFeatureRow({ submissionId, submissionUploadId: uploadB, featureTypeName: 'animal' });
       await insertContentEdge(e2, m);
       await indexNameProperty(e2, 'no-closure-content', SAMPLE_SITE_NAME_FTP_ID);
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadB);
 
       const contentTree: NormalizedExpressionTreeExpression = {
         type: 'expression',

--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -295,6 +295,34 @@ describe('expression-evaluation (integration)', function () {
     return result.rows[0].count;
   }
 
+  /**
+   * Seed a `dataset → animal → capture` parent chain under ONE upload, index `name` on the dataset, and
+   * rebuild the closure. The common fixture for closure descendant/ancestor reach tests anchored on the
+   * dataset name.
+   */
+  async function seedDatasetAnimalCaptureChain(
+    name: string
+  ): Promise<{ submissionId: number; uploadId: string; d: number; a: number; c: number }> {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(connection, submissionId);
+    const d = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+    const a = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'animal',
+      parentFeatureId: d
+    });
+    const c = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'capture',
+      parentFeatureId: a
+    });
+    await indexNameProperty(d, name, DATASET_NAME_FTP_ID);
+    await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+    return { submissionId, uploadId, d, a, c };
+  }
+
   /** Mint a real feature_type_property usable as a property-edge label, from source type to target type. */
   async function mintPropertyEdgeLabel(sourceFeatureType: string, targetFeatureType: string): Promise<number> {
     const { featureTypePropertyId } = await createFeatureTypeProperty(connection, sourceFeatureType, targetFeatureType);
@@ -478,25 +506,7 @@ describe('expression-evaluation (integration)', function () {
      * because the closure is probed in BOTH directions.
      */
     it('1: descendant reach — anchor below evidence is recovered via closureReverse', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(connection, submissionId);
-
-      const d = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
-      const a = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'animal',
-        parentFeatureId: d
-      });
-      const c = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'capture',
-        parentFeatureId: a
-      });
-      await indexNameProperty(d, 'Caribou Study', DATASET_NAME_FTP_ID);
-
-      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+      const { c } = await seedDatasetAnimalCaptureChain('Caribou Study');
 
       const tree: NormalizedExpressionTreeExpression = {
         type: 'expression',
@@ -871,25 +881,7 @@ describe('expression-evaluation (integration)', function () {
      * (dataset). The anchor type is the sole result filter over the reachable set.
      */
     it('11: anchor type filters the reachable set to one type', async () => {
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(connection, submissionId);
-
-      const d = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
-      const a = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'animal',
-        parentFeatureId: d
-      });
-      const c = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'capture',
-        parentFeatureId: a
-      });
-      await indexNameProperty(d, 'cross-type', DATASET_NAME_FTP_ID);
-
-      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+      const { d, a, c } = await seedDatasetAnimalCaptureChain('cross-type');
 
       const tree: NormalizedExpressionTreeExpression = {
         type: 'expression',
@@ -1025,9 +1017,11 @@ describe('expression-evaluation (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
 
+      // Chain of 8 nodes: indices 0-5 sample_site, 6 animal, 7 telemetry — the animal/telemetry anchors
+      // isolate the node at depth 6 (reachable) from the node at depth 7 (truncated).
+      const nodeTypes = [...Array.from({ length: 6 }, () => 'sample_site'), 'animal', 'telemetry'];
       const nodes: number[] = [];
-      for (let i = 0; i < 8; i++) {
-        const featureTypeName = i < 6 ? 'sample_site' : i === 6 ? 'animal' : 'telemetry';
+      for (const featureTypeName of nodeTypes) {
         nodes.push(await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName }));
       }
       for (let i = 0; i < nodes.length - 1; i++) {

--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -20,7 +20,9 @@ import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } 
 import { SecurityScopeRepository } from '../../repositories/authorization/security-scope-repository';
 import { SearchFeatureRepository } from '../../repositories/search-feature-repository';
 import { SecurityScopeService } from '../../services/access-policy/security-scope-service';
+import { SubmissionFeatureClosureService } from '../../services/submission-feature-closure-service';
 import { computeScopeHash } from '../../utils/scope-hash';
+import { createTestUpload } from '../helpers/test-feature-property-helpers';
 import {
   addTeamMember,
   computeAnchors,
@@ -94,6 +96,63 @@ describe('Security scope search (integration)', function () {
     `);
   }
 
+  /**
+   * Insert ONE submission_feature bound to a SPECIFIC upload, resolving feature_type_id by name.
+   *
+   * Read-path security is now resolved via the precomputed `submission_feature_closure`, which is
+   * UPLOAD-SCOPED and only links a parent and child when both share one submission_upload_id (both
+   * endpoints must be active features of the same upload). `createTestFeature` mints its OWN upload
+   * per call and cannot place a parent + child under one upload, so the closure-driven search-security
+   * fixtures insert features directly here under a shared upload. Mirrors the insertFeatureRow helper in
+   * cart-submission-feature-service.integration.ts / expression-evaluation.integration.ts.
+   *
+   * @returns The new submission_feature_id.
+   */
+  async function insertFeatureRow(params: {
+    submissionId: number;
+    submissionUploadId: string;
+    featureTypeName: string;
+    parentFeatureId?: number;
+  }): Promise<number> {
+    const systemUserId = connection.systemUserId();
+
+    const result = await connection.sql(SQL`
+      INSERT INTO submission_feature (
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        parent_submission_feature_id,
+        data,
+        data_byte_size,
+        record_effective_date,
+        create_user
+      )
+      VALUES (
+        ${params.submissionId},
+        ${params.submissionUploadId}::uuid,
+        (SELECT feature_type_id FROM feature_type WHERE name = ${params.featureTypeName} LIMIT 1),
+        ${params.parentFeatureId ?? null},
+        '{}'::jsonb,
+        500,
+        now(),
+        ${systemUserId}
+      )
+      RETURNING submission_feature_id;
+    `);
+
+    return result.rows[0].submission_feature_id;
+  }
+
+  /**
+   * Recompute the upload-scoped closure (self-loops + parent ancestry + property edges) for the given
+   * upload. Read-path search security (isEffectivelySecuredViaClosure / isAccessibleToUser) reads this
+   * closure, so it MUST be rebuilt AFTER seeding + securing and BEFORE the first search — otherwise the
+   * fragment finds nothing and every feature reads as unsecured.
+   */
+  async function rebuildClosure(uploadId: string): Promise<void> {
+    await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+  }
+
   async function countAnchors(securityScopeId: string): Promise<number> {
     const result = await connection.sql(SQL`
       SELECT count(*)::integer as count FROM security_scope_anchor
@@ -105,14 +164,26 @@ describe('Security scope search (integration)', function () {
   /**
    * Create a submission with a single secured feature and a scope chain for it.
    * Covers the common "one feature, one policy, one scope" setup pattern.
+   *
+   * The feature is seeded under a shared upload and the closure is rebuilt so the read path
+   * (searchInSubmission) resolves the feature's "directly secured" check via its closure self-loop.
+   * The anchor-recompute job tests that also use this helper read anchors (computed via the recursive
+   * isEffectivelySecured parent walk) and are unaffected by the closure rebuild.
    */
   async function setupSecuredScope(
-    featureName: string,
+    _featureName: string,
     policyName: string
   ): Promise<{ submissionId: number; featureId: number; scopeId: string; policyId: string; stmtId: string }> {
     const submissionId = await createTestSubmission(connection);
-    const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: featureName });
+    const uploadId = await createTestUpload(connection, submissionId);
+    const featureId = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'dataset'
+    });
     await secureFeature(connection, featureId);
+
+    await rebuildClosure(uploadId);
 
     const urn = `urn:${submissionId}:*:*`;
     const policyId = await createPolicy(connection, policyName);
@@ -133,10 +204,24 @@ describe('Security scope search (integration)', function () {
     urnOverride?: (submissionId: number, childId: number) => string
   ): Promise<{ submissionId: number; datasetId: number; childId: number; scopeId: string; policyId: string }> {
     const submissionId = await createTestSubmission(connection);
-    const datasetId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
-    const childId = await createTestFeature(connection, submissionId, childType, { name: 'Child' }, datasetId);
+    // Parent + child must share ONE upload so the closure stores the child -> dataset ancestor edge;
+    // securing the dataset then makes the child read as effectively secured (inherited) on the read path.
+    const uploadId = await createTestUpload(connection, submissionId);
+    const datasetId = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'dataset'
+    });
+    const childId = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: childType,
+      parentFeatureId: datasetId
+    });
 
     await secureFeature(connection, datasetId);
+
+    await rebuildClosure(uploadId);
 
     const urn = urnOverride ? urnOverride(submissionId, childId) : `urn:${submissionId}:${childType}:*`;
     const policyId = await createPolicy(connection, policyName);
@@ -501,11 +586,27 @@ describe('Security scope search (integration)', function () {
   // ── Search with security scopes ──────────────────────────────────────
 
   describe('Search with security scopes', () => {
+    // Read-path security is resolved via the precomputed submission_feature_closure
+    // (isEffectivelySecuredViaClosure / isAccessibleToUser), not a live recursive parent walk. The
+    // closure is UPLOAD-SCOPED, so every fixture here seeds its features under a SHARED upload
+    // (createTestUpload + insertFeatureRow) and rebuilds the closure AFTER seeding + securing and BEFORE
+    // the first search — otherwise the fragment finds nothing and every feature reads as unsecured.
     it('should show authorized secured features to authenticated user with matching scope', async () => {
       const submissionId = await createTestSubmission(connection);
-      const openFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Open' });
-      const securedFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const openFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const securedFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedFeature);
+
+      await rebuildClosure(uploadId);
 
       const userId = connection.systemUserId();
       await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, 'Auth Team');
@@ -522,9 +623,20 @@ describe('Security scope search (integration)', function () {
 
     it('should hide secured features from anonymous user', async () => {
       const submissionId = await createTestSubmission(connection);
-      const openFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Open' });
-      const securedFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const openFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const securedFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedFeature);
+
+      await rebuildClosure(uploadId);
 
       const results = await searchInSubmission(submissionId, ['dataset'], null);
       const featureIds = results.map((r) => r.submission_feature_id);
@@ -535,9 +647,20 @@ describe('Security scope search (integration)', function () {
 
     it('should hide secured features from authenticated user without matching scope', async () => {
       const submissionId = await createTestSubmission(connection);
-      const openFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Open' });
-      const securedFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const openFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const securedFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedFeature);
+
+      await rebuildClosure(uploadId);
 
       // User exists but has no team/policy/scope
       const userId = await createOtherUser();
@@ -550,33 +673,38 @@ describe('Security scope search (integration)', function () {
     });
 
     it('should hide descendant from anonymous when only the grandparent is secured (deep hierarchy)', async () => {
-      // Hierarchy: dataset(secured) → sample_site(open) → species_observation(open)
-      // The ancestor walk in buildSecurityFilter must find dataset's security row
-      // two levels up from species_observation and hide it.
+      // Hierarchy: dataset(secured) → sample_site(open) → species_observation(open), all under ONE upload
+      // so the closure stores each descendant's ancestry up to the secured grandparent.
+      // isEffectivelySecuredViaClosure resolves grandparent's security two levels up and hides the subtree.
       const submissionId = await createTestSubmission(connection);
-      const grandparent = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Root' });
-      const parent = await createTestFeature(
-        connection,
+      const uploadId = await createTestUpload(connection, submissionId);
+      const grandparent = await insertFeatureRow({
         submissionId,
-        'sample_site',
-        { name: 'Open Mid' },
-        grandparent
-      );
-      const child = await createTestFeature(
-        connection,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const parent = await insertFeatureRow({
         submissionId,
-        'species_observation',
-        { name: 'Open Leaf' },
-        parent
-      );
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: grandparent
+      });
+      const child = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'species_observation',
+        parentFeatureId: parent
+      });
 
-      // Only secure the root — descendants inherit security via ancestor walk
+      // Only secure the root — descendants inherit security via closure ancestry
       await secureFeature(connection, grandparent);
+
+      await rebuildClosure(uploadId);
 
       const results = await searchInSubmission(submissionId, ['dataset', 'sample_site', 'species_observation'], null);
       const featureIds = results.map((r) => r.submission_feature_id);
 
-      // All three should be hidden — grandparent is secured, and the ancestor walk
+      // All three should be hidden — grandparent is secured, and the closure ancestry
       // makes its descendants invisible to anonymous users
       expect(featureIds).to.not.include(grandparent);
       expect(featureIds).to.not.include(parent);
@@ -584,27 +712,32 @@ describe('Security scope search (integration)', function () {
     });
 
     it('should grant authenticated user access to deep descendants via scope anchored at grandparent', async () => {
-      // Hierarchy: dataset(secured) → sample_site(open) → species_observation(open)
-      // Scope anchored at dataset. Authenticated user should see all three because
-      // the ancestor walk finds the anchor in each feature's ancestor chain.
+      // Hierarchy: dataset(secured) → sample_site(open) → species_observation(open), all under ONE upload.
+      // Scope anchored at dataset. Authenticated user should see all three because isAccessibleToUser
+      // Branch 2 finds the anchor in each feature's closure ancestry.
       const submissionId = await createTestSubmission(connection);
-      const grandparent = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Root' });
-      const parent = await createTestFeature(
-        connection,
+      const uploadId = await createTestUpload(connection, submissionId);
+      const grandparent = await insertFeatureRow({
         submissionId,
-        'sample_site',
-        { name: 'Open Mid' },
-        grandparent
-      );
-      const child = await createTestFeature(
-        connection,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const parent = await insertFeatureRow({
         submissionId,
-        'species_observation',
-        { name: 'Open Leaf' },
-        parent
-      );
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: grandparent
+      });
+      const child = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'species_observation',
+        parentFeatureId: parent
+      });
 
       await secureFeature(connection, grandparent);
+
+      await rebuildClosure(uploadId);
 
       const userId = connection.systemUserId();
       await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, 'Deep Access Team');
@@ -621,23 +754,28 @@ describe('Security scope search (integration)', function () {
     it('should hide deep descendants from authenticated user without matching scope (deep hierarchy)', async () => {
       // Same hierarchy, but user has no scope — should behave like anonymous for secured subtree
       const submissionId = await createTestSubmission(connection);
-      const grandparent = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Root' });
-      const parent = await createTestFeature(
-        connection,
+      const uploadId = await createTestUpload(connection, submissionId);
+      const grandparent = await insertFeatureRow({
         submissionId,
-        'sample_site',
-        { name: 'Open Mid' },
-        grandparent
-      );
-      const child = await createTestFeature(
-        connection,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const parent = await insertFeatureRow({
         submissionId,
-        'species_observation',
-        { name: 'Open Leaf' },
-        parent
-      );
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: grandparent
+      });
+      const child = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'species_observation',
+        parentFeatureId: parent
+      });
 
       await secureFeature(connection, grandparent);
+
+      await rebuildClosure(uploadId);
 
       const userId = await createOtherUser();
 
@@ -651,10 +789,13 @@ describe('Security scope search (integration)', function () {
 
     it('should grant access to all secured features via wildcard scope', async () => {
       const submissionId = await createTestSubmission(connection);
-      const feat1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'DS 1' });
-      const feat2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'DS 2' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const feat1 = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const feat2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
       await secureFeature(connection, feat1);
       await secureFeature(connection, feat2);
+
+      await rebuildClosure(uploadId);
 
       const userId = connection.systemUserId();
       await setupFullAccess(connection, scopeRepo, 'urn:*:*:*', userId, 'Wildcard Team');
@@ -736,8 +877,15 @@ describe('Security scope search (integration)', function () {
 
     it('should block search access after policy deletion makes scope orphaned', async () => {
       const submissionId = await createTestSubmission(connection);
-      const securedFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Soon Hidden' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const securedFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedFeature);
+
+      await rebuildClosure(uploadId);
 
       const userId = connection.systemUserId();
       const { stmtId, teamId } = await setupFullAccess(
@@ -765,14 +913,26 @@ describe('Security scope search (integration)', function () {
 
   describe('Policy update → scope replacement', () => {
     it('should replace scopes and clean up orphaned anchors when statements are updated', async () => {
-      // Two submissions, each with a secured feature
+      // Two submissions, each with a secured feature under its own upload (closure rebuilt per upload)
       const sub1 = await createTestSubmission(connection);
-      const feat1 = await createTestFeature(connection, sub1, 'dataset', { name: 'Sub1 DS' });
+      const upload1 = await createTestUpload(connection, sub1);
+      const feat1 = await insertFeatureRow({
+        submissionId: sub1,
+        submissionUploadId: upload1,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, feat1);
+      await rebuildClosure(upload1);
 
       const sub2 = await createTestSubmission(connection);
-      const feat2 = await createTestFeature(connection, sub2, 'dataset', { name: 'Sub2 DS' });
+      const upload2 = await createTestUpload(connection, sub2);
+      const feat2 = await insertFeatureRow({
+        submissionId: sub2,
+        submissionUploadId: upload2,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, feat2);
+      await rebuildClosure(upload2);
 
       // Policy initially targets sub1
       const policyId = await createPolicy(connection, 'update-test');
@@ -823,8 +983,15 @@ describe('Security scope search (integration)', function () {
   describe('Team-policy deletion → access removal', () => {
     it('should remove team access and block search when team-policy is deleted', async () => {
       const submissionId = await createTestSubmission(connection);
-      const securedFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Team Access' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const securedFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedFeature);
+
+      await rebuildClosure(uploadId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'team-delete-test');
@@ -858,12 +1025,24 @@ describe('Security scope search (integration)', function () {
       // Team has Policy A (sub1 scope) and Policy B (sub2 scope).
       // Deleting team-policy A should leave sub2's scope intact.
       const sub1 = await createTestSubmission(connection);
-      const feat1 = await createTestFeature(connection, sub1, 'dataset', { name: 'Sub1 Secured' });
+      const upload1 = await createTestUpload(connection, sub1);
+      const feat1 = await insertFeatureRow({
+        submissionId: sub1,
+        submissionUploadId: upload1,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, feat1);
+      await rebuildClosure(upload1);
 
       const sub2 = await createTestSubmission(connection);
-      const feat2 = await createTestFeature(connection, sub2, 'dataset', { name: 'Sub2 Secured' });
+      const upload2 = await createTestUpload(connection, sub2);
+      const feat2 = await insertFeatureRow({
+        submissionId: sub2,
+        submissionUploadId: upload2,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, feat2);
+      await rebuildClosure(upload2);
 
       // Policy A covers sub1, Policy B covers sub2
       const policyA = await createPolicy(connection, 'multi-tp-A');
@@ -911,8 +1090,15 @@ describe('Security scope search (integration)', function () {
       // Policy A and Policy B both use same URN → same shared scope.
       // Deleting team-policy A should leave the scope intact via Policy B.
       const submissionId = await createTestSubmission(connection);
-      const securedFeature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Overlap' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const securedFeature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, securedFeature);
+
+      await rebuildClosure(uploadId);
 
       const urn = `urn:${submissionId}:*:*`;
 
@@ -1216,15 +1402,26 @@ describe('Security scope search (integration)', function () {
   // ── record_effective_date → search visibility ───────────────────────
 
   describe('record_effective_date → search visibility', () => {
+    // Read-path security reads the closure. The closure's active universe is record_end_date IS NULL only
+    // (it does NOT filter on record_effective_date), so the self-loop / ancestry rows exist regardless of
+    // approval; the effective-date predicate lives in isEffectivelySecuredViaClosure (sf_sec.record_effective_date
+    // <= now()). Each fixture seeds under a SHARED upload and rebuilds the closure before searching.
     for (const { label, markFn } of [
       { label: 'NULL', markFn: markFeatureUnapproved },
       { label: 'in the future', markFn: markFeatureFutureDate }
     ] as const) {
       it(`should NOT hide feature from anonymous when security rule exists but record_effective_date is ${label}`, async () => {
         const submissionId = await createTestSubmission(connection);
-        const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: `Secured ${label}` });
+        const uploadId = await createTestUpload(connection, submissionId);
+        const featureId = await insertFeatureRow({
+          submissionId,
+          submissionUploadId: uploadId,
+          featureTypeName: 'dataset'
+        });
         await secureFeature(connection, featureId);
         await markFn(featureId);
+
+        await rebuildClosure(uploadId);
 
         const results = await searchInSubmission(submissionId, ['dataset'], null);
         const featureIds = results.map((r) => r.submission_feature_id);
@@ -1236,11 +1433,18 @@ describe('Security scope search (integration)', function () {
     }
 
     it('should hide feature from anonymous when security rule exists and record_effective_date is approved', async () => {
-      // Baseline: createTestFeature sets record_effective_date = now(), so feature
+      // Baseline: insertFeatureRow sets record_effective_date = now(), so feature
       // with a security rule IS effectively secured. Anonymous should NOT see it.
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Approved Secured' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, featureId);
+
+      await rebuildClosure(uploadId);
 
       const results = await searchInSubmission(submissionId, ['dataset'], null);
       const featureIds = results.map((r) => r.submission_feature_id);
@@ -1252,10 +1456,18 @@ describe('Security scope search (integration)', function () {
       // Parent has a security rule but NULL record_effective_date. The parent is
       // NOT effectively secured, so its child should remain visible.
       const submissionId = await createTestSubmission(connection);
-      const parent = await createTestFeature(connection, submissionId, 'dataset', { name: 'Unapproved Parent' });
-      const child = await createTestFeature(connection, submissionId, 'sample_site', { name: 'Child' }, parent);
+      const uploadId = await createTestUpload(connection, submissionId);
+      const parent = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const child = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: parent
+      });
       await secureFeature(connection, parent);
       await markFeatureUnapproved(parent);
+
+      await rebuildClosure(uploadId);
 
       const results = await searchInSubmission(submissionId, ['dataset', 'sample_site'], null);
       const featureIds = results.map((r) => r.submission_feature_id);
@@ -1266,11 +1478,19 @@ describe('Security scope search (integration)', function () {
 
     it('should hide child from anonymous when parent is secured and approved', async () => {
       // Parent has a security rule AND record_effective_date = now(). The parent IS
-      // effectively secured, so its child inherits security and is hidden.
+      // effectively secured, so its child inherits security via closure ancestry and is hidden.
       const submissionId = await createTestSubmission(connection);
-      const parent = await createTestFeature(connection, submissionId, 'dataset', { name: 'Approved Parent' });
-      const child = await createTestFeature(connection, submissionId, 'sample_site', { name: 'Child' }, parent);
+      const uploadId = await createTestUpload(connection, submissionId);
+      const parent = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const child = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: parent
+      });
       await secureFeature(connection, parent);
+
+      await rebuildClosure(uploadId);
 
       const results = await searchInSubmission(submissionId, ['dataset', 'sample_site'], null);
       const featureIds = results.map((r) => r.submission_feature_id);
@@ -1283,9 +1503,16 @@ describe('Security scope search (integration)', function () {
       // Authenticated user without scope grants sees the same as anonymous for the
       // "not secured" branch. Unapproved security rule → feature is visible.
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Unapproved Auth' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, featureId);
       await markFeatureUnapproved(featureId);
+
+      await rebuildClosure(uploadId);
 
       const userId = await createOtherUser();
       const results = await searchInSubmission(submissionId, ['dataset'], userId);
@@ -1296,9 +1523,16 @@ describe('Security scope search (integration)', function () {
 
     it('should NOT hide feature from authenticated user (no scope) when record_effective_date is in the future', async () => {
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Future Auth' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, featureId);
       await markFeatureFutureDate(featureId);
+
+      await rebuildClosure(uploadId);
 
       const userId = await createOtherUser();
       const results = await searchInSubmission(submissionId, ['dataset'], userId);
@@ -1310,8 +1544,15 @@ describe('Security scope search (integration)', function () {
     it('should hide feature from authenticated user (no scope) when record_effective_date is approved', async () => {
       // Approved security rule + no scope grant → feature is hidden, same as anonymous.
       const submissionId = await createTestSubmission(connection);
-      const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Approved Auth' });
+      const uploadId = await createTestUpload(connection, submissionId);
+      const featureId = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
       await secureFeature(connection, featureId);
+
+      await rebuildClosure(uploadId);
 
       const userId = await createOtherUser();
       const results = await searchInSubmission(submissionId, ['dataset'], userId);

--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -579,6 +579,9 @@ describe('Security scope search (integration)', function () {
     it('should compute zero anchors when no matching secured features exist', async () => {
       const submissionId = await createTestSubmission(connection);
       await createTestFeature(connection, submissionId, 'dataset', { name: 'Unsecured' });
+      // Build the self-loop so the unsecured feature reads as effectively unsecured rather than
+      // hidden-by-default — isEffectivelySecured fails closed when a feature has no closure rows.
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:dataset:*`;
       const policyId = await createPolicy(connection, 'no-anchor-test');
@@ -1306,6 +1309,9 @@ describe('Security scope search (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const dataset = await createTestFeature(connection, submissionId, 'dataset', { name: 'Public Dataset' });
       await createTestFeature(connection, submissionId, 'telemetry', { name: 'Public Telemetry' }, dataset);
+      // Build the self-loops so both unsecured features read as effectively unsecured rather than
+      // hidden-by-default — isEffectivelySecured fails closed when a feature has no closure rows.
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:telemetry:*`;
       const policyId = await createPolicy(connection, 'no-security-test');

--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -255,6 +255,57 @@ describe('Security scope search (integration)', function () {
   }
 
   /**
+   * Seed one secured `dataset` feature under its own shared upload, closure rebuilt — the common
+   * "one submission, one secured feature, ready for a scope chain or search" fixture.
+   */
+  async function seedSecuredDataset(): Promise<{ submissionId: number; uploadId: string; featureId: number }> {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(connection, submissionId);
+    const featureId = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'dataset'
+    });
+    await secureFeature(connection, featureId);
+    await rebuildClosure(uploadId);
+    return { submissionId, uploadId, featureId };
+  }
+
+  /**
+   * Seed a 3-level hierarchy (dataset → sample_site → species_observation) under ONE upload with only the
+   * grandparent (dataset) secured, closure rebuilt. Descendants inherit security via the closure ancestry.
+   */
+  async function seedSecuredGrandparentHierarchy(): Promise<{
+    submissionId: number;
+    grandparent: number;
+    parent: number;
+    child: number;
+  }> {
+    const submissionId = await createTestSubmission(connection);
+    const uploadId = await createTestUpload(connection, submissionId);
+    const grandparent = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'dataset'
+    });
+    const parent = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'sample_site',
+      parentFeatureId: grandparent
+    });
+    const child = await insertFeatureRow({
+      submissionId,
+      submissionUploadId: uploadId,
+      featureTypeName: 'species_observation',
+      parentFeatureId: parent
+    });
+    await secureFeature(connection, grandparent);
+    await rebuildClosure(uploadId);
+    return { submissionId, grandparent, parent, child };
+  }
+
+  /**
    * Query anchor feature IDs for a scope.
    */
   async function getAnchorIds(scopeId: string): Promise<number[]> {
@@ -704,30 +755,7 @@ describe('Security scope search (integration)', function () {
       // Hierarchy: dataset(secured) → sample_site(open) → species_observation(open), all under ONE upload
       // so the closure stores each descendant's ancestry up to the secured grandparent.
       // isEffectivelySecured resolves grandparent's security two levels up and hides the subtree.
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(connection, submissionId);
-      const grandparent = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'dataset'
-      });
-      const parent = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'sample_site',
-        parentFeatureId: grandparent
-      });
-      const child = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'species_observation',
-        parentFeatureId: parent
-      });
-
-      // Only secure the root — descendants inherit security via closure ancestry
-      await secureFeature(connection, grandparent);
-
-      await rebuildClosure(uploadId);
+      const { submissionId, grandparent, parent, child } = await seedSecuredGrandparentHierarchy();
 
       const results = await searchInSubmission(submissionId, ['dataset', 'sample_site', 'species_observation'], null);
       const featureIds = results.map((r) => r.submission_feature_id);
@@ -743,29 +771,7 @@ describe('Security scope search (integration)', function () {
       // Hierarchy: dataset(secured) → sample_site(open) → species_observation(open), all under ONE upload.
       // Scope anchored at dataset. Authenticated user should see all three because isAccessibleToUser
       // Branch 2 finds the anchor in each feature's closure ancestry.
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(connection, submissionId);
-      const grandparent = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'dataset'
-      });
-      const parent = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'sample_site',
-        parentFeatureId: grandparent
-      });
-      const child = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'species_observation',
-        parentFeatureId: parent
-      });
-
-      await secureFeature(connection, grandparent);
-
-      await rebuildClosure(uploadId);
+      const { submissionId, grandparent, parent, child } = await seedSecuredGrandparentHierarchy();
 
       const userId = connection.systemUserId();
       await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, userId, 'Deep Access Team');
@@ -781,29 +787,7 @@ describe('Security scope search (integration)', function () {
 
     it('should hide deep descendants from authenticated user without matching scope (deep hierarchy)', async () => {
       // Same hierarchy, but user has no scope — should behave like anonymous for secured subtree
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(connection, submissionId);
-      const grandparent = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'dataset'
-      });
-      const parent = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'sample_site',
-        parentFeatureId: grandparent
-      });
-      const child = await insertFeatureRow({
-        submissionId,
-        submissionUploadId: uploadId,
-        featureTypeName: 'species_observation',
-        parentFeatureId: parent
-      });
-
-      await secureFeature(connection, grandparent);
-
-      await rebuildClosure(uploadId);
+      const { submissionId, grandparent, parent, child } = await seedSecuredGrandparentHierarchy();
 
       const userId = await createOtherUser();
 
@@ -943,25 +927,8 @@ describe('Security scope search (integration)', function () {
   describe('Policy update → scope replacement', () => {
     it('should replace scopes and clean up orphaned anchors when statements are updated', async () => {
       // Two submissions, each with a secured feature under its own upload (closure rebuilt per upload)
-      const sub1 = await createTestSubmission(connection);
-      const upload1 = await createTestUpload(connection, sub1);
-      const feat1 = await insertFeatureRow({
-        submissionId: sub1,
-        submissionUploadId: upload1,
-        featureTypeName: 'dataset'
-      });
-      await secureFeature(connection, feat1);
-      await rebuildClosure(upload1);
-
-      const sub2 = await createTestSubmission(connection);
-      const upload2 = await createTestUpload(connection, sub2);
-      const feat2 = await insertFeatureRow({
-        submissionId: sub2,
-        submissionUploadId: upload2,
-        featureTypeName: 'dataset'
-      });
-      await secureFeature(connection, feat2);
-      await rebuildClosure(upload2);
+      const { submissionId: sub1, featureId: feat1 } = await seedSecuredDataset();
+      const { submissionId: sub2, featureId: feat2 } = await seedSecuredDataset();
 
       // Policy initially targets sub1
       const policyId = await createPolicy(connection, 'update-test');
@@ -1053,25 +1020,8 @@ describe('Security scope search (integration)', function () {
     it('should preserve scopes from remaining policies when one team-policy is deleted', async () => {
       // Team has Policy A (sub1 scope) and Policy B (sub2 scope).
       // Deleting team-policy A should leave sub2's scope intact.
-      const sub1 = await createTestSubmission(connection);
-      const upload1 = await createTestUpload(connection, sub1);
-      const feat1 = await insertFeatureRow({
-        submissionId: sub1,
-        submissionUploadId: upload1,
-        featureTypeName: 'dataset'
-      });
-      await secureFeature(connection, feat1);
-      await rebuildClosure(upload1);
-
-      const sub2 = await createTestSubmission(connection);
-      const upload2 = await createTestUpload(connection, sub2);
-      const feat2 = await insertFeatureRow({
-        submissionId: sub2,
-        submissionUploadId: upload2,
-        featureTypeName: 'dataset'
-      });
-      await secureFeature(connection, feat2);
-      await rebuildClosure(upload2);
+      const { submissionId: sub1, featureId: feat1 } = await seedSecuredDataset();
+      const { submissionId: sub2, featureId: feat2 } = await seedSecuredDataset();
 
       // Policy A covers sub1, Policy B covers sub2
       const policyA = await createPolicy(connection, 'multi-tp-A');
@@ -1668,15 +1618,7 @@ describe('Security scope search (integration)', function () {
     it('should prune anchor when record_effective_date is set to NULL after initial computation', async () => {
       // Compute anchors for an approved+secured feature, then de-approve it.
       // deleteStaleAnchorBatch should remove the now-stale anchor.
-      const submissionId = await createTestSubmission(connection);
-      const dataset = await createTestFeature(connection, submissionId, 'dataset', { name: 'De-approved Dataset' });
-      await secureFeature(connection, dataset);
-      await rebuildClosureForSubmission(submissionId);
-
-      const urn = `urn:${submissionId}:*:*`;
-      const policyId = await createPolicy(connection, 'de-approve-anchor-test');
-      const stmtId = await createPolicyStatement(connection, policyId, urn);
-      const scopeId = await setupScopeChain(scopeRepo, stmtId, urn);
+      const { featureId: dataset, scopeId } = await setupSecuredScope('De-approved Dataset', 'de-approve-anchor-test');
 
       // Anchor exists for the approved+secured feature
       expect(await countAnchors(scopeId)).to.equal(1);

--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -145,12 +145,36 @@ describe('Security scope search (integration)', function () {
 
   /**
    * Recompute the upload-scoped closure (self-loops + parent ancestry + property edges) for the given
-   * upload. Read-path search security (isEffectivelySecuredViaClosure / isAccessibleToUser) reads this
+   * upload. Read-path search security (isEffectivelySecured / isAccessibleToUser) reads this
    * closure, so it MUST be rebuilt AFTER seeding + securing and BEFORE the first search — otherwise the
    * fragment finds nothing and every feature reads as unsecured.
    */
   async function rebuildClosure(uploadId: string): Promise<void> {
     await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+  }
+
+  /**
+   * Rebuild the closure for every upload that holds an active feature of the submission.
+   *
+   * The anchor-recompute write path now reads `isEffectivelySecured`, so a feature only reads
+   * as effectively secured when its closure rows exist. `createTestFeature` / `createTestFeaturesInBulk`
+   * mint a fresh upload per call (or per bulk batch), so directly-secured features each need their own
+   * upload's self-loop rebuilt. Cross-feature ancestry is still resolved by the recompute's live
+   * `ancestor_walk` over parent pointers, so per-upload self-loops are sufficient whenever the secured
+   * feature is secured directly. Tests that depend on a feature inheriting security from an ancestor must
+   * instead co-locate the hierarchy under ONE upload (createTestUpload + insertFeatureRow) so the closure
+   * stores the ancestry edge.
+   */
+  async function rebuildClosureForSubmission(submissionId: number): Promise<void> {
+    const uploads = await connection.sql(SQL`
+      SELECT DISTINCT submission_upload_id
+      FROM submission_feature
+      WHERE submission_id = ${submissionId}
+        AND record_end_date IS NULL;
+    `);
+    for (const row of uploads.rows) {
+      await rebuildClosure(row.submission_upload_id);
+    }
   }
 
   async function countAnchors(securityScopeId: string): Promise<number> {
@@ -165,10 +189,9 @@ describe('Security scope search (integration)', function () {
    * Create a submission with a single secured feature and a scope chain for it.
    * Covers the common "one feature, one policy, one scope" setup pattern.
    *
-   * The feature is seeded under a shared upload and the closure is rebuilt so the read path
-   * (searchInSubmission) resolves the feature's "directly secured" check via its closure self-loop.
-   * The anchor-recompute job tests that also use this helper read anchors (computed via the recursive
-   * isEffectivelySecured parent walk) and are unaffected by the closure rebuild.
+   * The feature is seeded under a shared upload and the closure is rebuilt so both the read path
+   * (searchInSubmission) and the anchor-recompute write path resolve the feature's "directly secured"
+   * check via its closure self-loop — both now read `isEffectivelySecured`.
    */
   async function setupSecuredScope(
     _featureName: string,
@@ -397,6 +420,8 @@ describe('Security scope search (integration)', function () {
       await markFeatureUnapproved(dataset);
     }
 
+    await rebuildClosureForSubmission(submissionId);
+
     const urn = `urn:${submissionId}:*:*`;
     const policyId = await createPolicy(connection, policyName);
     const stmtId = await createPolicyStatement(connection, policyId, urn);
@@ -428,6 +453,8 @@ describe('Security scope search (integration)', function () {
     for (const f of securedFeatures) {
       await secureFeature(connection, featureMap[f]);
     }
+
+    await rebuildClosureForSubmission(submissionId);
 
     const urnStr = urn(ids);
     const policyId = await createPolicy(connection, policyName);
@@ -483,6 +510,7 @@ describe('Security scope search (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Anchor Target' });
       await secureFeature(connection, featureId);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:dataset:*`;
       const policyId = await createPolicy(connection, 'anchor-test');
@@ -587,7 +615,7 @@ describe('Security scope search (integration)', function () {
 
   describe('Search with security scopes', () => {
     // Read-path security is resolved via the precomputed submission_feature_closure
-    // (isEffectivelySecuredViaClosure / isAccessibleToUser), not a live recursive parent walk. The
+    // (isEffectivelySecured / isAccessibleToUser), not a live recursive parent walk. The
     // closure is UPLOAD-SCOPED, so every fixture here seeds its features under a SHARED upload
     // (createTestUpload + insertFeatureRow) and rebuilds the closure AFTER seeding + securing and BEFORE
     // the first search — otherwise the fragment finds nothing and every feature reads as unsecured.
@@ -675,7 +703,7 @@ describe('Security scope search (integration)', function () {
     it('should hide descendant from anonymous when only the grandparent is secured (deep hierarchy)', async () => {
       // Hierarchy: dataset(secured) → sample_site(open) → species_observation(open), all under ONE upload
       // so the closure stores each descendant's ancestry up to the secured grandparent.
-      // isEffectivelySecuredViaClosure resolves grandparent's security two levels up and hides the subtree.
+      // isEffectivelySecured resolves grandparent's security two levels up and hides the subtree.
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
       const grandparent = await insertFeatureRow({
@@ -852,6 +880,7 @@ describe('Security scope search (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const featureId = await createTestFeature(connection, submissionId, 'dataset', { name: 'Shared Scope' });
       await secureFeature(connection, featureId);
+      await rebuildClosureForSubmission(submissionId);
 
       // Two policies with the same URN → shared scope
       const urn = `urn:${submissionId}:*:*`;
@@ -1145,6 +1174,7 @@ describe('Security scope search (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const feat1 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Already Secured' });
       await secureFeature(connection, feat1);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'new-anchor-test');
@@ -1156,6 +1186,7 @@ describe('Security scope search (integration)', function () {
       // Secure a NEW feature in the same submission
       const feat2 = await createTestFeature(connection, submissionId, 'dataset', { name: 'Newly Secured' });
       await secureFeature(connection, feat2);
+      await rebuildClosureForSubmission(submissionId);
 
       // Recompute anchors — new secured feature should become an anchor
       await computeAnchors(scopeRepo, scopeId);
@@ -1173,10 +1204,11 @@ describe('Security scope search (integration)', function () {
       // Hierarchy: grandparent → parent → child
       // Secured:   YES            NO        YES
       //
-      // This is the key regression test for the recursive ancestor walk.
-      // A single-level parent check would see child's immediate parent (parent) is
-      // NOT secured and incorrectly make child an anchor. The recursive walk finds
-      // grandparent (secured) two levels up and correctly excludes child.
+      // Key regression test for multi-level ancestry in anchor pruning. A single-level parent
+      // check would see child's immediate parent (parent) is NOT secured and incorrectly make
+      // child an anchor. The recompute's live ancestor_walk reaches grandparent (secured) two
+      // levels up — whose own closure self-loop makes it read as effectively secured — and
+      // correctly prunes child.
       const submissionId = await createTestSubmission(connection);
       const grandparent = await createTestFeature(connection, submissionId, 'dataset', { name: 'Grandparent' });
       const parent = await createTestFeature(connection, submissionId, 'sample_site', { name: 'Parent' }, grandparent);
@@ -1185,6 +1217,7 @@ describe('Security scope search (integration)', function () {
       // Secure grandparent and child, but NOT parent — gap in the chain
       await secureFeature(connection, grandparent);
       await secureFeature(connection, child);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'gap-hierarchy-test');
@@ -1208,6 +1241,7 @@ describe('Security scope search (integration)', function () {
 
       // Only the leaf is secured
       await secureFeature(connection, child);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'leaf-only-test');
@@ -1230,6 +1264,7 @@ describe('Security scope search (integration)', function () {
 
       // Only the middle level is secured
       await secureFeature(connection, parent);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'mid-only-test');
@@ -1279,12 +1314,31 @@ describe('Security scope search (integration)', function () {
     });
 
     it('should anchor specific child feature via inherited security (feature-scoped URN)', async () => {
-      // Two telemetry children — only the one named in the URN should be anchored
+      // Two telemetry children inherit security from the dataset — only the one named in the URN
+      // is anchored. The hierarchy is seeded under ONE upload so the closure stores each child's
+      // ancestor edge to the secured dataset (inherited security needs closure ancestry, not just
+      // self-loops).
       const submissionId = await createTestSubmission(connection);
-      const dataset = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Dataset' });
-      const telemetry1 = await createTestFeature(connection, submissionId, 'telemetry', { name: 'Target' }, dataset);
-      const telemetry2 = await createTestFeature(connection, submissionId, 'telemetry', { name: 'Other' }, dataset);
+      const uploadId = await createTestUpload(connection, submissionId);
+      const dataset = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const telemetry1 = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'telemetry',
+        parentFeatureId: dataset
+      });
+      const telemetry2 = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'telemetry',
+        parentFeatureId: dataset
+      });
       await secureFeature(connection, dataset);
+      await rebuildClosure(uploadId);
 
       const urn = `urn:${submissionId}:telemetry:${telemetry1}`;
       const policyId = await createPolicy(connection, 'feature-scoped-inherited-test');
@@ -1325,18 +1379,30 @@ describe('Security scope search (integration)', function () {
     });
 
     it('should anchor deep descendant via multi-level inherited security', async () => {
-      // dataset → sample_site → telemetry (2 levels deep)
+      // dataset → sample_site → telemetry (2 levels deep), all under ONE upload so the closure
+      // stores telemetry's ancestry up to the secured dataset (inherited security needs closure
+      // ancestry).
       const submissionId = await createTestSubmission(connection);
-      const dataset = await createTestFeature(connection, submissionId, 'dataset', { name: 'Secured Root' });
-      const sampleSite = await createTestFeature(connection, submissionId, 'sample_site', { name: 'Mid' }, dataset);
-      const telemetry = await createTestFeature(
-        connection,
+      const uploadId = await createTestUpload(connection, submissionId);
+      const dataset = await insertFeatureRow({
         submissionId,
-        'telemetry',
-        { name: 'Deep Leaf' },
-        sampleSite
-      );
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      const sampleSite = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: dataset
+      });
+      const telemetry = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'telemetry',
+        parentFeatureId: sampleSite
+      });
       await secureFeature(connection, dataset);
+      await rebuildClosure(uploadId);
 
       const urn = `urn:${submissionId}:telemetry:*`;
       const policyId = await createPolicy(connection, 'deep-inherited-test');
@@ -1373,6 +1439,7 @@ describe('Security scope search (integration)', function () {
       await secureFeature(connection, feat1);
       await secureFeature(connection, feat2);
       await secureFeature(connection, feat3);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'selective-anchor-test');
@@ -1404,7 +1471,7 @@ describe('Security scope search (integration)', function () {
   describe('record_effective_date → search visibility', () => {
     // Read-path security reads the closure. The closure's active universe is record_end_date IS NULL only
     // (it does NOT filter on record_effective_date), so the self-loop / ancestry rows exist regardless of
-    // approval; the effective-date predicate lives in isEffectivelySecuredViaClosure (sf_sec.record_effective_date
+    // approval; the effective-date predicate lives in isEffectivelySecured (sf_sec.record_effective_date
     // <= now()). Each fixture seeds under a SHARED upload and rebuilds the closure before searching.
     for (const { label, markFn } of [
       { label: 'NULL', markFn: markFeatureUnapproved },
@@ -1588,6 +1655,7 @@ describe('Security scope search (integration)', function () {
       await secureFeature(connection, dataset);
 
       await markFeatureFutureDate(dataset);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'future-date-anchor-test');
@@ -1603,6 +1671,7 @@ describe('Security scope search (integration)', function () {
       const submissionId = await createTestSubmission(connection);
       const dataset = await createTestFeature(connection, submissionId, 'dataset', { name: 'De-approved Dataset' });
       await secureFeature(connection, dataset);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'de-approve-anchor-test');
@@ -1676,6 +1745,9 @@ describe('Security scope search (integration)', function () {
       const dataset = await createTestFeature(connection, sub1, 'dataset', { name: 'Dataset' });
       await secureFeature(connection, dataset);
 
+      await rebuildClosureForSubmission(sub1);
+      await rebuildClosureForSubmission(sub2);
+
       const urn = 'urn:*:telemetry:*';
       const policyId = await createPolicy(connection, 'wildcard-sub-type-test');
       const stmtId = await createPolicyStatement(connection, policyId, urn);
@@ -1710,6 +1782,7 @@ describe('Security scope search (integration)', function () {
 
       await secureFeature(connection, dataset);
       await secureFeature(connection, child);
+      await rebuildClosureForSubmission(submissionId);
 
       // ── Step 1: Policy with urn:{sub}:*:* (broad) ──
       const broadUrn = `urn:${submissionId}:*:*`;
@@ -2008,6 +2081,7 @@ describe('Security scope search (integration)', function () {
       await secureFeature(connection, root);
       await secureFeature(connection, childA);
       await secureFeature(connection, childB);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'child-promotion-test');
@@ -2072,6 +2146,7 @@ describe('Security scope search (integration)', function () {
 
       // Secure all features in bulk
       await secureFeaturesInBulk(featureIds);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'multi-batch-stale-delete-test');
@@ -2137,6 +2212,7 @@ describe('Security scope search (integration)', function () {
 
       // Secure root + all children in bulk
       await secureFeaturesInBulk([root, ...childIds]);
+      await rebuildClosureForSubmission(submissionId);
 
       const urn = `urn:${submissionId}:*:*`;
       const policyId = await createPolicy(connection, 'multi-batch-test');

--- a/api/src/__integration__/system/download-system.integration.ts
+++ b/api/src/__integration__/system/download-system.integration.ts
@@ -114,8 +114,12 @@ describe('Download Worker', function () {
         await db('biohub.policy').whereIn('policy_id', createdPolicyIds).del();
       }
 
-      // 2. Delete submission features
+      // 2. Delete submission features (closure rows FK to submission_feature on both ends — drop them first)
       if (createdSubmissionFeatureIds.length > 0) {
+        await db('biohub.submission_feature_closure')
+          .whereIn('source_submission_feature_id', createdSubmissionFeatureIds)
+          .orWhereIn('target_submission_feature_id', createdSubmissionFeatureIds)
+          .del();
         await db('biohub.submission_feature').whereIn('submission_feature_id', createdSubmissionFeatureIds).del();
       }
 
@@ -230,6 +234,20 @@ describe('Download Worker', function () {
       .returning('submission_feature_id');
 
     createdSubmissionFeatureIds.push(row.submission_feature_id);
+
+    // The read-path security filter (isEffectivelySecured) fails closed on a feature with no closure
+    // rows. createTestFeature skips the indexing pipeline that builds the closure, so write the reflexive
+    // self-loop the recompute would produce (each feature is alone in its upload, so the self-loop IS its
+    // full closure) — without it the feature reads as secured and is dropped from the download/export.
+    await db('biohub.submission_feature_closure')
+      .insert({
+        source_submission_feature_id: row.submission_feature_id,
+        target_submission_feature_id: row.submission_feature_id,
+        is_ancestor: true
+      })
+      .onConflict(['source_submission_feature_id', 'target_submission_feature_id'])
+      .ignore();
+
     return row.submission_feature_id;
   }
 

--- a/api/src/__integration__/system/ingest-to-export.integration.ts
+++ b/api/src/__integration__/system/ingest-to-export.integration.ts
@@ -21,6 +21,7 @@ import { DownloadPipelineService } from '../../services/download/download-pipeli
 import { DownloadPolicyService } from '../../services/download/download-policy-service';
 import { DownloadService } from '../../services/download/download-service';
 import { BucketType, ObjectStorageService } from '../../services/object-storage/object-storage-service';
+import { SubmissionFeatureClosureService } from '../../services/submission-feature-closure-service';
 import { createTestFeature, createTestSubmission } from '../helpers/test-submission-helpers';
 
 /** Download a zip file from S3 and return it as an AdmZip instance. */
@@ -143,6 +144,16 @@ describe('Ingest → Download → Export (system integration)', function () {
 
     const featureId = await createTestFeature(connection, submissionId, 'telemetry', telemetryData);
     await indexTelemetryProperties(featureId, telemetryData);
+
+    // createTestFeature skips the indexing pipeline that builds the closure. The export's security filter
+    // (isEffectivelySecured) fails closed on a feature with no closure rows, so build the closure self-loop
+    // the recompute would write — otherwise the feature reads as secured and is dropped from the export.
+    const uploadRow = await connection.sql(SQL`
+      SELECT submission_upload_id FROM submission_feature WHERE submission_feature_id = ${featureId};
+    `);
+    await new SubmissionFeatureClosureService(connection).computeClosureForUpload(
+      uploadRow.rows[0].submission_upload_id
+    );
 
     // Build a download policy + download via the real services. Broad-path
     // policy on the telemetry feature type — at export time the security

--- a/api/src/constants/expression.ts
+++ b/api/src/constants/expression.ts
@@ -2,7 +2,11 @@ import type { PredicateOperator } from '../models/expression-predicate';
 import { FEATURE_PROPERTY_TYPE } from '../models/feature-property';
 
 /**
- * Maximum graph depth for recursive expression search projection.
+ * Maximum hop count for the recursive content-edge (`data.content`) walk in expression search.
+ *
+ * The closure precomputes parent-ancestry and property-reference reach, so the only run-time
+ * recursion left is the bounded walk over `submission_feature_feature` content edges. This caps
+ * that walk.
  */
 export const MAX_SEARCH_GRAPH_DEPTH = 6;
 

--- a/api/src/repositories/authorization/security-scope-repository.ts
+++ b/api/src/repositories/authorization/security-scope-repository.ts
@@ -134,9 +134,10 @@ export class SecurityScopeRepository extends BaseRepository {
    * the NOT EXISTS subquery finds nothing, so all anchors are deleted.
    *
    * **Why keyset pagination:** With ~10% of features secured per submission,
-   * a scope can have 50k+ anchors. The monolithic DELETE runs isEffectivelySecured()
-   * (recursive CTE) per anchor row — 50k recursive CTEs + WAL + row locks in one
-   * transaction. Keyset pagination bounds memory and WAL per batch.
+   * a scope can have 50k+ anchors. The monolithic DELETE runs
+   * isEffectivelySecured() (a closure ancestry probe) per anchor row — 50k
+   * probes + WAL + row locks in one transaction. Keyset pagination bounds memory and
+   * WAL per batch.
    *
    * **All-valid-batch fallback:** When no anchors in a batch are stale, no rows
    * are deleted but the batch is not exhausted. A boundary query advances the

--- a/api/src/repositories/cart-submission-feature-repository.test.ts
+++ b/api/src/repositories/cart-submission-feature-repository.test.ts
@@ -30,7 +30,12 @@ describe('CartSubmissionFeatureRepository', () => {
       expect(result).to.be.undefined;
     });
 
-    it('should use NOT EXISTS with recursive ancestor walk to block secured features', async () => {
+    it('should use NOT EXISTS over the closure ancestry to block secured features', async () => {
+      // Verifies: the unsecured-add query excludes secured features via the closure-based
+      // security fragment (NOT EXISTS over submission_feature_closure), and guards against
+      // soft-deleted ids with an active-record JOIN — no recursive parent walk.
+
+      // Step 1: Stub knex to capture the emitted query
       const knexStub = sinon.stub().resolves({
         rowCount: 1,
         rows: []
@@ -40,22 +45,37 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
+      // Step 2: Call the unsecured-add method
       await repo.createUnsecuredCartSubmissionFeatures('cart-1', [1, 2, 3]);
 
+      // Step 3: Capture the emitted SQL (lowercased for robust token matching)
       expect(knexStub).to.have.been.calledOnce;
-      const sqlText = knexStub.firstCall.args[0].toString();
+      const sqlText = knexStub.firstCall.args[0].toString().toLowerCase();
 
-      expect(sqlText).to.include('NOT EXISTS');
-      expect(sqlText).to.include('RECURSIVE');
-      expect(sqlText).to.include('ancestor_chain');
+      // Step 4: Verify it filters secured features via the closure-based fragment
+      expect(sqlText).to.include('not exists');
+      expect(sqlText).to.include('submission_feature_closure');
+      expect(sqlText).to.include('is_ancestor');
       expect(sqlText).to.include('submission_feature_security');
       expect(sqlText).to.include('record_effective_date');
-      expect(sqlText).to.include('record_end_date');
+
+      // Step 5: Verify the active-guard JOIN excludes soft-deleted ids
+      expect(sqlText).to.include('join submission_feature sf');
+      expect(sqlText).to.include('sf.record_end_date is null');
+
+      // Step 6: Verify it no longer uses the recursive parent walk
+      expect(sqlText).to.not.include('recursive');
+      expect(sqlText).to.not.include('ancestor_chain');
     });
   });
 
   describe('createCartSubmissionFeaturesWithScopeCheck', () => {
-    it('should use scope check SQL with recursive ancestor walk', async () => {
+    it('should use scope check SQL resolved through the closure ancestry', async () => {
+      // Verifies: the scope-checked add query resolves the scope grant through the closure
+      // ancestry (security_scope_anchor → team_security_scope → team_member) and guards
+      // against soft-deleted ids with an active-record JOIN — no recursive parent walk.
+
+      // Step 1: Stub knex to capture the emitted query
       const knexStub = sinon.stub().resolves({
         rowCount: 1,
         rows: []
@@ -65,15 +85,27 @@ describe('CartSubmissionFeatureRepository', () => {
 
       const repo = new CartSubmissionFeatureRepository(mockDBConnection);
 
+      // Step 2: Call the scope-checked add method with a system user id
       await repo.createCartSubmissionFeaturesWithScopeCheck('cart-1', [1, 2, 3], 42);
 
+      // Step 3: Capture the emitted SQL (lowercased for robust token matching)
       expect(knexStub).to.have.been.calledOnce;
-      const sqlText = knexStub.firstCall.args[0].toString();
+      const sqlText = knexStub.firstCall.args[0].toString().toLowerCase();
 
+      // Step 4: Verify the scope grant chain resolves through the closure ancestry
+      expect(sqlText).to.include('submission_feature_closure');
+      expect(sqlText).to.include('is_ancestor');
       expect(sqlText).to.include('security_scope_anchor');
       expect(sqlText).to.include('team_security_scope');
       expect(sqlText).to.include('team_member');
-      expect(sqlText).to.include('RECURSIVE');
+
+      // Step 5: Verify the active-guard JOIN excludes soft-deleted ids
+      expect(sqlText).to.include('join submission_feature sf');
+      expect(sqlText).to.include('sf.record_end_date is null');
+
+      // Step 6: Verify it no longer uses the recursive parent walk
+      expect(sqlText).to.not.include('recursive');
+      expect(sqlText).to.not.include('ancestor_chain');
     });
   });
 

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -3,7 +3,7 @@ import { getKnex } from '../database/db';
 import { CartStatus, CartSubmissionFeature } from '../models/cart';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
-import { isAccessibleToUser, isEffectivelySecured } from './sql-fragments';
+import { isAccessibleToUser, isEffectivelySecuredViaClosure } from './sql-fragments';
 
 /**
  * CartSubmissionFeature repository class.
@@ -16,8 +16,8 @@ import { isAccessibleToUser, isEffectivelySecured } from './sql-fragments';
 export class CartSubmissionFeatureRepository extends BaseRepository {
   /**
    * Add unsecured submission features to an active cart (anonymous path).
-   * Walks up the ancestor chain from each candidate feature; if any ancestor has an
-   * active submission_feature_security row, the feature is excluded.
+   * Reads the precomputed closure ancestry for each candidate; if the feature or any
+   * ancestor has an active submission_feature_security row, the feature is excluded.
    * Ignores existing relationships (idempotent via ON CONFLICT DO NOTHING).
    *
    * @param {string} cartId - The ID of the cart
@@ -42,7 +42,12 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       w_valid_features AS (
         SELECT wf.submission_feature_id
         FROM w_features wf
-        WHERE NOT ${isEffectivelySecured('wf.submission_feature_id')}
+        -- The closure has no row for soft-deleted features, so an inactive id would slip past
+        -- the security check (no row to mark it secured). Exclude inactive ids explicitly here
+        -- rather than relying on the security fragment to reject them.
+        JOIN submission_feature sf ON sf.submission_feature_id = wf.submission_feature_id
+          AND sf.record_end_date IS NULL
+        WHERE NOT ${isEffectivelySecuredViaClosure('wf.submission_feature_id')}
       )
       INSERT INTO cart_submission_feature (cart_id, submission_feature_id)
       SELECT wc.cart_id, wvf.submission_feature_id
@@ -59,7 +64,8 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
   /**
    * Add submission features to an active cart with scope-based access check (authenticated path).
    * Allows features that are unsecured OR where the user has scope access via
-   * security_scope_anchor → team_security_scope → team_member.
+   * security_scope_anchor → team_security_scope → team_member, resolved through the
+   * precomputed closure ancestry.
    * Ignores existing relationships (idempotent via ON CONFLICT DO NOTHING).
    *
    * @param {string} cartId - The ID of the cart
@@ -89,6 +95,11 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
       w_valid_features AS (
         SELECT wf.submission_feature_id
         FROM w_features wf
+        -- The closure has no row for soft-deleted features, so an inactive id would slip past
+        -- the security check (no row to mark it secured). Exclude inactive ids explicitly here
+        -- rather than relying on the security fragment to reject them.
+        JOIN submission_feature sf ON sf.submission_feature_id = wf.submission_feature_id
+          AND sf.record_end_date IS NULL
         WHERE
           ${isAccessibleToUser('wf.submission_feature_id')}
       )
@@ -168,7 +179,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
    * Get all submission features in an active cart with pagination, optionally filtered by submission feature ID.
    * Returns ALL features in the cart — authorization was enforced at insert time, not on read.
    * The `secured` field reflects current effective security status (feature or any ancestor has
-   * an active submission_feature_security row), computed via a bulk recursive CTE.
+   * an active submission_feature_security row), read from the precomputed closure ancestry.
    *
    * @param {string} cartId - The ID of the cart
    * @param {ApiPaginationOptions} [pagination] - Optional pagination options
@@ -197,7 +208,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
 
     const paginatedPageQuery = this.applyPagination(pageQuery, pagination);
 
-    // Step 2: Join feature metadata, check security via per-row correlated EXISTS
+    // Step 2: Join feature metadata, check security via per-row closure-ancestry EXISTS
     const query = knex
       .with('page', paginatedPageQuery)
       .select(
@@ -206,7 +217,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
         'sf.submission_id',
         'sf.feature_type_id',
         'ft.name as feature_type_name',
-        knex.raw(`${isEffectivelySecured('sf.submission_feature_id')} AS secured`)
+        knex.raw(`${isEffectivelySecuredViaClosure('sf.submission_feature_id')} AS secured`)
       )
       .from('page')
       .join('submission_feature as sf', 'sf.submission_feature_id', 'page.submission_feature_id')

--- a/api/src/repositories/cart-submission-feature-repository.ts
+++ b/api/src/repositories/cart-submission-feature-repository.ts
@@ -3,7 +3,7 @@ import { getKnex } from '../database/db';
 import { CartStatus, CartSubmissionFeature } from '../models/cart';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
-import { isAccessibleToUser, isEffectivelySecuredViaClosure } from './sql-fragments';
+import { isAccessibleToUser, isEffectivelySecured } from './sql-fragments';
 
 /**
  * CartSubmissionFeature repository class.
@@ -47,7 +47,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
         -- rather than relying on the security fragment to reject them.
         JOIN submission_feature sf ON sf.submission_feature_id = wf.submission_feature_id
           AND sf.record_end_date IS NULL
-        WHERE NOT ${isEffectivelySecuredViaClosure('wf.submission_feature_id')}
+        WHERE NOT ${isEffectivelySecured('wf.submission_feature_id')}
       )
       INSERT INTO cart_submission_feature (cart_id, submission_feature_id)
       SELECT wc.cart_id, wvf.submission_feature_id
@@ -217,7 +217,7 @@ export class CartSubmissionFeatureRepository extends BaseRepository {
         'sf.submission_id',
         'sf.feature_type_id',
         'ft.name as feature_type_name',
-        knex.raw(`${isEffectivelySecuredViaClosure('sf.submission_feature_id')} AS secured`)
+        knex.raw(`${isEffectivelySecured('sf.submission_feature_id')} AS secured`)
       )
       .from('page')
       .join('submission_feature as sf', 'sf.submission_feature_id', 'page.submission_feature_id')

--- a/api/src/repositories/expression-evaluation.test.ts
+++ b/api/src/repositories/expression-evaluation.test.ts
@@ -189,9 +189,9 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"ft"."name" = \'telemetry\'');
       expect(sql).to.include('"sf"."record_end_date" is null');
 
-      // The synthetic dataset↔same-submission membership edge is walked alongside content edges.
-      expect(sql).to.include('as "dataset_sf"');
-      expect(sql).to.include('"related_sf"."submission_id" = "dataset_sf"."submission_id"');
+      // The synthetic dataset↔same-submission membership edge has been removed — content edges only.
+      expect(sql).to.not.include('as "dataset_sf"');
+      expect(sql).to.not.include('"related_sf"."submission_id" = "dataset_sf"."submission_id"');
 
       // The old graph-edge union machinery is gone (parent/child reach now comes from the closure).
       expect(sql).to.not.include('connected_features');
@@ -324,7 +324,7 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"content_reach"."depth" < 6');
       expect(sql).to.include(' union ');
       expect(sql).to.include('"ft"."name" = \'species_observation\'');
-      expect(sql).to.include('as "dataset_sf"');
+      expect(sql).to.not.include('as "dataset_sf"');
       expect(sql).to.not.include('connected_features');
     });
   });

--- a/api/src/repositories/expression-evaluation.test.ts
+++ b/api/src/repositories/expression-evaluation.test.ts
@@ -146,7 +146,7 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"p"."feature_type_property_id" = 123');
     });
 
-    it('should project related predicate evidence to anchor feature ids through bounded graph traversal', () => {
+    it('should project related predicate evidence to anchor feature ids through the content walk and closure probes', () => {
       const expressionTree: NormalizedExpressionTreeExpression = {
         type: 'expression',
         operator: 'AND',
@@ -163,32 +163,38 @@ describe('expression-evaluation', () => {
 
       const sql = buildExpressionTreeFeatureIdsSubquery('telemetry', expressionTree, null).toString();
 
+      // Evidence CTE seeds the recursive content walk (WITH RECURSIVE is restored by the content-edge recursion).
       expect(sql).to.include('submission_feature_property_taxon');
-      expect(sql).to.include('with recursive "evidence"');
-      expect(sql).to.include('"connected_features" as');
-      expect(sql).to.include('as "graph_edges"');
-      expect(sql).to.include('"evidence"."submission_feature_id" as "root_feature_id"');
-      expect(sql).to.include('"evidence"."submission_feature_id" as "connected_feature_id"');
-      expect(sql).to.include('0 as depth');
-      expect(sql).to.include('from "submission_feature_feature"');
-      expect(sql).to.include('inner join "submission_feature" as "source_sf"');
-      expect(sql).to.include('inner join "submission_feature" as "target_sf"');
+      expect(sql).to.include('with recursive "evidence" as');
+
+      // Bounded recursive content walk over submission_feature_feature edges.
+      expect(sql).to.include('"content_edges"');
+      expect(sql).to.include('"content_reach"');
+      expect(sql).to.include('from "submission_feature_feature" as "sff"');
       expect(sql).to.include('"source_sf"."record_end_date" is null');
       expect(sql).to.include('"target_sf"."record_end_date" is null');
-      expect(sql).to.include('"source_feature_id" as "from_feature_id"');
-      expect(sql).to.include('"target_feature_id" as "to_feature_id"');
-      expect(sql).to.include('"target_feature_id" as "from_feature_id"');
-      expect(sql).to.include('"source_feature_id" as "to_feature_id"');
-      expect(sql).to.include('"parent_submission_feature_id" as "from_feature_id"');
-      expect(sql).to.include('"parent_submission_feature_id" as "to_feature_id"');
-      expect(sql).to.include('"dataset_ft"."name" = \'dataset\'');
-      expect(sql).to.include('"related_sf"."submission_id" = "dataset_sf"."submission_id"');
-      expect(sql).to.include('"dataset_sf"."submission_feature_id" as "from_feature_id"');
-      expect(sql).to.include('"dataset_sf"."submission_feature_id" as "to_feature_id"');
-      expect(sql).to.include('"connected_features"."depth" < 6');
-      expect(sql).to.include('NOT edges.to_feature_id = ANY(connected_features.path)');
+      // Depth bound and cycle guard on the recursive term.
+      expect(sql).to.include('"content_reach"."depth" < 6');
+      expect(sql).to.include('= ANY(content_reach.path)');
+
+      // Closure probed from every content-reached node — forward (by source) and reverse (by target).
+      expect(sql).to.include('from "submission_feature_closure" as "c"');
+      expect(sql).to.include('"cr"."feature_id" = "c"."source_submission_feature_id"');
+      expect(sql).to.include('"cr"."feature_id" = "c"."target_submission_feature_id"');
+      expect(sql).to.include('"c"."target_submission_feature_id" as "submission_feature_id"');
+      expect(sql).to.include('"c"."source_submission_feature_id" as "submission_feature_id"');
+
+      // The reachable selects are UNION-combined (dedup), and the anchor type is applied to the resolved targets.
+      expect(sql).to.include(' union ');
       expect(sql).to.include('"ft"."name" = \'telemetry\'');
       expect(sql).to.include('"sf"."record_end_date" is null');
+
+      // The old graph-edge machinery is gone (only the content-edge recursion remains).
+      expect(sql).to.not.include('connected_features');
+      expect(sql).to.not.include('graph_edges');
+      expect(sql).to.not.include('dataset_sf');
+      expect(sql).to.not.include('parent_submission_feature_id as');
+      expect(sql).to.not.include('root_feature_id');
     });
 
     it('should union child target sets for OR expressions', () => {
@@ -286,7 +292,7 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"p_not_equals"."value" = \'red\'');
     });
 
-    it('should project parent dataset evidence to species observation targets through hierarchy edges', () => {
+    it('should project predicate evidence to species_observation targets through the content walk and closure probes', () => {
       const expressionTree: NormalizedExpressionTreeExpression = {
         type: 'expression',
         operator: 'AND',
@@ -305,12 +311,18 @@ describe('expression-evaluation', () => {
 
       expect(sql).to.include('submission_feature_property_string');
       expect(sql).to.include('"ftp"."feature_property_id" = 46');
-      expect(sql).to.include('from "submission_feature"');
-      expect(sql).to.include('"parent_submission_feature_id" as "from_feature_id"');
-      expect(sql).to.include('"submission_feature_id" as "from_feature_id"');
-      expect(sql).to.include('"dataset_ft"."name" = \'dataset\'');
-      expect(sql).to.include('"related_sf"."submission_id" = "dataset_sf"."submission_id"');
+      expect(sql).to.include('with recursive "evidence" as');
+      expect(sql).to.include('"content_reach"');
+      expect(sql).to.include('"content_edges"');
+      expect(sql).to.include('from "submission_feature_feature" as "sff"');
+      expect(sql).to.include('from "submission_feature_closure" as "c"');
+      expect(sql).to.include('"cr"."feature_id" = "c"."source_submission_feature_id"');
+      expect(sql).to.include('"cr"."feature_id" = "c"."target_submission_feature_id"');
+      expect(sql).to.include('"content_reach"."depth" < 6');
+      expect(sql).to.include(' union ');
       expect(sql).to.include('"ft"."name" = \'species_observation\'');
+      expect(sql).to.not.include('connected_features');
+      expect(sql).to.not.include('dataset_sf');
     });
   });
 

--- a/api/src/repositories/expression-evaluation.test.ts
+++ b/api/src/repositories/expression-evaluation.test.ts
@@ -189,10 +189,13 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"ft"."name" = \'telemetry\'');
       expect(sql).to.include('"sf"."record_end_date" is null');
 
-      // The old graph-edge machinery is gone (only the content-edge recursion remains).
+      // The synthetic dataset↔same-submission membership edge is walked alongside content edges.
+      expect(sql).to.include('as "dataset_sf"');
+      expect(sql).to.include('"related_sf"."submission_id" = "dataset_sf"."submission_id"');
+
+      // The old graph-edge union machinery is gone (parent/child reach now comes from the closure).
       expect(sql).to.not.include('connected_features');
       expect(sql).to.not.include('graph_edges');
-      expect(sql).to.not.include('dataset_sf');
       expect(sql).to.not.include('parent_submission_feature_id as');
       expect(sql).to.not.include('root_feature_id');
     });
@@ -321,8 +324,8 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"content_reach"."depth" < 6');
       expect(sql).to.include(' union ');
       expect(sql).to.include('"ft"."name" = \'species_observation\'');
+      expect(sql).to.include('as "dataset_sf"');
       expect(sql).to.not.include('connected_features');
-      expect(sql).to.not.include('dataset_sf');
     });
   });
 

--- a/api/src/repositories/expression-evaluation.ts
+++ b/api/src/repositories/expression-evaluation.ts
@@ -16,10 +16,16 @@ import { buildSecurityFilter } from './sql-fragments';
  * subqueries returning matching submission_feature_id values for an anchor
  * feature type.
  *
+ * Each predicate compiles into a bounded recursive content walk plus closure
+ * probes: a `WITH RECURSIVE` CTE walks the `submission_feature_feature` content
+ * (`data.content`) edges the closure deliberately omits, and the precomputed
+ * `submission_feature_closure` table is probed from every content-reached node
+ * to resolve parent-ancestry and property-reference reach with indexed joins.
+ *
  * Read-time evaluator shared by the search wrapper (POST /api/search/feature)
  * and the download pipeline (POST /api/download). Both paths consume the same
  * emitted SQL, so a single substrate keeps semantics — including security
- * filtering and graph traversal — identical across both consumers.
+ * filtering — identical across both consumers.
  *
  * Inputs are assumed to be normalized: semantic validation runs at write time
  * inside `writeExpressionTree`. These functions only emit SQL.
@@ -99,7 +105,7 @@ export const dependencies = {
  * Recursively builds a target submission_feature_id query for an expression-tree clause.
  *
  * Every child query returns target feature IDs for the route feature type. Predicate clauses first find evidence
- * features that directly satisfy the predicate and then project those evidence features through the graph to target
+ * features that directly satisfy the predicate and then project those evidence features to related target
  * features. Expression clauses combine child target sets with INTERSECT for AND and UNION for OR.
  */
 function buildExpressionTargetIdsQuery(
@@ -136,8 +142,8 @@ function buildExpressionTargetIdsQuery(
 /**
  * Wraps target ID queries before set operations.
  *
- * Predicate clauses use their own WITH RECURSIVE traversal CTEs. PostgreSQL accepts those CTEs inside a derived
- * table, but not directly as a parenthesized INTERSECT/UNION operand.
+ * Predicate clauses carry a `WITH RECURSIVE` CTE (the bounded content-edge walk). PostgreSQL accepts a WITH-bearing
+ * query inside a derived table, but not directly as a parenthesized INTERSECT/UNION operand, so the wrap is required.
  */
 function wrapTargetIdsQuery(query: Knex.QueryBuilder, knex: Knex, alias: string): Knex.QueryBuilder {
   return knex.select('submission_feature_id').from(query.as(alias));
@@ -212,15 +218,32 @@ function buildPredicateEvidenceIdsQuery(
 /**
  * Projects evidence feature IDs to the requested target feature type.
  *
- * Depth 0 returns evidence that is already the target type. root_feature_id preserves which evidence feature seeded
- * the traversal. path prevents cycles. The route anchor feature type is applied after traversal so every predicate
- * leaf contributes a target set, not an evidence set.
+ * Relatedness is the union of two reachability sources:
+ *   (a) the precomputed `submission_feature_closure` reachability — parent-ancestry plus property-reference, in
+ *       BOTH directions; and
+ *   (b) a bounded recursive walk over `submission_feature_feature` content (`data.content`) edges, which the
+ *       closure deliberately omits because closing over content would make the closure the complete O(N^2)
+ *       same-upload digraph.
  *
- * The security filter is applied a second time to the projected target rows. Filtering only the evidence is not
- * sufficient: graph traversal can reach a secured target feature from an unsecured evidence feature, which would
- * leak the target id to any consumer that uses this subquery directly (e.g. the download pipeline). The search
- * wrapper used to bear this responsibility alone via a final outer-query filter; landing it here ensures every
- * consumer of the subquery sees the same target-level security boundary.
+ * The walk starts from the evidence features and follows content edges out to MAX_SEARCH_GRAPH_DEPTH hops,
+ * cycle-guarded by the visited path. Every content-reached node is then probed against the closure in BOTH
+ * directions (forward by source: its ancestors + referenced features; reverse by target: its descendants +
+ * referencing features), so a predicate that filters one feature type resolves results deeper or shallower in the
+ * hierarchy, and content cross-references chain transitively into the closure reach. A forward-only or one-hop
+ * probe would silently drop the common "filter the container, return the contained" search and multi-hop content
+ * chains. Because `content_reach` is seeded from the evidence, probing the closure from `content_reach` already
+ * covers the closure reach of the evidence features themselves — no separate evidence-to-closure probe is needed.
+ *
+ * `is_ancestor` is NOT consulted here. That flag marks the authorization (parent-ancestry) subset only; search
+ * relatedness uses the full reachability set, so every closure row counts.
+ *
+ * The three reachability selects are combined with UNION (not UNION ALL) so a feature reachable through more than
+ * one path is counted once — a downstream count(*) wrap must not double-count it.
+ *
+ * The security filter is re-applied to the resolved target rows, not only the evidence. Relatedness can reach a
+ * secured target feature from unsecured evidence, which would leak the target id to any consumer that uses this
+ * subquery directly (e.g. the download pipeline). Applying it here protects every consumer of this shared
+ * subquery — search and download alike — with the same target-level security boundary.
  */
 function projectEvidenceToTargetIdsQuery(
   anchorFeatureType: string,
@@ -228,16 +251,37 @@ function projectEvidenceToTargetIdsQuery(
   knex: Knex,
   systemUserId?: number | null
 ): Knex.QueryBuilder {
+  // reachable set: the content-reached nodes themselves, plus the closure probed in both directions from every
+  // content-reached node. Inlined here (not a top-level CTE) because it must reference the content_reach CTE.
+  // UNION (not UNION ALL) dedups a feature reachable via more than one path — a count(*) wrap must not double-count.
+  const reachable = knex
+    .select('content_reach.feature_id as submission_feature_id')
+    .from('content_reach')
+    .union([
+      // closure forward: ancestors + referenced features of every content-reached node
+      knex
+        .select('c.target_submission_feature_id as submission_feature_id')
+        .from('submission_feature_closure as c')
+        .join('content_reach as cr', 'cr.feature_id', 'c.source_submission_feature_id'),
+      // closure reverse: descendants + referencing features of every content-reached node
+      knex
+        .select('c.source_submission_feature_id as submission_feature_id')
+        .from('submission_feature_closure as c')
+        .join('content_reach as cr', 'cr.feature_id', 'c.target_submission_feature_id')
+    ]);
+
   const query = knex
     .queryBuilder()
     .with('evidence', evidenceQuery.clone())
-    .with('edges', (qb) => {
-      qb.select('from_feature_id', 'to_feature_id').from(buildGraphEdgesQuery(knex).as('graph_edges'));
+    // content (data.content) edges, bidirectional, active-guarded — excluded from the closure, walked here
+    .with('content_edges', (qb) => {
+      qb.select('from_feature_id', 'to_feature_id').from(buildContentEdgesQuery(knex).as('content_feature_edges'));
     })
-    .withRecursive('connected_features', (qb) => {
+    // recursive content walk: from each evidence feature, follow content edges out to MAX_SEARCH_GRAPH_DEPTH hops,
+    // cycle-guarded by the visited path. parent/property transitivity is NOT walked here — the closure handles it.
+    .withRecursive('content_reach', (qb) => {
       qb.select(
-        'evidence.submission_feature_id as root_feature_id',
-        'evidence.submission_feature_id as connected_feature_id',
+        'evidence.submission_feature_id as feature_id',
         knex.raw('ARRAY[evidence.submission_feature_id] as path'),
         knex.raw('0 as depth')
       )
@@ -245,21 +289,20 @@ function projectEvidenceToTargetIdsQuery(
         .unionAll([
           knex
             .select(
-              'connected_features.root_feature_id',
-              'edges.to_feature_id as connected_feature_id',
-              knex.raw('connected_features.path || edges.to_feature_id as path'),
-              knex.raw('connected_features.depth + 1 as depth')
+              'content_edges.to_feature_id as feature_id',
+              knex.raw('content_reach.path || content_edges.to_feature_id as path'),
+              knex.raw('content_reach.depth + 1 as depth')
             )
-            .from('connected_features')
-            .join('edges', 'edges.from_feature_id', 'connected_features.connected_feature_id')
-            .where('connected_features.depth', '<', MAX_SEARCH_GRAPH_DEPTH)
-            .whereRaw('NOT edges.to_feature_id = ANY(connected_features.path)')
+            .from('content_reach')
+            .join('content_edges', 'content_edges.from_feature_id', 'content_reach.feature_id')
+            .where('content_reach.depth', '<', MAX_SEARCH_GRAPH_DEPTH)
+            .whereRaw('NOT content_edges.to_feature_id = ANY(content_reach.path)')
         ]);
     })
     .distinct()
-    .select('connected_features.connected_feature_id as submission_feature_id')
-    .from('connected_features')
-    .join('submission_feature as sf', 'sf.submission_feature_id', 'connected_features.connected_feature_id')
+    .select('sf.submission_feature_id')
+    .from(reachable.as('reachable'))
+    .join('submission_feature as sf', 'sf.submission_feature_id', 'reachable.submission_feature_id')
     .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id')
     .where('ft.name', anchorFeatureType)
     .whereNull('sf.record_end_date')
@@ -274,25 +317,14 @@ function projectEvidenceToTargetIdsQuery(
 }
 
 /**
- * Builds normalized direct graph edges as from_feature_id -> to_feature_id.
+ * Builds the bidirectional content (`data.content`) edges that the closure deliberately omits, so the search-time
+ * recursion can walk them, emitted as from_feature_id -> to_feature_id.
  *
- * This intentionally uses direct relationships only. The recursive traversal in projectEvidenceToTargetIdsQuery
- * expands over these edges with a depth bound and cycle checks.
+ * `submission_feature_feature` stores direct content edges only and has no record_end_date column. Active-record
+ * filtering is applied to the source and target submission_feature rows instead, because either endpoint may
+ * reference a soft-deleted feature.
  */
-function buildGraphEdgesQuery(knex: Knex): Knex.QueryBuilder {
-  return buildSubmissionFeatureRelationshipEdgesQuery(knex).unionAll([
-    buildParentChildEdgesQuery(knex),
-    buildDatasetSubmissionMembershipEdgesQuery(knex)
-  ]);
-}
-
-/**
- * Builds bidirectional edges from explicit submission_feature_feature relationships.
- *
- * `submission_feature_feature` stores direct edges only and has no record_end_date column. Active-record filtering is
- * applied to the source and target submission_feature rows instead.
- */
-function buildSubmissionFeatureRelationshipEdgesQuery(knex: Knex): Knex.QueryBuilder {
+function buildContentEdgesQuery(knex: Knex): Knex.QueryBuilder {
   const forward = knex('submission_feature_feature as sff')
     .select('sff.source_feature_id as from_feature_id', 'sff.target_feature_id as to_feature_id')
     .join('submission_feature as source_sf', 'source_sf.submission_feature_id', 'sff.source_feature_id')
@@ -308,66 +340,6 @@ function buildSubmissionFeatureRelationshipEdgesQuery(knex: Knex): Knex.QueryBui
     .whereNull('target_sf.record_end_date');
 
   return forward.unionAll([reverse]);
-}
-
-/**
- * Builds bidirectional parent/child feature edges.
- *
- * Parent-child links are columns on submission_feature, so active-record filtering is applied to both endpoint rows.
- */
-function buildParentChildEdgesQuery(knex: Knex): Knex.QueryBuilder {
-  const parentToChild = knex('submission_feature as child_sf')
-    .select(
-      'child_sf.parent_submission_feature_id as from_feature_id',
-      'child_sf.submission_feature_id as to_feature_id'
-    )
-    .join('submission_feature as parent_sf', 'parent_sf.submission_feature_id', 'child_sf.parent_submission_feature_id')
-    .whereNotNull('child_sf.parent_submission_feature_id')
-    .whereNull('child_sf.record_end_date')
-    .whereNull('parent_sf.record_end_date');
-
-  const childToParent = knex('submission_feature as child_sf')
-    .select(
-      'child_sf.submission_feature_id as from_feature_id',
-      'child_sf.parent_submission_feature_id as to_feature_id'
-    )
-    .join('submission_feature as parent_sf', 'parent_sf.submission_feature_id', 'child_sf.parent_submission_feature_id')
-    .whereNotNull('child_sf.parent_submission_feature_id')
-    .whereNull('child_sf.record_end_date')
-    .whereNull('parent_sf.record_end_date');
-
-  return parentToChild.unionAll([childToParent]);
-}
-
-/**
- * Builds synthetic dataset-to-same-submission feature edges in both directions.
- *
- * Dataset synthetic edges intentionally connect dataset features to other features in the same submission. This
- * supports dataset-level predicates returning target features from that submission. This can be high fanout for
- * submissions with many features and should be monitored.
- */
-function buildDatasetSubmissionMembershipEdgesQuery(knex: Knex): Knex.QueryBuilder {
-  const datasetToRelated = knex('submission_feature as dataset_sf')
-    .select('dataset_sf.submission_feature_id as from_feature_id', 'related_sf.submission_feature_id as to_feature_id')
-    .join('feature_type as dataset_ft', 'dataset_ft.feature_type_id', 'dataset_sf.feature_type_id')
-    .join('submission_feature as related_sf', 'related_sf.submission_id', 'dataset_sf.submission_id')
-    .where('dataset_ft.name', 'dataset')
-    .whereRaw('related_sf.submission_feature_id != dataset_sf.submission_feature_id')
-    .whereNull('dataset_ft.record_end_date')
-    .whereNull('dataset_sf.record_end_date')
-    .whereNull('related_sf.record_end_date');
-
-  const relatedToDataset = knex('submission_feature as dataset_sf')
-    .select('related_sf.submission_feature_id as from_feature_id', 'dataset_sf.submission_feature_id as to_feature_id')
-    .join('feature_type as dataset_ft', 'dataset_ft.feature_type_id', 'dataset_sf.feature_type_id')
-    .join('submission_feature as related_sf', 'related_sf.submission_id', 'dataset_sf.submission_id')
-    .where('dataset_ft.name', 'dataset')
-    .whereRaw('related_sf.submission_feature_id != dataset_sf.submission_feature_id')
-    .whereNull('dataset_ft.record_end_date')
-    .whereNull('dataset_sf.record_end_date')
-    .whereNull('related_sf.record_end_date');
-
-  return datasetToRelated.unionAll([relatedToDataset]);
 }
 
 /**

--- a/api/src/repositories/expression-evaluation.ts
+++ b/api/src/repositories/expression-evaluation.ts
@@ -221,9 +221,9 @@ function buildPredicateEvidenceIdsQuery(
  * Relatedness is the union of two reachability sources:
  *   (a) the precomputed `submission_feature_closure` reachability — parent-ancestry plus property-reference, in
  *       BOTH directions; and
- *   (b) a bounded recursive walk over the edges the closure deliberately omits — `submission_feature_feature`
- *       content (`data.content`) edges and the synthetic dataset↔same-submission membership edges — both excluded
- *       from the closure because closing over them would make the closure the complete O(N^2) same-upload digraph.
+ *   (b) a bounded recursive walk over the `submission_feature_feature` content (`data.content`) edges the closure
+ *       deliberately omits — excluded from the closure because closing over them would make the closure the
+ *       complete O(N^2) same-upload digraph.
  *
  * The walk starts from the evidence features and follows those edges out to MAX_SEARCH_GRAPH_DEPTH hops,
  * cycle-guarded by the visited path. Every content-reached node is then probed against the closure in BOTH
@@ -273,16 +273,10 @@ function projectEvidenceToTargetIdsQuery(
   const query = knex
     .queryBuilder()
     .with('evidence', evidenceQuery.clone())
-    // edges the closure deliberately omits, walked here: bidirectional content (data.content) edges and
-    // bidirectional synthetic dataset↔same-submission membership edges. Both builders are active-guarded.
+    // edges the closure deliberately omits, walked here: bidirectional content (data.content) edges.
+    // The builder is active-guarded.
     .with('content_edges', (qb) => {
-      qb.select('from_feature_id', 'to_feature_id')
-        .from(buildContentEdgesQuery(knex).as('content_feature_edges'))
-        .unionAll([
-          knex
-            .select('from_feature_id', 'to_feature_id')
-            .from(buildDatasetSubmissionMembershipEdgesQuery(knex).as('dataset_membership_edges'))
-        ]);
+      qb.select('from_feature_id', 'to_feature_id').from(buildContentEdgesQuery(knex).as('content_feature_edges'));
     })
     // recursive content walk: from each evidence feature, follow content edges out to MAX_SEARCH_GRAPH_DEPTH hops,
     // cycle-guarded by the visited path. parent/property transitivity is NOT walked here — the closure handles it.
@@ -347,37 +341,6 @@ function buildContentEdgesQuery(knex: Knex): Knex.QueryBuilder {
     .whereNull('target_sf.record_end_date');
 
   return forward.unionAll([reverse]);
-}
-
-/**
- * Builds synthetic dataset-to-same-submission feature edges in both directions.
- *
- * Dataset synthetic edges intentionally connect dataset features to other features in the same submission. This
- * supports dataset-level predicates returning target features from that submission. This can be high fanout for
- * submissions with many features and should be monitored.
- */
-function buildDatasetSubmissionMembershipEdgesQuery(knex: Knex): Knex.QueryBuilder {
-  const datasetToRelated = knex('submission_feature as dataset_sf')
-    .select('dataset_sf.submission_feature_id as from_feature_id', 'related_sf.submission_feature_id as to_feature_id')
-    .join('feature_type as dataset_ft', 'dataset_ft.feature_type_id', 'dataset_sf.feature_type_id')
-    .join('submission_feature as related_sf', 'related_sf.submission_id', 'dataset_sf.submission_id')
-    .where('dataset_ft.name', 'dataset')
-    .whereRaw('related_sf.submission_feature_id != dataset_sf.submission_feature_id')
-    .whereNull('dataset_ft.record_end_date')
-    .whereNull('dataset_sf.record_end_date')
-    .whereNull('related_sf.record_end_date');
-
-  const relatedToDataset = knex('submission_feature as dataset_sf')
-    .select('related_sf.submission_feature_id as from_feature_id', 'dataset_sf.submission_feature_id as to_feature_id')
-    .join('feature_type as dataset_ft', 'dataset_ft.feature_type_id', 'dataset_sf.feature_type_id')
-    .join('submission_feature as related_sf', 'related_sf.submission_id', 'dataset_sf.submission_id')
-    .where('dataset_ft.name', 'dataset')
-    .whereRaw('related_sf.submission_feature_id != dataset_sf.submission_feature_id')
-    .whereNull('dataset_ft.record_end_date')
-    .whereNull('dataset_sf.record_end_date')
-    .whereNull('related_sf.record_end_date');
-
-  return datasetToRelated.unionAll([relatedToDataset]);
 }
 
 /**

--- a/api/src/repositories/expression-evaluation.ts
+++ b/api/src/repositories/expression-evaluation.ts
@@ -221,11 +221,11 @@ function buildPredicateEvidenceIdsQuery(
  * Relatedness is the union of two reachability sources:
  *   (a) the precomputed `submission_feature_closure` reachability — parent-ancestry plus property-reference, in
  *       BOTH directions; and
- *   (b) a bounded recursive walk over `submission_feature_feature` content (`data.content`) edges, which the
- *       closure deliberately omits because closing over content would make the closure the complete O(N^2)
- *       same-upload digraph.
+ *   (b) a bounded recursive walk over the edges the closure deliberately omits — `submission_feature_feature`
+ *       content (`data.content`) edges and the synthetic dataset↔same-submission membership edges — both excluded
+ *       from the closure because closing over them would make the closure the complete O(N^2) same-upload digraph.
  *
- * The walk starts from the evidence features and follows content edges out to MAX_SEARCH_GRAPH_DEPTH hops,
+ * The walk starts from the evidence features and follows those edges out to MAX_SEARCH_GRAPH_DEPTH hops,
  * cycle-guarded by the visited path. Every content-reached node is then probed against the closure in BOTH
  * directions (forward by source: its ancestors + referenced features; reverse by target: its descendants +
  * referencing features), so a predicate that filters one feature type resolves results deeper or shallower in the
@@ -273,9 +273,16 @@ function projectEvidenceToTargetIdsQuery(
   const query = knex
     .queryBuilder()
     .with('evidence', evidenceQuery.clone())
-    // content (data.content) edges, bidirectional, active-guarded — excluded from the closure, walked here
+    // edges the closure deliberately omits, walked here: bidirectional content (data.content) edges and
+    // bidirectional synthetic dataset↔same-submission membership edges. Both builders are active-guarded.
     .with('content_edges', (qb) => {
-      qb.select('from_feature_id', 'to_feature_id').from(buildContentEdgesQuery(knex).as('content_feature_edges'));
+      qb.select('from_feature_id', 'to_feature_id')
+        .from(buildContentEdgesQuery(knex).as('content_feature_edges'))
+        .unionAll([
+          knex
+            .select('from_feature_id', 'to_feature_id')
+            .from(buildDatasetSubmissionMembershipEdgesQuery(knex).as('dataset_membership_edges'))
+        ]);
     })
     // recursive content walk: from each evidence feature, follow content edges out to MAX_SEARCH_GRAPH_DEPTH hops,
     // cycle-guarded by the visited path. parent/property transitivity is NOT walked here — the closure handles it.
@@ -340,6 +347,37 @@ function buildContentEdgesQuery(knex: Knex): Knex.QueryBuilder {
     .whereNull('target_sf.record_end_date');
 
   return forward.unionAll([reverse]);
+}
+
+/**
+ * Builds synthetic dataset-to-same-submission feature edges in both directions.
+ *
+ * Dataset synthetic edges intentionally connect dataset features to other features in the same submission. This
+ * supports dataset-level predicates returning target features from that submission. This can be high fanout for
+ * submissions with many features and should be monitored.
+ */
+function buildDatasetSubmissionMembershipEdgesQuery(knex: Knex): Knex.QueryBuilder {
+  const datasetToRelated = knex('submission_feature as dataset_sf')
+    .select('dataset_sf.submission_feature_id as from_feature_id', 'related_sf.submission_feature_id as to_feature_id')
+    .join('feature_type as dataset_ft', 'dataset_ft.feature_type_id', 'dataset_sf.feature_type_id')
+    .join('submission_feature as related_sf', 'related_sf.submission_id', 'dataset_sf.submission_id')
+    .where('dataset_ft.name', 'dataset')
+    .whereRaw('related_sf.submission_feature_id != dataset_sf.submission_feature_id')
+    .whereNull('dataset_ft.record_end_date')
+    .whereNull('dataset_sf.record_end_date')
+    .whereNull('related_sf.record_end_date');
+
+  const relatedToDataset = knex('submission_feature as dataset_sf')
+    .select('related_sf.submission_feature_id as from_feature_id', 'dataset_sf.submission_feature_id as to_feature_id')
+    .join('feature_type as dataset_ft', 'dataset_ft.feature_type_id', 'dataset_sf.feature_type_id')
+    .join('submission_feature as related_sf', 'related_sf.submission_id', 'dataset_sf.submission_id')
+    .where('dataset_ft.name', 'dataset')
+    .whereRaw('related_sf.submission_feature_id != dataset_sf.submission_feature_id')
+    .whereNull('dataset_ft.record_end_date')
+    .whereNull('dataset_sf.record_end_date')
+    .whereNull('related_sf.record_end_date');
+
+  return datasetToRelated.unionAll([relatedToDataset]);
 }
 
 /**

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -5,7 +5,7 @@ import { SearchFeatureResultWithRelevancy } from '../services/search-feature-ser
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 import { dependencies as expressionEvaluation } from './expression-evaluation';
-import { buildSecurityFilter, isEffectivelySecuredViaClosure } from './sql-fragments';
+import { buildSecurityFilter, isEffectivelySecured } from './sql-fragments';
 
 /**
  * Repository for searching submission features by expression-tree criteria.
@@ -127,7 +127,7 @@ export class SearchFeatureRepository extends BaseRepository {
         'feature_name',
         'feature_description',
         'submission_name',
-        knex.raw(`${isEffectivelySecuredViaClosure('expression_results.submission_feature_id')} AS is_secured`),
+        knex.raw(`${isEffectivelySecured('expression_results.submission_feature_id')} AS is_secured`),
         'relevancy_score',
         'create_date'
       );

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -5,7 +5,7 @@ import { SearchFeatureResultWithRelevancy } from '../services/search-feature-ser
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 import { dependencies as expressionEvaluation } from './expression-evaluation';
-import { buildSecurityFilter, isEffectivelySecured } from './sql-fragments';
+import { buildSecurityFilter, isEffectivelySecuredViaClosure } from './sql-fragments';
 
 /**
  * Repository for searching submission features by expression-tree criteria.
@@ -127,7 +127,7 @@ export class SearchFeatureRepository extends BaseRepository {
         'feature_name',
         'feature_description',
         'submission_name',
-        knex.raw(`${isEffectivelySecured('expression_results.submission_feature_id')} AS is_secured`),
+        knex.raw(`${isEffectivelySecuredViaClosure('expression_results.submission_feature_id')} AS is_secured`),
         'relevancy_score',
         'create_date'
       );

--- a/api/src/repositories/sql-fragments.test.ts
+++ b/api/src/repositories/sql-fragments.test.ts
@@ -1,14 +1,105 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { isAccessibleToUser } from './sql-fragments';
+import { isAccessibleToUser, isEffectivelySecured, isEffectivelySecuredViaClosure } from './sql-fragments';
 
 describe('sql-fragments', () => {
+  describe('isEffectivelySecuredViaClosure', () => {
+    it('reads the precomputed closure ancestry instead of a recursive parent walk', () => {
+      // Verifies: the closure-based fragment probes submission_feature_closure on the
+      // ancestry subset (is_ancestor = true), joins security on the target id, and gates
+      // on the effective date — without any recursive CTE.
+
+      // Step 1: Build the fragment for a feature id expression and lowercase for token matching
+      const sql = isEffectivelySecuredViaClosure('wf.submission_feature_id').toLowerCase();
+
+      // Step 2: Verify it reads the closure ancestry (source side keyed to the candidate feature)
+      expect(sql).to.include('submission_feature_closure');
+      expect(sql).to.include('is_ancestor');
+      expect(sql).to.include('c.source_submission_feature_id =');
+
+      // Step 3: Verify the security join is on the closure target id and gated by effective date
+      expect(sql).to.include('sfs.submission_feature_id = c.target_submission_feature_id');
+      expect(sql).to.include('record_effective_date <= now()');
+
+      // Step 4: Verify it does NOT fall back to the recursive parent walk
+      expect(sql).to.not.include('with recursive');
+      expect(sql).to.not.include('ancestor_chain');
+    });
+
+    it('contains zero bound placeholders', () => {
+      // Verifies: the closure fragment is fully self-contained SQL with no `?` to bind
+
+      // Step 1: Build the fragment
+      const sql = isEffectivelySecuredViaClosure('wf.submission_feature_id');
+
+      // Step 2: Count `?` placeholders — must be none
+      expect((sql.match(/\?/g) || []).length).to.equal(0);
+    });
+  });
+
   describe('isAccessibleToUser', () => {
     it('requires active team records for scope grants', () => {
       const sql = isAccessibleToUser('wf.submission_feature_id').toLowerCase();
 
       expect(sql).to.include('join team t on t.team_id = tss.team_id');
       expect(sql).to.include('and t.record_end_date is null');
+    });
+
+    it('probes the closure ancestry for a scope anchor instead of a recursive parent walk', () => {
+      // Verifies: the rewritten access check resolves ancestry via the precomputed closure
+      // (is_ancestor = true) and joins security_scope_anchor on the closure target id — no
+      // recursive CTE.
+
+      // Step 1: Build the fragment and lowercase for token matching
+      const sql = isAccessibleToUser('wf.submission_feature_id').toLowerCase();
+
+      // Step 2: Verify it reads the closure ancestry
+      expect(sql).to.include('submission_feature_closure');
+      expect(sql).to.include('is_ancestor');
+
+      // Step 3: Verify the scope anchor is joined on the closure target id
+      expect(sql).to.include(
+        'security_scope_anchor ssa on ssa.anchor_submission_feature_id = c.target_submission_feature_id'
+      );
+
+      // Step 4: Verify it does NOT use the recursive parent walk
+      expect(sql).to.not.include('with recursive');
+      expect(sql).to.not.include('ancestor_chain');
+    });
+
+    it('contains exactly one bound placeholder for systemUserId', () => {
+      // Verifies: only the team_member.system_user_id comparison is parameterized — exactly one `?`
+
+      // Step 1: Build the fragment
+      const sql = isAccessibleToUser('wf.submission_feature_id');
+
+      // Step 2: Count `?` placeholders — must be exactly one (the system user id)
+      expect((sql.match(/\?/g) || []).length).to.equal(1);
+    });
+  });
+
+  describe('isEffectivelySecured (recursive, scope-anchor job)', () => {
+    it('still walks live parent pointers with a recursive CTE', () => {
+      // Verifies: the recursive fragment consumed by the scope-anchor recompute job was left
+      // intact (it must resolve ancestry from live submission_feature parent pointers because
+      // the closure may be stale/absent when the job runs).
+
+      // Step 1: Build the fragment and lowercase for token matching
+      const sql = isEffectivelySecured('wf.submission_feature_id').toLowerCase();
+
+      // Step 2: Verify it still uses the recursive ancestor walk
+      expect(sql).to.include('with recursive');
+      expect(sql).to.include('ancestor_chain');
+    });
+
+    it('contains zero bound placeholders', () => {
+      // Verifies: the recursive fragment is fully self-contained SQL with no `?` to bind
+
+      // Step 1: Build the fragment
+      const sql = isEffectivelySecured('wf.submission_feature_id');
+
+      // Step 2: Count `?` placeholders — must be none
+      expect((sql.match(/\?/g) || []).length).to.equal(0);
     });
   });
 });

--- a/api/src/repositories/sql-fragments.test.ts
+++ b/api/src/repositories/sql-fragments.test.ts
@@ -1,16 +1,16 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { isAccessibleToUser, isEffectivelySecured, isEffectivelySecuredViaClosure } from './sql-fragments';
+import { isAccessibleToUser, isEffectivelySecured } from './sql-fragments';
 
 describe('sql-fragments', () => {
-  describe('isEffectivelySecuredViaClosure', () => {
+  describe('isEffectivelySecured', () => {
     it('reads the precomputed closure ancestry instead of a recursive parent walk', () => {
       // Verifies: the closure-based fragment probes submission_feature_closure on the
       // ancestry subset (is_ancestor = true), joins security on the target id, and gates
       // on the effective date — without any recursive CTE.
 
       // Step 1: Build the fragment for a feature id expression and lowercase for token matching
-      const sql = isEffectivelySecuredViaClosure('wf.submission_feature_id').toLowerCase();
+      const sql = isEffectivelySecured('wf.submission_feature_id').toLowerCase();
 
       // Step 2: Verify it reads the closure ancestry (source side keyed to the candidate feature)
       expect(sql).to.include('submission_feature_closure');
@@ -30,7 +30,7 @@ describe('sql-fragments', () => {
       // Verifies: the closure fragment is fully self-contained SQL with no `?` to bind
 
       // Step 1: Build the fragment
-      const sql = isEffectivelySecuredViaClosure('wf.submission_feature_id');
+      const sql = isEffectivelySecured('wf.submission_feature_id');
 
       // Step 2: Count `?` placeholders — must be none
       expect((sql.match(/\?/g) || []).length).to.equal(0);
@@ -75,31 +75,6 @@ describe('sql-fragments', () => {
 
       // Step 2: Count `?` placeholders — must be exactly one (the system user id)
       expect((sql.match(/\?/g) || []).length).to.equal(1);
-    });
-  });
-
-  describe('isEffectivelySecured (recursive, scope-anchor job)', () => {
-    it('still walks live parent pointers with a recursive CTE', () => {
-      // Verifies: the recursive fragment consumed by the scope-anchor recompute job was left
-      // intact (it must resolve ancestry from live submission_feature parent pointers because
-      // the closure may be stale/absent when the job runs).
-
-      // Step 1: Build the fragment and lowercase for token matching
-      const sql = isEffectivelySecured('wf.submission_feature_id').toLowerCase();
-
-      // Step 2: Verify it still uses the recursive ancestor walk
-      expect(sql).to.include('with recursive');
-      expect(sql).to.include('ancestor_chain');
-    });
-
-    it('contains zero bound placeholders', () => {
-      // Verifies: the recursive fragment is fully self-contained SQL with no `?` to bind
-
-      // Step 1: Build the fragment
-      const sql = isEffectivelySecured('wf.submission_feature_id');
-
-      // Step 2: Count `?` placeholders — must be none
-      expect((sql.match(/\?/g) || []).length).to.equal(0);
     });
   });
 });

--- a/api/src/repositories/sql-fragments.ts
+++ b/api/src/repositories/sql-fragments.ts
@@ -22,14 +22,15 @@ import { Knex } from 'knex';
  * `target_submission_feature_id`. This matters because it runs on every search, cart,
  * and download request.
  *
- * Requires the closure to be populated for the feature's upload. This holds on every
- * caller: features only become searchable after indexing rebuilds the closure, and the
- * anchor recompute write path is only ever triggered for already-indexed submissions
- * (applying a security rule or approving a policy never changes a feature's ancestry,
- * so the closure built at index time is still current). Any feature reaching this check
- * therefore already has its closure rows (at minimum the self-loop). Callers that
- * operate on un-indexed or possibly-inactive ids (e.g. raw id arrays) must filter to
- * active features first, since the closure has no row for soft-deleted features.
+ * Fails closed on missing closure rows. The closure is built by an async recompute job
+ * that runs *after* an upload is flipped to `indexed` (and therefore searchable), in a
+ * separate transaction; a recompute that has not yet run, or that failed, does not revert
+ * that status. So an active, searchable, secured feature can transiently — or, on a failed
+ * recompute, indefinitely — have no closure rows. Rather than read "no rows" as "unsecured"
+ * (which would leak the feature), this check treats the absence of any closure ancestry row
+ * as secured: if we cannot prove a feature is unsecured, we hide it. Under normal operation
+ * every active feature carries at least its self-loop `(F, F)`, so the fail-closed branch is
+ * inert on the happy path.
  *
  * Returns an `EXISTS (...)` SQL expression (returns boolean) with zero `?` placeholders.
  *
@@ -37,15 +38,27 @@ import { Knex } from 'knex';
  *   (e.g. 'wf.submission_feature_id', 'expression_results.submission_feature_id')
  */
 export function isEffectivelySecured(featureIdExpr: string): string {
-  return `EXISTS (
-    SELECT 1
-    FROM submission_feature_closure c
-    JOIN submission_feature_security sfs ON sfs.submission_feature_id = c.target_submission_feature_id
-    JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = c.target_submission_feature_id
-    WHERE c.source_submission_feature_id = ${featureIdExpr}
-      AND c.is_ancestor = true
-      AND sfs.record_end_date IS NULL
-      AND sf_sec.record_effective_date <= now()
+  return `(
+    EXISTS (
+      SELECT 1
+      FROM submission_feature_closure c
+      JOIN submission_feature_security sfs ON sfs.submission_feature_id = c.target_submission_feature_id
+      JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = c.target_submission_feature_id
+      WHERE c.source_submission_feature_id = ${featureIdExpr}
+        AND c.is_ancestor = true
+        AND sfs.record_end_date IS NULL
+        AND sf_sec.record_effective_date <= now()
+    )
+    -- Fail closed: the reflexive self-loop (F, F) is written for every active feature when its upload's
+    -- closure is built, so its absence means the closure is not built (recompute not yet run, or failed).
+    -- We then cannot prove the feature is unsecured — treat it as secured rather than leak it. This is a
+    -- direct primary-key probe ((source, target) is the PK).
+    OR NOT EXISTS (
+      SELECT 1
+      FROM submission_feature_closure c
+      WHERE c.source_submission_feature_id = ${featureIdExpr}
+        AND c.target_submission_feature_id = ${featureIdExpr}
+    )
   )`;
 }
 

--- a/api/src/repositories/sql-fragments.ts
+++ b/api/src/repositories/sql-fragments.ts
@@ -9,52 +9,10 @@
 import { Knex } from 'knex';
 
 /**
- * Per-row "effectively secured" check that resolves ancestry by walking UP the
- * live `submission_feature` parent pointers with a recursive CTE: a feature is
- * effectively secured when it or any ancestor has an active security rule whose
- * feature is past its effective date.
- *
- * Returns an `EXISTS (...)` SQL expression suitable for use in WHERE clauses
- * or as a SELECT column (returns boolean).
- *
- * This intentionally walks live parent pointers rather than reading the derived
- * `submission_feature_closure` table. It is consumed by the scope-anchor recompute
- * job (`security-scope-repository.ts`), which can run BEFORE the closure has been
- * rebuilt for an upload — so the closure may be stale or absent at that point and
- * cannot be trusted. Resolving ancestry directly from `submission_feature` parent
- * pointers is the only correct source there. Read paths (search / cart / download)
- * must NOT use this; they use `isEffectivelySecuredViaClosure`, which reads the
- * precomputed closure and avoids the per-row recursive walk.
- *
- * Cost is O(tree_depth) per row (~3–5 levels), bounded by the feature
- * hierarchy depth regardless of total feature count.
- *
- * @param featureIdExpr SQL expression for the starting submission_feature_id
- *   (e.g. 'wf.submission_feature_id', 'candidate.submission_feature_id')
- */
-export function isEffectivelySecured(featureIdExpr: string): string {
-  return `EXISTS (
-    WITH RECURSIVE ancestor_chain(id) AS (
-      SELECT ${featureIdExpr}
-      UNION ALL
-      SELECT p.parent_submission_feature_id
-      FROM ancestor_chain ac
-      JOIN submission_feature p ON p.submission_feature_id = ac.id
-      WHERE p.parent_submission_feature_id IS NOT NULL
-        AND p.record_end_date IS NULL
-    )
-    SELECT 1 FROM ancestor_chain ac
-    JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
-    JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = ac.id
-    WHERE sfs.record_end_date IS NULL
-      AND sf_sec.record_effective_date <= now()
-  )`;
-}
-
-/**
- * Closure-based "effectively secured" check for the hot read paths (search / cart /
- * download): a feature is effectively secured when it or an ancestor has an active
- * security rule that is past its effective date.
+ * Closure-based "effectively secured" check used on every security-resolving path —
+ * the hot read paths (search / cart / download) and the scope-anchor recompute write
+ * path: a feature is effectively secured when it or an ancestor has an active security
+ * rule that is past its effective date.
  *
  * Instead of a per-row recursive parent walk, this reads the precomputed
  * `submission_feature_closure` ancestry subset — `is_ancestor = true`, which is the
@@ -64,19 +22,21 @@ export function isEffectivelySecured(featureIdExpr: string): string {
  * `target_submission_feature_id`. This matters because it runs on every search, cart,
  * and download request.
  *
- * Requires the closure to be populated for the feature's upload. This is always true on
- * read paths: features only become searchable after indexing rebuilds the closure, so
- * any feature reaching this check already has its closure rows (at minimum the
- * self-loop). Callers that operate on un-indexed or possibly-inactive ids (e.g. raw
- * id arrays) must filter to active features first, since the closure has no row for
- * soft-deleted features.
+ * Requires the closure to be populated for the feature's upload. This holds on every
+ * caller: features only become searchable after indexing rebuilds the closure, and the
+ * anchor recompute write path is only ever triggered for already-indexed submissions
+ * (applying a security rule or approving a policy never changes a feature's ancestry,
+ * so the closure built at index time is still current). Any feature reaching this check
+ * therefore already has its closure rows (at minimum the self-loop). Callers that
+ * operate on un-indexed or possibly-inactive ids (e.g. raw id arrays) must filter to
+ * active features first, since the closure has no row for soft-deleted features.
  *
  * Returns an `EXISTS (...)` SQL expression (returns boolean) with zero `?` placeholders.
  *
  * @param featureIdExpr SQL expression for the starting submission_feature_id
  *   (e.g. 'wf.submission_feature_id', 'expression_results.submission_feature_id')
  */
-export function isEffectivelySecuredViaClosure(featureIdExpr: string): string {
+export function isEffectivelySecured(featureIdExpr: string): string {
   return `EXISTS (
     SELECT 1
     FROM submission_feature_closure c
@@ -101,7 +61,7 @@ export function isEffectivelySecuredViaClosure(featureIdExpr: string): string {
  *
  * This reads the precomputed `submission_feature_closure` ancestry subset
  * (`is_ancestor = true`) instead of doing a recursive parent walk. Branch 1 reuses
- * `isEffectivelySecuredViaClosure`; Branch 2 probes the closure for an ancestor that is
+ * `isEffectivelySecured`; Branch 2 probes the closure for an ancestor that is
  * a scope anchor the user's team can reach. Both are cheap PK-served closure probes
  * (`source_submission_feature_id`), so the old concern of walking the ancestor chain
  * twice no longer applies — there is no recursive walk at all.
@@ -114,7 +74,7 @@ export function isAccessibleToUser(featureIdExpr: string): string {
     SELECT 1
     WHERE
       -- Branch 1: feature is NOT effectively secured
-      NOT ${isEffectivelySecuredViaClosure(featureIdExpr)}
+      NOT ${isEffectivelySecured(featureIdExpr)}
       -- Branch 2: user has a team scope grant via an ancestor that is a scope anchor
       OR EXISTS (
         SELECT 1
@@ -141,7 +101,7 @@ export function isAccessibleToUser(featureIdExpr: string): string {
  * For anonymous users (systemUserId is null), only unsecured features pass.
  *
  * Composes the closure-based read-path fragments above:
- * - `isEffectivelySecuredViaClosure` — a feature is "effectively secured" only when it or an
+ * - `isEffectivelySecured` — a feature is "effectively secured" only when it or an
  *   ancestor has an active security rule AND the feature is past its `record_effective_date`,
  *   resolved via the precomputed closure ancestry subset.
  * - `isAccessibleToUser` — probes the same closure ancestry for a scope anchor the user's team
@@ -172,7 +132,7 @@ export function buildSecurityFilter(
 
   if (!systemUserId) {
     // Anonymous: only unsecured features
-    return knex.raw(`NOT ${isEffectivelySecuredViaClosure(submissionFeatureIdColumn)}`);
+    return knex.raw(`NOT ${isEffectivelySecured(submissionFeatureIdColumn)}`);
   }
 
   // Authenticated: feature is unsecured OR user has team scope grant (indexed closure lookups)

--- a/api/src/repositories/sql-fragments.ts
+++ b/api/src/repositories/sql-fragments.ts
@@ -9,12 +9,22 @@
 import { Knex } from 'knex';
 
 /**
- * Per-row "effectively secured" check: walks UP from a feature through its
- * ancestors to determine if it or any ancestor has an active security rule
- * whose feature is past its effective date.
+ * Per-row "effectively secured" check that resolves ancestry by walking UP the
+ * live `submission_feature` parent pointers with a recursive CTE: a feature is
+ * effectively secured when it or any ancestor has an active security rule whose
+ * feature is past its effective date.
  *
  * Returns an `EXISTS (...)` SQL expression suitable for use in WHERE clauses
  * or as a SELECT column (returns boolean).
+ *
+ * This intentionally walks live parent pointers rather than reading the derived
+ * `submission_feature_closure` table. It is consumed by the scope-anchor recompute
+ * job (`security-scope-repository.ts`), which can run BEFORE the closure has been
+ * rebuilt for an upload — so the closure may be stale or absent at that point and
+ * cannot be trusted. Resolving ancestry directly from `submission_feature` parent
+ * pointers is the only correct source there. Read paths (search / cart / download)
+ * must NOT use this; they use `isEffectivelySecuredViaClosure`, which reads the
+ * precomputed closure and avoids the per-row recursive walk.
  *
  * Cost is O(tree_depth) per row (~3–5 levels), bounded by the feature
  * hierarchy depth regardless of total feature count.
@@ -42,72 +52,105 @@ export function isEffectivelySecured(featureIdExpr: string): string {
 }
 
 /**
- * Combined security + scope-grant check for authenticated users. Walks the ancestor
- * chain ONCE, then checks two conditions against the materialized CTE:
+ * Closure-based "effectively secured" check for the hot read paths (search / cart /
+ * download): a feature is effectively secured when it or an ancestor has an active
+ * security rule that is past its effective date.
  *
- * 1. Feature is NOT effectively secured (no active approved security rule in chain), OR
- * 2. User has a team scope grant via `security_scope_anchor` in the ancestor chain
+ * Instead of a per-row recursive parent walk, this reads the precomputed
+ * `submission_feature_closure` ancestry subset — `is_ancestor = true`, which is the
+ * pure parent-ancestry reach including the feature's own self-loop `(F, F)` — joined
+ * to the security tables. The ancestry lookup is served by the closure primary key on
+ * `source_submission_feature_id`; the security joins are index-served on
+ * `target_submission_feature_id`. This matters because it runs on every search, cart,
+ * and download request.
+ *
+ * Requires the closure to be populated for the feature's upload. This is always true on
+ * read paths: features only become searchable after indexing rebuilds the closure, so
+ * any feature reaching this check already has its closure rows (at minimum the
+ * self-loop). Callers that operate on un-indexed or possibly-inactive ids (e.g. raw
+ * id arrays) must filter to active features first, since the closure has no row for
+ * soft-deleted features.
+ *
+ * Returns an `EXISTS (...)` SQL expression (returns boolean) with zero `?` placeholders.
+ *
+ * @param featureIdExpr SQL expression for the starting submission_feature_id
+ *   (e.g. 'wf.submission_feature_id', 'expression_results.submission_feature_id')
+ */
+export function isEffectivelySecuredViaClosure(featureIdExpr: string): string {
+  return `EXISTS (
+    SELECT 1
+    FROM submission_feature_closure c
+    JOIN submission_feature_security sfs ON sfs.submission_feature_id = c.target_submission_feature_id
+    JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = c.target_submission_feature_id
+    WHERE c.source_submission_feature_id = ${featureIdExpr}
+      AND c.is_ancestor = true
+      AND sfs.record_end_date IS NULL
+      AND sf_sec.record_effective_date <= now()
+  )`;
+}
+
+/**
+ * Combined security + scope-grant check for authenticated users on the read paths.
+ * A feature is accessible when either:
+ *
+ * 1. The feature is NOT effectively secured (no active approved security rule in its
+ *    ancestry), OR
+ * 2. The user has a team scope grant via a `security_scope_anchor` on an ancestor.
  *
  * Returns an `EXISTS (...)` SQL expression with a single `?` placeholder for `systemUserId`.
  *
- * This avoids the double-walk penalty of calling `isEffectivelySecured` and a separate
- * scope-grant check independently — both reuse the same recursive ancestor traversal.
+ * This reads the precomputed `submission_feature_closure` ancestry subset
+ * (`is_ancestor = true`) instead of doing a recursive parent walk. Branch 1 reuses
+ * `isEffectivelySecuredViaClosure`; Branch 2 probes the closure for an ancestor that is
+ * a scope anchor the user's team can reach. Both are cheap PK-served closure probes
+ * (`source_submission_feature_id`), so the old concern of walking the ancestor chain
+ * twice no longer applies — there is no recursive walk at all.
  *
  * @param featureIdExpr SQL expression for the starting submission_feature_id
  *   (e.g. 'wf.submission_feature_id', 'aggregated_results.submission_feature_id')
  */
 export function isAccessibleToUser(featureIdExpr: string): string {
   return `EXISTS (
-    -- Walk up the feature hierarchy once, materialized by PostgreSQL
-    WITH RECURSIVE ancestor_chain(id) AS (
-      SELECT ${featureIdExpr}
-      UNION ALL
-      SELECT p.parent_submission_feature_id
-      FROM ancestor_chain ac
-      JOIN submission_feature p ON p.submission_feature_id = ac.id
-      WHERE p.parent_submission_feature_id IS NOT NULL
-        AND p.record_end_date IS NULL
-    )
     SELECT 1
     WHERE
-      -- Branch 1: feature is NOT effectively secured (no active approved security rule in chain)
-      NOT EXISTS (
-        SELECT 1 FROM ancestor_chain ac
-        JOIN submission_feature_security sfs ON sfs.submission_feature_id = ac.id
-        JOIN submission_feature sf_sec ON sf_sec.submission_feature_id = ac.id
-        WHERE sfs.record_end_date IS NULL
-          AND sf_sec.record_effective_date <= now()
-      )
-      -- Branch 2: user has a team scope grant via an anchor in the ancestor chain
+      -- Branch 1: feature is NOT effectively secured
+      NOT ${isEffectivelySecuredViaClosure(featureIdExpr)}
+      -- Branch 2: user has a team scope grant via an ancestor that is a scope anchor
       OR EXISTS (
-        SELECT 1 FROM ancestor_chain ac
-        JOIN security_scope_anchor ssa ON ssa.anchor_submission_feature_id = ac.id
+        SELECT 1
+        FROM submission_feature_closure c
+        JOIN security_scope_anchor ssa ON ssa.anchor_submission_feature_id = c.target_submission_feature_id
         JOIN team_security_scope tss ON tss.security_scope_id = ssa.security_scope_id
         JOIN team t ON t.team_id = tss.team_id
           AND t.record_end_date IS NULL
         JOIN team_member tm ON tm.team_id = tss.team_id
           AND tm.system_user_id = ?  -- bound by caller
           AND tm.record_end_date IS NULL
+        WHERE c.source_submission_feature_id = ${featureIdExpr}
+          AND c.is_ancestor = true
       )
   )`;
 }
 
 /**
- * Builds a single security filter that walks ancestors once per candidate feature and checks:
- *   1. Unsecured — no ancestor has a submission_feature_security row → visible
+ * Builds a single security filter, applied per candidate feature, that checks:
+ *   1. Unsecured — no ancestor has an active submission_feature_security row → visible
  *   2. Secured + granted — any ancestor is a scope anchor the user's team can reach → visible
  *   3. Secured + denied — secured but no matching scope anchor → filtered out
  *
  * For anonymous users (systemUserId is null), only unsecured features pass.
  *
- * Composes the shared fragments above:
- * - `isEffectivelySecured` — a feature is "effectively secured" only when it or an ancestor
- *   has an active security rule AND the feature is past its `record_effective_date`.
- * - `isAccessibleToUser` — walks ancestors to find a scope anchor the user's team can reach.
+ * Composes the closure-based read-path fragments above:
+ * - `isEffectivelySecuredViaClosure` — a feature is "effectively secured" only when it or an
+ *   ancestor has an active security rule AND the feature is past its `record_effective_date`,
+ *   resolved via the precomputed closure ancestry subset.
+ * - `isAccessibleToUser` — probes the same closure ancestry for a scope anchor the user's team
+ *   can reach.
  *
- * Walk-up (not expand-down) strategy: callers have already narrowed features to a small
- * candidate set. For each candidate, walk UP the parent chain (~3-5 levels) to check
- * scope anchors. Cost is O(candidates × depth), not O(features in scope).
+ * Both fragments are indexed closure lookups (PK-served on `source_submission_feature_id`), not
+ * per-row recursive parent walks. Callers have already narrowed features to a small candidate
+ * set, so the filter applies a couple of cheap probes per candidate — cost is O(candidates),
+ * not O(features in scope).
  *
  * Shared by the filter-based search wrapper and the expression-tree evaluator so both
  * read paths apply identical security semantics.
@@ -129,9 +172,9 @@ export function buildSecurityFilter(
 
   if (!systemUserId) {
     // Anonymous: only unsecured features
-    return knex.raw(`NOT ${isEffectivelySecured(submissionFeatureIdColumn)}`);
+    return knex.raw(`NOT ${isEffectivelySecuredViaClosure(submissionFeatureIdColumn)}`);
   }
 
-  // Authenticated: feature is unsecured OR user has team scope grant (single ancestor walk)
+  // Authenticated: feature is unsecured OR user has team scope grant (indexed closure lookups)
   return knex.raw(`${isAccessibleToUser(submissionFeatureIdColumn)}`, [systemUserId]);
 }

--- a/database/src/seeds/06_submission_data.ts
+++ b/database/src/seeds/06_submission_data.ts
@@ -106,6 +106,13 @@ export async function seed(knex: Knex): Promise<void> {
       )
       WHERE sf.data_byte_size IS NULL;
     `);
+
+    // Derived reachability closure — recomputed wholesale per upload (DELETE + recursive-CTE INSERT),
+    // mirroring SubmissionFeatureClosureRepository. Search resolves relatedness against this table, so
+    // seeded uploads need their closure rows to be searchable.
+    for (const { submission_upload_id } of seedContexts) {
+      await computeSubmissionFeatureClosureForUpload(trx, submission_upload_id);
+    }
   });
 }
 
@@ -189,6 +196,93 @@ const insertMockRelatedSubmissionFeatures = async (
     .insert(relationshipRows)
     .onConflict(['source_feature_id', 'target_feature_id'])
     .ignore();
+};
+
+/**
+ * Recompute the derived reachability closure for a single upload (DELETE + recursive-CTE INSERT).
+ *
+ * Mirrors {@link SubmissionFeatureClosureRepository.deleteClosureForUpload} +
+ * {@link SubmissionFeatureClosureRepository.computeClosureForUpload} as a standalone knex helper, since
+ * the database package cannot import the api repository. Closure is reachability over the upload's parent
+ * and property (feature-reference) edges — content edges (submission_feature_feature) are intentionally
+ * excluded. is_ancestor flags the pure parent-ancestry subset (the authorization reach); search reads all
+ * rows. Delete-then-insert in one transaction keeps the wholesale recompute idempotent.
+ *
+ * @param {SeedConnection} knex
+ * @param {string} submission_upload_id The submission upload scope.
+ * @returns {Promise<void>}
+ */
+const computeSubmissionFeatureClosureForUpload = async (
+  knex: SeedConnection,
+  submission_upload_id: string
+): Promise<void> => {
+  await knex.raw(
+    `
+      DELETE FROM submission_feature_closure c
+      USING submission_feature sf
+      WHERE sf.submission_upload_id = ?::uuid
+        AND c.source_submission_feature_id = sf.submission_feature_id;
+    `,
+    [submission_upload_id]
+  );
+
+  await knex.raw(
+    `
+      WITH RECURSIVE
+      active_features AS (
+        SELECT submission_feature_id
+        FROM submission_feature
+        WHERE submission_upload_id = ?::uuid
+          AND record_end_date IS NULL
+      ),
+      self_loops AS (
+        SELECT submission_feature_id AS source, submission_feature_id AS target
+        FROM active_features
+      ),
+      parent_edges AS (
+        SELECT child.submission_feature_id AS source, child.parent_submission_feature_id AS target
+        FROM submission_feature child
+        JOIN active_features af_src ON af_src.submission_feature_id = child.submission_feature_id
+        JOIN active_features af_tgt ON af_tgt.submission_feature_id = child.parent_submission_feature_id
+        WHERE child.parent_submission_feature_id IS NOT NULL
+      ),
+      property_edges AS (
+        SELECT pf.submission_feature_id AS source, pf.referenced_submission_feature_id AS target
+        FROM submission_feature_property_feature pf
+        JOIN active_features af_src ON af_src.submission_feature_id = pf.submission_feature_id
+        JOIN active_features af_tgt ON af_tgt.submission_feature_id = pf.referenced_submission_feature_id
+      ),
+      ancestry_edges AS (
+        SELECT source, target FROM self_loops
+        UNION ALL SELECT source, target FROM parent_edges
+      ),
+      direct_edges AS (
+        SELECT source, target FROM self_loops
+        UNION ALL SELECT source, target FROM parent_edges
+        UNION ALL SELECT source, target FROM property_edges
+      ),
+      ancestry_closure AS (
+        SELECT source, target FROM ancestry_edges
+        UNION
+        SELECT c.source, d.target
+        FROM ancestry_closure c
+        JOIN ancestry_edges d ON d.source = c.target
+      ),
+      closure AS (
+        SELECT source, target FROM direct_edges
+        UNION
+        SELECT c.source, d.target
+        FROM closure c
+        JOIN direct_edges d ON d.source = c.target
+      )
+      INSERT INTO submission_feature_closure (source_submission_feature_id, target_submission_feature_id, is_ancestor)
+      SELECT cl.source, cl.target, (anc.source IS NOT NULL) AS is_ancestor
+      FROM closure cl
+      LEFT JOIN ancestry_closure anc
+        ON anc.source = cl.source AND anc.target = cl.target;
+    `,
+    [submission_upload_id]
+  );
 };
 
 /**


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-1025](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1025)

## Description of Changes

As a system administrator, I want expression search to use `submission_feature_closure` to determine whether two features are related, so that search no longer performs recursive graph traversal at query time.

### Background

Expression search currently resolves related features by recursively traversing feature relationships.

The new closure table precomputes those relationships. Search should use the closure table as a lookup:

> Is evidence feature A related to target feature B?

Instead of recursively walking from A to B during the search request, the query should check for an existing row:

- `submission_feature_closure.source_submission_feature_id` = evidence feature id
- `submission_feature_closure.target_submission_feature_id` = target feature id

### Scope

- Replace recursive relationship traversal in expression search with closure-table lookup
- Replace the recursive ancestor walk in the shared security fragments (`isEffectivelySecured` / `isAccessibleToUser` in `sql-fragments.ts`) with a `submission_feature_closure` lookup over the `is_ancestor = true` subset — in place, so all callers switch (see AC #3)
- Preserve existing expression search behaviour
- Preserve evidence and target security filtering
- Preserve pagination and count behaviour
- Keep the public search API unchanged

## Acceptance Criteria

### 1. Use Closure Lookup for Relationship Checks

WHEN expression search needs to determine whether an evidence feature is related to a target feature
THEN it should check `submission_feature_closure`
AND it should not recursively traverse feature relationships at query time

### 2. Remove Runtime Recursive Traversal

WHEN expression search runs
THEN it should not dynamically recurse through:
- `submission_feature_feature`
- `parent_submission_feature_id`
- `submission_feature_property_feature`

AND it should rely on `submission_feature_closure` to determine feature relatedness

### 3. Use Closure Lookup for the Security Ancestor Walk

WHEN a security check needs the ancestor chain of a feature (to find an active security rule or a reachable scope anchor)
THEN the shared fragments `isEffectivelySecured` and `isAccessibleToUser` should resolve ancestors via `submission_feature_closure` (`source_submission_feature_id` = the feature, `WHERE is_ancestor = true`)
AND they should not use `WITH RECURSIVE ancestor_chain` to walk `parent_submission_feature_id` at query time

### 4. Preserve Security Semantics Across All Callers

WHEN the rewritten fragments are used by any caller — expression search, filter search, cart, and the authorization scope-anchor recompute job
THEN each caller returns the same visibility/security result as the recursive implementation
AND anonymous-vs-authenticated, effective-date, and scope-grant semantics are unchanged

## Implementation Notes

Current conceptual shape:

```
predicate
  -> evidence feature ids
  -> recursive traversal
  -> target feature ids
```

Target conceptual shape:

```
predicate
  -> evidence feature ids
  -> closure table lookup
  -> target feature ids
```

The core lookup should be equivalent to:

```sql
JOIN submission_feature_closure c
  ON c.source_submission_feature_id = evidence.submission_feature_id
JOIN submission_feature target_sf
  ON target_sf.submission_feature_id = c.target_submission_feature_id
```

The public expression tree API should not change.

## Out of Scope

- This ticket assumes `submission_feature_closure` is already populated by the pg-boss closure rebuild job.
- This ticket does not update download expansion.


## Testing Notes

**Backend only**

```bash
make test
make test-db
make test-sys 
```

