### PR TITLE
SIMSBIOHUB-1033: Fix support for array feature type property

### DIFF
--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -1139,8 +1139,7 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
             'artifact_key',
             'code',
             'taxon',
-            'feature',
-            'array'
+            'feature'
           )
       ),
       grouped_errors AS (

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -1139,7 +1139,8 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
             'artifact_key',
             'code',
             'taxon',
-            'feature'
+            'feature',
+            'array'
           )
       ),
       grouped_errors AS (

--- a/database/src/migrations/20260530120000_allow_multiple_array_properties.ts
+++ b/database/src/migrations/20260530120000_allow_multiple_array_properties.ts
@@ -1,24 +1,68 @@
 import { Knex } from 'knex';
 
 /**
- * Sets allow_multiple = true on every feature_type_property row whose backing
- * feature_property is of type 'array'.
+ * Converts all array-typed feature_property rows to their appropriate scalar types,
+ * sets allow_multiple = true for their feature_type_property rows, then drops the
+ * now-unused 'array' feature_property_type.
  *
- * This covers properties such as collected_data, focal_species,
- * site_select_strategy, associated_species, and attractant without hardcoding
- * individual names.
+ * Scalar mapping:
+ *   focal_species      -> taxon
+ *   associated_species -> taxon
+ *   site_select_strategy -> code
+ *   collected_data     -> code
+ *   attractant         -> code
  */
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
+    --------------------------------------------------------------------------------
+    -- 1. Ensure the 'code' feature_property_type exists
+    --------------------------------------------------------------------------------
+    INSERT INTO feature_property_type (name, description)
+    SELECT 'code', 'A code reference type (code::<codeset>::<code> slug)'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM feature_property_type WHERE name = 'code' AND record_end_date IS NULL
+    );
+
+    --------------------------------------------------------------------------------
+    -- 2. Set allow_multiple = true for all feature_type_property rows whose
+    --    feature_property is currently typed as 'array' (before retyping, while
+    --    the 'array' link still identifies the full set).
+    --------------------------------------------------------------------------------
     UPDATE feature_type_property ftp
     SET allow_multiple = true
     FROM feature_property fp
-    JOIN feature_property_type fpt
-      ON fpt.feature_property_type_id = fp.feature_property_type_id
+    JOIN feature_property_type fpt ON fpt.feature_property_type_id = fp.feature_property_type_id
     WHERE ftp.feature_property_id = fp.feature_property_id
       AND fpt.name = 'array';
+
+    --------------------------------------------------------------------------------
+    -- 3. Retype each array property to its scalar type
+    --------------------------------------------------------------------------------
+    UPDATE feature_property
+    SET feature_property_type_id = (
+      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'taxon' AND record_end_date IS NULL
+    )
+    WHERE name IN ('focal_species', 'associated_species')
+      AND record_end_date IS NULL;
+
+    UPDATE feature_property
+    SET feature_property_type_id = (
+      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'code' AND record_end_date IS NULL
+    )
+    WHERE name IN ('site_select_strategy', 'collected_data', 'attractant')
+      AND record_end_date IS NULL;
+
+    --------------------------------------------------------------------------------
+    -- 4. Drop the 'array' feature_property_type now that no properties reference it
+    --------------------------------------------------------------------------------
+    DELETE FROM feature_property_type
+    WHERE name = 'array'
+      AND NOT EXISTS (
+        SELECT 1 FROM feature_property fp
+        WHERE fp.feature_property_type_id = feature_property_type.feature_property_type_id
+      );
   `);
 }
 
@@ -26,12 +70,43 @@ export async function down(knex: Knex): Promise<void> {
   await knex.raw(`
     SET SEARCH_PATH = biohub, public;
 
+    --------------------------------------------------------------------------------
+    -- 1. Re-insert the 'array' feature_property_type
+    --------------------------------------------------------------------------------
+    INSERT INTO feature_property_type (name, description)
+    SELECT 'array', 'An array type'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM feature_property_type WHERE name = 'array' AND record_end_date IS NULL
+    );
+
+    --------------------------------------------------------------------------------
+    -- 2. Retype the five properties back to 'array'
+    --------------------------------------------------------------------------------
+    UPDATE feature_property
+    SET feature_property_type_id = (
+      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'array' AND record_end_date IS NULL
+    )
+    WHERE name IN ('focal_species', 'associated_species', 'site_select_strategy', 'collected_data', 'attractant')
+      AND record_end_date IS NULL;
+
+    --------------------------------------------------------------------------------
+    -- 3. Reset allow_multiple = false for the reverted properties
+    --------------------------------------------------------------------------------
     UPDATE feature_type_property ftp
     SET allow_multiple = false
     FROM feature_property fp
-    JOIN feature_property_type fpt
-      ON fpt.feature_property_type_id = fp.feature_property_type_id
+    JOIN feature_property_type fpt ON fpt.feature_property_type_id = fp.feature_property_type_id
     WHERE ftp.feature_property_id = fp.feature_property_id
       AND fpt.name = 'array';
+
+    --------------------------------------------------------------------------------
+    -- 4. Drop the 'code' feature_property_type if nothing references it
+    --------------------------------------------------------------------------------
+    DELETE FROM feature_property_type
+    WHERE name = 'code'
+      AND NOT EXISTS (
+        SELECT 1 FROM feature_property fp
+        WHERE fp.feature_property_type_id = feature_property_type.feature_property_type_id
+      );
   `);
 }

--- a/database/src/migrations/20260530120000_allow_multiple_array_properties.ts
+++ b/database/src/migrations/20260530120000_allow_multiple_array_properties.ts
@@ -1,0 +1,37 @@
+import { Knex } from 'knex';
+
+/**
+ * Sets allow_multiple = true on every feature_type_property row whose backing
+ * feature_property is of type 'array'.
+ *
+ * This covers properties such as collected_data, focal_species,
+ * site_select_strategy, associated_species, and attractant without hardcoding
+ * individual names.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    UPDATE feature_type_property ftp
+    SET allow_multiple = true
+    FROM feature_property fp
+    JOIN feature_property_type fpt
+      ON fpt.feature_property_type_id = fp.feature_property_type_id
+    WHERE ftp.feature_property_id = fp.feature_property_id
+      AND fpt.name = 'array';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    UPDATE feature_type_property ftp
+    SET allow_multiple = false
+    FROM feature_property fp
+    JOIN feature_property_type fpt
+      ON fpt.feature_property_type_id = fp.feature_property_type_id
+    WHERE ftp.feature_property_id = fp.feature_property_id
+      AND fpt.name = 'array';
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1033](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1033)

## Links to Related Pull Requests

- [SIMS PR](https://github.com/bcgov/biohubbc/pull/1641) - Dependency

## Description of Changes

- Drop the `array` feature property type in favour of scalar types with `allow_multiple = true`.
- Add migration `20260530120000_allow_multiple_array_properties` that:
  1. Idempotently creates the `code` feature_property_type row.
  2. Sets `allow_multiple = true` on all `feature_type_property` rows whose backing `feature_property` is currently typed as `array` (identified before retyping so the `array` link still covers the full set).
  3. Retypes the five previously-array properties to their appropriate scalar types:
     - `focal_species`, `associated_species` → `taxon`
     - `site_select_strategy`, `collected_data`, `attractant` → `code`
  4. Deletes the now-unreferenced `array` feature_property_type row.
- The `down` migration re-inserts `array`, retypes all five properties back, resets `allow_multiple = false`, and removes the `code` type if unreferenced.

## Testing Notes

- Run `make migrate` against a local environment and confirm the migration applies cleanly.
- Import a tarball whose `dataset` feature contains multi-value properties (`focal_species`, `collected_data`, `site_select_strategy`) as flat scalar arrays (e.g. `"focal_species": [180702]`, `"collected_data": ["code::type::9", "code::type::10"]`).
- Confirm no `MULTIPLE_VALUES_NOT_ALLOWED` or `UNSUPPORTED_PROPERTY_TYPE` errors in the ingestion logs.
- Confirm `allow_multiple = true` is set for the relevant `feature_type_property` rows in the database.
- Confirm the `array` row is absent from `feature_property_type` after migration.