### PR TITLE
SIMSBIOHUB-1040: Bug fix to prevent duplicate search request

### DIFF
--- a/app/src/features/search/result/SearchResultPage.test.tsx
+++ b/app/src/features/search/result/SearchResultPage.test.tsx
@@ -271,6 +271,7 @@ describe('SearchResultPage', () => {
     const { getByRole, rerender } = renderPage();
 
     fireEvent.click(getByRole('button', { name: /apply expression/i }));
+    rerender(<SearchResultPage />);
 
     await waitFor(() => {
       expect(mockUseSearchResults).toHaveBeenLastCalledWith(
@@ -301,10 +302,11 @@ describe('SearchResultPage', () => {
   });
 
   it('refreshes with a null expression when applying no expression filters', async () => {
-    const { getByRole } = renderPage();
+    const { getByRole, rerender } = renderPage();
     const callCountBeforeApply = mockUseSearchResults.mock.calls.length;
 
     fireEvent.click(getByRole('button', { name: /apply empty expression/i }));
+    rerender(<SearchResultPage />);
 
     await waitFor(() => {
       expect(mockUseSearchResults.mock.calls.length).toBeGreaterThan(callCountBeforeApply);

--- a/app/src/features/search/result/hooks/useSearchResultExpression.ts
+++ b/app/src/features/search/result/hooks/useSearchResultExpression.ts
@@ -70,16 +70,14 @@ export const useSearchResultExpression = () => {
    * param is removed and sort/order are cleared so results revert to their
    * default ordering.
    *
-   * Incrementing `expressionApplyRevision` ensures that re-applying the same
-   * expression (which would produce an identical URL) still triggers an
-   * immediate, non-debounced search refresh.
+   * Incrementing `expressionApplyRevision` only when the URL is unchanged ensures
+   * re-applying the same expression still refreshes without double-firing normal
+   * applies, where the URL change itself triggers the search.
    *
    * @param {ExpressionTreeExpression | null} nextExpressionTree - Expression to apply, or `null` to clear filters.
    */
   const handleExpressionApply = useCallback(
     (nextExpressionTree: ExpressionTreeExpression | null) => {
-      setExpressionApplyRevision((current) => current + 1);
-
       const nextParams: Partial<Record<UrlParamKey, string>> = {
         [URL_PARAMS.PAGE]: '1'
       };
@@ -109,6 +107,15 @@ export const useSearchResultExpression = () => {
         // Use super.set directly on the underlying URLSearchParams to store the
         // base64url value as-is (TypedURLSearchParams.set lowercases values).
         URLSearchParams.prototype.set.call(newParams, URL_PARAMS.EXPR, encodeExpressionToUrl(nextExpressionTree));
+      }
+
+      // Most applies change the URL; the search hook observes that URL/expression change
+      // and fires one request. Re-applying the exact same filters produces the same URL,
+      // so React Router may not rerender. Bump this explicit revision only for that
+      // same-URL case so Apply still refreshes without double-requesting normal applies.
+      if (newParams.toString() === searchParams.toString()) {
+        setExpressionApplyRevision((current) => current + 1);
+        return;
       }
 
       setRawSearchParams(newParams);

--- a/app/src/features/search/result/hooks/useSearchResults.test.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.test.tsx
@@ -18,6 +18,17 @@ const mockSearchFeatures = vi.fn();
 
 describe('useSearchResults', () => {
   const expectAbortOptions = expect.objectContaining({ signal: expect.any(Object) });
+  const defaultSearchFeatureResponse = {
+    features: [],
+    pagination: {
+      total: 0,
+      per_page: 25,
+      current_page: 2,
+      last_page: 1,
+      sort: 'create_date',
+      order: 'asc'
+    }
+  };
   const expressionTree: ExpressionTreeExpression = {
     type: 'expression',
     operator: 'AND',
@@ -33,17 +44,7 @@ describe('useSearchResults', () => {
   };
 
   beforeEach(() => {
-    mockSearchFeatures.mockResolvedValue({
-      features: [],
-      pagination: {
-        total: 0,
-        per_page: 25,
-        current_page: 2,
-        last_page: 1,
-        sort: 'create_date',
-        order: 'asc'
-      }
-    });
+    mockSearchFeatures.mockResolvedValue(defaultSearchFeatureResponse);
 
     (useApi as Mock).mockReturnValue({
       search: {
@@ -215,6 +216,42 @@ describe('useSearchResults', () => {
     });
 
     expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps loading until the first successful response when the initial API result is undefined', async () => {
+    vi.useFakeTimers();
+
+    mockSearchFeatures.mockResolvedValueOnce(undefined).mockResolvedValueOnce(defaultSearchFeatureResponse);
+
+    const { result, rerender } = renderHook(
+      ({ refreshKey }) => useSearchResults('species_observation', true, null, refreshKey),
+      {
+        initialProps: { refreshKey: 0 }
+      }
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.pagination).toBeUndefined();
+
+    await act(async () => {
+      rerender({ refreshKey: 1 });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(2);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.pagination).toEqual(defaultSearchFeatureResponse.pagination);
   });
 
   it('starts one immediate request when the applied expression changes', async () => {

--- a/app/src/features/search/result/hooks/useSearchResults.test.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.test.tsx
@@ -175,6 +175,154 @@ describe('useSearchResults', () => {
     );
   });
 
+  it('sets loading immediately while a debounced URL-param search is pending', async () => {
+    vi.useFakeTimers();
+
+    let currentSearchParams = new URLSearchParams('page=2&limit=25');
+    const setSearchParams = vi.fn((nextSearchParams: URLSearchParams) => {
+      currentSearchParams = nextSearchParams;
+    });
+
+    (useSearchQueryParams as Mock).mockImplementation(() => ({
+      searchParams: currentSearchParams,
+      setSearchParams
+    }));
+
+    const { result, rerender } = renderHook(() => useSearchResults('species_observation', true, null));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    mockSearchFeatures.mockClear();
+
+    act(() => {
+      result.current.setSearchParams({ [URL_PARAMS.PAGE]: '3' });
+    });
+    rerender();
+
+    expect(result.current.isLoading).toBe(true);
+    expect(mockSearchFeatures).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts one immediate request when the applied expression changes', async () => {
+    vi.useFakeTimers();
+
+    const nextExpressionTree: ExpressionTreeExpression = {
+      type: 'expression',
+      operator: 'AND',
+      clauses: [
+        {
+          type: 'predicate',
+          feature_property_id: 11,
+          feature_type_property_id: null,
+          operator: 'ILike',
+          value: 'trout'
+        }
+      ]
+    };
+
+    const { rerender } = renderHook(
+      ({ appliedExpression }) => useSearchResults('species_observation', true, appliedExpression),
+      {
+        initialProps: { appliedExpression: null as ExpressionTreeExpression | null }
+      }
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+    mockSearchFeatures.mockClear();
+
+    await act(async () => {
+      rerender({ appliedExpression: nextExpressionTree });
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+    expect(mockSearchFeatures).toHaveBeenLastCalledWith(
+      'species_observation',
+      nextExpressionTree,
+      {
+        page: 2,
+        limit: 25,
+        sort: 'create_date',
+        order: 'asc'
+      },
+      expectAbortOptions
+    );
+  });
+
+  it('keeps loading true when switching feature types while a request is in flight', async () => {
+    vi.useFakeTimers();
+
+    mockSearchFeatures.mockImplementation(
+      (_featureType, _expressionTree, _pagination, options: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener('abort', () => {
+            const error = new Error('canceled');
+            error.name = 'CanceledError';
+            reject(error);
+          });
+        })
+    );
+
+    const { result, rerender } = renderHook(({ featureTypeName }) => useSearchResults(featureTypeName, true, null), {
+      initialProps: { featureTypeName: 'species_observation' }
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      rerender({ featureTypeName: 'telemetry' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(2);
+    expect(mockSearchFeatures).toHaveBeenLastCalledWith(
+      'telemetry',
+      null,
+      {
+        page: 2,
+        limit: 25,
+        sort: 'create_date',
+        order: 'asc'
+      },
+      expectAbortOptions
+    );
+  });
+
   it('refreshes with a null expression when the explicit refresh key changes', async () => {
     vi.useFakeTimers();
 

--- a/app/src/features/search/result/hooks/useSearchResults.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.tsx
@@ -75,6 +75,7 @@ export const useSearchResults = (
   const { searchParams, setSearchParams: setRawSearchParams } = useSearchQueryParams();
   const [data, setData] = useState<SearchFeatureResponse>();
   const [isLoading, setIsLoading] = useState(false);
+  const [hasSettled, setHasSettled] = useState(false);
   const searchApiRef = useRef(api.search);
   const dialogContextRef = useRef(dialogContext);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -143,6 +144,7 @@ export const useSearchResults = (
 
       if (nextData) {
         setData(nextData);
+        setHasSettled(true);
       }
 
       setIsLoading(false);
@@ -228,6 +230,7 @@ export const useSearchResults = (
       debouncedRefresh.cancel();
       abortControllerRef.current?.abort();
       setData(buildEmptyResponse(pagination));
+      setHasSettled(true);
       setIsLoading(false);
       return;
     }
@@ -267,7 +270,7 @@ export const useSearchResults = (
 
   return {
     rows: data?.features ?? [],
-    isLoading: isLoading || data === undefined,
+    isLoading: isLoading || !hasSettled,
     searchParams,
     setSearchParams,
     pagination: data?.pagination

--- a/app/src/features/search/result/hooks/useSearchResults.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.tsx
@@ -80,6 +80,7 @@ export const useSearchResults = (
   const abortControllerRef = useRef<AbortController | null>(null);
   const requestIdRef = useRef(0);
   const previousRefreshKeyRef = useRef(refreshKey);
+  const previousExpressionTreeRef = useRef(expressionTree);
 
   useEffect(() => {
     searchApiRef.current = api.search;
@@ -149,7 +150,20 @@ export const useSearchResults = (
     [loadSearchResults]
   );
 
-  const debouncedRefresh = useMemo(() => debounce(startSearch, 300), [startSearch]);
+  const debouncedRefresh = useMemo(() => {
+    const debouncedSearch = debounce(startSearch, 300);
+    const refresh = (input: Omit<SearchResultsLoaderInput, 'signal'>) => {
+      // The request itself is debounced so quick pagination/sort changes coalesce,
+      // but the table should enter its loading state immediately. Otherwise stale
+      // rows or the "No results found" empty state can flash during the 300ms wait.
+      setIsLoading(true);
+      debouncedSearch(input);
+    };
+
+    refresh.cancel = debouncedSearch.cancel;
+
+    return refresh;
+  }, [startSearch]);
 
   /**
    * Writes normalized result query params to the router.
@@ -220,16 +234,26 @@ export const useSearchResults = (
 
     const input = { params: searchParams, expressionTree, featureTypeName };
     const isExplicitExpressionApply = previousRefreshKeyRef.current !== refreshKey;
+    const isExpressionTreeChange = previousExpressionTreeRef.current !== expressionTree;
     previousRefreshKeyRef.current = refreshKey;
+    previousExpressionTreeRef.current = expressionTree;
 
-    abortControllerRef.current?.abort();
-
-    if (isExplicitExpressionApply) {
+    // Applying filters should feel immediate. A changed expression comes from the
+    // URL update; an unchanged re-apply comes from refreshKey. Both skip the
+    // debounce and start exactly one request.
+    if (isExplicitExpressionApply || isExpressionTreeChange) {
       debouncedRefresh.cancel();
       startSearch(input);
       return;
     }
 
+    // For debounced route/param changes, invalidate the in-flight request before
+    // aborting it. The aborted request can still resolve its catch path; without
+    // advancing requestId first, that stale completion can set isLoading=false
+    // while the new debounced search is still pending, causing an empty-state flash
+    // when switching tabs.
+    requestIdRef.current += 1;
+    abortControllerRef.current?.abort();
     debouncedRefresh(input);
   }, [searchParams, expressionTree, featureTypeName, enabled, refreshKey, debouncedRefresh, startSearch]);
 
@@ -243,7 +267,7 @@ export const useSearchResults = (
 
   return {
     rows: data?.features ?? [],
-    isLoading,
+    isLoading: isLoading || data === undefined,
     searchParams,
     setSearchParams,
     pagination: data?.pagination


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1040

## Description of Changes

- Deduplicates search-expression update handling so only one endpoint request is triggered per change.
- Prevents redundant loading-state transitions caused by overlapping duplicate requests.
- Stabilizes skeleton loader rendering so it does not flicker during search expression updates.

## Testing Notes

1) Submit a search expression 
2) Change tabs
3) Update search expression
4) Confirm the skeleton loader does not flicker
5) Confirm only one request per expression change
