### PR TITLE
SIMSBIOHUB-1058: Fix search results pagination

### DIFF
--- a/app/src/features/search/result/SearchResultPage.test.tsx
+++ b/app/src/features/search/result/SearchResultPage.test.tsx
@@ -78,6 +78,7 @@ const mockCreateDataRequest = vi.fn();
 const mockGetAvailableUsers = vi.fn();
 const mockSetSnackbar = vi.fn();
 const mockSetOkDialog = vi.fn();
+const mockSetResultSearchParams = vi.fn();
 
 const codesPayload = {
   feature_type_with_properties: [
@@ -133,7 +134,7 @@ describe('SearchResultPage', () => {
       properties: [],
       isLoading: false,
       searchParams: new URLSearchParams(),
-      setSearchParams: vi.fn(),
+      setSearchParams: mockSetResultSearchParams,
       pagination: { total: 5, current_page: 1, last_page: 1, per_page: 10 }
     });
   });
@@ -143,6 +144,15 @@ describe('SearchResultPage', () => {
 
     expect(getByRole('button', { name: /create download/i })).toBeInTheDocument();
     expect(queryByRole('button', { name: /^download all$/i })).not.toBeInTheDocument();
+  });
+
+  it('updates the result limit when the rows-per-page control changes', () => {
+    const { getByRole } = renderPage();
+
+    fireEvent.mouseDown(getByRole('combobox', { name: /rows per page/i }));
+    fireEvent.click(getByRole('option', { name: /25/i }));
+
+    expect(mockSetResultSearchParams).toHaveBeenCalledWith({ limit: '25' });
   });
 
   it('opens an OkDialog when Create Download is clicked with zero results', () => {

--- a/app/src/features/search/result/content/SearchResultPanel.tsx
+++ b/app/src/features/search/result/content/SearchResultPanel.tsx
@@ -128,7 +128,7 @@ export const SearchResultPanel = ({
 
         <Divider />
 
-        <Box sx={{ flex: 1, overflow: 'auto' }}>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
           <SearchResultOptions
             rows={rows}
             featureTypeProperties={featureTypeProperties}

--- a/app/src/features/search/result/hooks/useSearchResultPagingSort.ts
+++ b/app/src/features/search/result/hooks/useSearchResultPagingSort.ts
@@ -70,7 +70,7 @@ export const useSearchResultPagingSort = ({ pagination, setSearchParams }: UseSe
    */
   const handlePageSizeChange = useCallback(
     (limit: number) => {
-      setSearchParams({ [URL_PARAMS.LIMIT]: String(limit), [URL_PARAMS.PAGE]: '1' });
+      setSearchParams({ [URL_PARAMS.LIMIT]: String(limit) });
     },
     [setSearchParams]
   );

--- a/app/src/features/search/result/hooks/useSearchResults.test.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.test.tsx
@@ -176,6 +176,56 @@ describe('useSearchResults', () => {
     );
   });
 
+  it('uses updated limit in the next request after page size changes', async () => {
+    vi.useFakeTimers();
+
+    let currentSearchParams = new URLSearchParams('page=2&limit=10');
+    const setSearchParams = vi.fn((nextSearchParams: URLSearchParams) => {
+      currentSearchParams = nextSearchParams;
+    });
+
+    (useSearchQueryParams as Mock).mockImplementation(() => ({
+      searchParams: currentSearchParams,
+      setSearchParams
+    }));
+
+    const { result, rerender } = renderHook(() => useSearchResults('species_observation', true, null));
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+    mockSearchFeatures.mockClear();
+
+    act(() => {
+      result.current.setSearchParams({ [URL_PARAMS.LIMIT]: '50', [URL_PARAMS.PAGE]: '1' });
+    });
+    rerender();
+
+    expect(setSearchParams).toHaveBeenCalledWith(new URLSearchParams('limit=50&page=1'));
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(mockSearchFeatures).toHaveBeenCalledTimes(1);
+    expect(mockSearchFeatures).toHaveBeenLastCalledWith(
+      'species_observation',
+      null,
+      {
+        page: 1,
+        limit: 50,
+        sort: undefined,
+        order: undefined
+      },
+      expectAbortOptions
+    );
+  });
+
   it('sets loading immediately while a debounced URL-param search is pending', async () => {
     vi.useFakeTimers();
 

--- a/app/src/features/search/result/layout/table/SearchResultTableLayout.test.tsx
+++ b/app/src/features/search/result/layout/table/SearchResultTableLayout.test.tsx
@@ -11,11 +11,16 @@ interface MockDataGridProps {
   rows: SearchFeatureResultWithRelevancy[];
   columns: GridColDef[];
   onRowClick?: (params: { row: SearchFeatureResultWithRelevancy }) => void;
+  paginationModel?: { page: number; pageSize: number };
+  pageSizeOptions?: number[];
 }
 
 vi.mock('components/data-grid/CustomDataGrid', () => ({
-  default: ({ rows, columns, onRowClick }: MockDataGridProps) => (
-    <div data-testid="mock-data-grid">
+  default: ({ rows, columns, onRowClick, paginationModel, pageSizeOptions }: MockDataGridProps) => (
+    <div
+      data-testid="mock-data-grid"
+      data-has-pagination-model={String(Boolean(paginationModel))}
+      data-page-size-options={pageSizeOptions?.join(',')}>
       <div data-testid="columns">{columns.map((column) => column.headerName).join('|')}</div>
       {rows.map((row) => (
         <div key={row.uuid} data-testid={`row-${row.submission_feature_id}`} onClick={() => onRowClick?.({ row })}>
@@ -157,5 +162,16 @@ describe('SearchResultTableLayout', () => {
     expect(getByTestId('cell-property:count')).toHaveTextContent('12');
     expect(getByTestId('cell-property:tags')).toHaveTextContent('coastal, survey');
     expect(getByTestId('cell-property:scientific_name').querySelector('.MuiTypography-root')).toBeInTheDocument();
+  });
+
+  it('does not configure internal data grid pagination', () => {
+    const results = Array.from({ length: 25 }, (_value, index) =>
+      createMockSearchFeature(index + 1, `Dataset ${index + 1}`, false)
+    );
+
+    const { getByTestId } = render(<SearchResultTableLayout results={results} featureTypeProperties={[]} />);
+
+    expect(getByTestId('mock-data-grid')).toHaveAttribute('data-has-pagination-model', 'false');
+    expect(getByTestId('mock-data-grid')).not.toHaveAttribute('data-page-size-options');
   });
 });

--- a/app/src/features/search/result/layout/table/SearchResultTableLayout.tsx
+++ b/app/src/features/search/result/layout/table/SearchResultTableLayout.tsx
@@ -87,15 +87,11 @@ export const SearchResultTableLayout = ({ results, featureTypeProperties, onClic
       onRowClick={(params) => {
         onClick?.(params.row as SearchFeatureResultWithRelevancy);
       }}
-      pageSizeOptions={[5, 10, 20]}
       disableRowSelectionOnClick
       disableColumnSelector
       disableColumnMenu
       hideFooter
       sortingOrder={['asc', 'desc']}
-      initialState={{
-        pagination: { paginationModel: { pageSize: 10 } }
-      }}
       sx={{
         minWidth: '100%',
         '& .MuiDataGrid-root': {

--- a/app/src/features/submissions/page/components/SearchResultList.tsx
+++ b/app/src/features/submissions/page/components/SearchResultList.tsx
@@ -52,7 +52,7 @@ const SearchResultList: React.FC<ISearchResultListProps> = (props) => {
   };
 
   return (
-    <Box display="flex" flexDirection="column" height="100%" overflow="hidden">
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
       <Box flex="0 0 auto">
         <Box display="flex" alignItems="center" justifyContent="space-between" p={3}>
           <Typography variant="h3" component="h1">
@@ -76,9 +76,10 @@ const SearchResultList: React.FC<ISearchResultListProps> = (props) => {
       </Box>
 
       <Box
-        flex="1 1 auto"
-        mt="-1px"
         sx={{
+          flex: '1 1 auto',
+          minHeight: 0,
+          mt: '-1px',
           overflowY: 'auto'
         }}>
         <List>


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1058

## Description of Changes

- Fixes search result scrolling by adding minHeight: 0 to flex containers.
- Removes internal DataGrid pagination config from search result tables.
- Reverts to page 1 when limit changes

## Testing Notes

- Verify that changing the page or rows-per-page value in the search results footer updates the URL query params and sends the expected pagination values in the search request body.
