### PR TITLE
SIMSBIOHUB-1048: Wrap text in multiline custom text fields

### DIFF
--- a/app/src/themes/appTheme.ts
+++ b/app/src/themes/appTheme.ts
@@ -350,6 +350,13 @@ const appTheme = createTheme({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap'
           },
+          // Inputs default to single-line truncation (nowrap + ellipsis, above); reset the
+          // multiline textarea back to native wrapping so typed text flows onto the next line.
+          '& .MuiInputBase-inputMultiline': {
+            whiteSpace: 'pre-wrap', // wrap long lines AND preserve user-entered newlines
+            overflow: 'auto', // allow vertical scroll for fixed-`rows` textareas
+            textOverflow: 'clip' // ellipsis is meaningless once text wraps
+          },
           '& .MuiInputBase-input::placeholder': {
             color: theme.palette.text.secondary,
             opacity: 0.7,


### PR DESCRIPTION
## Description

Text in `CustomTextField` / `CustomTextFieldFormik` now wraps onto the next line in `multiline` mode instead of running off the right edge.

## Root cause

The components are thin pass-throughs to MUI `TextField` and carry no styling of their own. The bug was in `app/src/themes/appTheme.ts`: a global override forces `whiteSpace: 'nowrap'` (+ `overflow: hidden` + `textOverflow: ellipsis`) onto every `.MuiInputBase-input` for single-line truncation. That same selector also hit the `<textarea>` MUI renders for `multiline`, suppressing its native wrapping.

## Fix

Added a `.MuiInputBase-inputMultiline` reset inside the existing `MuiTextField` `root` override (placed there so it matches the offending rule's specificity and wins on source order):

```ts
'& .MuiInputBase-inputMultiline': {
  whiteSpace: 'pre-wrap', // wrap long lines AND preserve user-entered newlines
  overflow: 'auto',
  textOverflow: 'clip'
}
```

Single-line inputs keep their truncate-with-ellipsis behavior; only the multiline textarea is affected. Fixes all multiline fields app-wide (all route through these two components).

## Testing Notes

- `make test` — green; `make lint` clean.
- Manual smoke on the Create Ticket dialog (`/admin/tickets`):
  - Long text in the multiline **Description** wraps onto the next line.
  - Long **Subject** (single-line) stays on one line — wrap reset does not bleed into single-line inputs.
