### PR TITLE
SIMSBIOHUB-1045: Apply blueprint during property indexing

### DIFF
--- a/api/src/__integration__/system/process-submission-features-worker.integration.ts
+++ b/api/src/__integration__/system/process-submission-features-worker.integration.ts
@@ -164,6 +164,7 @@ describe('Process Submission Features Worker', function () {
     uploadId: string;
     submissionUploadId: string;
     ticketId: string;
+    blueprintId: number;
     artifactId: string;
     objectKey: string;
   }> {
@@ -218,12 +219,17 @@ describe('Process Submission Features Worker', function () {
     // 5. ticket (required FK for submission_upload)
     const ticketId = await getOrCreateTestTicketId(db, submission.submission_id, upload.upload_id, SYSTEM_USER_ID);
 
-    // 6. submission_upload (links submission to upload)
+    // 6. submission_upload (links submission to upload; pinned to the active default Blueprint)
+    const [{ blueprint_id: blueprintId }] = await db('biohub.blueprint')
+      .where({ is_default: true })
+      .whereNull('record_end_date')
+      .select('blueprint_id');
     const [submissionUpload] = await db('biohub.submission_upload')
       .insert({
         submission_id: submission.submission_id,
         upload_id: upload.upload_id,
-        ticket_id: ticketId
+        ticket_id: ticketId,
+        blueprint_id: blueprintId
       })
       .returning('submission_upload_id');
 
@@ -239,6 +245,7 @@ describe('Process Submission Features Worker', function () {
       uploadId: upload.upload_id,
       submissionUploadId: submissionUpload.submission_upload_id,
       ticketId,
+      blueprintId,
       artifactId: artifact.artifact_id,
       objectKey
     };
@@ -253,6 +260,7 @@ describe('Process Submission Features Worker', function () {
     submissionId: number;
     uploadId: string;
     ticketId: string;
+    blueprintId: number;
   }): Promise<void> {
     const connection = getAPIUserDBConnection();
     try {
@@ -262,7 +270,8 @@ describe('Process Submission Features Worker', function () {
         submission_id: params.submissionId,
         upload_id: params.uploadId,
         status: 'uploaded',
-        ticket_id: params.ticketId
+        ticket_id: params.ticketId,
+        blueprint_id: params.blueprintId
       });
       await connection.commit();
       expect(result.status).to.equal('published');
@@ -295,8 +304,10 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
-    await publishJob({ submissionUploadId, submissionId, uploadId, ticketId });
+    const { submissionId, uploadId, submissionUploadId, ticketId, blueprintId } = await setupSubmissionWithTar(
+      tarBuffer
+    );
+    await publishJob({ submissionUploadId, submissionId, uploadId, ticketId, blueprintId });
 
     // Wait for the worker to finish
     const validation = await waitForValidationStatus(db, submissionId);
@@ -362,8 +373,10 @@ describe('Process Submission Features Worker', function () {
       }
     ]);
 
-    const { submissionId, uploadId, submissionUploadId, ticketId } = await setupSubmissionWithTar(tarBuffer);
-    await publishJob({ submissionUploadId, submissionId, uploadId, ticketId });
+    const { submissionId, uploadId, submissionUploadId, ticketId, blueprintId } = await setupSubmissionWithTar(
+      tarBuffer
+    );
+    await publishJob({ submissionUploadId, submissionId, uploadId, ticketId, blueprintId });
 
     const validation = await waitForValidationStatus(db, submissionId);
     expect(validation.status).to.equal('completed');
@@ -459,9 +472,13 @@ describe('SubmissionIngestionService pipeline (system)', function () {
    * block's setupSubmissionWithTar, using Knex (auto-committed) so the service's
    * own short-lived transactions can see the rows.
    */
-  async function setupSubmissionWithTar(
-    tarBuffer: Buffer
-  ): Promise<{ submissionId: number; uploadId: string; submissionUploadId: string; ticketId: string }> {
+  async function setupSubmissionWithTar(tarBuffer: Buffer): Promise<{
+    submissionId: number;
+    uploadId: string;
+    submissionUploadId: string;
+    ticketId: string;
+    blueprintId: number;
+  }> {
     const objectKey = `${TEST_PREFIX}/${Date.now()}/archive.tar`;
 
     await storageService.uploadBuffer(BucketType.MAIN, tarBuffer, 'application/x-tar', objectKey);
@@ -513,12 +530,17 @@ describe('SubmissionIngestionService pipeline (system)', function () {
     const ticketId = await getOrCreateTestTicketId(db, submission.submission_id, upload.upload_id, SYSTEM_USER_ID);
     createdTicketIds.push(ticketId);
 
-    // 6. submission_upload
+    // 6. submission_upload (pinned to the active default Blueprint)
+    const [{ blueprint_id: blueprintId }] = await db('biohub.blueprint')
+      .where({ is_default: true })
+      .whereNull('record_end_date')
+      .select('blueprint_id');
     const [submissionUpload] = await db('biohub.submission_upload')
       .insert({
         submission_id: submission.submission_id,
         upload_id: upload.upload_id,
-        ticket_id: ticketId
+        ticket_id: ticketId,
+        blueprint_id: blueprintId
       })
       .returning('submission_upload_id');
 
@@ -533,7 +555,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       submissionId: submission.submission_id,
       uploadId: upload.upload_id,
       submissionUploadId: submissionUpload.submission_upload_id,
-      ticketId
+      ticketId,
+      blueprintId
     };
   }
 
@@ -552,7 +575,8 @@ describe('SubmissionIngestionService pipeline (system)', function () {
       submission_id: setup.submissionId,
       upload_id: setup.uploadId,
       status: 'uploaded',
-      ticket_id: setup.ticketId
+      ticket_id: setup.ticketId,
+      blueprint_id: setup.blueprintId
     });
     return { result, ...setup };
   }

--- a/api/src/models/submission-upload.ts
+++ b/api/src/models/submission-upload.ts
@@ -25,6 +25,7 @@ export const SubmissionUpload = z.object({
   upload_id: z.string().uuid(),
   status: SubmissionUploadJobStatus,
   ticket_id: z.string().uuid(),
+  blueprint_id: z.number(),
   comment: z.string().nullable().optional(),
   record_end_date: z.coerce.date().nullable().optional()
 });
@@ -38,6 +39,7 @@ export const CreateSubmissionUpload = z.object({
   upload_id: z.string().uuid(),
   ticket_id: z.string().uuid(),
   status: SubmissionUploadJobStatus,
+  blueprint_id: z.number(),
   comment: z.string().nullable().optional()
 });
 export type CreateSubmissionUpload = z.infer<typeof CreateSubmissionUpload>;

--- a/api/src/openapi/schemas/upload.ts
+++ b/api/src/openapi/schemas/upload.ts
@@ -22,6 +22,11 @@ export const CreateSubmissionUploadRequestSchema: OpenAPIV3.SchemaObject = {
     comment: {
       type: 'string',
       description: 'Comments for system administrators about the submission'
+    },
+    blueprint_id: {
+      type: 'integer',
+      description:
+        'Optional Blueprint to index this upload against. Defaults to the prior upload Blueprint, or the system default Blueprint for a new submission.'
     }
   }
 };
@@ -124,6 +129,11 @@ export const SubmissionUploadRequestSchema: OpenAPIV3.SchemaObject = {
     comment: {
       type: 'string',
       description: 'Comments for system administrators about the submission.'
+    },
+    blueprint_id: {
+      type: 'integer',
+      description:
+        'Optional Blueprint to index this upload against. Defaults to the prior upload Blueprint, or the system default Blueprint for a new submission.'
     }
   }
 };

--- a/api/src/paths/submission/upload/archive/index.ts
+++ b/api/src/paths/submission/upload/archive/index.ts
@@ -63,11 +63,11 @@ export function startUpload(): RequestHandler {
       const system_user_id = req.system_user!.system_user_id;
       const contributorId = req.contributor_id!;
 
-      const { bytes, ...rest } = req.body;
+      const { bytes, blueprint_id, ...rest } = req.body;
       const submission = { ...rest, uuid: v4(), system_user_id, contributor_id: contributorId } as ICreateSubmission;
       const uploadIngestionService = new UploadIngestionService(connection);
 
-      const result = await uploadIngestionService.startArchiveUpload(bytes, submission);
+      const result = await uploadIngestionService.startArchiveUpload(bytes, submission, blueprint_id);
 
       await connection.commit();
 

--- a/api/src/paths/submission/{submissionId}/upload/index.ts
+++ b/api/src/paths/submission/{submissionId}/upload/index.ts
@@ -69,10 +69,14 @@ export function createSubmissionUpload(): RequestHandler {
       await connection.open();
 
       const submissionUuid = req.params.submissionId as string;
-      const { bytes } = req.body;
+      const { bytes, blueprint_id } = req.body;
 
       const uploadIngestionService = new UploadIngestionService(connection);
-      const result = await uploadIngestionService.startArchiveUploadForExistingSubmissionByUuid(bytes, submissionUuid);
+      const result = await uploadIngestionService.startArchiveUploadForExistingSubmissionByUuid(
+        bytes,
+        submissionUuid,
+        blueprint_id
+      );
 
       await connection.commit();
 

--- a/api/src/repositories/blueprint-repository.test.ts
+++ b/api/src/repositories/blueprint-repository.test.ts
@@ -41,7 +41,7 @@ describe('BlueprintRepository', () => {
 
       const result = await repo.findActiveBlueprintById(99);
 
-      expect(result).to.equal(null);
+      expect(result).to.be.null;
     });
   });
 
@@ -67,7 +67,7 @@ describe('BlueprintRepository', () => {
 
       const result = await repo.findDefaultBlueprintId();
 
-      expect(result).to.equal(null);
+      expect(result).to.be.null;
     });
   });
 });

--- a/api/src/repositories/blueprint-repository.test.ts
+++ b/api/src/repositories/blueprint-repository.test.ts
@@ -27,7 +27,9 @@ describe('BlueprintRepository', () => {
       expect(sqlText).to.contain('FROM');
       expect(sqlText).to.contain('blueprint');
       expect(sqlText).to.contain('record_end_date IS NULL');
-      // Availability for a caller-provided id is gated only on record_end_date, not the default flag.
+      expect(sqlText).to.contain('record_effective_date <= now()');
+      // Availability for a caller-provided id is gated on record_end_date and record_effective_date,
+      // not the default flag.
       expect(sqlText).to.not.contain('is_default');
       expect(sqlStub.firstCall.args[0].values).to.include(7);
     });

--- a/api/src/repositories/blueprint-repository.test.ts
+++ b/api/src/repositories/blueprint-repository.test.ts
@@ -1,0 +1,71 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import { QueryResult } from 'pg';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
+import { BlueprintRepository } from './blueprint-repository';
+
+chai.use(sinonChai);
+
+describe('BlueprintRepository', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('findActiveBlueprintById', () => {
+    it('returns the blueprint_id when the Blueprint is available (record_end_date IS NULL)', async () => {
+      const mockQueryResponse = { rowCount: 1, rows: [{ blueprint_id: 7 }] } as any as Promise<QueryResult<any>>;
+      const sqlStub = sinon.stub().resolves(mockQueryResponse);
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repo = new BlueprintRepository(mockDBConnection);
+
+      const result = await repo.findActiveBlueprintById(7);
+
+      expect(result).to.equal(7);
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      expect(sqlText).to.contain('FROM');
+      expect(sqlText).to.contain('blueprint');
+      expect(sqlText).to.contain('record_end_date IS NULL');
+      // Availability for a caller-provided id is gated only on record_end_date, not the default flag.
+      expect(sqlText).to.not.contain('is_default');
+      expect(sqlStub.firstCall.args[0].values).to.include(7);
+    });
+
+    it('returns null when the Blueprint is not available', async () => {
+      const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new BlueprintRepository(mockDBConnection);
+
+      const result = await repo.findActiveBlueprintById(99);
+
+      expect(result).to.equal(null);
+    });
+  });
+
+  describe('findDefaultBlueprintId', () => {
+    it('returns the active default blueprint_id', async () => {
+      const mockQueryResponse = { rowCount: 1, rows: [{ blueprint_id: 1 }] } as any as Promise<QueryResult<any>>;
+      const sqlStub = sinon.stub().resolves(mockQueryResponse);
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repo = new BlueprintRepository(mockDBConnection);
+
+      const result = await repo.findDefaultBlueprintId();
+
+      expect(result).to.equal(1);
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      expect(sqlText).to.contain('is_default = true');
+      expect(sqlText).to.contain('record_end_date IS NULL');
+    });
+
+    it('returns null when no active default Blueprint exists', async () => {
+      const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new BlueprintRepository(mockDBConnection);
+
+      const result = await repo.findDefaultBlueprintId();
+
+      expect(result).to.equal(null);
+    });
+  });
+});

--- a/api/src/repositories/blueprint-repository.ts
+++ b/api/src/repositories/blueprint-repository.ts
@@ -5,7 +5,9 @@ export class BlueprintRepository extends BaseRepository {
   /**
    * Find a Blueprint's id only if it is currently available for new uploads.
    *
-   * A Blueprint is available when `record_end_date IS NULL` (not soft-deleted). This is the only
+   * A Blueprint is available when `record_end_date IS NULL` (not soft-deleted) and
+   * `record_effective_date <= now()` (live, not a draft or future-dated). A null
+   * `record_effective_date` represents a draft Blueprint that is not yet available. This is the only
    * availability check applied to a caller-provided `blueprint_id`; once stored on an upload the
    * Blueprint is grandfathered in and is not re-validated during indexing.
    *
@@ -20,7 +22,8 @@ export class BlueprintRepository extends BaseRepository {
         blueprint
       WHERE
         blueprint_id = ${blueprintId}
-        AND record_end_date IS NULL;
+        AND record_end_date IS NULL
+        AND record_effective_date <= now();
     `;
 
     const response = await this.connection.sql<{ blueprint_id: number }>(sqlStatement);

--- a/api/src/repositories/blueprint-repository.ts
+++ b/api/src/repositories/blueprint-repository.ts
@@ -1,0 +1,57 @@
+import { SQL } from 'sql-template-strings';
+import { BaseRepository } from './base-repository';
+
+export class BlueprintRepository extends BaseRepository {
+  /**
+   * Find a Blueprint's id only if it is currently available for new uploads.
+   *
+   * A Blueprint is available when `record_end_date IS NULL` (not soft-deleted). This is the only
+   * availability check applied to a caller-provided `blueprint_id`; once stored on an upload the
+   * Blueprint is grandfathered in and is not re-validated during indexing.
+   *
+   * @param {number} blueprintId - The requested Blueprint id.
+   * @returns {Promise<number | null>} - The `blueprint_id` if available, otherwise null.
+   */
+  async findActiveBlueprintById(blueprintId: number): Promise<number | null> {
+    const sqlStatement = SQL`
+      SELECT
+        blueprint_id
+      FROM
+        blueprint
+      WHERE
+        blueprint_id = ${blueprintId}
+        AND record_end_date IS NULL;
+    `;
+
+    const response = await this.connection.sql<{ blueprint_id: number }>(sqlStatement);
+
+    return response.rows[0]?.blueprint_id ?? null;
+  }
+
+  /**
+   * Find the id of the active default Blueprint (`is_default = true AND record_end_date IS NULL`).
+   *
+   * Used as the fallback for a brand-new submission that has no prior upload to inherit a Blueprint
+   * from. At most one active default Blueprint exists (enforced by a partial unique index).
+   *
+   * @returns {Promise<number | null>} - The default `blueprint_id`, or null if none is configured.
+   */
+  async findDefaultBlueprintId(): Promise<number | null> {
+    const sqlStatement = SQL`
+      SELECT
+        blueprint_id
+      FROM
+        blueprint
+      WHERE
+        is_default = true
+        AND record_end_date IS NULL
+      ORDER BY
+        version_number DESC
+      LIMIT 1;
+    `;
+
+    const response = await this.connection.sql<{ blueprint_id: number }>(sqlStatement);
+
+    return response.rows[0]?.blueprint_id ?? null;
+  }
+}

--- a/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
@@ -334,16 +334,18 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
       const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
 
-      await repository.populateResolvedPropertyStagingBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+      await repository.populateResolvedPropertyStagingBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000', 7);
 
       expect(sqlStub.calledOnce).to.equal(true);
       const sqlText = sqlStub.firstCall.args[0].text as string;
 
       expect(sqlText).to.include('INSERT INTO submission_upload_staging_resolved_property');
 
-      // Selected Blueprint is the active default Blueprint available for indexing.
-      expect(sqlText).to.include('is_default = true');
-      expect(sqlText).to.include('record_effective_date IS NOT NULL');
+      // Selected Blueprint is the one pinned to the upload, passed in by the caller — not re-selected
+      // here. The default Blueprint is no longer chosen inside the SQL.
+      expect(sqlText).to.include('::integer AS blueprint_id');
+      expect(sqlText).to.not.include('is_default');
+      expect(sqlStub.firstCall.args[0].values).to.include(7);
 
       // Feature-type inclusion and property assignment come from the Blueprint tables.
       expect(sqlText).to.include('blueprint_feature_type bft');
@@ -379,16 +381,28 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
       const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
 
-      await repository.recordMissingRequiredPropertyErrorsBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+      await repository.recordMissingRequiredPropertyErrorsBySubmissionUploadId(
+        '550e8400-e29b-41d4-a716-446655440000',
+        7
+      );
 
       const sqlText = sqlStub.firstCall.args[0].text as string;
-      expect(sqlText).to.include('is_default = true');
+
+      // Selected Blueprint is pinned to the upload and passed in — not re-selected from the default.
+      expect(sqlText).to.include('::integer AS blueprint_id');
+      expect(sqlText).to.not.include('is_default');
+      expect(sqlStub.firstCall.args[0].values).to.include(7);
+
       expect(sqlText).to.include('blueprint_feature_type_property bftp');
       expect(sqlText).to.include('bftp.required_value = TRUE');
 
       // The Blueprint assignment is joined through its new foreign keys.
       expect(sqlText).to.include('bftp.blueprint_feature_type_id = bft.blueprint_feature_type_id');
       expect(sqlText).to.include('ftp.feature_type_property_id = bftp.feature_type_property_id');
+
+      // The pool-entry bridge is constrained to the Blueprint feature type, so a property assigned
+      // under a different feature type cannot satisfy a requiredness check.
+      expect(sqlText).to.include('ftp.feature_type_id = bft.feature_type_id');
 
       // The columns removed from blueprint_feature_type_property must not be referenced.
       expect(sqlText).to.not.include('bftp.blueprint_id');
@@ -404,7 +418,10 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });
       const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
 
-      await repository.recordMissingRequiredPropertyErrorsBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+      await repository.recordMissingRequiredPropertyErrorsBySubmissionUploadId(
+        '550e8400-e29b-41d4-a716-446655440000',
+        7
+      );
 
       expect(sqlStub.calledOnce).to.equal(true);
       const sqlText = sqlStub.firstCall.args[0].text as string;

--- a/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.test.ts
@@ -328,7 +328,77 @@ describe('SubmissionFeaturePropertyIngestionRepository', () => {
     });
   });
 
+  describe('populateResolvedPropertyStagingBySubmissionUploadId', () => {
+    it('resolves assignment and validation flags through the selected Blueprint', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([]));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
+
+      await repository.populateResolvedPropertyStagingBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      expect(sqlStub.calledOnce).to.equal(true);
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+
+      expect(sqlText).to.include('INSERT INTO submission_upload_staging_resolved_property');
+
+      // Selected Blueprint is the active default Blueprint available for indexing.
+      expect(sqlText).to.include('is_default = true');
+      expect(sqlText).to.include('record_effective_date IS NOT NULL');
+
+      // Feature-type inclusion and property assignment come from the Blueprint tables.
+      expect(sqlText).to.include('blueprint_feature_type bft');
+      expect(sqlText).to.include('blueprint_feature_type_property bftp');
+
+      // The Blueprint assignment is joined through its new foreign keys: blueprint_feature_type_id
+      // (to the included feature type) and feature_type_property_id (to the pool entry).
+      expect(sqlText).to.include('bftp.blueprint_feature_type_id = bft.blueprint_feature_type_id');
+      expect(sqlText).to.include('bftp.feature_type_property_id = ftp.feature_type_property_id');
+
+      // The columns removed from blueprint_feature_type_property must not be referenced.
+      expect(sqlText).to.not.include('bftp.blueprint_id');
+      expect(sqlText).to.not.include('bftp.feature_type_id');
+      expect(sqlText).to.not.include('bftp.feature_property_id');
+
+      // Requiredness and multiplicity are sourced from the Blueprint assignment.
+      expect(sqlText).to.include('COALESCE(bftp.allow_multiple, false)');
+      expect(sqlText).to.include('COALESCE(bftp.required_value, false)');
+
+      // Primitive property type still read from feature_property_type.
+      expect(sqlText).to.include('feature_property_type fpt');
+      expect(sqlText).to.include('fpt.name AS property_type_name');
+
+      // feature_type_property is not the source of requiredness or multiplicity.
+      expect(sqlText).to.not.include('COALESCE(ftp.allow_multiple');
+      expect(sqlText).to.not.include('COALESCE(ftp.required_value');
+    });
+  });
+
   describe('recordMissingRequiredPropertyErrorsBySubmissionUploadId', () => {
+    it('sources requiredness from the selected Blueprint', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([]));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repository = new SubmissionFeaturePropertyIngestionRepository(mockDBConnection);
+
+      await repository.recordMissingRequiredPropertyErrorsBySubmissionUploadId('550e8400-e29b-41d4-a716-446655440000');
+
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      expect(sqlText).to.include('is_default = true');
+      expect(sqlText).to.include('blueprint_feature_type_property bftp');
+      expect(sqlText).to.include('bftp.required_value = TRUE');
+
+      // The Blueprint assignment is joined through its new foreign keys.
+      expect(sqlText).to.include('bftp.blueprint_feature_type_id = bft.blueprint_feature_type_id');
+      expect(sqlText).to.include('ftp.feature_type_property_id = bftp.feature_type_property_id');
+
+      // The columns removed from blueprint_feature_type_property must not be referenced.
+      expect(sqlText).to.not.include('bftp.blueprint_id');
+      expect(sqlText).to.not.include('bftp.feature_type_id');
+      expect(sqlText).to.not.include('bftp.feature_property_id');
+
+      // Requiredness no longer derived from feature_type_property.
+      expect(sqlText).to.not.include('COALESCE(ftp.required_value, false) = TRUE');
+    });
+
     it('uses an indexable raw-property anti-lookup for present required properties', async () => {
       const sqlStub = sinon.stub().resolves(mockQueryResult([]));
       const mockDBConnection = getMockDBConnection({ sql: sqlStub });

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -194,9 +194,8 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   /**
    * Clear upload-scoped rows from `submission_upload_staging_resolved_property`.
    *
-   * This table links raw staged property names to active feature/property metadata
-   * (`feature_type_property`, logical type, required/multi flags). Clearing avoids
-   * stale resolution rows on retries.
+   * This table links raw staged property names to the selected Blueprint's assignment metadata
+   * (logical type, required/multi flags). Clearing avoids stale resolution rows on retries.
    *
    * @param {string} submissionUploadId Upload scope.
    * @returns {Promise<void>}
@@ -210,22 +209,28 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   }
 
   /**
-   * Populate resolved-property staging by joining raw properties to active metadata.
+   * Populate resolved-property staging by resolving raw properties through the selected Blueprint
+   * (the active default Blueprint).
    *
-   * For each row in `submission_upload_staging_raw_property`, this method resolves:
-   * - matching `feature_property` by property name
-   * - matching `feature_type_property` for the feature's type
-   * - logical `feature_property_type` name
-   * - `allow_multiple` and `required_value` behavior flags
-   *
-   * Unresolved properties are preserved with nullable metadata so downstream phases
-   * can detect and report validation/resolution issues.
+   * Property assignment, requiredness, and multiplicity come from the Blueprint; the logical type is
+   * still read from `feature_property_type`. `feature_type_property` supplies only the canonical
+   * `feature_type_property_id` surrogate, and only for properties the Blueprint assigns — since that
+   * id gates downstream parsing, unassigned properties are kept with a null id for later reporting.
    *
    * @param {string} submissionUploadId Upload scope.
    * @returns {Promise<void>}
    */
   async populateResolvedPropertyStagingBySubmissionUploadId(submissionUploadId: string): Promise<void> {
     const sql = SQL`
+      WITH selected_blueprint AS (
+        SELECT blueprint_id
+        FROM blueprint
+        WHERE is_default = true
+          AND record_effective_date IS NOT NULL
+          AND record_end_date IS NULL
+        ORDER BY version_number DESC
+        LIMIT 1
+      )
       INSERT INTO submission_upload_staging_resolved_property (
         submission_feature_id,
         submission_upload_id,
@@ -243,9 +248,15 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
         s.feature_type_id,
         s.property_name,
         s.value,
-        ftp.feature_type_property_id,
-        COALESCE(ftp.allow_multiple, false) AS allow_multiple,
-        COALESCE(ftp.required_value, false) AS required_value,
+        -- Surrogate id only when the Blueprint includes the feature type and assigns the property;
+        -- this gates downstream parsing.
+        CASE
+          WHEN bft.blueprint_feature_type_id IS NOT NULL
+           AND bftp.blueprint_feature_type_property_id IS NOT NULL
+          THEN ftp.feature_type_property_id
+        END AS feature_type_property_id,
+        COALESCE(bftp.allow_multiple, false) AS allow_multiple,
+        COALESCE(bftp.required_value, false) AS required_value,
         fpt.name AS property_type_name
       FROM submission_upload_staging_raw_property s
       LEFT JOIN feature_property fp
@@ -254,10 +265,23 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
       LEFT JOIN feature_property_type fpt
         ON fpt.feature_property_type_id = fp.feature_property_type_id
        AND fpt.record_end_date IS NULL
+      LEFT JOIN selected_blueprint sb ON TRUE
+      -- Feature type included in the Blueprint.
+      LEFT JOIN blueprint_feature_type bft
+        ON bft.blueprint_id = sb.blueprint_id
+       AND bft.feature_type_id = s.feature_type_id
+       AND bft.record_end_date IS NULL
+      -- Canonical feature-type/property pool entry; supplies the surrogate id and bridges to the
+      -- Blueprint assignment. Not a source of assignment, requiredness, or multiplicity.
       LEFT JOIN feature_type_property ftp
         ON ftp.feature_type_id = s.feature_type_id
        AND ftp.feature_property_id = fp.feature_property_id
        AND ftp.record_end_date IS NULL
+      -- Property assigned to the Blueprint feature type; source of requiredness and multiplicity.
+      LEFT JOIN blueprint_feature_type_property bftp
+        ON bftp.blueprint_feature_type_id = bft.blueprint_feature_type_id
+       AND bftp.feature_type_property_id = ftp.feature_type_property_id
+       AND bftp.record_end_date IS NULL
       WHERE s.submission_upload_id = ${submissionUploadId}::uuid;
     `;
     await this.connection.sql(sql);
@@ -274,7 +298,7 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
    *
    * Note: array detection here is transport-shape handling. Logical property type
    * is still determined by `property_type_name`; multiplicity is governed by
-   * `allow_multiple` on `feature_type_property`.
+   * `allow_multiple` from the selected Blueprint's property assignment.
    *
    * @param {string} submissionUploadId Upload scope.
    * @returns {Promise<void>}
@@ -961,15 +985,26 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   /**
    * Record missing required-property errors for features in an upload.
    *
-   * Requiredness is evaluated by feature type against active metadata. A required property is
-   * considered present only when staging has a non-null value and, for arrays, at least one element.
+   * Requiredness comes from the selected Blueprint (the active default Blueprint): a property is
+   * required when its `blueprint_feature_type_property.required_value` is true. A required property
+   * is considered present only when staging has a non-null value and, for arrays, at least one
+   * element.
    *
    * @param {string} submissionUploadId Upload scope.
    * @returns {Promise<void>}
    */
   async recordMissingRequiredPropertyErrorsBySubmissionUploadId(submissionUploadId: string): Promise<void> {
     const sql = SQL`
-      WITH upload_feature_types AS (
+      WITH selected_blueprint AS (
+        SELECT blueprint_id
+        FROM blueprint
+        WHERE is_default = true
+          AND record_effective_date IS NOT NULL
+          AND record_end_date IS NULL
+        ORDER BY version_number DESC
+        LIMIT 1
+      ),
+      upload_feature_types AS (
         SELECT DISTINCT feature_type_id
         FROM submission_feature
         WHERE submission_upload_id = ${submissionUploadId}::uuid
@@ -980,14 +1015,25 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
           ftp.feature_type_id,
           ftp.feature_type_property_id,
           fp.name AS property_name
-        FROM feature_type_property ftp
+        FROM selected_blueprint sb
+        -- Feature type included in the Blueprint.
+        JOIN blueprint_feature_type bft
+          ON bft.blueprint_id = sb.blueprint_id
+         AND bft.record_end_date IS NULL
+        -- Required properties assigned by the Blueprint.
+        JOIN blueprint_feature_type_property bftp
+          ON bftp.blueprint_feature_type_id = bft.blueprint_feature_type_id
+         AND bftp.record_end_date IS NULL
+         AND bftp.required_value = TRUE
+        -- Canonical pool entry; bridges the assignment to its feature type / property and surrogate id.
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = bftp.feature_type_property_id
+         AND ftp.record_end_date IS NULL
         JOIN feature_property fp
           ON fp.feature_property_id = ftp.feature_property_id
          AND fp.record_end_date IS NULL
         JOIN upload_feature_types uft
-          ON uft.feature_type_id = ftp.feature_type_id
-        WHERE ftp.record_end_date IS NULL
-          AND COALESCE(ftp.required_value, false) = TRUE
+          ON uft.feature_type_id = bft.feature_type_id
       ),
       grouped_errors AS (
         SELECT

--- a/api/src/repositories/submission-feature-property-ingestion-repository.ts
+++ b/api/src/repositories/submission-feature-property-ingestion-repository.ts
@@ -209,27 +209,26 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   }
 
   /**
-   * Populate resolved-property staging by resolving raw properties through the selected Blueprint
-   * (the active default Blueprint).
+   * Populate resolved-property staging by resolving raw properties through the selected Blueprint.
    *
-   * Property assignment, requiredness, and multiplicity come from the Blueprint; the logical type is
-   * still read from `feature_property_type`. `feature_type_property` supplies only the canonical
-   * `feature_type_property_id` surrogate, and only for properties the Blueprint assigns — since that
-   * id gates downstream parsing, unassigned properties are kept with a null id for later reporting.
+   * The selected Blueprint is the one pinned to the upload (`submission_upload.blueprint_id`), passed
+   * in by the caller — it is not re-selected here. Property assignment, requiredness, and multiplicity
+   * come from the Blueprint; the logical type is still read from `feature_property_type`.
+   * `feature_type_property` supplies only the canonical `feature_type_property_id` surrogate, and only
+   * for properties the Blueprint assigns — since that id gates downstream parsing, unassigned
+   * properties are kept with a null id for later reporting.
    *
    * @param {string} submissionUploadId Upload scope.
+   * @param {number} blueprintId The Blueprint pinned to the upload.
    * @returns {Promise<void>}
    */
-  async populateResolvedPropertyStagingBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+  async populateResolvedPropertyStagingBySubmissionUploadId(
+    submissionUploadId: string,
+    blueprintId: number
+  ): Promise<void> {
     const sql = SQL`
       WITH selected_blueprint AS (
-        SELECT blueprint_id
-        FROM blueprint
-        WHERE is_default = true
-          AND record_effective_date IS NOT NULL
-          AND record_end_date IS NULL
-        ORDER BY version_number DESC
-        LIMIT 1
+        SELECT ${blueprintId}::integer AS blueprint_id
       )
       INSERT INTO submission_upload_staging_resolved_property (
         submission_feature_id,
@@ -985,24 +984,22 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
   /**
    * Record missing required-property errors for features in an upload.
    *
-   * Requiredness comes from the selected Blueprint (the active default Blueprint): a property is
-   * required when its `blueprint_feature_type_property.required_value` is true. A required property
-   * is considered present only when staging has a non-null value and, for arrays, at least one
-   * element.
+   * Requiredness comes from the selected Blueprint pinned to the upload
+   * (`submission_upload.blueprint_id`), passed in by the caller: a property is required when its
+   * `blueprint_feature_type_property.required_value` is true. A required property is considered
+   * present only when staging has a non-null value and, for arrays, at least one element.
    *
    * @param {string} submissionUploadId Upload scope.
+   * @param {number} blueprintId The Blueprint pinned to the upload.
    * @returns {Promise<void>}
    */
-  async recordMissingRequiredPropertyErrorsBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+  async recordMissingRequiredPropertyErrorsBySubmissionUploadId(
+    submissionUploadId: string,
+    blueprintId: number
+  ): Promise<void> {
     const sql = SQL`
       WITH selected_blueprint AS (
-        SELECT blueprint_id
-        FROM blueprint
-        WHERE is_default = true
-          AND record_effective_date IS NOT NULL
-          AND record_end_date IS NULL
-        ORDER BY version_number DESC
-        LIMIT 1
+        SELECT ${blueprintId}::integer AS blueprint_id
       ),
       upload_feature_types AS (
         SELECT DISTINCT feature_type_id
@@ -1026,8 +1023,11 @@ export class SubmissionFeaturePropertyIngestionRepository extends BaseRepository
          AND bftp.record_end_date IS NULL
          AND bftp.required_value = TRUE
         -- Canonical pool entry; bridges the assignment to its feature type / property and surrogate id.
+        -- Constrain to the Blueprint feature type: the FK on bftp.feature_type_property_id only proves
+        -- the property exists in the global pool, not that it belongs to bft.feature_type_id.
         JOIN feature_type_property ftp
           ON ftp.feature_type_property_id = bftp.feature_type_property_id
+         AND ftp.feature_type_id = bft.feature_type_id
          AND ftp.record_end_date IS NULL
         JOIN feature_property fp
           ON fp.feature_property_id = ftp.feature_property_id

--- a/api/src/repositories/upload/submission-upload-repository.test.ts
+++ b/api/src/repositories/upload/submission-upload-repository.test.ts
@@ -249,6 +249,7 @@ describe('SubmissionUploadRepository', () => {
         upload_id: 'a-1',
         ticket_id: '11111111-1111-1111-1111-111111111111',
         status: 'uploaded',
+        blueprint_id: 7,
         comment: 'Upload-specific note'
       };
 
@@ -264,18 +265,55 @@ describe('SubmissionUploadRepository', () => {
     it('returns the inserted record ID if successful', async () => {
       const mockRow = { submission_upload_id: 'id-1' };
       const mockQueryResponse = { rowCount: 1, rows: [mockRow] } as any as Promise<QueryResult<any>>;
-      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const sqlStub = sinon.stub().resolves(mockQueryResponse);
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
       const repo = new SubmissionUploadRepository(mockDBConnection);
 
       const payload: CreateSubmissionUpload = {
         submission_id: 123,
         upload_id: 'a-1',
         ticket_id: '11111111-1111-1111-1111-111111111111',
-        status: 'uploaded'
+        status: 'uploaded',
+        blueprint_id: 7
       };
       const result = await repo.insertSubmissionUpload(payload);
 
       expect(result).to.eql(mockRow);
+
+      // The pinned Blueprint is persisted with the upload.
+      expect(sqlStub.firstCall.args[0].text).to.contain('blueprint_id');
+      expect(sqlStub.firstCall.args[0].values).to.include(7);
+    });
+  });
+
+  describe('findMostRecentBlueprintIdBySubmissionId', () => {
+    it('returns the most recent prior blueprint_id ordered by create_date', async () => {
+      const mockQueryResponse = { rowCount: 1, rows: [{ blueprint_id: 9 }] } as any as Promise<QueryResult<any>>;
+      const sqlStub = sinon.stub().resolves(mockQueryResponse);
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const repo = new SubmissionUploadRepository(mockDBConnection);
+
+      const result = await repo.findMostRecentBlueprintIdBySubmissionId(123);
+
+      expect(result).to.equal(9);
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      expect(sqlText).to.contain('FROM');
+      expect(sqlText).to.contain('submission_upload');
+      expect(sqlText).to.contain('create_date DESC');
+      expect(sqlText).to.contain('LIMIT 1');
+      // Soft-deleted prior uploads still pin a valid Blueprint, so record_end_date is not filtered.
+      expect(sqlText).to.not.contain('record_end_date');
+      expect(sqlStub.firstCall.args[0].values).to.include(123);
+    });
+
+    it('returns null when the submission has no prior upload', async () => {
+      const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
+      const mockDBConnection = getMockDBConnection({ sql: () => mockQueryResponse });
+      const repo = new SubmissionUploadRepository(mockDBConnection);
+
+      const result = await repo.findMostRecentBlueprintIdBySubmissionId(123);
+
+      expect(result).to.equal(null);
     });
   });
 

--- a/api/src/repositories/upload/submission-upload-repository.test.ts
+++ b/api/src/repositories/upload/submission-upload-repository.test.ts
@@ -313,7 +313,7 @@ describe('SubmissionUploadRepository', () => {
 
       const result = await repo.findMostRecentBlueprintIdBySubmissionId(123);
 
-      expect(result).to.equal(null);
+      expect(result).to.be.null;
     });
   });
 

--- a/api/src/repositories/upload/submission-upload-repository.ts
+++ b/api/src/repositories/upload/submission-upload-repository.ts
@@ -28,6 +28,7 @@ export class SubmissionUploadRepository extends BaseRepository {
         upload_id,
         status,
         ticket_id,
+        blueprint_id,
         comment
       FROM
         submission_upload
@@ -72,6 +73,7 @@ export class SubmissionUploadRepository extends BaseRepository {
         upload_id,
         status,
         ticket_id,
+        blueprint_id,
         comment
       FROM
         submission_upload
@@ -119,6 +121,7 @@ export class SubmissionUploadRepository extends BaseRepository {
         su.upload_id,
         su.status,
         su.ticket_id,
+        su.blueprint_id,
         su.comment,
         su.record_end_date
       FROM
@@ -170,6 +173,7 @@ export class SubmissionUploadRepository extends BaseRepository {
         'submission_upload.upload_id',
         'submission_upload.status',
         'submission_upload.ticket_id',
+        'submission_upload.blueprint_id',
         'submission_upload.comment'
       )
       .from('submission_upload')
@@ -313,12 +317,14 @@ export class SubmissionUploadRepository extends BaseRepository {
         upload_id,
         ticket_id,
         status,
+        blueprint_id,
         comment
       ) VALUES (
         ${submissionUpload.submission_id},
         ${submissionUpload.upload_id},
         ${submissionUpload.ticket_id},
         ${submissionUpload.status},
+        ${submissionUpload.blueprint_id},
         ${submissionUpload.comment ?? null}
       )
       RETURNING submission_upload_id;
@@ -334,6 +340,36 @@ export class SubmissionUploadRepository extends BaseRepository {
     }
 
     return response.rows[0];
+  }
+
+  /**
+   * Find the `blueprint_id` of the most recent prior submission_upload for a submission.
+   *
+   * Used to pin a new upload to the same Blueprint as the submission's previous upload, so
+   * re-submissions remain stable when the default Blueprint changes. The most recent upload is
+   * selected by `create_date` regardless of `record_end_date` — a soft-deleted prior upload's
+   * Blueprint is still a valid pin.
+   *
+   * @param {number} submissionId - The submission whose prior uploads should be inspected.
+   * @returns {Promise<number | null>} - The prior upload's `blueprint_id`, or null if none exists.
+   */
+  async findMostRecentBlueprintIdBySubmissionId(submissionId: number): Promise<number | null> {
+    const sqlStatement = SQL`
+      SELECT
+        blueprint_id
+      FROM
+        submission_upload
+      WHERE
+        submission_id = ${submissionId}
+      ORDER BY
+        create_date DESC,
+        submission_upload_id DESC
+      LIMIT 1;
+    `;
+
+    const response = await this.connection.sql<{ blueprint_id: number }>(sqlStatement);
+
+    return response.rows[0]?.blueprint_id ?? null;
   }
 
   /**
@@ -436,6 +472,7 @@ export class SubmissionUploadRepository extends BaseRepository {
         upload_id,
         status,
         ticket_id,
+        blueprint_id,
         comment
       FROM
         submission_upload

--- a/api/src/services/ingestion/submission-feature-property-ingestion-service.test.ts
+++ b/api/src/services/ingestion/submission-feature-property-ingestion-service.test.ts
@@ -8,6 +8,7 @@ import { SubmissionFeaturePropertyIngestionRepository } from '../../repositories
 import { SubmissionRepository } from '../../repositories/submission-repository';
 import { ContributorService } from '../contributor-service';
 import { SubmissionUploadReviewService } from '../upload/submission-upload-review-service';
+import { SubmissionUploadService } from '../upload/submission-upload-service';
 import { SubmissionFeaturePropertyIngestionService } from './submission-feature-property-ingestion-service';
 
 describe('SubmissionFeaturePropertyIngestionService', () => {
@@ -21,6 +22,14 @@ describe('SubmissionFeaturePropertyIngestionService', () => {
     const service = new SubmissionFeaturePropertyIngestionService(getMockDBConnection({ systemUserId: () => 11 }));
 
     sinon.stub(ContributorService.prototype, 'getContributorBySubmissionUploadId').resolves(contributor);
+    sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUpload').resolves({
+      submission_upload_id: '550e8400-e29b-41d4-a716-446655440000',
+      submission_id: 1,
+      upload_id: '660e8400-e29b-41d4-a716-446655440000',
+      status: 'indexing',
+      ticket_id: '770e8400-e29b-41d4-a716-446655440000',
+      blueprint_id: 42
+    });
     const requestDefaultReviewsStub = sinon
       .stub(SubmissionUploadReviewService.prototype, 'requestDefaultReviewsForUpload')
       .resolves([]);
@@ -203,6 +212,14 @@ describe('SubmissionFeaturePropertyIngestionService', () => {
     const service = new SubmissionFeaturePropertyIngestionService(getMockDBConnection());
 
     sinon.stub(ContributorService.prototype, 'getContributorBySubmissionUploadId').resolves(contributor);
+    sinon.stub(SubmissionUploadService.prototype, 'getSubmissionUpload').resolves({
+      submission_upload_id: '550e8400-e29b-41d4-a716-446655440000',
+      submission_id: 1,
+      upload_id: '660e8400-e29b-41d4-a716-446655440000',
+      status: 'indexing',
+      ticket_id: '770e8400-e29b-41d4-a716-446655440000',
+      blueprint_id: 42
+    });
     const requestDefaultReviewsStub = sinon
       .stub(SubmissionUploadReviewService.prototype, 'requestDefaultReviewsForUpload')
       .resolves([]);

--- a/api/src/services/ingestion/submission-feature-property-ingestion-service.ts
+++ b/api/src/services/ingestion/submission-feature-property-ingestion-service.ts
@@ -6,6 +6,7 @@ import { getLogger } from '../../utils/logger';
 import { ContributorService } from '../contributor-service';
 import { DBService } from '../db-service';
 import { SubmissionUploadReviewService } from '../upload/submission-upload-review-service';
+import { SubmissionUploadService } from '../upload/submission-upload-service';
 import { SubmissionFeaturePropertyValidationOutcome } from './submission-feature-property-ingestion-service.interface';
 
 const defaultLog = getLogger('services/ingestion/submission-feature-property-ingestion-service');
@@ -16,6 +17,7 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
   featureIngestionRepository: FeatureIngestionRepository;
   contributorService: ContributorService;
   submissionUploadReviewService: SubmissionUploadReviewService;
+  submissionUploadService: SubmissionUploadService;
 
   constructor(connection: IDBConnection) {
     super(connection);
@@ -25,6 +27,7 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
     this.featureIngestionRepository = new FeatureIngestionRepository(connection);
     this.contributorService = new ContributorService(connection);
     this.submissionUploadReviewService = new SubmissionUploadReviewService(connection);
+    this.submissionUploadService = new SubmissionUploadService(connection);
   }
 
   /**
@@ -59,6 +62,18 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
         submissionId,
         submissionUploadId,
         contributorId: contributor.contributor_id
+      });
+
+      // Resolve the Blueprint pinned to this upload. Property resolution and requiredness checks use
+      // this Blueprint rather than re-selecting the current default (the upload is grandfathered in).
+      currentPhase = 'resolve upload blueprint';
+      const { blueprint_id: blueprintId } = await this.submissionUploadService.getSubmissionUpload(submissionUploadId);
+      defaultLog.debug({
+        label: 'indexSubmissionPropertiesBySubmissionUploadId',
+        message: 'resolved blueprint',
+        submissionId,
+        submissionUploadId,
+        blueprintId
       });
       // Cleanup for idempotency.
       currentPhase = 'cleanup existing property records and relationships';
@@ -107,7 +122,7 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
         submissionUploadId,
         phase: currentPhase
       });
-      await this.populateUploadPropertyWorkingSetBySubmissionUploadId(submissionUploadId);
+      await this.populateUploadPropertyWorkingSetBySubmissionUploadId(submissionUploadId, blueprintId);
       await this.submissionFeaturePropertyIngestionRepository.deleteIngestionErrorsBySubmissionUploadId(
         submissionUploadId
       );
@@ -122,7 +137,8 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
         phase: currentPhase
       });
       await this.submissionFeaturePropertyIngestionRepository.recordMissingRequiredPropertyErrorsBySubmissionUploadId(
-        submissionUploadId
+        submissionUploadId,
+        blueprintId
       );
       await this.submissionFeaturePropertyIngestionRepository.recordPrimitiveValidationErrorsBySubmissionUploadId(
         submissionUploadId
@@ -354,15 +370,20 @@ export class SubmissionFeaturePropertyIngestionService extends DBService {
    * validation, and downstream typed inserts.
    *
    * @param {string} submissionUploadId Upload scope.
+   * @param {number} blueprintId The Blueprint pinned to the upload.
    * @returns {Promise<void>}
    */
-  private async populateUploadPropertyWorkingSetBySubmissionUploadId(submissionUploadId: string): Promise<void> {
+  private async populateUploadPropertyWorkingSetBySubmissionUploadId(
+    submissionUploadId: string,
+    blueprintId: number
+  ): Promise<void> {
     await this.submissionFeaturePropertyIngestionRepository.clearUploadPropertyWorkingSetStagingBySubmissionUploadId(
       submissionUploadId
     );
 
     await this.submissionFeaturePropertyIngestionRepository.populateResolvedPropertyStagingBySubmissionUploadId(
-      submissionUploadId
+      submissionUploadId,
+      blueprintId
     );
 
     await this.submissionFeaturePropertyIngestionRepository.populateTypedPropertyValueStagingBySubmissionUploadId(

--- a/api/src/services/upload/submission-upload-service.test.ts
+++ b/api/src/services/upload/submission-upload-service.test.ts
@@ -3,8 +3,10 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { IDBConnection } from '../../database/db';
-import { ApiConflictError } from '../../errors/api-error';
+import { ApiConflictError, ApiGeneralError } from '../../errors/api-error';
+import { HTTP400 } from '../../errors/http-error';
 import { CreateSubmissionUpload, SubmissionUpload, UpdateSubmissionUpload } from '../../models/submission-upload';
+import { BlueprintRepository } from '../../repositories/blueprint-repository';
 import { SubmissionUploadRepository } from '../../repositories/upload/submission-upload-repository';
 import { SubmissionUploadService } from './submission-upload-service';
 
@@ -167,6 +169,71 @@ describe('SubmissionUploadService', () => {
         expect.fail('Expected error not thrown');
       } catch (err) {
         expect((err as Error).message).to.equal('Insert failed');
+      }
+    });
+  });
+
+  describe('resolveBlueprintIdForUpload', () => {
+    it('uses a supplied blueprint_id when it is available', async () => {
+      const getActiveStub = sinon.stub(BlueprintRepository.prototype, 'findActiveBlueprintById').resolves(5);
+      const priorStub = sinon.stub(SubmissionUploadRepository.prototype, 'findMostRecentBlueprintIdBySubmissionId');
+      const defaultStub = sinon.stub(BlueprintRepository.prototype, 'findDefaultBlueprintId');
+
+      const result = await service.resolveBlueprintIdForUpload(1, 5);
+
+      expect(result).to.equal(5);
+      expect(getActiveStub).to.have.been.calledOnceWith(5);
+      // A supplied id short-circuits the prior-upload and default fallbacks.
+      expect(priorStub).to.not.have.been.called;
+      expect(defaultStub).to.not.have.been.called;
+    });
+
+    it('throws HTTP400 when a supplied blueprint_id is not available', async () => {
+      sinon.stub(BlueprintRepository.prototype, 'findActiveBlueprintById').resolves(null);
+
+      try {
+        await service.resolveBlueprintIdForUpload(1, 999);
+        expect.fail('Expected error not thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP400);
+        expect((error as HTTP400).message).to.equal('Requested Blueprint is not available');
+      }
+    });
+
+    it('defaults to the most recent prior upload Blueprint when none is supplied', async () => {
+      const priorStub = sinon
+        .stub(SubmissionUploadRepository.prototype, 'findMostRecentBlueprintIdBySubmissionId')
+        .resolves(8);
+      const defaultStub = sinon.stub(BlueprintRepository.prototype, 'findDefaultBlueprintId');
+
+      const result = await service.resolveBlueprintIdForUpload(1);
+
+      expect(result).to.equal(8);
+      expect(priorStub).to.have.been.calledOnceWith(1);
+      // The prior upload Blueprint wins over the system default for re-submissions.
+      expect(defaultStub).to.not.have.been.called;
+    });
+
+    it('falls back to the default Blueprint when there is no prior upload', async () => {
+      sinon.stub(SubmissionUploadRepository.prototype, 'findMostRecentBlueprintIdBySubmissionId').resolves(null);
+      const defaultStub = sinon.stub(BlueprintRepository.prototype, 'findDefaultBlueprintId').resolves(1);
+
+      const result = await service.resolveBlueprintIdForUpload(1);
+
+      expect(result).to.equal(1);
+      expect(defaultStub).to.have.been.calledOnce;
+    });
+
+    it('throws when no prior upload and no default Blueprint exist', async () => {
+      sinon.stub(SubmissionUploadRepository.prototype, 'findMostRecentBlueprintIdBySubmissionId').resolves(null);
+      sinon.stub(BlueprintRepository.prototype, 'findDefaultBlueprintId').resolves(null);
+
+      try {
+        await service.resolveBlueprintIdForUpload(1);
+        expect.fail('Expected error not thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(ApiGeneralError);
+        expect((error as ApiGeneralError).message).to.equal('No default Blueprint is configured');
       }
     });
   });

--- a/api/src/services/upload/submission-upload-service.ts
+++ b/api/src/services/upload/submission-upload-service.ts
@@ -1,5 +1,6 @@
 import { IDBConnection } from '../../database/db';
-import { ApiConflictError } from '../../errors/api-error';
+import { ApiConflictError, ApiGeneralError } from '../../errors/api-error';
+import { HTTP400 } from '../../errors/http-error';
 import {
   CreateSubmissionUpload,
   SubmissionUpload,
@@ -7,12 +8,14 @@ import {
   TicketSubmissionUpload,
   UpdateSubmissionUpload
 } from '../../models/submission-upload';
+import { BlueprintRepository } from '../../repositories/blueprint-repository';
 import { SubmissionUploadRepository } from '../../repositories/upload/submission-upload-repository';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { DBService } from '../db-service';
 
 export class SubmissionUploadService extends DBService {
   submissionUploadRepository: SubmissionUploadRepository;
+  blueprintRepository: BlueprintRepository;
 
   /**
    * Creates an instance of SubmissionUploadService.
@@ -23,6 +26,58 @@ export class SubmissionUploadService extends DBService {
   constructor(connection: IDBConnection) {
     super(connection);
     this.submissionUploadRepository = new SubmissionUploadRepository(connection);
+    this.blueprintRepository = new BlueprintRepository(connection);
+  }
+
+  /**
+   * Resolve the Blueprint a new upload should be pinned to.
+   *
+   * Resolution order:
+   * 1. If a `blueprint_id` was supplied, validate it is currently available (`record_end_date IS
+   *    NULL`) and use it. An unavailable id is a client error (HTTP 400).
+   * 2. Otherwise inherit the most recent prior upload's Blueprint for the same submission, so
+   *    re-submissions stay stable when the system default Blueprint changes.
+   * 3. Otherwise (no prior upload) fall back to the active default Blueprint.
+   *
+   * @param {number} submissionId - The submission the upload belongs to.
+   * @param {number | null} [requestedBlueprintId] - Optional caller-supplied Blueprint id.
+   * @returns {Promise<number>} - The resolved `blueprint_id` to store on the upload.
+   * @throws {HTTP400} If a requested Blueprint id is not available.
+   * @throws {ApiGeneralError} If no Blueprint can be resolved (no prior upload and no default).
+   * @memberof SubmissionUploadService
+   */
+  async resolveBlueprintIdForUpload(submissionId: number, requestedBlueprintId?: number | null): Promise<number> {
+    if (requestedBlueprintId != null) {
+      const blueprintId = await this.blueprintRepository.findActiveBlueprintById(requestedBlueprintId);
+
+      if (blueprintId === null) {
+        throw new HTTP400('Requested Blueprint is not available', [
+          'SubmissionUploadService->resolveBlueprintIdForUpload',
+          `blueprint_id ${requestedBlueprintId} does not exist or is no longer available for new uploads`
+        ]);
+      }
+
+      return blueprintId;
+    }
+
+    const priorBlueprintId = await this.submissionUploadRepository.findMostRecentBlueprintIdBySubmissionId(
+      submissionId
+    );
+
+    if (priorBlueprintId !== null) {
+      return priorBlueprintId;
+    }
+
+    const defaultBlueprintId = await this.blueprintRepository.findDefaultBlueprintId();
+
+    if (defaultBlueprintId === null) {
+      throw new ApiGeneralError('No default Blueprint is configured', [
+        'SubmissionUploadService->resolveBlueprintIdForUpload',
+        `submission_id ${submissionId} has no prior upload and no active default Blueprint exists`
+      ]);
+    }
+
+    return defaultBlueprintId;
   }
 
   /**

--- a/api/src/services/upload/upload-ingestion-service.test.ts
+++ b/api/src/services/upload/upload-ingestion-service.test.ts
@@ -40,10 +40,13 @@ describe('UploadIngestionService', () => {
     comment: 'Test Comment'
   };
 
+  const mockBlueprintId = 7;
+
   beforeEach(() => {
     mockConnection = getMockDBConnection({ systemUserId: () => 1 });
     service = new UploadIngestionService(mockConnection);
     sinon.stub(SubmissionUploadReviewService.prototype, 'createDefaultReviewsForUpload').resolves([]);
+    sinon.stub(SubmissionUploadService.prototype, 'resolveBlueprintIdForUpload').resolves(mockBlueprintId);
   });
 
   afterEach(() => {
@@ -110,6 +113,7 @@ describe('UploadIngestionService', () => {
           upload_id: mockUploadId,
           ticket_id: '11111111-1111-1111-1111-111111111111',
           status: 'uploaded',
+          blueprint_id: mockBlueprintId,
           comment: mockSubmission.comment
         })
       );

--- a/api/src/services/upload/upload-ingestion-service.ts
+++ b/api/src/services/upload/upload-ingestion-service.ts
@@ -57,9 +57,15 @@ export class UploadIngestionService extends DBService {
    *
    * @param {number} bytes
    * @param {ICreateSubmission} submission
+   * @param {number | null} [requestedBlueprintId] Optional Blueprint to pin the upload to; defaults to
+   * the system default Blueprint when omitted (new submissions have no prior upload to inherit from).
    * @returns {Promise<PresignedUploadUrlResponse>}
    */
-  async startArchiveUpload(bytes: number, submission: ICreateSubmission): Promise<PresignedUploadUrlResponse> {
+  async startArchiveUpload(
+    bytes: number,
+    submission: ICreateSubmission,
+    requestedBlueprintId?: number | null
+  ): Promise<PresignedUploadUrlResponse> {
     // 1. Create submission (intent)
     const { submission_id } = await this.submissionService.insertSubmissionRecord(submission);
 
@@ -72,7 +78,8 @@ export class UploadIngestionService extends DBService {
       submission_id,
       submissionUuidFromTable,
       [submission.system_user_id],
-      submission.comment
+      submission.comment,
+      requestedBlueprintId
     );
   }
 
@@ -82,12 +89,15 @@ export class UploadIngestionService extends DBService {
    *
    * @param {number} bytes
    * @param {string} submissionUuid - Submission UUID (submission.uuid).
+   * @param {number | null} [requestedBlueprintId] Optional Blueprint to pin the upload to; defaults to
+   * the submission's most recent prior upload Blueprint when omitted.
    * @returns {Promise<PresignedUploadUrlResponse>}
    * @throws {ApiNotFoundError} If no submission exists for the given UUID (mapped to 404 by error handler).
    */
   async startArchiveUploadForExistingSubmissionByUuid(
     bytes: number,
-    submissionUuid: string
+    submissionUuid: string,
+    requestedBlueprintId?: number | null
   ): Promise<PresignedUploadUrlResponse> {
     const byUuid = await this.submissionService.getSubmissionIdByUUID(submissionUuid);
     const submissionRecord = await this.submissionService.getSubmissionRecordBySubmissionId(byUuid.submission_id);
@@ -96,7 +106,8 @@ export class UploadIngestionService extends DBService {
       byUuid.submission_id,
       submissionRecord.uuid,
       [submissionRecord.system_user_id],
-      submissionRecord.comment ?? null
+      submissionRecord.comment ?? null,
+      requestedBlueprintId
     );
   }
 
@@ -107,6 +118,10 @@ export class UploadIngestionService extends DBService {
    * @param {number} bytes
    * @param {number} submissionId - Integer PK for DB operations
    * @param {string} submissionUuid - Submission UUID; used when building response (API returns this as submissionId for client use).
+   * @param {number[]} systemUserIds - System users to associate with the upload's ticket.
+   * @param {string | null} [comment] - Optional upload comment.
+   * @param {number | null} [requestedBlueprintId] - Optional Blueprint to pin the upload to; resolved
+   * to provided → most recent prior upload → system default.
    * @returns {Promise<PresignedUploadUrlResponse>}
    */
   async _startArchiveUploadForSubmission(
@@ -114,8 +129,15 @@ export class UploadIngestionService extends DBService {
     submissionId: number,
     submissionUuid: string,
     systemUserIds: number[],
-    comment?: string | null
+    comment?: string | null,
+    requestedBlueprintId?: number | null
   ): Promise<PresignedUploadUrlResponse> {
+    // 0. Pin the Blueprint this upload will be indexed with (provided → prior upload → default).
+    const blueprint_id = await this.submissionUploadService.resolveBlueprintIdForUpload(
+      submissionId,
+      requestedBlueprintId
+    );
+
     // 1. Create upload session
     const { upload_id } = await this.uploadService.insertUpload({
       upload_status: UploadStatusEnum.PENDING,
@@ -137,6 +159,7 @@ export class UploadIngestionService extends DBService {
       upload_id,
       ticket_id: ticket.ticket_id,
       status: 'uploaded',
+      blueprint_id,
       comment: comment ?? null
     });
 

--- a/database/src/migrations/20260619120000_add_blueprint_id_to_submission_upload.ts
+++ b/database/src/migrations/20260619120000_add_blueprint_id_to_submission_upload.ts
@@ -1,0 +1,56 @@
+import { Knex } from 'knex';
+
+/**
+ * Adds `submission_upload.blueprint_id` so each upload is pinned to the Blueprint it was created with.
+ *
+ * Indexing resolves feature properties through this stored Blueprint rather than re-selecting the
+ * current default Blueprint, so existing uploads remain stable when the default Blueprint changes
+ * later. Existing rows are backfilled with the active default Blueprint to preserve current behavior.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE submission_upload ADD COLUMN blueprint_id integer;
+
+    COMMENT ON COLUMN submission_upload.blueprint_id IS 'Foreign key to the blueprint used to index this upload. Pinned at upload creation so indexing is stable when the default Blueprint changes.';
+
+    -- Backfill existing rows with the active default Blueprint, matching prior indexing behavior.
+    UPDATE submission_upload su
+    SET blueprint_id = b.blueprint_id
+    FROM blueprint b
+    WHERE su.blueprint_id IS NULL
+      AND b.is_default = true
+      AND b.record_end_date IS NULL;
+
+    ALTER TABLE submission_upload ALTER COLUMN blueprint_id SET NOT NULL;
+
+    ALTER TABLE submission_upload ADD CONSTRAINT submission_upload_blueprint_fk
+      FOREIGN KEY (blueprint_id) REFERENCES blueprint(blueprint_id);
+
+    CREATE INDEX submission_upload_blueprint_idx ON submission_upload(blueprint_id);
+  `);
+}
+
+/**
+ * Reverses {@link up}: drops the index, foreign key, and column.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    DROP INDEX IF EXISTS submission_upload_blueprint_idx;
+
+    ALTER TABLE submission_upload DROP CONSTRAINT IF EXISTS submission_upload_blueprint_fk;
+
+    ALTER TABLE submission_upload DROP COLUMN IF EXISTS blueprint_id;
+  `);
+}

--- a/database/src/seeds/04_mock_test_data.ts
+++ b/database/src/seeds/04_mock_test_data.ts
@@ -193,12 +193,20 @@ export const insertSubmissionUploadRecord = async (
 ): Promise<string> => {
   const ticket_id = await ensureTicketForSubmissionUpload(knex, { submission_id, upload_id });
 
+  // Pin the upload to the active default Blueprint (seeded by the initial-blueprint migration).
+  const blueprintRow = await knex('blueprint')
+    .where({ is_default: true })
+    .whereNull('record_end_date')
+    .select('blueprint_id')
+    .first();
+
   const [{ submission_upload_id }] = await knex('submission_upload')
     .insert({
       submission_id,
       upload_id,
       create_user: 1,
-      ticket_id
+      ticket_id,
+      blueprint_id: blueprintRow.blueprint_id
     })
     .returning('submission_upload_id');
 


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1045](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1045)

## Description of Changes

- Property indexing now resolves staged properties through the **selected Blueprint** instead of `feature_type_property`. A property is parsed only when the Blueprint includes its feature type (`blueprint_feature_type`) and assigns the property (`blueprint_feature_type_property`); `required_value` / `allow_multiple` come from the assignment. Primitive type lookup stays on `feature_property_type`.
- Each upload is **pinned to a Blueprint**: new `submission_upload.blueprint_id` (migration, NOT NULL + FK). On creation the id is resolved as: provided `blueprint_id` (validated `record_end_date IS NULL`, else 400) → most recent prior upload for the submission → active default. Optional `blueprint_id` is accepted on the upload request schemas and threaded through `_startArchiveUploadForSubmission`.
- Indexing uses `submission_upload.blueprint_id` as the source of truth — the default Blueprint is no longer selected inside the indexing SQL. Uploads are grandfathered in (no re-validation).
- Review fix: the required-property check constrains the pool-entry join with `ftp.feature_type_id = bft.feature_type_id` so a property assigned under another feature type can't satisfy requiredness.

## Testing Notes

- Re-submissions stay stable when the system default Blueprint changes (they reuse the prior upload's Blueprint).
- Behavior is unchanged for the seeded default Blueprint (1:1 with `feature_type_property`); the migration backfills existing uploads and the mock-data seed pins the default.
- Unit tests added (Blueprint resolver branches, repo lookups, indexing SQL); full suite + `tsc` + ESLint clean.