### PR TITLE
SIMSBIOHUB-1038: Fix SQL query

### DIFF
--- a/api/src/repositories/upload/submission-upload-review-repository.ts
+++ b/api/src/repositories/upload/submission-upload-review-repository.ts
@@ -247,12 +247,11 @@ export class SubmissionUploadReviewRepository extends BaseRepository {
           requested_by = ${requestedBy}
         FROM
           submission_upload su
-        INNER JOIN
+        CROSS JOIN
           requested_scopes rs
-        ON
-          rs.scope = sur.scope
         WHERE
           sur.submission_upload_id = su.submission_upload_id
+          AND rs.scope = sur.scope
           AND su.submission_id = ${submissionId}
           AND su.submission_upload_id = ${submissionUploadId}
           AND su.record_end_date IS NULL


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1038](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1038)

## Description of Changes

- Fix `requestDefaultSubmissionUploadReviews` in `submission-upload-review-repository.ts`, which failed with `invalid reference to FROM-clause entry for table "sur"`.
- PostgreSQL does not allow the `UPDATE` target table (`sur`) to be referenced in a `JOIN ON` clause inside `UPDATE ... FROM`. Replaced `INNER JOIN requested_scopes rs ON rs.scope = sur.scope` with `CROSS JOIN requested_scopes rs` and moved the scope filter to `WHERE rs.scope = sur.scope`.
- This unblocks the end of the submission feature indexing pipeline, which calls this query after validation and canonical property writes succeed.

## Testing Notes

- Re-run a tarball upload whose indexing previously failed at `indexSubmissionFeaturesJobHandler` with the `sur` SQL error.
- Confirm the job completes and default validation/security review rows are moved from `pending` to `requested`.
- Verify no regression in other `submission_upload_review` repository methods (`updateSubmissionUploadReview`, `softDeleteActiveSubmissionUploadReviewsByScope`, etc.).