### PR TITLE
SIMSBIOHUB-1057: Conditionally Prompt Data Requests

### DIFF
--- a/api/src/__integration__/db/security-scope-search.integration.ts
+++ b/api/src/__integration__/db/security-scope-search.integration.ts
@@ -825,6 +825,105 @@ describe('Security scope search (integration)', function () {
     });
   });
 
+  // ── has_more_secured_features (hidden-secured-match signal) ───────────
+  //
+  // Drives the "Request Data" banner. True when the search matched secured features the caller
+  // cannot access. Wildcard-grant holders are excluded via direct URN scope matching so anchor
+  // recomputation lag does not raise a false positive.
+  describe('hasInaccessibleSecuredFeaturesByExpressionTree', () => {
+    it('is FALSE for a wildcard (urn:*:*:*) caller even when secured matches exist (AC3)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+      const feat1 = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      const feat2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName: 'dataset' });
+      await secureFeature(connection, feat1);
+      await secureFeature(connection, feat2);
+
+      await rebuildClosure(uploadId);
+
+      const userId = connection.systemUserId();
+      await setupFullAccess(connection, scopeRepo, 'urn:*:*:*', userId, 'Wildcard Team');
+
+      const hasHidden = await searchRepo.hasInaccessibleSecuredFeaturesByExpressionTree('dataset', undefined, userId);
+
+      // The caller can access every secured match via the wildcard grant — nothing left to request.
+      expect(hasHidden).to.be.false;
+    });
+
+    it('is TRUE for a wildcard caller when a secured match has no anchor yet (anchor lag — banner shows transiently)', async () => {
+      // A feature secured AFTER the wildcard scope's anchors were computed has no security_scope_anchor
+      // (recompute lag), so isAccessibleToUser reports it inaccessible to everyone — the wildcard caller
+      // included. The banner probe is anchor-only (kept consistent with the visible-results access
+      // filter), so it raises the flag during this short (~10s) recompute window until anchors catch up.
+      // Accepted tradeoff: a brief false-positive banner rather than a more permissive probe that would
+      // hide the banner while the rows themselves stay filtered out.
+      const submissionId = await createTestSubmission(connection);
+      const feature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Lagged Secured' });
+      await rebuildClosureForSubmission(submissionId);
+
+      const wildcardUser = connection.systemUserId();
+      // Grant wildcard access BEFORE the feature is secured, so the anchor computation does not cover it.
+      await setupFullAccess(connection, scopeRepo, 'urn:*:*:*', wildcardUser, 'Wildcard Team');
+
+      // Now secure it — effectively secured on the read path, but with no scope anchor.
+      await secureFeature(connection, feature);
+
+      const hasHidden = await searchRepo.hasInaccessibleSecuredFeaturesByExpressionTree(
+        'dataset',
+        undefined,
+        wildcardUser
+      );
+
+      expect(hasHidden).to.be.true;
+    });
+
+    it('is TRUE when a secured match is grantable to another team but not the caller (AC2)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const feature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Other Team Secured' });
+      await secureFeature(connection, feature);
+      await rebuildClosureForSubmission(submissionId);
+
+      // Grant access to a DIFFERENT user's team — the feature now has an anchor + standing grant,
+      // so it is requestable, just not by our caller.
+      const otherUser = await createOtherUser();
+      await setupFullAccess(connection, scopeRepo, `urn:${submissionId}:*:*`, otherUser, 'Other Team');
+
+      const caller = await createOtherUser(); // authenticated, but in no team
+      const hasHidden = await searchRepo.hasInaccessibleSecuredFeaturesByExpressionTree('dataset', undefined, caller);
+
+      expect(hasHidden).to.be.true;
+    });
+
+    it('is TRUE for an anonymous caller when secured matches exist (AC4)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+      const feature = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'dataset'
+      });
+      await secureFeature(connection, feature);
+      await rebuildClosure(uploadId);
+
+      const hasHidden = await searchRepo.hasInaccessibleSecuredFeaturesByExpressionTree('dataset', undefined, null);
+
+      expect(hasHidden).to.be.true;
+    });
+
+    it('is TRUE for an authenticated caller with no covering policy (AC2 — banner shows)', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const feature = await createTestFeature(connection, submissionId, 'dataset', { name: 'Ungranted Secured' });
+      await secureFeature(connection, feature);
+      await rebuildClosureForSubmission(submissionId);
+
+      // Authenticated, but holds no team/policy/scope at all.
+      const caller = await createOtherUser();
+      const hasHidden = await searchRepo.hasInaccessibleSecuredFeaturesByExpressionTree('dataset', undefined, caller);
+
+      expect(hasHidden).to.be.true;
+    });
+  });
+
   // ── Policy deletion → scope cleanup ──────────────────────────────────
 
   describe('Policy deletion → scope cleanup', () => {

--- a/api/src/openapi/schemas/search/search-feature.ts
+++ b/api/src/openapi/schemas/search/search-feature.ts
@@ -135,7 +135,7 @@ export const featureSearchRequestBodySchema: OpenAPIV3.RequestBodyObject = {
  */
 export const featureSearchResponseSchema: OpenAPIV3.SchemaObject = {
   type: 'object',
-  required: ['features', 'properties', 'pagination'],
+  required: ['features', 'properties', 'pagination', 'has_more_secured_features'],
   properties: {
     features: {
       type: 'array',
@@ -145,6 +145,11 @@ export const featureSearchResponseSchema: OpenAPIV3.SchemaObject = {
       type: 'array',
       items: featureSearchPropertySchema
     },
-    pagination: paginationResponseSchema
+    pagination: paginationResponseSchema,
+    has_more_secured_features: {
+      type: 'boolean',
+      description:
+        'True when the search matched secured features that were excluded from the results because the caller cannot access them.'
+    }
   }
 };

--- a/api/src/paths/search/feature/{feature_type}/index.test.ts
+++ b/api/src/paths/search/feature/{feature_type}/index.test.ts
@@ -67,7 +67,7 @@ describe('searchFeatures', () => {
 
     const searchStub = sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: mockResults, properties: [], count: mockResults.length });
+      .resolves({ features: mockResults, properties: [], count: mockResults.length, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
@@ -85,7 +85,8 @@ describe('searchFeatures', () => {
         last_page: 1,
         sort: undefined,
         order: undefined
-      }
+      },
+      has_more_secured_features: false
     });
   });
 
@@ -110,7 +111,7 @@ describe('searchFeatures', () => {
 
     const searchStub = sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: [], properties: [], count: 0 });
+      .resolves({ features: [], properties: [], count: 0, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
@@ -156,12 +157,13 @@ describe('searchFeatures', () => {
 
     sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: mockResults, properties: [], count: mockResults.length });
+      .resolves({ features: mockResults, properties: [], count: mockResults.length, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
 
     expect(mockRes.statusValue).to.equal(200);
+    // A visible secured row the caller CAN see must not, by itself, set has_more_secured_features.
     expect(mockRes.jsonValue).to.eql({
       features: mockResults,
       properties: [],
@@ -172,8 +174,38 @@ describe('searchFeatures', () => {
         last_page: 1,
         sort: undefined,
         order: undefined
-      }
+      },
+      has_more_secured_features: false
     });
+  });
+
+  it('should expose has_more_secured_features when secured matches are hidden from the caller', async () => {
+    const dbConnectionObj = getMockDBConnection({
+      commit: sinon.stub().resolves(),
+      rollback: sinon.stub().resolves(),
+      release: sinon.stub().resolves(),
+      open: sinon.stub().resolves()
+    });
+    sinon.stub(db.dbDependencies, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+    const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+    mockReq.params = { feature_type: 'dataset' };
+    mockReq.body = {
+      expression: expressionTree,
+      pagination: { page: '1', limit: '10' }
+    };
+
+    sinon
+      .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
+      .resolves({ features: [], properties: [], count: 0, has_more_secured_features: true });
+
+    const requestHandler = search.searchFeatures();
+    await requestHandler(mockReq, mockRes, mockNext);
+
+    expect(mockRes.statusValue).to.equal(200);
+    expect(mockRes.jsonValue.has_more_secured_features).to.equal(true);
+    // No hidden secured rows are leaked alongside the flag.
+    expect(mockRes.jsonValue.features).to.eql([]);
   });
 
   it('should handle pagination with multiple pages', async () => {
@@ -215,7 +247,7 @@ describe('searchFeatures', () => {
 
     sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: mockResults, properties: [], count: 25 });
+      .resolves({ features: mockResults, properties: [], count: 25, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
@@ -231,7 +263,8 @@ describe('searchFeatures', () => {
         last_page: 5,
         sort: 'feature_type_name',
         order: 'asc'
-      }
+      },
+      has_more_secured_features: false
     });
   });
 
@@ -257,7 +290,7 @@ describe('searchFeatures', () => {
 
     sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: [], properties: [], count: 0 });
+      .resolves({ features: [], properties: [], count: 0, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
@@ -273,7 +306,8 @@ describe('searchFeatures', () => {
         last_page: 1,
         sort: undefined,
         order: undefined
-      }
+      },
+      has_more_secured_features: false
     });
   });
 
@@ -373,7 +407,7 @@ describe('searchFeatures', () => {
 
     const searchStub = sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: mockResults, properties: [], count: 37 });
+      .resolves({ features: mockResults, properties: [], count: 37, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
@@ -424,7 +458,7 @@ describe('searchFeatures', () => {
 
     sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: mockResults, properties: [], count: mockResults.length });
+      .resolves({ features: mockResults, properties: [], count: mockResults.length, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
@@ -440,7 +474,8 @@ describe('searchFeatures', () => {
         last_page: 1,
         sort: undefined,
         order: undefined
-      }
+      },
+      has_more_secured_features: false
     });
   });
 
@@ -463,7 +498,7 @@ describe('searchFeatures', () => {
 
     const searchStub = sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: [], properties: [], count: 0 });
+      .resolves({ features: [], properties: [], count: 0, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);
@@ -493,7 +528,7 @@ describe('searchFeatures', () => {
 
     const searchStub = sinon
       .stub(SearchFeatureService.prototype, 'searchFeaturesByExpressionTreeWithCount')
-      .resolves({ features: [], properties: [], count: 0 });
+      .resolves({ features: [], properties: [], count: 0, has_more_secured_features: false });
 
     const requestHandler = search.searchFeatures();
     await requestHandler(mockReq, mockRes, mockNext);

--- a/api/src/paths/search/feature/{feature_type}/index.ts
+++ b/api/src/paths/search/feature/{feature_type}/index.ts
@@ -76,12 +76,8 @@ export function searchFeatures(): RequestHandler {
 
       const expressionTree = expressionTreeParseResult?.data;
 
-      const { features, properties, count } = await service.searchFeaturesByExpressionTreeWithCount(
-        featureType,
-        expressionTree,
-        pagination,
-        systemUserId
-      );
+      const { features, properties, count, has_more_secured_features } =
+        await service.searchFeaturesByExpressionTreeWithCount(featureType, expressionTree, pagination, systemUserId);
 
       await connection.commit();
 
@@ -90,7 +86,8 @@ export function searchFeatures(): RequestHandler {
       return res.status(200).json({
         features,
         properties,
-        pagination: makePaginationResponse(count, pagination)
+        pagination: makePaginationResponse(count, pagination),
+        has_more_secured_features
       });
     } catch (error) {
       defaultLog.error({ label: 'searchFeatures', message: 'error', error });

--- a/api/src/paths/search/feature/{feature_type}/index.ts
+++ b/api/src/paths/search/feature/{feature_type}/index.ts
@@ -81,8 +81,6 @@ export function searchFeatures(): RequestHandler {
 
       await connection.commit();
 
-      res.setHeader('Cache-Control', 'public, max-age=90');
-
       return res.status(200).json({
         features,
         properties,

--- a/api/src/repositories/expression-evaluation.test.ts
+++ b/api/src/repositories/expression-evaluation.test.ts
@@ -2,7 +2,11 @@ import { expect } from 'chai';
 import Sinon from 'sinon';
 import { NormalizedExpressionTreeExpression } from '../models/expression-tree-internal';
 import { parseTimestamp } from '../utils/timestamp';
-import { buildBroadFeatureTypeSubquery, buildExpressionTreeFeatureIdsSubquery } from './expression-evaluation';
+import {
+  buildBroadFeatureTypeSubquery,
+  buildExpressionTreeFeatureIdsSubquery,
+  buildUnfilteredExpressionTreeFeatureIdsSubquery
+} from './expression-evaluation';
 
 const normalizedPredicate = (
   feature_property_id: number,
@@ -422,6 +426,38 @@ describe('expression-evaluation', () => {
       // Anonymous: emits NOT EXISTS (uppercase, raw SQL fragment) with no scope-anchor branch
       expect(sql.toLowerCase()).to.include('not exists');
       expect(sql).to.not.include('security_scope_anchor');
+    });
+  });
+
+  describe('buildUnfilteredExpressionTreeFeatureIdsSubquery', () => {
+    const expressionTree: NormalizedExpressionTreeExpression = {
+      type: 'expression',
+      operator: 'AND',
+      clauses: [
+        {
+          ...normalizedPredicate(10, null, {
+            type: 'number',
+            operator: 'Exists'
+          })
+        }
+      ]
+    };
+
+    it('emits the same expression criteria as the filtered variant', () => {
+      const sql = buildUnfilteredExpressionTreeFeatureIdsSubquery('dataset', expressionTree).toString();
+
+      expect(sql).to.include('"ft"."name" = \'dataset\'');
+      expect(sql).to.include('submission_feature_property_number');
+      expect(sql).to.include('"p"."submission_feature_id"');
+    });
+
+    it('applies NO security/access filter (the candidate set before access filtering)', () => {
+      const sql = buildUnfilteredExpressionTreeFeatureIdsSubquery('dataset', expressionTree).toString();
+
+      // Neither the authenticated scope-grant probe nor the anonymous NOT-secured probe is emitted.
+      expect(sql).to.not.include('security_scope_anchor');
+      expect(sql).to.not.include('team_security_scope');
+      expect(sql).to.not.include('submission_feature_security');
     });
   });
 });

--- a/api/src/repositories/expression-evaluation.ts
+++ b/api/src/repositories/expression-evaluation.ts
@@ -90,13 +90,40 @@ export function buildBroadFeatureTypeSubquery(featureTypeName: string, systemUse
 }
 
 /**
+ * Build a Knex subquery that returns submission_feature_id rows matching the given normalized
+ * expression tree, scoped to the anchor feature type, WITHOUT any security/access filtering.
+ *
+ * This is the expression-matched candidate set *before* the caller access filter is applied.
+ * It exists solely to detect whether a search matched secured features the caller cannot see
+ * (`has_more_secured_features`) — it must never be used to return feature rows to a caller,
+ * because it does not exclude inaccessible secured features.
+ *
+ * Routes through the same `buildExpressionTargetIdsQuery` substrate as the filtered variant, but
+ * passes `systemUserId = undefined` so `buildSecurityFilter` returns `null` at every layer (both
+ * the evidence-level and target-level filters), leaving the candidate set unfiltered.
+ *
+ * @param {string} anchorFeatureType - Route anchor/result feature type
+ * @param {NormalizedExpressionTreeExpression} normalizedExpression - Normalized expression tree criteria
+ * @return {Knex.QueryBuilder} Unexecuted subquery returning submission_feature_id rows, no security filter applied
+ */
+export function buildUnfilteredExpressionTreeFeatureIdsSubquery(
+  anchorFeatureType: string,
+  normalizedExpression: NormalizedExpressionTreeExpression
+): Knex.QueryBuilder {
+  const knex = getKnex();
+  // systemUserId omitted → buildSecurityFilter returns null at every layer → no access filtering.
+  return buildExpressionTargetIdsQuery(anchorFeatureType, normalizedExpression, knex);
+}
+
+/**
  * Stubbable dependency surface. Production callers route through this bag so
  * tests can replace individual builders with sinon stubs (ESM exports cannot
  * be reassigned directly).
  */
 export const dependencies = {
   buildExpressionTreeFeatureIdsSubquery,
-  buildBroadFeatureTypeSubquery
+  buildBroadFeatureTypeSubquery,
+  buildUnfilteredExpressionTreeFeatureIdsSubquery
 };
 
 /**

--- a/api/src/repositories/search-feature-repository.test.ts
+++ b/api/src/repositories/search-feature-repository.test.ts
@@ -170,6 +170,97 @@ describe('SearchFeatureRepository', () => {
     });
   });
 
+  describe('hasInaccessibleSecuredFeaturesByExpressionTree', () => {
+    const expressionTree: NormalizedExpressionTreeExpression = {
+      type: 'expression',
+      operator: 'AND',
+      clauses: [
+        {
+          ...normalizedPredicate(46, null, {
+            type: 'string',
+            operator: 'Equals',
+            value: 'moose'
+          })
+        }
+      ]
+    };
+
+    it('should build the candidate set from the UNFILTERED expression subquery (no access filter pre-applied)', async () => {
+      const knexSpy = Sinon.stub().resolves({ rowCount: 0, rows: [] });
+      const mockDBConnection = getMockDBConnection({ knex: knexSpy });
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      const unfilteredStub = Sinon.stub(
+        expressionEvaluation,
+        'buildUnfilteredExpressionTreeFeatureIdsSubquery'
+      ).returns(getKnex()('unfiltered_table').select('submission_feature_id'));
+      const filteredStub = Sinon.stub(expressionEvaluation, 'buildExpressionTreeFeatureIdsSubquery');
+
+      await repository.hasInaccessibleSecuredFeaturesByExpressionTree('telemetry', expressionTree, 42);
+
+      // The hidden-secured check must use the unfiltered candidate set, never the access-filtered one.
+      expect(unfilteredStub.calledOnce).to.equal(true);
+      expect(unfilteredStub.getCall(0).args).to.deep.equal(['telemetry', expressionTree]);
+      expect(filteredStub.notCalled).to.equal(true);
+
+      const sql = knexSpy.getCall(0).args[0].toString();
+      // The unfiltered subquery is the candidate source directly (it already restricts to active
+      // anchor-type features), so it is selected FROM rather than re-wrapped/whereIn'd by feature type.
+      expect(sql).to.include('unfiltered_table');
+      expect(sql).to.not.include('"sf"."submission_feature_id" in');
+      expect(sql).to.include('limit 1');
+    });
+
+    it('should check effectively-secured and not-accessible (anchor-only) for authenticated users', async () => {
+      const knexSpy = Sinon.stub().resolves({ rowCount: 1, rows: [{ '?column?': 1 }] });
+      const mockDBConnection = getMockDBConnection({ knex: knexSpy });
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      const result = await repository.hasInaccessibleSecuredFeaturesByExpressionTree('telemetry', undefined, 42);
+
+      expect(result).to.equal(true);
+
+      const sql = knexSpy.getCall(0).args[0].toString();
+      // effectively-secured probe over the matched candidate set
+      expect(sql).to.include('submission_feature_closure');
+      expect(sql).to.include('submission_feature_security');
+      // authenticated accessibility probe, negated (isAccessibleToUser → team_member bound to the caller)
+      expect(sql).to.include('NOT EXISTS');
+      expect(sql).to.include('team_member');
+      expect(sql).to.include('security_scope_anchor');
+      // anchor-only: no direct URN scope grant probe is emitted (consistent with the visible-results filter)
+      expect(sql).to.not.include('urn_submission_id');
+    });
+
+    it('should check only effectively-secured for anonymous users (no accessibility probe)', async () => {
+      const knexSpy = Sinon.stub().resolves({ rowCount: 0, rows: [] });
+      const mockDBConnection = getMockDBConnection({ knex: knexSpy });
+      const repository = new SearchFeatureRepository(mockDBConnection);
+
+      const result = await repository.hasInaccessibleSecuredFeaturesByExpressionTree('telemetry', undefined, null);
+
+      expect(result).to.equal(false);
+
+      const sql = knexSpy.getCall(0).args[0].toString();
+      expect(sql).to.include('submission_feature_security');
+      // anonymous: every secured match is hidden, so no team-based accessibility probe is emitted
+      expect(sql).to.not.include('team_member');
+      expect(sql).to.not.include('security_scope_anchor');
+    });
+
+    it('should return true when the EXISTS probe yields a row and false otherwise', async () => {
+      const truthyKnex = Sinon.stub().resolves({ rowCount: 1, rows: [{ '?column?': 1 }] });
+      const trueRepo = new SearchFeatureRepository(getMockDBConnection({ knex: truthyKnex }));
+      expect(await trueRepo.hasInaccessibleSecuredFeaturesByExpressionTree('telemetry', undefined, 42)).to.equal(true);
+
+      const emptyKnex = Sinon.stub().resolves({ rowCount: 0, rows: [] });
+      const falseRepo = new SearchFeatureRepository(getMockDBConnection({ knex: emptyKnex }));
+      expect(await falseRepo.hasInaccessibleSecuredFeaturesByExpressionTree('telemetry', undefined, 42)).to.equal(
+        false
+      );
+    });
+  });
+
   describe('searchFeaturesByExpressionTreeProperties', () => {
     it('should build a typed-property schema query over the filtered feature set', async () => {
       const knexSpy = Sinon.stub().resolves({ rowCount: 0, rows: [] });

--- a/api/src/repositories/search-feature-repository.test.ts
+++ b/api/src/repositories/search-feature-repository.test.ts
@@ -230,6 +230,9 @@ describe('SearchFeatureRepository', () => {
       expect(sql).to.include('security_scope_anchor');
       // anchor-only: no direct URN scope grant probe is emitted (consistent with the visible-results filter)
       expect(sql).to.not.include('urn_submission_id');
+      // "unfiltered" drops only the access/security filter, never validity: the candidate set still
+      // requires active features (isSubmissionFeatureActive → record_effective_date / record_end_date).
+      expect(sql).to.include('record_effective_date');
     });
 
     it('should check only effectively-secured for anonymous users (no accessibility probe)', async () => {

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -6,7 +6,12 @@ import { SearchFeatureResultWithRelevancy } from '../services/search-feature-ser
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 import { dependencies as expressionEvaluation } from './expression-evaluation';
-import { buildSecurityFilter, isAccessibleToUser, isEffectivelySecured, isSubmissionFeatureActive } from './sql-fragments';
+import {
+  buildSecurityFilter,
+  isAccessibleToUser,
+  isEffectivelySecured,
+  isSubmissionFeatureActive
+} from './sql-fragments';
 
 /**
  * Repository for searching submission features by expression-tree criteria.

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -6,7 +6,7 @@ import { SearchFeatureResultWithRelevancy } from '../services/search-feature-ser
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 import { dependencies as expressionEvaluation } from './expression-evaluation';
-import { buildSecurityFilter, isEffectivelySecured, isSubmissionFeatureActive } from './sql-fragments';
+import { buildSecurityFilter, isAccessibleToUser, isEffectivelySecured, isSubmissionFeatureActive } from './sql-fragments';
 
 /**
  * Repository for searching submission features by expression-tree criteria.
@@ -84,6 +84,63 @@ export class SearchFeatureRepository extends BaseRepository {
     const countQuery = knex.from(query.as('sf_filtered')).select(knex.raw('count(*)::integer as count'));
     const response = await this.connection.knex(countQuery);
     return response.rows[0]?.count ?? 0;
+  }
+
+  /**
+   * Checks whether the expression matched secured features that are not visible to the caller.
+   *
+   * This is the source of the `has_more_secured_features` flag. It is a sibling of the visible search
+   * query that reuses the same expression criteria and feature-type filter, but deliberately does NOT
+   * apply the caller access filter before checking for inaccessible secured matches — otherwise the
+   * very features we want to detect would already be removed.
+   *
+   * Implemented as an `EXISTS`/`LIMIT 1` probe over the unhydrated candidate set:
+   * - For authenticated users: true when any matched feature is effectively secured and NOT accessible
+   *   to the caller via the anchor-based read path (`isAccessibleToUser`). A caller holding a blanket
+   *   grant (e.g. `urn:*:*:*`) over a feature secured before anchor recomputation ran may see a
+   *   transient false-positive banner until anchors catch up (a short window, ~10s); this is accepted
+   *   so the probe stays consistent with the visible-results access filter (also anchor-only).
+   * - For anonymous users: true when any matched feature is effectively secured (none are accessible).
+   *
+   * No feature data is selected — only the boolean is returned, so no hidden secured rows are exposed.
+   *
+   * @param {string} anchorFeatureType - Target feature type returned by the search
+   * @param {NormalizedExpressionTreeExpression | undefined} expressionTree - Expression tree criteria
+   * @param {number | null} [systemUserId] - Security context (null = anonymous)
+   * @return {Promise<boolean>} True if matching secured features exist that the caller cannot access
+   */
+  async hasInaccessibleSecuredFeaturesByExpressionTree(
+    anchorFeatureType: string,
+    expressionTree: NormalizedExpressionTreeExpression | undefined,
+    systemUserId?: number | null
+  ): Promise<boolean> {
+    const knex = getKnex();
+
+    // Candidate anchor features matched by the expression, WITHOUT the caller access filter. The
+    // expression subquery already restricts to active anchor-type features, so it is used directly;
+    // only the no-expression case needs the feature-type filter from buildExpressionTreeMatchingFeaturesQuery.
+    const matchingFeatures = expressionTree
+      ? expressionEvaluation.buildUnfilteredExpressionTreeFeatureIdsSubquery(anchorFeatureType, expressionTree)
+      : this.buildExpressionTreeMatchingFeaturesQuery(knex, anchorFeatureType, null);
+
+    const existsQuery = knex
+      .select(knex.raw('1'))
+      .from(matchingFeatures.as('mf'))
+      .whereRaw(isEffectivelySecured('mf.submission_feature_id'))
+      .limit(1);
+
+    // Authenticated: a secured match is hidden when the caller cannot access it. Reuses the canonical
+    // isAccessibleToUser check (anchor-based, identical to the visible-results access filter) so the
+    // banner stays consistent with which rows are actually shown. The candidate is already effectively
+    // secured here, so isAccessibleToUser short-circuits to its team-scope-anchor branch.
+    // Anonymous (null/undefined): every secured match is hidden.
+    if (systemUserId) {
+      existsQuery.whereRaw(`NOT ${isAccessibleToUser('mf.submission_feature_id')}`, [systemUserId]);
+    }
+
+    const response = await this.connection.knex(existsQuery);
+
+    return response.rows.length > 0;
   }
 
   /**

--- a/api/src/repositories/sql-fragments.ts
+++ b/api/src/repositories/sql-fragments.ts
@@ -84,16 +84,22 @@ export function isEffectivelySecured(featureIdExpr: string): string {
  *
  * 1. The feature is NOT effectively secured (no active approved security rule in its
  *    ancestry), OR
- * 2. The user has a team scope grant via a `security_scope_anchor` on an ancestor.
+ * 2. The caller's team holds a scope anchored on this feature or one of its ancestors
+ *    (`security_scope_anchor` reachable via the caller's `team_member`).
  *
  * Returns an `EXISTS (...)` SQL expression with a single `?` placeholder for `systemUserId`.
  *
  * This reads the precomputed `submission_feature_closure` ancestry subset
- * (`is_ancestor = true`) instead of doing a recursive parent walk. Branch 1 reuses
- * `isEffectivelySecured`; Branch 2 probes the closure for an ancestor that is
- * a scope anchor the user's team can reach. Both are cheap PK-served closure probes
- * (`source_submission_feature_id`), so the old concern of walking the ancestor chain
- * twice no longer applies — there is no recursive walk at all.
+ * (`is_ancestor = true`, which includes the feature's own self-loop) instead of doing a
+ * recursive parent walk. Branch 1 reuses `isEffectivelySecured`; Branch 2 probes the closure
+ * for an ancestor that is a scope anchor the user's team can reach. Both are cheap PK-served
+ * closure probes (`source_submission_feature_id`), so the old concern of walking the ancestor
+ * chain twice no longer applies — there is no recursive walk at all.
+ *
+ * Note: a caller that has already established the feature is effectively secured (e.g. the
+ * hidden-secured probe) still passes the whole expression here — Branch 1 then re-evaluates
+ * `isEffectivelySecured` (a couple of indexed PK probes) and short-circuits to Branch 2. The cost
+ * is small, and using the canonical check keeps the probe consistent with the visible-results filter.
  *
  * @param featureIdExpr SQL expression for the starting submission_feature_id
  *   (e.g. 'wf.submission_feature_id', 'aggregated_results.submission_feature_id')
@@ -104,7 +110,7 @@ export function isAccessibleToUser(featureIdExpr: string): string {
     WHERE
       -- Branch 1: feature is NOT effectively secured
       NOT ${isEffectivelySecured(featureIdExpr)}
-      -- Branch 2: user has a team scope grant via an ancestor that is a scope anchor
+      -- Branch 2: the caller's team holds a scope anchored on this feature or one of its ancestors
       OR EXISTS (
         SELECT 1
         FROM submission_feature_closure c

--- a/api/src/services/search-feature-service.test.ts
+++ b/api/src/services/search-feature-service.test.ts
@@ -100,6 +100,9 @@ describe('SearchFeatureService', () => {
       const propertiesStub = sinon
         .stub(SearchFeatureRepository.prototype, 'searchFeaturesByExpressionTreeProperties')
         .resolves(mockProperties);
+      const hiddenSecuredStub = sinon
+        .stub(SearchFeatureRepository.prototype, 'hasInaccessibleSecuredFeaturesByExpressionTree')
+        .resolves(true);
 
       const result = await service.searchFeaturesByExpressionTreeWithCount('survey', tree);
 
@@ -108,7 +111,13 @@ describe('SearchFeatureService', () => {
       expect(searchStub.firstCall.args).to.deep.equal(['survey', normalized, undefined, undefined]);
       expect(propertiesStub).to.have.been.calledOnceWith('survey', normalized, undefined);
       expect(countStub).to.have.been.calledOnceWith('survey', normalized, undefined);
-      expect(result).to.deep.equal({ features: mockFeatures, properties: mockProperties, count: 123 });
+      expect(hiddenSecuredStub).to.have.been.calledOnceWith('survey', normalized, undefined);
+      expect(result).to.deep.equal({
+        features: mockFeatures,
+        properties: mockProperties,
+        count: 123,
+        has_more_secured_features: true
+      });
     });
   });
 

--- a/api/src/services/search-feature-service.ts
+++ b/api/src/services/search-feature-service.ts
@@ -64,14 +64,19 @@ export class SearchFeatureService extends DBService {
    * @param {ExpressionTree} [expressionTree] - Optional structured expression tree criteria
    * @param {ApiPaginationOptions} [pagination] - Optional pagination settings
    * @param {number | null} [systemUserId] - Security context
-   * @return {Promise<{ features: SearchFeatureResultWithRelevancy[]; properties: FeatureTypeProperty[]; count: number }>}
+   * @return {Promise<{ features: SearchFeatureResultWithRelevancy[]; properties: FeatureTypeProperty[]; count: number; has_more_secured_features: boolean }>}
    */
   async searchFeaturesByExpressionTreeWithCount(
     anchorFeatureType: string,
     expressionTree: ExpressionTree | undefined,
     pagination?: ApiPaginationOptions,
     systemUserId?: number | null
-  ): Promise<{ features: SearchFeatureResultWithRelevancy[]; properties: FeatureTypeProperty[]; count: number }> {
+  ): Promise<{
+    features: SearchFeatureResultWithRelevancy[];
+    properties: FeatureTypeProperty[];
+    count: number;
+    has_more_secured_features: boolean;
+  }> {
     defaultLog.debug({
       label: 'searchFeaturesByExpressionTreeWithCount',
       anchorFeatureType,
@@ -84,7 +89,7 @@ export class SearchFeatureService extends DBService {
       ? await this.semanticValidator.validateExpressionTree(expressionTree)
       : undefined;
 
-    const [features, properties, count] = await Promise.all([
+    const [features, properties, count, has_more_secured_features] = await Promise.all([
       this.searchFeatureRepository.searchFeaturesByExpressionTree(
         anchorFeatureType,
         normalizedExpressionTree,
@@ -100,10 +105,15 @@ export class SearchFeatureService extends DBService {
         anchorFeatureType,
         normalizedExpressionTree,
         systemUserId
+      ),
+      this.searchFeatureRepository.hasInaccessibleSecuredFeaturesByExpressionTree(
+        anchorFeatureType,
+        normalizedExpressionTree,
+        systemUserId
       )
     ]);
 
-    return { features, properties, count };
+    return { features, properties, count, has_more_secured_features };
   }
 
   /**

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,7 +7,7 @@ import { WebStorageStateStore } from 'oidc-client-ts';
 import { AuthProvider, AuthProviderProps } from 'react-oidc-context';
 import { BrowserRouter } from 'react-router-dom';
 import appTheme from 'themes/appTheme';
-import { buildUrl, stripOidcParams } from 'utils/Utils';
+import { buildUrl, getPostLoginReturnTo, stripOidcParams } from 'utils/Utils';
 
 const App = () => {
   return (
@@ -34,9 +34,18 @@ const App = () => {
               // Automatically load additional user profile information
               loadUserInfo: true,
               userStore: new WebStorageStateStore({ store: window.localStorage }),
-              onSigninCallback: (_): void => {
+              onSigninCallback: (user): void => {
                 // See https://github.com/authts/react-oidc-context#getting-started
-                // Strip only the OIDC response params so any original search params on the
+                // When a caller carried a return location via the OIDC `state` param (e.g. the
+                // unauthenticated "Request Access" flow), navigate to it — the registered redirect_uri is a
+                // fixed origin, so login otherwise lands on `/`. A full navigation lets React Router render
+                // the search route fresh; the captured returnTo carries no OIDC params, so it won't re-trigger.
+                const returnTo = getPostLoginReturnTo(user);
+                if (returnTo) {
+                  globalThis.location.replace(returnTo);
+                  return;
+                }
+                // Otherwise strip only the OIDC response params so any original search params on the
                 // return URL (e.g. the encoded `expr` search expression) are preserved.
                 globalThis.history.replaceState({}, document.title, stripOidcParams(globalThis.location.href));
               }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,7 +7,7 @@ import { WebStorageStateStore } from 'oidc-client-ts';
 import { AuthProvider, AuthProviderProps } from 'react-oidc-context';
 import { BrowserRouter } from 'react-router-dom';
 import appTheme from 'themes/appTheme';
-import { buildUrl } from 'utils/Utils';
+import { buildUrl, stripOidcParams } from 'utils/Utils';
 
 const App = () => {
   return (
@@ -36,7 +36,9 @@ const App = () => {
               userStore: new WebStorageStateStore({ store: window.localStorage }),
               onSigninCallback: (_): void => {
                 // See https://github.com/authts/react-oidc-context#getting-started
-                window.history.replaceState({}, document.title, window.location.pathname);
+                // Strip only the OIDC response params so any original search params on the
+                // return URL (e.g. the encoded `expr` search expression) are preserved.
+                globalThis.history.replaceState({}, document.title, stripOidcParams(globalThis.location.href));
               }
             };
 

--- a/app/src/features/search/result/SearchResultPage.test.tsx
+++ b/app/src/features/search/result/SearchResultPage.test.tsx
@@ -356,10 +356,12 @@ describe('SearchResultPage', () => {
     );
   });
 
-  it('P1: hides the secured-results banner when no rows are secured', () => {
+  it('P1: hides the secured-results banner when there are no hidden secured matches, even if a visible row is secured', () => {
+    // A visible secured row the caller CAN see must not, by itself, surface the banner.
     mockUseSearchResults.mockReturnValue({
-      rows: [{ uuid: 'result-1', submission_feature_id: 1, is_secured: false }],
+      rows: [{ uuid: 'result-1', submission_feature_id: 1, is_secured: true }],
       properties: [],
+      hasMoreSecuredFeatures: false,
       isLoading: false,
       searchParams: new URLSearchParams(),
       setSearchParams: vi.fn(),
@@ -371,13 +373,11 @@ describe('SearchResultPage', () => {
     expect(queryByRole('button', { name: /request access/i })).not.toBeInTheDocument();
   });
 
-  it('P2: shows the banner and opens the create-data-request dialog without navigating', async () => {
+  it('P2: shows the banner when secured matches are hidden and opens the create-data-request dialog without navigating', async () => {
     mockUseSearchResults.mockReturnValue({
-      rows: [
-        { uuid: 'result-1', submission_feature_id: 1, is_secured: false },
-        { uuid: 'result-2', submission_feature_id: 2, is_secured: true }
-      ],
+      rows: [{ uuid: 'result-1', submission_feature_id: 1, is_secured: false }],
       properties: [],
+      hasMoreSecuredFeatures: true,
       isLoading: false,
       searchParams: new URLSearchParams(),
       setSearchParams: vi.fn(),
@@ -397,8 +397,9 @@ describe('SearchResultPage', () => {
     mockCreateDataRequest.mockResolvedValue({});
     mockUseParams.mockReturnValue({ featureType: 'SURVEY' });
     mockUseSearchResults.mockReturnValue({
-      rows: [{ uuid: 'result-1', submission_feature_id: 1, is_secured: true }],
+      rows: [{ uuid: 'result-1', submission_feature_id: 1, is_secured: false }],
       properties: [],
+      hasMoreSecuredFeatures: true,
       isLoading: false,
       searchParams: new URLSearchParams(),
       setSearchParams: vi.fn(),
@@ -424,8 +425,9 @@ describe('SearchResultPage', () => {
   it('P4: surfaces an API error and keeps the create-data-request dialog open on failure', async () => {
     mockCreateDataRequest.mockRejectedValue({ message: 'Server exploded' });
     mockUseSearchResults.mockReturnValue({
-      rows: [{ uuid: 'result-1', submission_feature_id: 1, is_secured: true }],
+      rows: [{ uuid: 'result-1', submission_feature_id: 1, is_secured: false }],
       properties: [],
+      hasMoreSecuredFeatures: true,
       isLoading: false,
       searchParams: new URLSearchParams(),
       setSearchParams: vi.fn(),

--- a/app/src/features/search/result/SearchResultPage.tsx
+++ b/app/src/features/search/result/SearchResultPage.tsx
@@ -42,12 +42,8 @@ export const SearchResultPage = () => {
     [codesDataLoader.data?.feature_type_with_properties]
   );
   const { expressionTree, expressionApplyRevision, handleExpressionApply } = useSearchResultExpression();
-  const { rows, properties, isLoading, searchParams, setSearchParams, pagination } = useSearchResults(
-    routeConfig?.featureTypeName,
-    Boolean(routeConfig),
-    expressionTree,
-    expressionApplyRevision
-  );
+  const { rows, properties, hasMoreSecuredFeatures, isLoading, searchParams, setSearchParams, pagination } =
+    useSearchResults(routeConfig?.featureTypeName, Boolean(routeConfig), expressionTree, expressionApplyRevision);
   const { activeSort, sortOptions, handleSortChange, handlePageChange, handlePageSizeChange } =
     useSearchResultPagingSort({ pagination, setSearchParams });
   const { handleResultClick, handleFeatureTypeTabChange } = useSearchResultNavigation(featureTypeLinks);
@@ -68,7 +64,9 @@ export const SearchResultPage = () => {
   } = useSearchResultDataRequest({ featureType: routeConfig?.featureTypeName, expressionTree });
 
   const searchQuery = searchParams.get(URL_PARAMS.SEARCH_QUERY) || '';
-  const hasSecuredResults = rows.some((row) => row.is_secured);
+  // Show the "request access" banner when the search matched secured features hidden from the caller,
+  // not merely because visible rows the caller can already see are secured.
+  const hasHiddenSecuredResults = hasMoreSecuredFeatures;
 
   if (routeConfig) {
     return (
@@ -83,7 +81,7 @@ export const SearchResultPage = () => {
             onFeatureTypeChange={handleFeatureTypeTabChange}
           />
 
-          {hasSecuredResults && <SearchResultSecuredAlert onRequestAccess={handleOpenCreateDataRequest} />}
+          {hasHiddenSecuredResults && <SearchResultSecuredAlert onRequestAccess={handleOpenCreateDataRequest} />}
 
           <SearchResultPanel
             rows={rows}

--- a/app/src/features/search/result/content/SearchResultSecuredAlert.tsx
+++ b/app/src/features/search/result/content/SearchResultSecuredAlert.tsx
@@ -10,11 +10,12 @@ interface SearchResultSecuredAlertProps {
 }
 
 /**
- * Displays the secured-results notice shown above search results when one or more
- * returned rows are hidden by data security rules.
+ * Displays the secured-results notice shown above search results when the search
+ * matched secured features the caller cannot access (and were therefore hidden).
  *
- * Rendered when current rows include secured records. Navigation stays in the
- * parent and is passed in as the access-request callback.
+ * Rendered when the search response reports hidden secured matches
+ * (`has_more_secured_features`), not merely when visible rows are secured.
+ * Navigation stays in the parent and is passed in as the access-request callback.
  *
  * @param {SearchResultSecuredAlertProps} props - Callback for the "Request Access" action.
  * @returns {JSX.Element} Standard alert banner explaining secured results.

--- a/app/src/features/search/result/hooks/useSearchResultDataRequest.test.tsx
+++ b/app/src/features/search/result/hooks/useSearchResultDataRequest.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { APIError } from 'hooks/api/useAxios';
 import { useApi } from 'hooks/useApi';
+import { useAuthStateContext } from 'hooks/useAuthStateContext';
 import { useDialogContext } from 'hooks/useContext';
 import { ExpressionTreeExpression } from 'interfaces/expression.interface';
 import { CreateDataRequestDialogValues } from 'features/data-request/components/CreateDataRequestDialog';
@@ -8,10 +9,18 @@ import { Mock, vi } from 'vitest';
 import { useSearchResultDataRequest } from './useSearchResultDataRequest';
 
 vi.mock('hooks/useApi');
+vi.mock('hooks/useAuthStateContext');
 vi.mock('hooks/useContext');
 
 const mockCreateDataRequest = vi.fn();
 const mockSetSnackbar = vi.fn();
+const mockSigninRedirect = vi.fn();
+
+const setupAuth = (isAuthenticated: boolean) => {
+  (useAuthStateContext as Mock).mockReturnValue({
+    auth: { isAuthenticated, signinRedirect: mockSigninRedirect }
+  });
+};
 
 const expressionTree: ExpressionTreeExpression = {
   type: 'expression',
@@ -45,13 +54,17 @@ describe('useSearchResultDataRequest', () => {
     (useDialogContext as Mock).mockReturnValue({
       setSnackbar: mockSetSnackbar
     });
+
+    setupAuth(true);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('H1: opens the dialog without calling the API', () => {
+  it('H1: opens the dialog without calling the API or redirecting (authenticated)', () => {
+    setupAuth(true);
+
     const { result } = renderHook(() => useSearchResultDataRequest({ featureType: 'observation', expressionTree }));
 
     expect(result.current.isCreateDataRequestDialogOpen).toBe(false);
@@ -62,6 +75,38 @@ describe('useSearchResultDataRequest', () => {
 
     expect(result.current.isCreateDataRequestDialogOpen).toBe(true);
     expect(mockCreateDataRequest).not.toHaveBeenCalled();
+    expect(mockSigninRedirect).not.toHaveBeenCalled();
+  });
+
+  it('H1b: unauthenticated open redirects to login preserving the search location and does not open the dialog', () => {
+    setupAuth(false);
+
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        origin: 'https://biohub.example',
+        pathname: '/search/species_observation',
+        search: '?expr=eyJhYmMiOjF9&page=2'
+      }
+    });
+
+    try {
+      const { result } = renderHook(() => useSearchResultDataRequest({ featureType: 'observation', expressionTree }));
+
+      act(() => {
+        result.current.handleOpenCreateDataRequest();
+      });
+
+      expect(result.current.isCreateDataRequestDialogOpen).toBe(false);
+      expect(mockCreateDataRequest).not.toHaveBeenCalled();
+      expect(mockSigninRedirect).toHaveBeenCalledTimes(1);
+      expect(mockSigninRedirect).toHaveBeenCalledWith({
+        redirect_uri: 'https://biohub.example/search/species_observation?expr=eyJhYmMiOjF9&page=2'
+      });
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    }
   });
 
   it('H2: closes the dialog when featureType changes', () => {

--- a/app/src/features/search/result/hooks/useSearchResultDataRequest.test.tsx
+++ b/app/src/features/search/result/hooks/useSearchResultDataRequest.test.tsx
@@ -101,8 +101,10 @@ describe('useSearchResultDataRequest', () => {
       expect(result.current.isCreateDataRequestDialogOpen).toBe(false);
       expect(mockCreateDataRequest).not.toHaveBeenCalled();
       expect(mockSigninRedirect).toHaveBeenCalledTimes(1);
+      // The return location travels via the OIDC `state` param (a relative path), not a dynamic
+      // redirect_uri — prod SSO rejects wildcard redirect URIs.
       expect(mockSigninRedirect).toHaveBeenCalledWith({
-        redirect_uri: 'https://biohub.example/search/species_observation?expr=eyJhYmMiOjF9&page=2'
+        state: { returnTo: '/search/species_observation?expr=eyJhYmMiOjF9&page=2' }
       });
     } finally {
       Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });

--- a/app/src/features/search/result/hooks/useSearchResultDataRequest.ts
+++ b/app/src/features/search/result/hooks/useSearchResultDataRequest.ts
@@ -1,5 +1,6 @@
 import { APIError } from 'hooks/api/useAxios';
 import { useApi } from 'hooks/useApi';
+import { useAuthStateContext } from 'hooks/useAuthStateContext';
 import { useDialogContext } from 'hooks/useContext';
 import useIsMounted from 'hooks/useIsMounted';
 import { useSerializedAsync } from 'hooks/useSerializedAsync';
@@ -22,6 +23,7 @@ interface UseSearchResultDataRequestProps {
  */
 export const useSearchResultDataRequest = ({ featureType, expressionTree }: UseSearchResultDataRequestProps) => {
   const api = useApi();
+  const { auth } = useAuthStateContext();
   const dialogContext = useDialogContext();
   const isMounted = useIsMounted();
   const { runSerialized } = useSerializedAsync();
@@ -34,11 +36,22 @@ export const useSearchResultDataRequest = ({ featureType, expressionTree }: UseS
   }, [featureType]);
 
   /**
-   * Opens the create-data-request dialog.
+   * Opens the create-data-request dialog for authenticated users.
+   *
+   * The data-request flow requires an authenticated BioHub user. When the caller
+   * is unauthenticated they are redirected to the Keycloak login page, preserving
+   * the current search location (path + query string, which includes the encoded
+   * `expr` search expression) as the return URL so the search results are
+   * restored after login.
    */
   const handleOpenCreateDataRequest = useCallback(() => {
+    if (!auth.isAuthenticated) {
+      const redirectUri = `${globalThis.location.origin}${globalThis.location.pathname}${globalThis.location.search}`;
+      auth.signinRedirect({ redirect_uri: redirectUri });
+      return;
+    }
     setIsCreateDataRequestDialogOpen(true);
-  }, []);
+  }, [auth]);
 
   /**
    * Submits the create-data-request form for the current expression search.

--- a/app/src/features/search/result/hooks/useSearchResultDataRequest.ts
+++ b/app/src/features/search/result/hooks/useSearchResultDataRequest.ts
@@ -39,15 +39,16 @@ export const useSearchResultDataRequest = ({ featureType, expressionTree }: UseS
    * Opens the create-data-request dialog for authenticated users.
    *
    * The data-request flow requires an authenticated BioHub user. When the caller
-   * is unauthenticated they are redirected to the Keycloak login page, preserving
-   * the current search location (path + query string, which includes the encoded
-   * `expr` search expression) as the return URL so the search results are
-   * restored after login.
+   * is unauthenticated they are redirected to the Keycloak login page. The current
+   * search location (path + query string, which includes the encoded `expr` search
+   * expression) is carried through the OIDC `state` param — not a dynamic
+   * `redirect_uri`, which prod SSO rejects as a wildcard URI — so the post-login
+   * callback can restore the search results.
    */
   const handleOpenCreateDataRequest = useCallback(() => {
     if (!auth.isAuthenticated) {
-      const redirectUri = `${globalThis.location.origin}${globalThis.location.pathname}${globalThis.location.search}`;
-      auth.signinRedirect({ redirect_uri: redirectUri });
+      const returnTo = `${globalThis.location.pathname}${globalThis.location.search}`;
+      auth.signinRedirect({ state: { returnTo } });
       return;
     }
     setIsCreateDataRequestDialogOpen(true);

--- a/app/src/features/search/result/hooks/useSearchResults.test.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.test.tsx
@@ -27,7 +27,8 @@ describe('useSearchResults', () => {
       last_page: 1,
       sort: 'create_date',
       order: 'asc'
-    }
+    },
+    has_more_secured_features: false
   };
   const expressionTree: ExpressionTreeExpression = {
     type: 'expression',

--- a/app/src/features/search/result/hooks/useSearchResults.tsx
+++ b/app/src/features/search/result/hooks/useSearchResults.tsx
@@ -44,7 +44,8 @@ const buildEmptyResponse = (pagination: SearchResultsPagination): SearchFeatureR
     last_page: 1,
     sort: pagination.sort,
     order: pagination.order
-  }
+  },
+  has_more_secured_features: false
 });
 
 const isAbortError = (error: unknown) => {
@@ -272,7 +273,7 @@ export const useSearchResults = (
   return {
     rows: data?.features ?? [],
     properties: data?.properties ?? [],
-
+    hasMoreSecuredFeatures: data?.has_more_secured_features ?? false,
     isLoading: isLoading || !hasSettled,
     searchParams,
     setSearchParams,

--- a/app/src/hooks/api/useSearchApi.test.ts
+++ b/app/src/hooks/api/useSearchApi.test.ts
@@ -62,7 +62,8 @@ describe('useSearchApi', () => {
           last_page: 1,
           sort: 'relevance',
           order: 'desc'
-        }
+        },
+        has_more_secured_features: false
       };
 
       mock.onPost('/api/search/feature/survey').reply(200, mockResponse);
@@ -104,7 +105,8 @@ describe('useSearchApi', () => {
           last_page: 1,
           sort: undefined,
           order: undefined
-        }
+        },
+        has_more_secured_features: false
       };
 
       mock.onPost('/api/search/feature/survey').reply(200, mockResponse);
@@ -131,7 +133,8 @@ describe('useSearchApi', () => {
           last_page: 1,
           sort: undefined,
           order: undefined
-        }
+        },
+        has_more_secured_features: false
       };
 
       mock.onPost('/api/search/feature/telemetry').reply(200, mockResponse);
@@ -157,7 +160,8 @@ describe('useSearchApi', () => {
           last_page: 1,
           sort: undefined,
           order: undefined
-        }
+        },
+        has_more_secured_features: false
       };
 
       mock.onPost('/api/search/feature/survey').reply(200, mockResponse);

--- a/app/src/interfaces/useSearchApi.interface.ts
+++ b/app/src/interfaces/useSearchApi.interface.ts
@@ -28,6 +28,8 @@ export interface SearchFeatureResponse {
   features: SearchFeatureResultWithRelevancy[];
   properties: FeatureTypeProperty[];
   pagination: ApiPaginationResponseParams;
+  /** True when the search matched secured features hidden from the caller by access filtering. */
+  has_more_secured_features: boolean;
 }
 
 /** Search result representing a matched feature with relevancy */

--- a/app/src/utils/Utils.test.ts
+++ b/app/src/utils/Utils.test.ts
@@ -15,8 +15,43 @@ import {
   jsonStringifyObjectProperties,
   pluralize,
   safeJSONParse,
-  safeJSONStringify
+  safeJSONStringify,
+  stripOidcParams
 } from './Utils';
+
+describe('stripOidcParams', () => {
+  it('removes all OIDC response params while preserving application query params', () => {
+    const href =
+      'https://biohub.example/search/species_observation?expr=eyJhYmMiOjF9&page=2&code=abc&state=xyz&session_state=s1&iss=https%3A%2F%2Fkc';
+
+    expect(stripOidcParams(href)).toEqual('/search/species_observation?expr=eyJhYmMiOjF9&page=2');
+  });
+
+  it('removes OIDC error params (error, error_description)', () => {
+    const href = 'https://biohub.example/search/dataset?search=caribou&error=access_denied&error_description=denied';
+
+    expect(stripOidcParams(href)).toEqual('/search/dataset?search=caribou');
+  });
+
+  it('returns the path with no query string when only OIDC params are present', () => {
+    const href = 'https://biohub.example/search/species_observation?code=abc&state=xyz';
+
+    expect(stripOidcParams(href)).toEqual('/search/species_observation');
+  });
+
+  it('preserves a path that has no query string', () => {
+    const href = 'https://biohub.example/search/species_observation';
+
+    expect(stripOidcParams(href)).toEqual('/search/species_observation');
+  });
+
+  it('keeps an application param that merely shares a substring with an OIDC param', () => {
+    // `state_code` must survive — only exact-name OIDC params are stripped.
+    const href = 'https://biohub.example/search/dataset?state_code=BC&code=abc';
+
+    expect(stripOidcParams(href)).toEqual('/search/dataset?state_code=BC');
+  });
+});
 
 describe('ensureProtocol', () => {
   it('upgrades the URL if string begins with `http://`', async () => {

--- a/app/src/utils/Utils.test.ts
+++ b/app/src/utils/Utils.test.ts
@@ -13,6 +13,7 @@ import {
   isObject,
   jsonParseObjectProperties,
   jsonStringifyObjectProperties,
+  getPostLoginReturnTo,
   pluralize,
   safeJSONParse,
   safeJSONStringify,
@@ -50,6 +51,28 @@ describe('stripOidcParams', () => {
     const href = 'https://biohub.example/search/dataset?state_code=BC&code=abc';
 
     expect(stripOidcParams(href)).toEqual('/search/dataset?state_code=BC');
+  });
+});
+
+describe('getPostLoginReturnTo', () => {
+  it('returns the relative returnTo carried on the OIDC state', () => {
+    const user = { state: { returnTo: '/search/species_observation?expr=eyJhYmMiOjF9&page=2' } };
+
+    expect(getPostLoginReturnTo(user)).toEqual('/search/species_observation?expr=eyJhYmMiOjF9&page=2');
+  });
+
+  it('returns undefined when there is no state or returnTo', () => {
+    expect(getPostLoginReturnTo(undefined)).toBeUndefined();
+    expect(getPostLoginReturnTo(null)).toBeUndefined();
+    expect(getPostLoginReturnTo({})).toBeUndefined();
+    expect(getPostLoginReturnTo({ state: {} })).toBeUndefined();
+    expect(getPostLoginReturnTo({ state: { returnTo: 42 } })).toBeUndefined();
+  });
+
+  it('rejects unsafe (non-relative) return targets to guard against open redirects', () => {
+    expect(getPostLoginReturnTo({ state: { returnTo: 'https://evil.example/phish' } })).toBeUndefined();
+    expect(getPostLoginReturnTo({ state: { returnTo: '//evil.example/phish' } })).toBeUndefined();
+    expect(getPostLoginReturnTo({ state: { returnTo: 'search/dataset' } })).toBeUndefined();
   });
 });
 

--- a/app/src/utils/Utils.ts
+++ b/app/src/utils/Utils.ts
@@ -287,6 +287,23 @@ export const buildUrl = (...urlParts: (string | undefined)[]): string => {
     .replace(/([^:]\/)\/+/g, '$1'); // Trim double slashes
 };
 
+/** OIDC authorization-response query params appended by Keycloak to the return URL after login. */
+const OIDC_RESPONSE_PARAMS = ['code', 'state', 'session_state', 'iss', 'error', 'error_description'];
+
+/**
+ * Strips the OIDC authorization-response params from a return URL while preserving any original
+ * application query params (e.g. the encoded `expr` search expression). Used by the post-login
+ * `onSigninCallback` so the user lands back on the same search results after authenticating.
+ *
+ * @param {string} href The full return URL (e.g. `window.location.href`).
+ * @returns The path + remaining query string, with the OIDC response params removed.
+ */
+export const stripOidcParams = (href: string): string => {
+  const url = new URL(href);
+  OIDC_RESPONSE_PARAMS.forEach((param) => url.searchParams.delete(param));
+  return `${url.pathname}${url.search}`;
+};
+
 /**
  * Generates the <title> tag text for a React route
  * @param pageName The name of the page, e.g. 'Projects'

--- a/app/src/utils/Utils.ts
+++ b/app/src/utils/Utils.ts
@@ -305,6 +305,29 @@ export const stripOidcParams = (href: string): string => {
 };
 
 /**
+ * Reads the post-login return location carried through the OIDC `state` param (set by callers such as
+ * the "Request Access" flow that redirect unauthenticated users to login). Used by `onSigninCallback` to
+ * navigate back to the originating search after authenticating, since the registered `redirect_uri` is a
+ * fixed origin and login otherwise lands on `/`.
+ *
+ * Only a safe same-origin relative path is returned (must start with a single `/`); anything else —
+ * absent state, an absolute URL, or a protocol-relative `//host` — yields `undefined`, guarding against
+ * open redirects.
+ *
+ * @param {unknown} user The OIDC user passed to `onSigninCallback` (its `state` holds the value set at signin).
+ * @returns The relative return path, or `undefined` when none/unsafe.
+ */
+export const getPostLoginReturnTo = (user: unknown): string | undefined => {
+  const returnTo = (user as { state?: { returnTo?: unknown } } | null | undefined)?.state?.returnTo;
+
+  if (typeof returnTo === 'string' && returnTo.startsWith('/') && !returnTo.startsWith('//')) {
+    return returnTo;
+  }
+
+  return undefined;
+};
+
+/**
  * Generates the <title> tag text for a React route
  * @param pageName The name of the page, e.g. 'Projects'
  * @returns The content to be rendered in the <title> tag

--- a/database/src/seed-utils.ts
+++ b/database/src/seed-utils.ts
@@ -1,0 +1,95 @@
+import { Knex } from 'knex';
+
+export type SeedConnection = Knex | Knex.Transaction;
+
+/**
+ * Recompute the derived reachability closure for a single upload (DELETE + recursive-CTE INSERT).
+ *
+ * Mirrors `SubmissionFeatureClosureRepository.deleteClosureForUpload` +
+ * `SubmissionFeatureClosureRepository.computeClosureForUpload` as a standalone knex helper, since the
+ * database package cannot import the api repository. Closure is reachability over the upload's parent
+ * and property (feature-reference) edges — content edges (submission_feature_feature) are intentionally
+ * excluded. `is_ancestor` flags the pure parent-ancestry subset (the authorization reach); search reads
+ * all rows. Delete-then-insert in one transaction keeps the wholesale recompute idempotent.
+ *
+ * Seeds MUST call this for every upload they create. Read-path security (isEffectivelySecured /
+ * isAccessibleToUser) resolves against this table and fails closed when a feature has no closure rows,
+ * so closure-less seeded features read as secured-and-inaccessible to everyone — hiding them from search
+ * and raising the "Request Data" banner even when nothing is actually policy-secured.
+ *
+ * @param {SeedConnection} knex
+ * @param {string} submission_upload_id The submission upload scope.
+ * @returns {Promise<void>}
+ */
+export const computeSubmissionFeatureClosureForUpload = async (
+  knex: SeedConnection,
+  submission_upload_id: string
+): Promise<void> => {
+  await knex.raw(
+    `
+      DELETE FROM submission_feature_closure c
+      USING submission_feature sf
+      WHERE sf.submission_upload_id = ?::uuid
+        AND c.source_submission_feature_id = sf.submission_feature_id;
+    `,
+    [submission_upload_id]
+  );
+
+  await knex.raw(
+    `
+      WITH RECURSIVE
+      active_features AS (
+        SELECT submission_feature_id
+        FROM submission_feature
+        WHERE submission_upload_id = ?::uuid
+          AND record_end_date IS NULL
+      ),
+      self_loops AS (
+        SELECT submission_feature_id AS source, submission_feature_id AS target
+        FROM active_features
+      ),
+      parent_edges AS (
+        SELECT child.submission_feature_id AS source, child.parent_submission_feature_id AS target
+        FROM submission_feature child
+        JOIN active_features af_src ON af_src.submission_feature_id = child.submission_feature_id
+        JOIN active_features af_tgt ON af_tgt.submission_feature_id = child.parent_submission_feature_id
+        WHERE child.parent_submission_feature_id IS NOT NULL
+      ),
+      property_edges AS (
+        SELECT pf.submission_feature_id AS source, pf.referenced_submission_feature_id AS target
+        FROM submission_feature_property_feature pf
+        JOIN active_features af_src ON af_src.submission_feature_id = pf.submission_feature_id
+        JOIN active_features af_tgt ON af_tgt.submission_feature_id = pf.referenced_submission_feature_id
+      ),
+      ancestry_edges AS (
+        SELECT source, target FROM self_loops
+        UNION ALL SELECT source, target FROM parent_edges
+      ),
+      direct_edges AS (
+        SELECT source, target FROM self_loops
+        UNION ALL SELECT source, target FROM parent_edges
+        UNION ALL SELECT source, target FROM property_edges
+      ),
+      ancestry_closure AS (
+        SELECT source, target FROM ancestry_edges
+        UNION
+        SELECT c.source, d.target
+        FROM ancestry_closure c
+        JOIN ancestry_edges d ON d.source = c.target
+      ),
+      closure AS (
+        SELECT source, target FROM direct_edges
+        UNION
+        SELECT c.source, d.target
+        FROM closure c
+        JOIN direct_edges d ON d.source = c.target
+      )
+      INSERT INTO submission_feature_closure (source_submission_feature_id, target_submission_feature_id, is_ancestor)
+      SELECT cl.source, cl.target, (anc.source IS NOT NULL) AS is_ancestor
+      FROM closure cl
+      LEFT JOIN ancestry_closure anc
+        ON anc.source = cl.source AND anc.target = cl.target;
+    `,
+    [submission_upload_id]
+  );
+};

--- a/database/src/seeds/04_mock_test_data.ts
+++ b/database/src/seeds/04_mock_test_data.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 // @ts-ignore ignore error over missing geojson-random declaration (.d.ts) file
 import random from 'geojson-random';
 import { Knex } from 'knex';
+import { computeSubmissionFeatureClosureForUpload } from '../seed-utils';
 
 // Disable mock data seeding by default. Set `ENABLE_MOCK_FEATURE_DATA=true` to enable.
 const ENABLE_MOCK_FEATURE_SEEDING = Boolean(process.env.ENABLE_MOCK_FEATURE_SEEDING === 'true' || false);
@@ -116,6 +117,10 @@ const insertRecord = async (knex: Knex) => {
 
   // Wait for all sample sites and telemetry to complete concurrently
   await Promise.all([...sampleSitePromises, ...telemetryPromises]);
+
+  // Build the derived reachability closure for this upload. Read-path security resolves against it and
+  // fails closed when absent, so without this every seeded feature reads as secured-and-inaccessible.
+  await computeSubmissionFeatureClosureForUpload(knex, submission_upload_id);
 };
 
 export const insertSubmissionRecord = async (

--- a/database/src/seeds/06_submission_data.ts
+++ b/database/src/seeds/06_submission_data.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { Knex } from 'knex';
+import { computeSubmissionFeatureClosureForUpload } from '../seed-utils';
 import {
   insertSampleSiteRecord,
   insertSubmissionRecord,
@@ -196,93 +197,6 @@ const insertMockRelatedSubmissionFeatures = async (
     .insert(relationshipRows)
     .onConflict(['source_feature_id', 'target_feature_id'])
     .ignore();
-};
-
-/**
- * Recompute the derived reachability closure for a single upload (DELETE + recursive-CTE INSERT).
- *
- * Mirrors {@link SubmissionFeatureClosureRepository.deleteClosureForUpload} +
- * {@link SubmissionFeatureClosureRepository.computeClosureForUpload} as a standalone knex helper, since
- * the database package cannot import the api repository. Closure is reachability over the upload's parent
- * and property (feature-reference) edges — content edges (submission_feature_feature) are intentionally
- * excluded. is_ancestor flags the pure parent-ancestry subset (the authorization reach); search reads all
- * rows. Delete-then-insert in one transaction keeps the wholesale recompute idempotent.
- *
- * @param {SeedConnection} knex
- * @param {string} submission_upload_id The submission upload scope.
- * @returns {Promise<void>}
- */
-const computeSubmissionFeatureClosureForUpload = async (
-  knex: SeedConnection,
-  submission_upload_id: string
-): Promise<void> => {
-  await knex.raw(
-    `
-      DELETE FROM submission_feature_closure c
-      USING submission_feature sf
-      WHERE sf.submission_upload_id = ?::uuid
-        AND c.source_submission_feature_id = sf.submission_feature_id;
-    `,
-    [submission_upload_id]
-  );
-
-  await knex.raw(
-    `
-      WITH RECURSIVE
-      active_features AS (
-        SELECT submission_feature_id
-        FROM submission_feature
-        WHERE submission_upload_id = ?::uuid
-          AND record_end_date IS NULL
-      ),
-      self_loops AS (
-        SELECT submission_feature_id AS source, submission_feature_id AS target
-        FROM active_features
-      ),
-      parent_edges AS (
-        SELECT child.submission_feature_id AS source, child.parent_submission_feature_id AS target
-        FROM submission_feature child
-        JOIN active_features af_src ON af_src.submission_feature_id = child.submission_feature_id
-        JOIN active_features af_tgt ON af_tgt.submission_feature_id = child.parent_submission_feature_id
-        WHERE child.parent_submission_feature_id IS NOT NULL
-      ),
-      property_edges AS (
-        SELECT pf.submission_feature_id AS source, pf.referenced_submission_feature_id AS target
-        FROM submission_feature_property_feature pf
-        JOIN active_features af_src ON af_src.submission_feature_id = pf.submission_feature_id
-        JOIN active_features af_tgt ON af_tgt.submission_feature_id = pf.referenced_submission_feature_id
-      ),
-      ancestry_edges AS (
-        SELECT source, target FROM self_loops
-        UNION ALL SELECT source, target FROM parent_edges
-      ),
-      direct_edges AS (
-        SELECT source, target FROM self_loops
-        UNION ALL SELECT source, target FROM parent_edges
-        UNION ALL SELECT source, target FROM property_edges
-      ),
-      ancestry_closure AS (
-        SELECT source, target FROM ancestry_edges
-        UNION
-        SELECT c.source, d.target
-        FROM ancestry_closure c
-        JOIN ancestry_edges d ON d.source = c.target
-      ),
-      closure AS (
-        SELECT source, target FROM direct_edges
-        UNION
-        SELECT c.source, d.target
-        FROM closure c
-        JOIN direct_edges d ON d.source = c.target
-      )
-      INSERT INTO submission_feature_closure (source_submission_feature_id, target_submission_feature_id, is_ancestor)
-      SELECT cl.source, cl.target, (anc.source IS NOT NULL) AS is_ancestor
-      FROM closure cl
-      LEFT JOIN ancestry_closure anc
-        ON anc.source = cl.source AND anc.target = cl.target;
-    `,
-    [submission_upload_id]
-  );
 };
 
 /**


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1057](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1057)
- [SIMSBIOHUB-1067](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1067)

## Description of Changes

Adds a `has_more_secured_features` signal to the feature search response, drives the "Request Data" banner from it, and prompts unauthenticated users to log in before requesting data.

**Backend**
- Feature search response now includes a top-level boolean `has_more_secured_features` (OpenAPI schema + service + handler), computed in parallel with the existing search/count/properties queries.
- New `SearchFeatureRepository.hasInaccessibleSecuredFeaturesByExpressionTree`: an `EXISTS`/`LIMIT 1` probe over the expression-matched candidate set **without** the caller access filter. True when a matched feature is effectively secured and not accessible to the caller — using `NOT isAccessibleToUser`, the same anchor-based definition as the visible-results filter, so the banner stays consistent with which rows are shown. Returns only the boolean; no hidden row data is exposed.
- New `buildUnfilteredExpressionTreeFeatureIdsSubquery` for the unfiltered candidate set.

**Frontend**
- "Request Data" banner is driven by `has_more_secured_features` (replaces deriving it from visible `is_secured` rows). Visible secured rows still render with `is_secured`.
- Unauthenticated "Request Access" redirects to login, preserving the search location (path + encoded `expr` query) as the return URL. The OIDC callback strips only the auth params (via the unit-tested `stripOidcParams` helper) so the search is restored after login.

**Seed**
- Mock seed (`04_mock_test_data.ts`) now builds `submission_feature_closure` per upload (shared `seed-utils.ts`), matching the indexing pipeline. Without closures, seeded features read as fail-closed-secured — producing false banners and hidden rows.

**Behavior note**
- The banner's accessibility check is anchor-based, identical to the visible-row filter. During the brief (~10s) anchor-recompute lag after a feature is secured, a caller with a covering policy grant may see a transient banner until anchors catch up. Accepted, in exchange for the banner always matching the rows that are shown.

## Testing Notes

- Requires `submission_feature_closure` to be built (the seed change handles this — **rebuild the `db_setup` image** so the seed fix is picked up). On a DB with unbuilt closures, every feature reads as secured.
- Verify: logged out / no-policy → banner shows when secured matches exist; `urn:*:*:*` user → no banner and secured rows visible with lock icons; delete the policy → banner returns.
- Tests: API unit (`search-feature-repository`, service, path, `expression-evaluation`) + DB integration (`security-scope-search.integration.ts`, incl. the anchor-lag transient-banner case). App: `SearchResultPage`, `useSearchResultDataRequest`, `stripOidcParams` (`Utils`), `useSearchApi`.
- Known local-only noise: two `findScopeIdsMatchingSubmission` integration tests can fail if a `urn:*:*:*` scope was created manually (count assertion); they pass on a clean DB.
