### PR TITLE
SIMSBIOHUB-1029: Update Submission Upload Status from ClamAV job

### DIFF
--- a/api/src/queue/jobs/malware-scan-job.test.ts
+++ b/api/src/queue/jobs/malware-scan-job.test.ts
@@ -54,17 +54,20 @@ describe('malware-scan-job', () => {
       expect(releaseStub.calledOnce).to.be.true;
     });
 
-    it('throws error and releases connection on executeScan error (no rollback - executeScan commits FAILED record)', async () => {
+    it('rolls back, throws error, and releases connection on executeScan error', async () => {
       const mockDBConnection = getMockDBConnection();
       const testError = new Error('Scan error');
 
       mockDBConnection.open = sinon.stub().resolves();
       mockDBConnection.commit = sinon.stub().resolves();
+      const rollbackStub = sinon.stub().resolves();
       const releaseStub = sinon.stub();
+      mockDBConnection.rollback = rollbackStub;
       mockDBConnection.release = releaseStub;
 
       sinon.stub(db.dbDependencies, 'getAPIUserDBConnection').returns(mockDBConnection);
-      // executeScan commits the FAILED scan record internally before throwing
+      // executeScan commits the FAILED scan record internally before throwing; withConnection
+      // still issues a rollback on the rethrow (a no-op against the already-committed record).
       sinon.stub(ArtifactSecurityService.prototype, 'executeScan').rejects(testError);
 
       const mockJobs = [createMockJob('security-1')];
@@ -74,7 +77,7 @@ describe('malware-scan-job', () => {
         expect.fail('Expected an error to be thrown');
       } catch (error) {
         expect(error).to.equal(testError);
-        // No rollback - executeScan handles committing the FAILED scan record
+        expect(rollbackStub.calledOnce).to.be.true;
         expect(releaseStub.calledOnce).to.be.true;
       }
     });
@@ -197,13 +200,15 @@ describe('malware-scan-job', () => {
       expect(releaseStub.callCount).to.equal(2);
     });
 
-    it('releases connection even when update fails', async () => {
+    it('rolls back and releases connection when update fails', async () => {
       const mockDBConnection = getMockDBConnection();
       const testError = new Error('Update failed');
 
       mockDBConnection.open = sinon.stub().resolves();
       mockDBConnection.commit = sinon.stub().resolves();
+      const rollbackStub = sinon.stub().resolves();
       const releaseStub = sinon.stub();
+      mockDBConnection.rollback = rollbackStub;
       mockDBConnection.release = releaseStub;
 
       sinon.stub(db.dbDependencies, 'getAPIUserDBConnection').returns(mockDBConnection);
@@ -216,6 +221,7 @@ describe('malware-scan-job', () => {
         expect.fail('Expected error not thrown');
       } catch (err) {
         expect(err).to.equal(testError);
+        expect(rollbackStub.calledOnce).to.be.true;
         expect(releaseStub.calledOnce).to.be.true;
       }
     });

--- a/api/src/queue/jobs/malware-scan-job.test.ts
+++ b/api/src/queue/jobs/malware-scan-job.test.ts
@@ -149,6 +149,9 @@ describe('malware-scan-job', () => {
       const updateSecurityStub = sinon
         .stub(ArtifactSecurityService.prototype, 'updateArtifactSecurity')
         .resolves(mockArtifactSecurity);
+      const failSubmissionUploadStub = sinon
+        .stub(ArtifactSecurityService.prototype, 'failSubmissionUploadByArtifactSecurityId')
+        .resolves();
 
       const mockJobs = [createMockFailedJob('security-1')];
 
@@ -156,6 +159,9 @@ describe('malware-scan-job', () => {
 
       // Verify correct status update
       expect(updateSecurityStub.calledOnceWith('security-1', { security: SecurityStatusEnum.ERROR })).to.be.true;
+
+      // Verify the owning submission upload is marked as failed so it does not stay stuck at `uploaded`
+      expect(failSubmissionUploadStub.calledOnceWith('security-1')).to.be.true;
 
       // Verify transaction committed and connection released
       expect(commitStub.calledOnce).to.be.true;
@@ -180,6 +186,7 @@ describe('malware-scan-job', () => {
         security: SecurityStatusEnum.ERROR
       };
       sinon.stub(ArtifactSecurityService.prototype, 'updateArtifactSecurity').resolves(mockArtifactSecurity);
+      sinon.stub(ArtifactSecurityService.prototype, 'failSubmissionUploadByArtifactSecurityId').resolves();
 
       const mockJobs = [createMockFailedJob('security-1', 'job-1'), createMockFailedJob('security-2', 'job-2')];
 

--- a/api/src/queue/jobs/malware-scan-job.ts
+++ b/api/src/queue/jobs/malware-scan-job.ts
@@ -1,8 +1,8 @@
 import PgBoss from 'pg-boss';
-import { getAPIUserDBConnection } from '../../database/db';
 import { SecurityStatusEnum } from '../../models/security-status';
 import { ArtifactSecurityService } from '../../services/upload/artifact-security-service';
 import { getLogger } from '../../utils/logger';
+import { withConnection } from '../with-connection';
 
 const defaultLog = getLogger('queue/jobs/malware-scan-job');
 
@@ -64,16 +64,12 @@ export const malwareScanJobHandler: PgBoss.WorkHandler<IMalwareScanJobData> = as
       artifactSecurityId
     });
 
-    const connection = getAPIUserDBConnection();
-
     try {
-      await connection.open();
+      await withConnection(async (connection) => {
+        const artifactSecurityService = new ArtifactSecurityService(connection);
 
-      const artifactSecurityService = new ArtifactSecurityService(connection);
-
-      await artifactSecurityService.executeScan(artifactSecurityId);
-
-      await connection.commit();
+        await artifactSecurityService.executeScan(artifactSecurityId);
+      });
 
       defaultLog.info({
         label: 'malwareScanJobHandler',
@@ -93,8 +89,6 @@ export const malwareScanJobHandler: PgBoss.WorkHandler<IMalwareScanJobData> = as
       });
 
       throw error; // pg-boss will handle retry based on configuration
-    } finally {
-      connection.release();
     }
   }
 };
@@ -113,11 +107,7 @@ export const malwareScanFailedHandler: PgBoss.WorkHandler<IMalwareScanJobData> =
       output: jobOutput
     });
 
-    const connection = getAPIUserDBConnection();
-
-    try {
-      await connection.open();
-
+    await withConnection(async (connection) => {
       const artifactSecurityService = new ArtifactSecurityService(connection);
 
       await artifactSecurityService.updateArtifactSecurity(artifactSecurityId, {
@@ -126,16 +116,12 @@ export const malwareScanFailedHandler: PgBoss.WorkHandler<IMalwareScanJobData> =
 
       // Propagate the scan failure to the owning submission upload so it does not stay stuck at `uploaded`.
       await artifactSecurityService.failSubmissionUploadByArtifactSecurityId(artifactSecurityId);
+    });
 
-      await connection.commit();
-
-      defaultLog.info({
-        label: 'malwareScanFailedHandler',
-        message: 'Failed job status updated',
-        jobId: job.id
-      });
-    } finally {
-      connection.release();
-    }
+    defaultLog.info({
+      label: 'malwareScanFailedHandler',
+      message: 'Failed job status updated',
+      jobId: job.id
+    });
   }
 };

--- a/api/src/queue/jobs/malware-scan-job.ts
+++ b/api/src/queue/jobs/malware-scan-job.ts
@@ -124,6 +124,9 @@ export const malwareScanFailedHandler: PgBoss.WorkHandler<IMalwareScanJobData> =
         security: SecurityStatusEnum.ERROR
       });
 
+      // Propagate the scan failure to the owning submission upload so it does not stay stuck at `uploaded`.
+      await artifactSecurityService.failSubmissionUploadByArtifactSecurityId(artifactSecurityId);
+
       await connection.commit();
 
       defaultLog.info({

--- a/api/src/repositories/upload/upload-archive-repository.test.ts
+++ b/api/src/repositories/upload/upload-archive-repository.test.ts
@@ -115,6 +115,45 @@ describe('UploadArchiveRepository', () => {
     });
   });
 
+  describe('findUploadArchiveByArtifactId', () => {
+    it('returns null when no record is found', async () => {
+      const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new UploadArchiveRepository(mockDBConnection);
+
+      const result = await repo.findUploadArchiveByArtifactId('artifact-id-1');
+      expect(result).to.be.null;
+    });
+
+    it('returns the record when one is found', async () => {
+      const mockRecord: UploadArchive = {
+        upload_archive_id: 'upload-archive-id-1',
+        upload_id: 'upload-id-1',
+        artifact_id: 'artifact-id-1',
+        archive_status: ProcessStatusStatusEnum.PENDING
+      };
+      const mockQueryResponse = { rowCount: 1, rows: [mockRecord] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new UploadArchiveRepository(mockDBConnection);
+
+      const result = await repo.findUploadArchiveByArtifactId('artifact-id-1');
+      expect(result).to.eql(mockRecord);
+    });
+
+    it('throws an error when more than one record is found', async () => {
+      const mockQueryResponse = { rowCount: 2, rows: [] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new UploadArchiveRepository(mockDBConnection);
+
+      try {
+        await repo.findUploadArchiveByArtifactId('artifact-id-1');
+        expect.fail('Expected error not thrown');
+      } catch (err) {
+        expect((err as Error).message).to.equal('Unexpected row count');
+      }
+    });
+  });
+
   describe('insertUploadArchive', () => {
     it('throws an error if insert fails', async () => {
       const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;

--- a/api/src/repositories/upload/upload-archive-repository.ts
+++ b/api/src/repositories/upload/upload-archive-repository.ts
@@ -88,14 +88,15 @@ export class UploadArchiveRepository extends BaseRepository {
   }
 
   /**
-   * Get upload archive by artifact ID
+   * Find a single upload archive by artifact ID, returning null when none exists.
+   *
+   * A missing record is a valid result (the artifact may not be part of an archive) rather than an error.
    *
    * @param {string} artifactId - The ID of the artifact.
-   * @returns {Promise<UploadArchive>} - The upload archive record.
-   * @throws {ApiNotFoundError} - If the upload archive is not found.
-   * @throws {ApiExecuteSQLError} - If an unexpected row count is returned.
+   * @returns {Promise<UploadArchive | null>} - The upload archive record, or null if not found.
+   * @throws {ApiExecuteSQLError} - If more than one record is returned.
    */
-  async getUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive> {
+  async findUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive | null> {
     const sqlStatement = SQL`
       SELECT
         upload_archive_id,
@@ -110,21 +111,14 @@ export class UploadArchiveRepository extends BaseRepository {
 
     const response = await this.connection.sql(sqlStatement, UploadArchive);
 
-    if (response.rowCount === 0) {
-      throw new ApiNotFoundError('Upload archive not found', [
-        'UploadArchiveRepository->getUploadArchiveByArtifactId',
-        { artifactId }
-      ]);
-    }
-
-    if (response.rowCount !== 1) {
+    if ((response.rowCount ?? 0) > 1) {
       throw new ApiExecuteSQLError('Unexpected row count', [
-        'UploadArchiveRepository->getUploadArchiveByArtifactId',
-        `expected rowCount=1, actual rowCount=${response.rowCount}`
+        'UploadArchiveRepository->findUploadArchiveByArtifactId',
+        `expected rowCount<=1, actual rowCount=${response.rowCount}`
       ]);
     }
 
-    return response.rows[0];
+    return response.rows[0] ?? null;
   }
 
   /**

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -4,7 +4,6 @@ import sinonChai from 'sinon-chai';
 import { Readable } from 'stream';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { IDBConnection } from '../../database/db';
-import { ApiConflictError, ApiNotFoundError } from '../../errors/api-error';
 import { Artifact, ArtifactStatusEnum } from '../../models/artifact';
 import { ArtifactSecurity, CreateArtifactSecurity, UpdateArtifactSecurity } from '../../models/artifact-security';
 import { ProcessStatusStatusEnum } from '../../models/process-status';
@@ -369,7 +368,7 @@ describe('ArtifactSecurityService', () => {
         .stub(ObjectStorageService.prototype, 'promoteFromSecurity')
         .resolves({ key: 'test.tar' });
       sinon.stub(ArtifactService.prototype, 'updateArtifact').resolves({ artifact_id: 'artifact-1' });
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon.stub(UploadArchiveService.prototype, 'findUploadArchiveByArtifactId').resolves(mockUploadArchive);
       sinon.stub(UploadArchiveService.prototype, 'updateUploadArchive').resolves({ upload_archive_id: 'archive-1' });
       sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
         submission_upload_id: 'su-1',
@@ -414,9 +413,7 @@ describe('ArtifactSecurityService', () => {
         scanStream: sinon.stub().resolves({ isInfected: false })
       } as any);
 
-      sinon
-        .stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId')
-        .rejects(new ApiNotFoundError('Upload archive not found'));
+      sinon.stub(UploadArchiveService.prototype, 'findUploadArchiveByArtifactId').resolves(null);
       const promoteStub = sinon
         .stub(ObjectStorageService.prototype, 'promoteFromSecurity')
         .resolves({ key: 'test.tar' });
@@ -534,7 +531,7 @@ describe('ArtifactSecurityService', () => {
         scanStream: sinon.stub().resolves({ isInfected: false })
       } as any);
 
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon.stub(UploadArchiveService.prototype, 'findUploadArchiveByArtifactId').resolves(mockUploadArchive);
       sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves({
         submission_upload_id: 'su-1',
         submission_id: 123,
@@ -731,7 +728,7 @@ describe('ArtifactSecurityService', () => {
 
     it('transitions the owning submission upload to failed', async () => {
       sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon.stub(UploadArchiveService.prototype, 'findUploadArchiveByArtifactId').resolves(mockUploadArchive);
       sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves(mockSubmissionUpload);
       const transitionStub = sinon
         .stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus')
@@ -750,9 +747,7 @@ describe('ArtifactSecurityService', () => {
 
     it('is a no-op when the artifact has no upload_archive', async () => {
       sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
-      sinon
-        .stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId')
-        .rejects(new ApiNotFoundError('Upload archive not found'));
+      sinon.stub(UploadArchiveService.prototype, 'findUploadArchiveByArtifactId').resolves(null);
       const getSubmissionUploadStub = sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId');
       const transitionStub = sinon.stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus');
 
@@ -762,24 +757,23 @@ describe('ArtifactSecurityService', () => {
       expect(transitionStub).to.not.have.been.called;
     });
 
-    it('swallows ApiConflictError when the upload cannot transition to failed', async () => {
+    it('is a no-op when the upload has already reached a terminal status', async () => {
       sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
-      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
-      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves(mockSubmissionUpload);
-      const transitionStub = sinon
-        .stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus')
-        .rejects(new ApiConflictError('Invalid submission upload status transition'));
+      sinon.stub(UploadArchiveService.prototype, 'findUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon
+        .stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId')
+        .resolves({ ...mockSubmissionUpload, status: 'indexed' });
+      const transitionStub = sinon.stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus');
 
-      // Should resolve without throwing.
       await service.failSubmissionUploadByArtifactSecurityId('uuid-1');
 
-      expect(transitionStub).to.have.been.calledOnce;
+      expect(transitionStub).to.not.have.been.called;
     });
 
-    it('propagates non-not-found errors from the upload_archive lookup', async () => {
+    it('propagates errors from the upload_archive lookup', async () => {
       sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
       sinon
-        .stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId')
+        .stub(UploadArchiveService.prototype, 'findUploadArchiveByArtifactId')
         .rejects(new Error('DB connection lost'));
 
       try {

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -4,7 +4,7 @@ import sinonChai from 'sinon-chai';
 import { Readable } from 'stream';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { IDBConnection } from '../../database/db';
-import { ApiNotFoundError } from '../../errors/api-error';
+import { ApiConflictError, ApiNotFoundError } from '../../errors/api-error';
 import { Artifact, ArtifactStatusEnum } from '../../models/artifact';
 import { ArtifactSecurity, CreateArtifactSecurity, UpdateArtifactSecurity } from '../../models/artifact-security';
 import { ProcessStatusStatusEnum } from '../../models/process-status';
@@ -709,6 +709,82 @@ describe('ArtifactSecurityService', () => {
         expect.fail('expected publishNextPipelineStep to throw');
       } catch (error) {
         expect((error as Error).message).to.equal('pg-boss unavailable');
+      }
+    });
+  });
+
+  describe('failSubmissionUploadByArtifactSecurityId', () => {
+    const mockUploadArchive: UploadArchive = {
+      upload_archive_id: 'archive-1',
+      upload_id: 'upload-1',
+      artifact_id: 'artifact-1',
+      archive_status: ProcessStatusStatusEnum.PENDING
+    };
+
+    const mockSubmissionUpload = {
+      submission_upload_id: 'su-1',
+      submission_id: 999,
+      upload_id: 'upload-1',
+      status: 'uploaded' as const,
+      ticket_id: '22222222-2222-2222-2222-222222222222'
+    };
+
+    it('transitions the owning submission upload to failed', async () => {
+      sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
+      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves(mockSubmissionUpload);
+      const transitionStub = sinon
+        .stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus')
+        .resolves();
+
+      await service.failSubmissionUploadByArtifactSecurityId('uuid-1');
+
+      expect(transitionStub).to.have.been.calledOnceWith('su-1', 'failed', [
+        'uploaded',
+        'ingesting',
+        'ingested',
+        'indexing',
+        'failed'
+      ]);
+    });
+
+    it('is a no-op when the artifact has no upload_archive', async () => {
+      sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
+      sinon
+        .stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId')
+        .rejects(new ApiNotFoundError('Upload archive not found'));
+      const getSubmissionUploadStub = sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId');
+      const transitionStub = sinon.stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus');
+
+      await service.failSubmissionUploadByArtifactSecurityId('uuid-1');
+
+      expect(getSubmissionUploadStub).to.not.have.been.called;
+      expect(transitionStub).to.not.have.been.called;
+    });
+
+    it('swallows ApiConflictError when the upload cannot transition to failed', async () => {
+      sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
+      sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
+      sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves(mockSubmissionUpload);
+      sinon
+        .stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus')
+        .rejects(new ApiConflictError('Invalid submission upload status transition'));
+
+      // Should resolve without throwing.
+      await service.failSubmissionUploadByArtifactSecurityId('uuid-1');
+    });
+
+    it('propagates non-not-found errors from the upload_archive lookup', async () => {
+      sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
+      sinon
+        .stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId')
+        .rejects(new Error('DB connection lost'));
+
+      try {
+        await service.failSubmissionUploadByArtifactSecurityId('uuid-1');
+        expect.fail('Expected error not thrown');
+      } catch (err) {
+        expect((err as Error).message).to.equal('DB connection lost');
       }
     });
   });

--- a/api/src/services/upload/artifact-security-service.test.ts
+++ b/api/src/services/upload/artifact-security-service.test.ts
@@ -766,12 +766,14 @@ describe('ArtifactSecurityService', () => {
       sinon.stub(ArtifactSecurityRepository.prototype, 'getArtifactSecurity').resolves(mockSecurityRecord);
       sinon.stub(UploadArchiveService.prototype, 'getUploadArchiveByArtifactId').resolves(mockUploadArchive);
       sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUploadByUploadId').resolves(mockSubmissionUpload);
-      sinon
+      const transitionStub = sinon
         .stub(SubmissionUploadService.prototype, 'transitionSubmissionUploadStatus')
         .rejects(new ApiConflictError('Invalid submission upload status transition'));
 
       // Should resolve without throwing.
       await service.failSubmissionUploadByArtifactSecurityId('uuid-1');
+
+      expect(transitionStub).to.have.been.calledOnce;
     });
 
     it('propagates non-not-found errors from the upload_archive lookup', async () => {

--- a/api/src/services/upload/artifact-security-service.ts
+++ b/api/src/services/upload/artifact-security-service.ts
@@ -1,6 +1,6 @@
 import { HeadObjectCommandOutput } from '@aws-sdk/client-s3';
+import { TERMINAL_UPLOAD_STATUSES } from '../../constants/submission-upload';
 import { IDBConnection } from '../../database/db';
-import { ApiConflictError, ApiNotFoundError } from '../../errors/api-error';
 import { ClamAvScanValidationError } from '../../errors/clamav-errors';
 import { ArtifactStatusEnum } from '../../models/artifact';
 import { ArtifactSecurity, CreateArtifactSecurity, UpdateArtifactSecurity } from '../../models/artifact-security';
@@ -166,7 +166,7 @@ export class ArtifactSecurityService extends DBService {
    * so a scan that fails after all retries does not leave the `submission_upload` stuck at `uploaded`.
    *
    * Tolerant by design so it cannot throw the failure handler into a retry loop: no-op when the artifact has no
-   * `upload_archive`, and swallows the {@link ApiConflictError} raised when the upload is already terminal.
+   * `upload_archive`, and no-op when the upload has already reached a terminal status.
    *
    * @param {string} artifactSecurityId - Artifact security record identifier.
    * @returns {Promise<void>}
@@ -174,14 +174,7 @@ export class ArtifactSecurityService extends DBService {
   async failSubmissionUploadByArtifactSecurityId(artifactSecurityId: string): Promise<void> {
     const securityRecord = await this.getArtifactSecurity(artifactSecurityId);
 
-    let uploadArchive: UploadArchive | null = null;
-    try {
-      uploadArchive = await this.uploadArchiveService.getUploadArchiveByArtifactId(securityRecord.artifact_id);
-    } catch (error) {
-      if (!(error instanceof ApiNotFoundError)) {
-        throw error;
-      }
-    }
+    const uploadArchive = await this.uploadArchiveService.findUploadArchiveByArtifactId(securityRecord.artifact_id);
 
     if (!uploadArchive) {
       // Non-archive artifact (e.g. a standalone attachment) — no submission_upload lifecycle to fail.
@@ -190,18 +183,16 @@ export class ArtifactSecurityService extends DBService {
 
     const submissionUpload = await this.submissionUploadService.getSubmissionUploadByUploadId(uploadArchive.upload_id);
 
-    try {
-      await this.submissionUploadService.transitionSubmissionUploadStatus(
-        submissionUpload.submission_upload_id,
-        'failed',
-        ['uploaded', 'ingesting', 'ingested', 'indexing', 'failed']
-      );
-    } catch (error) {
-      // Already terminal/invalid — nothing to fail. Swallow so the dead letter handler still commits.
-      if (!(error instanceof ApiConflictError)) {
-        throw error;
-      }
+    if (TERMINAL_UPLOAD_STATUSES.includes(submissionUpload.status)) {
+      // Already terminal — nothing to fail.
+      return;
     }
+
+    await this.submissionUploadService.transitionSubmissionUploadStatus(
+      submissionUpload.submission_upload_id,
+      'failed',
+      ['uploaded', 'ingesting', 'ingested', 'indexing', 'failed']
+    );
   }
 
   /**
@@ -273,14 +264,7 @@ export class ArtifactSecurityService extends DBService {
         // still reads `security = PENDING`, so `executeScan` re-runs the full flow and
         // converges. Without this ordering, a queue outage at this step leaves a clean
         // artifact with no downstream submission-processing job.
-        let uploadArchive: UploadArchive | null = null;
-        try {
-          uploadArchive = await this.uploadArchiveService.getUploadArchiveByArtifactId(artifact.artifact_id);
-        } catch (error) {
-          if (!(error instanceof ApiNotFoundError)) {
-            throw error;
-          }
-        }
+        const uploadArchive = await this.uploadArchiveService.findUploadArchiveByArtifactId(artifact.artifact_id);
 
         if (uploadArchive) {
           await this.publishNextPipelineStep(uploadArchive);

--- a/api/src/services/upload/artifact-security-service.ts
+++ b/api/src/services/upload/artifact-security-service.ts
@@ -1,6 +1,6 @@
 import { HeadObjectCommandOutput } from '@aws-sdk/client-s3';
 import { IDBConnection } from '../../database/db';
-import { ApiNotFoundError } from '../../errors/api-error';
+import { ApiConflictError, ApiNotFoundError } from '../../errors/api-error';
 import { ClamAvScanValidationError } from '../../errors/clamav-errors';
 import { ArtifactStatusEnum } from '../../models/artifact';
 import { ArtifactSecurity, CreateArtifactSecurity, UpdateArtifactSecurity } from '../../models/artifact-security';
@@ -157,6 +157,51 @@ export class ArtifactSecurityService extends DBService {
     const submissionUpload = await this.submissionUploadService.getSubmissionUploadByUploadId(uploadArchive.upload_id);
 
     await ArtifactSecurityService.dependencies.publishProcessSubmissionFeaturesJob(this.connection, submissionUpload);
+  }
+
+  /**
+   * Transition the `submission_upload` owning an artifact security record to `failed`.
+   *
+   * Resolves the upload via the artifact's `upload_archive` bridge. Used by the malware scan dead letter handler
+   * so a scan that fails after all retries does not leave the `submission_upload` stuck at `uploaded`.
+   *
+   * Tolerant by design so it cannot throw the failure handler into a retry loop: no-op when the artifact has no
+   * `upload_archive`, and swallows the {@link ApiConflictError} raised when the upload is already terminal.
+   *
+   * @param {string} artifactSecurityId - Artifact security record identifier.
+   * @returns {Promise<void>}
+   */
+  async failSubmissionUploadByArtifactSecurityId(artifactSecurityId: string): Promise<void> {
+    const securityRecord = await this.getArtifactSecurity(artifactSecurityId);
+
+    let uploadArchive: UploadArchive | null = null;
+    try {
+      uploadArchive = await this.uploadArchiveService.getUploadArchiveByArtifactId(securityRecord.artifact_id);
+    } catch (error) {
+      if (!(error instanceof ApiNotFoundError)) {
+        throw error;
+      }
+    }
+
+    if (!uploadArchive) {
+      // Non-archive artifact (e.g. a standalone attachment) — no submission_upload lifecycle to fail.
+      return;
+    }
+
+    const submissionUpload = await this.submissionUploadService.getSubmissionUploadByUploadId(uploadArchive.upload_id);
+
+    try {
+      await this.submissionUploadService.transitionSubmissionUploadStatus(
+        submissionUpload.submission_upload_id,
+        'failed',
+        ['uploaded', 'ingesting', 'ingested', 'indexing', 'failed']
+      );
+    } catch (error) {
+      // Already terminal/invalid — nothing to fail. Swallow so the dead letter handler still commits.
+      if (!(error instanceof ApiConflictError)) {
+        throw error;
+      }
+    }
   }
 
   /**

--- a/api/src/services/upload/upload-archive-service.test.ts
+++ b/api/src/services/upload/upload-archive-service.test.ts
@@ -195,6 +195,35 @@ describe('UploadArchiveService', () => {
     });
   });
 
+  describe('findUploadArchiveByArtifactId', () => {
+    it('should return the upload archive record for a given artifact ID', async () => {
+      const fakeUploadArchive: UploadArchive = {
+        upload_archive_id: 'archive-1',
+        upload_id: 'upload-1',
+        artifact_id: 'artifact-1',
+        archive_status: ProcessStatusStatusEnum.PENDING
+      };
+
+      const stub = sinon
+        .stub(UploadArchiveRepository.prototype, 'findUploadArchiveByArtifactId')
+        .resolves(fakeUploadArchive);
+
+      const result = await service.findUploadArchiveByArtifactId('artifact-1');
+
+      expect(stub).to.have.been.calledWith('artifact-1');
+      expect(result).to.eql(fakeUploadArchive);
+    });
+
+    it('should return null when no record exists', async () => {
+      const stub = sinon.stub(UploadArchiveRepository.prototype, 'findUploadArchiveByArtifactId').resolves(null);
+
+      const result = await service.findUploadArchiveByArtifactId('artifact-1');
+
+      expect(stub).to.have.been.calledWith('artifact-1');
+      expect(result).to.be.null;
+    });
+  });
+
   describe('deleteUploadArchive', () => {
     it('should delete an upload archive record by ID', async () => {
       const stub = sinon.stub(UploadArchiveRepository.prototype, 'deleteUploadArchive').resolves();

--- a/api/src/services/upload/upload-archive-service.ts
+++ b/api/src/services/upload/upload-archive-service.ts
@@ -75,14 +75,14 @@ export class UploadArchiveService extends DBService {
   }
 
   /**
-   * Retrieves an upload archive record by artifact ID.
+   * Finds an upload archive record by artifact ID, returning null when none exists.
    *
    * @param {string} artifactId The ID of the artifact
-   * @return {Promise<UploadArchive | null>} The upload archive record or null if not found
+   * @return {Promise<UploadArchive | null>} The upload archive record, or null if not found
    * @memberof UploadArchiveService
    */
-  async getUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive> {
-    return this.uploadArchiveRepository.getUploadArchiveByArtifactId(artifactId);
+  async findUploadArchiveByArtifactId(artifactId: string): Promise<UploadArchive | null> {
+    return this.uploadArchiveRepository.findUploadArchiveByArtifactId(artifactId);
   }
 
   /**


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1029](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1029)

## Description of Changes

Previously, when a malware scan job failed after exhausting all retries, the `submission_upload` was left stuck at status `uploaded`. The dead letter handler only marked `artifact_security` as `ERROR` and never propagated the failure to the owning upload.

- Added `ArtifactSecurityService.failSubmissionUploadByArtifactSecurityId`, which resolves the owning `submission_upload` via the artifact's `upload_archive` bridge and transitions it to `failed`. It is tolerant by design (runs in a terminal failure handler): no-op when the artifact has no `upload_archive`, and swallows the `ApiConflictError` raised when the upload is already in a terminal state.
- Wired this into `malwareScanFailedHandler` so a scan failure marks both `artifact_security` (`ERROR`) and `submission_upload` (`failed`) in the same transaction.

## Testing Notes

- Unit tests added for `failSubmissionUploadByArtifactSecurityId` (happy path, no-archive no-op, conflict swallowed, error propagation) and updated for `malwareScanFailedHandler` to assert the upload is marked `failed`.
- To verify manually: upload a submission with ClamAV unreachable so the scan job exhausts its retries. Confirm the job lands in the `MALWARE_SCAN_FAILED` dead letter queue and the `submission_upload` status moves from `uploaded` to `failed` (rather than staying stuck at `uploaded`).
- Confirm the happy path is unaffected: with ClamAV reachable, a clean scan still promotes the tarball to the main bucket and the upload progresses to `ingesting`.
