### PR TITLE
SIMSBIOHUB-1053: Fix feature-property definitions

### DIFF
--- a/database/src/migrations/20260611120000_fix_partnerships_property_type.ts
+++ b/database/src/migrations/20260611120000_fix_partnerships_property_type.ts
@@ -1,0 +1,80 @@
+import { Knex } from 'knex';
+
+/**
+ * Retype the two partnership feature properties from the unsupported `array` type to `string`.
+ *
+ * `indigenous_partnerships` and `stakeholder_partnerships` were inserted as `array`-typed properties
+ * (20260113000000_add_codeset_feature_type) and were never converted by the array-removal migration
+ * (20260530120000_allow_multiple_array_properties), which only retyped focal_species, associated_species,
+ * site_select_strategy, collected_data, and attractant. The ingestion validator treats `array` as an
+ * unsupported property type (UNSUPPORTED_PROPERTY_TYPE), so any published partnership values fail.
+ *
+ * SIMS publishes both as arrays of plain strings, so they are modelled here as `string` properties with
+ * `allow_multiple = true`. Retyping these is also what finally allows the now-unused `array`
+ * feature_property_type to be dropped, completing the cleanup started in 20260530120000.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- 1. Ensure allow_multiple = true on the partnership feature_type_property rows
+    --------------------------------------------------------------------------------
+    UPDATE feature_type_property ftp
+    SET allow_multiple = true
+    FROM feature_property fp
+    WHERE ftp.feature_property_id = fp.feature_property_id
+      AND fp.name IN ('indigenous_partnerships', 'stakeholder_partnerships')
+      AND fp.record_end_date IS NULL
+      AND ftp.record_end_date IS NULL;
+
+    --------------------------------------------------------------------------------
+    -- 2. Retype both partnership properties from array -> string
+    --------------------------------------------------------------------------------
+    UPDATE feature_property
+    SET feature_property_type_id = (
+      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'string' AND record_end_date IS NULL
+    )
+    WHERE name IN ('indigenous_partnerships', 'stakeholder_partnerships')
+      AND record_end_date IS NULL;
+
+    --------------------------------------------------------------------------------
+    -- 3. Drop the now-unused 'array' feature_property_type if nothing references it
+    --------------------------------------------------------------------------------
+    DELETE FROM feature_property_type
+    WHERE name = 'array'
+      AND NOT EXISTS (
+        SELECT 1 FROM feature_property fp
+        WHERE fp.feature_property_type_id = feature_property_type.feature_property_type_id
+      );
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    --------------------------------------------------------------------------------
+    -- 1. Re-insert the 'array' feature_property_type
+    --------------------------------------------------------------------------------
+    INSERT INTO feature_property_type (name, description)
+    SELECT 'array', 'An array type'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM feature_property_type WHERE name = 'array' AND record_end_date IS NULL
+    );
+
+    --------------------------------------------------------------------------------
+    -- 2. Retype both partnership properties back to array
+    --------------------------------------------------------------------------------
+    UPDATE feature_property
+    SET feature_property_type_id = (
+      SELECT feature_property_type_id FROM feature_property_type WHERE name = 'array' AND record_end_date IS NULL
+    )
+    WHERE name IN ('indigenous_partnerships', 'stakeholder_partnerships')
+      AND record_end_date IS NULL;
+  `);
+}

--- a/database/src/migrations/20260611130000_method_technique_code_property.ts
+++ b/database/src/migrations/20260611130000_method_technique_code_property.ts
@@ -1,0 +1,52 @@
+import { Knex } from 'knex';
+
+/**
+ * Convert the sampling-period method technique property to a code reference.
+ *
+ * The property was originally inserted as `method_technique_id` with type `number`
+ * (20260211000000_fix_feature_properties_and_assignments). SIMS now publishes the sampling period's
+ * method technique as a code reference (`code::method_technique::<id>`) resolved against a survey-scoped
+ * `method_technique` codeset, so the property is:
+ *   - renamed `method_technique_id` -> `method_technique` (it no longer carries a raw id), and
+ *   - retyped `number` -> `code`.
+ *
+ * The `feature_type_property` assignment on `sample_period` is unaffected; it references the property by
+ * `feature_property_id`, which does not change.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    UPDATE feature_property
+    SET
+      name = 'method_technique',
+      display_name = 'Method technique',
+      description = 'The sampling or method technique, as a code reference.',
+      feature_property_type_id = (
+        SELECT feature_property_type_id FROM feature_property_type WHERE name = 'code' AND record_end_date IS NULL
+      )
+    WHERE name = 'method_technique_id'
+      AND record_end_date IS NULL;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    SET SEARCH_PATH = biohub, public;
+
+    UPDATE feature_property
+    SET
+      name = 'method_technique_id',
+      display_name = 'Method technique identifier',
+      description = 'Identifier of the sampling or method technique.',
+      feature_property_type_id = (
+        SELECT feature_property_type_id FROM feature_property_type WHERE name = 'number' AND record_end_date IS NULL
+      )
+    WHERE name = 'method_technique'
+      AND record_end_date IS NULL;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1053](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1053)

## Description of Changes

Two migrations correcting feature-property definitions so SIMS submissions validate and ingest:

- `20260611120000_fix_partnerships_property_type.ts` — retypes `indigenous_partnerships` and `stakeholder_partnerships` from the unsupported `array` type to `string` (with `allow_multiple`), and drops the now-unused `array` property type.
- `20260611130000_method_technique_code_property.ts` — renames `method_technique_id` → `method_technique` and retypes it `number` → `code`.

Requires the corresponding SIMS PR to be deployed together.

## Testing Notes

- Run both migrations up, then down, then up again — confirm they apply cleanly and are idempotent.
- After `up`: confirm `method_technique` exists as a `code`-typed property (no `method_technique_id`), the partnership properties are `string` with `allow_multiple = true`, and the `array` property type is gone.
- Confirm the `sample_period` → method-technique `feature_type_property` link survives the rename.
- Ingest a SIMS tarball and verify the `method_technique` code reference resolves against the ingested `method_technique` codeset, and that partnerships ingest as multiple string values.