### PR TITLE
SIMSBIOHUB-1032: Accept short UTC timezone offsets

### DIFF
--- a/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
@@ -51,6 +51,20 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
       expect(sqlText).to.include("WHERE v.property_type_name = 'datetime'");
       expect(sqlText).to.not.include('submission_upload_staging_valid_property_value');
     });
+
+    it('accepts short UTC offsets (+HH / -HH) in datetime regex patterns', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([]));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
+
+      await repository.populateDatetimeCandidateStagingBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      // Short-offset form: (:\d{2})? makes the minutes optional in both datetime arms
+      expect(sqlText).to.include('(:\\d{2})?');
+      // The old fixed-width form (no optional group) must not appear
+      expect(sqlText).to.not.include('[+-]\\d{2}:\\d{2})?$');
+    });
   });
 
   describe('populateArtifactCandidateStagingBySubmissionUploadId', () => {

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -557,16 +557,16 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
         c.*,
         CASE
           WHEN c.value_text ~ '^\\d{4}-\\d{2}-\\d{2}$' THEN c.value_text::date
-          WHEN c.value_text ~ '^\\d{4}-\\d{2}-\\d{2}[T\\s]\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,6})?)?(Z|[+-]\\d{2}:\\d{2})?$'
+          WHEN c.value_text ~ '^\\d{4}-\\d{2}-\\d{2}[T\\s]\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,6})?)?(Z|[+-]\\d{2}(:\\d{2})?)?$'
             THEN substring(c.value_text FROM 1 FOR 10)::date
           ELSE NULL::date
         END AS date_value,
         CASE
           WHEN c.value_text ~ '^\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,6})?)?$' THEN c.value_text::time
-          WHEN c.value_text ~ '^\\d{4}-\\d{2}-\\d{2}[T\\s]\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,6})?)?(Z|[+-]\\d{2}:\\d{2})?$'
+          WHEN c.value_text ~ '^\\d{4}-\\d{2}-\\d{2}[T\\s]\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,6})?)?(Z|[+-]\\d{2}(:\\d{2})?)?$'
             THEN regexp_replace(
               regexp_replace(c.value_text, '^\\d{4}-\\d{2}-\\d{2}[T\\s]', ''),
-              '(Z|[+-]\\d{2}:\\d{2})$',
+              '(Z|[+-]\\d{2}(:\\d{2})?)$',
               ''
             )::time
           ELSE NULL::time

--- a/api/src/utils/timestamp.test.ts
+++ b/api/src/utils/timestamp.test.ts
@@ -23,6 +23,32 @@ describe('parseTimestamp', () => {
     });
   });
 
+  it('parses short UTC offset forms (+HH / -HH)', () => {
+    expect(parseTimestamp('14:30:00+00')).to.eql({
+      kind: 'time',
+      date_value: null,
+      time_value: '14:30:00+00'
+    });
+
+    expect(parseTimestamp('14:30:00-07')).to.eql({
+      kind: 'time',
+      date_value: null,
+      time_value: '14:30:00-07'
+    });
+
+    expect(parseTimestamp('2024-02-29T14:30:00+00')).to.eql({
+      kind: 'datetime',
+      date_value: '2024-02-29',
+      time_value: '14:30:00+00'
+    });
+
+    expect(parseTimestamp('2024-02-29T14:30:00-07')).to.eql({
+      kind: 'datetime',
+      date_value: '2024-02-29',
+      time_value: '14:30:00-07'
+    });
+  });
+
   it('rejects invalid calendar dates and times', () => {
     expect(parseTimestamp('2024-02-31')).to.equal(null);
     expect(parseTimestamp('2024-13-01')).to.equal(null);

--- a/api/src/utils/timestamp.ts
+++ b/api/src/utils/timestamp.ts
@@ -94,12 +94,18 @@ const isValidTimeOnly = (value: string): boolean => {
  * @return {{ time: string; offset: string | null } | null} Time without offset plus offset, or null for invalid offset.
  */
 const splitTimeAndOffset = (value: string): { time: string; offset: string | null } | null => {
-  const offsetMatch = /(Z|[+-]\d{2}:\d{2})$/.exec(value);
+  const offsetMatch = /(Z|[+-]\d{2}(:\d{2})?)$/.exec(value);
   const offset = offsetMatch?.[0] ?? null;
   const time = offset ? value.slice(0, -offset.length) : value;
 
-  if (offset && !dayjs(`2000-01-01T00:00:00${offset}`).isValid()) {
-    return null;
+  if (offset) {
+    // dayjs requires full offset form (+HH:MM) to recognise it as a valid timezone offset.
+    // Normalise short offsets (+HH / -HH) to full form for the validity check only; the
+    // returned `offset` still carries the original string so callers can round-trip it.
+    const normalizedOffset = /^[+-]\d{2}$/.test(offset) ? `${offset}:00` : offset;
+    if (!dayjs(`2000-01-01T00:00:00${normalizedOffset}`).isValid()) {
+      return null;
+    }
   }
 
   return { time, offset };


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1032](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1032)

## Description of Changes

- Loosen the timestamp regex to accept `2015-03-05T08:00:00` as a valid timestamp, which SIMS publishes for telemetry data.

## Testing Notes

- Publish from SIMS or upload submission tarball and confirm `INVALID_TIMESTAMP_VALUE` doesn't exist in the queue logs