### PR TITLE
SIMSBIOHUB-1080: Do not show inactive features as search results

### DIFF
--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.test.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.test.ts
@@ -6,7 +6,7 @@ import * as index from '.';
 import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../../__mocks__/db';
 import * as db from '../../../../../../database/db';
 import { HTTP400, HTTPError } from '../../../../../../errors/http-error';
-import { SubmissionFeatureService } from '../../../../../../services/submission-feature-service';
+import { SubmissionFeaturePropertyService } from '../../../../../../services/submission-feature-property-service';
 
 chai.use(sinonChai);
 
@@ -21,7 +21,7 @@ describe('properties index', () => {
       sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
 
       const getSubmissionFeaturePropertiesStub = sinon
-        .stub(SubmissionFeatureService.prototype, 'getSubmissionFeatureProperties')
+        .stub(SubmissionFeaturePropertyService.prototype, 'getSubmissionFeatureProperties')
         .throws(new HTTP400('Error', ['Error']));
 
       const requestHandler = index.getSubmissionFeatureProperties();
@@ -48,7 +48,7 @@ describe('properties index', () => {
       sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
 
       const getSubmissionFeaturePropertiesStub = sinon
-        .stub(SubmissionFeatureService.prototype, 'getSubmissionFeatureProperties')
+        .stub(SubmissionFeaturePropertyService.prototype, 'getSubmissionFeatureProperties')
         .resolves({
           properties: [
             { id: 'species_name', property: 'species name', value: 'Wolf' },

--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.ts
@@ -8,7 +8,7 @@ import {
   paginationResponseSchema
 } from '../../../../../../openapi/schemas/pagination';
 import { authorizeRequestHandler } from '../../../../../../request-handlers/security/authorization';
-import { SubmissionFeatureService } from '../../../../../../services/submission-feature-service';
+import { SubmissionFeaturePropertyService } from '../../../../../../services/submission-feature-property-service';
 import { getLogger } from '../../../../../../utils/logger';
 import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../../../../utils/pagination';
 
@@ -118,8 +118,8 @@ export function getSubmissionFeatureProperties(): RequestHandler {
     try {
       await connection.open();
 
-      const submissionFeatureService = new SubmissionFeatureService(connection);
-      const result = await submissionFeatureService.getSubmissionFeatureProperties(
+      const submissionFeaturePropertyService = new SubmissionFeaturePropertyService(connection);
+      const result = await submissionFeaturePropertyService.getSubmissionFeatureProperties(
         submissionFeatureId,
         pagination,
         filters

--- a/api/src/repositories/authorization/security-scope-repository.ts
+++ b/api/src/repositories/authorization/security-scope-repository.ts
@@ -6,7 +6,7 @@ import { PolicyEffect } from '../../models/policy-statement';
 import { SecurityScope, SecurityScopeId } from '../../models/security-scope';
 import { AnchorBatchResult, SecurityScopeUrn } from '../../services/access-policy/security-scope-service.interface';
 import { BaseRepository } from '../base-repository';
-import { isEffectivelySecured } from '../sql-fragments';
+import { isEffectivelySecured, isSubmissionFeatureActive } from '../sql-fragments';
 
 /**
  * Repository for security scope tables — the normalized access model that replaces
@@ -197,12 +197,11 @@ export class SecurityScopeRepository extends BaseRepository {
            AND ps.effect = '${PolicyEffect.ALLOW}'
            AND p.record_end_date IS NULL
            AND p.status = 'approved'
-           AND anchor_sf.record_end_date IS NULL
+           AND ${isSubmissionFeatureActive('anchor_sf')}
            AND (ss.urn_submission_id = anchor_sf.submission_id::text OR ss.urn_submission_id = '*')
            AND (ss.urn_feature_type = ft.name                       OR ss.urn_feature_type = '*')
            AND (ss.urn_feature_id = anchor_sf.submission_feature_id::text OR ss.urn_feature_id = '*')
            AND ${isEffectivelySecured('anchor_sf.submission_feature_id')}
-           AND anchor_sf.record_effective_date <= now()
        )`,
       [securityScopeId, afterId, SECURITY_SCOPE_ANCHOR_BATCH_SIZE]
     );
@@ -342,13 +341,12 @@ export class SecurityScopeRepository extends BaseRepository {
                 candidate.parent_submission_feature_id
          FROM submission_feature candidate
          JOIN feature_type ft ON ft.feature_type_id = candidate.feature_type_id
-         WHERE candidate.record_end_date IS NULL
+         WHERE ${isSubmissionFeatureActive('candidate')}
            AND candidate.submission_feature_id > $1
            AND ($2 = candidate.submission_id::text OR $2 = '*')
            AND ($3 = ft.name                       OR $3 = '*')
            AND ($4 = candidate.submission_feature_id::text OR $4 = '*')
            AND ${isEffectivelySecured('candidate.submission_feature_id')}
-           AND candidate.record_effective_date <= now()
          ORDER BY candidate.submission_feature_id
          LIMIT $5
        ),
@@ -366,7 +364,7 @@ export class SecurityScopeRepository extends BaseRepository {
          FROM ancestor_walk aw
          JOIN submission_feature sf ON sf.submission_feature_id = aw.ancestor_id
          WHERE sf.parent_submission_feature_id IS NOT NULL
-           AND sf.record_end_date IS NULL
+           AND ${isSubmissionFeatureActive('sf')}
        ),
 
        -- Re-evaluate candidate criteria per ancestor via index lookups.
@@ -376,12 +374,11 @@ export class SecurityScopeRepository extends BaseRepository {
          FROM ancestor_walk aw
          JOIN submission_feature ancestor ON ancestor.submission_feature_id = aw.ancestor_id
          JOIN feature_type ft ON ft.feature_type_id = ancestor.feature_type_id
-         WHERE ancestor.record_end_date IS NULL
+         WHERE ${isSubmissionFeatureActive('ancestor')}
            AND ($2 = ancestor.submission_id::text OR $2 = '*')
            AND ($3 = ft.name                      OR $3 = '*')
            AND ($4 = ancestor.submission_feature_id::text OR $4 = '*')
            AND ${isEffectivelySecured('ancestor.submission_feature_id')}
-           AND ancestor.record_effective_date <= now()
        )
 
        -- Prune to topmost candidates only (anchors). A candidate with a candidate
@@ -421,13 +418,12 @@ export class SecurityScopeRepository extends BaseRepository {
          SELECT candidate.submission_feature_id
          FROM submission_feature candidate
          JOIN feature_type ft ON ft.feature_type_id = candidate.feature_type_id
-         WHERE candidate.record_end_date IS NULL
+         WHERE ${isSubmissionFeatureActive('candidate')}
            AND candidate.submission_feature_id > $1
            AND ($2 = candidate.submission_id::text OR $2 = '*')
            AND ($3 = ft.name                       OR $3 = '*')
            AND ($4 = candidate.submission_feature_id::text OR $4 = '*')
            AND ${isEffectivelySecured('candidate.submission_feature_id')}
-           AND candidate.record_effective_date <= now()
          ORDER BY candidate.submission_feature_id
          LIMIT $5
        ) candidate`,

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -641,7 +641,7 @@ describe('DownloadRepository', () => {
       expect(result[0].value).to.deep.equal(['urn:1:obs:42', 'urn:1:obs:43']);
     });
 
-    it('includes the sf.record_end_date IS NULL filter', async () => {
+    it('includes the referenced feature active-window filter', async () => {
       const queryStub = sinon.stub();
       queryStub.resolves({ rows: [] });
 
@@ -651,8 +651,26 @@ describe('DownloadRepository', () => {
       await repo.fetchTypedPropertyRows([100], ['feature']);
 
       const sqlText = String(queryStub.getCall(0).args[0]);
+      expect(sqlText).to.include('sf.record_effective_date <= now()');
       expect(sqlText).to.include('sf.record_end_date IS NULL');
+      expect(sqlText).to.include('now() < sf.record_end_date');
       expect(sqlText).to.include('referenced_submission_feature_id');
+    });
+
+    it('hydrates artifact_key rows only when the feature type has one artifact_key property', async () => {
+      const queryStub = sinon.stub();
+      queryStub.resolves({ rows: [] });
+
+      const mockDBConnection = getMockDBConnection({ query: queryStub });
+      const repo = new DownloadRepository(mockDBConnection);
+
+      await repo.fetchTypedPropertyRows([100], ['artifact_key']);
+
+      const sqlText = String(queryStub.getCall(0).args[0]);
+      expect(sqlText).to.include('submission_feature_artifact sfa');
+      expect(sqlText).to.include('artifact_ftp.feature_type_id = sf.feature_type_id');
+      expect(sqlText).to.include('fpt.name = \'artifact_key\'');
+      expect(sqlText).to.include('HAVING COUNT(*) = 1');
     });
 
     it('skips unknown property type names', async () => {

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -668,6 +668,7 @@ describe('DownloadRepository', () => {
 
       const sqlText = String(queryStub.getCall(0).args[0]);
       expect(sqlText).to.include('submission_feature_artifact sfa');
+      expect(sqlText).to.include("a.artifact_status = 'uploaded'");
       expect(sqlText).to.include('artifact_ftp.feature_type_id = sf.feature_type_id');
       expect(sqlText).to.include("fpt.name = 'artifact_key'");
       expect(sqlText).to.include('HAVING COUNT(*) = 1');

--- a/api/src/repositories/download/download-repository.test.ts
+++ b/api/src/repositories/download/download-repository.test.ts
@@ -669,7 +669,7 @@ describe('DownloadRepository', () => {
       const sqlText = String(queryStub.getCall(0).args[0]);
       expect(sqlText).to.include('submission_feature_artifact sfa');
       expect(sqlText).to.include('artifact_ftp.feature_type_id = sf.feature_type_id');
-      expect(sqlText).to.include('fpt.name = \'artifact_key\'');
+      expect(sqlText).to.include("fpt.name = 'artifact_key'");
       expect(sqlText).to.include('HAVING COUNT(*) = 1');
     });
 

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -15,6 +15,7 @@ import {
 } from '../../models/download';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
+import { isSubmissionFeatureActive } from '../sql-fragments';
 
 /**
  * Row shape for the typed-cursor base query.
@@ -408,7 +409,7 @@ export class DownloadRepository extends BaseRepository {
         SELECT
           sf.submission_feature_id,
           sf.uuid,
-          sf.data,
+          '{}'::jsonb AS data,
           ft.name AS feature_type_name,
           parent_sf.uuid AS parent_uuid
         FROM submission_feature sf
@@ -552,8 +553,8 @@ export class DownloadRepository extends BaseRepository {
        *   matching the same-file `spatial` precedent's use of `::jsonb`.
        * - `ORDER BY sf.submission_feature_id` is mandatory: export reruns must be byte-identical
        *   for the same data so downstream hash-based diff tooling stays valid.
-       * - The `sf.record_end_date IS NULL` filter is defense-in-depth — ingestion already excludes
-       *   inactive features, but soft-delete-on-read is the codebase convention.
+       * - The `sf` active-window filter is defense-in-depth — ingestion already excludes
+       *   inactive referenced features, but read paths must never surface pending/end-dated rows.
        * - `submission_feature_property_feature` has no soft-delete column, so no `p`-side filter is needed.
        */
       feature: `SELECT
@@ -565,9 +566,39 @@ export class DownloadRepository extends BaseRepository {
       INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
       INNER JOIN submission_feature sf
         ON sf.submission_feature_id = p.referenced_submission_feature_id
-        AND sf.record_end_date IS NULL
+        AND ${isSubmissionFeatureActive('sf')}
       WHERE p.submission_feature_id = ANY($1)
-      GROUP BY p.submission_feature_id, fp.name`
+      GROUP BY p.submission_feature_id, fp.name`,
+      artifact_key: `SELECT
+        sfa.submission_feature_id,
+        fp.name,
+        jsonb_agg(a.object_key ORDER BY a.object_key) AS value
+      FROM submission_feature_artifact sfa
+      INNER JOIN submission_feature sf ON sf.submission_feature_id = sfa.submission_feature_id
+      INNER JOIN artifact a ON a.artifact_id = sfa.artifact_id
+      INNER JOIN (
+        SELECT
+          ftp.feature_type_id,
+          MIN(ftp.feature_type_property_id) AS feature_type_property_id
+        FROM feature_type_property ftp
+        INNER JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+          AND fp.record_end_date IS NULL
+        INNER JOIN feature_property_type fpt
+          ON fpt.feature_property_type_id = fp.feature_property_type_id
+          AND fpt.name = 'artifact_key'
+          AND fpt.record_end_date IS NULL
+        WHERE ftp.record_end_date IS NULL
+        GROUP BY ftp.feature_type_id
+        HAVING COUNT(*) = 1
+      ) artifact_ftp
+        ON artifact_ftp.feature_type_id = sf.feature_type_id
+      INNER JOIN feature_type_property ftp
+        ON ftp.feature_type_property_id = artifact_ftp.feature_type_property_id
+      INNER JOIN feature_property fp ON ftp.feature_property_id = fp.feature_property_id
+      WHERE sfa.submission_feature_id = ANY($1)
+        AND ${isSubmissionFeatureActive('sf')}
+      GROUP BY sfa.submission_feature_id, fp.name`
     };
 
     // Query only the typed tables for property types present in this batch

--- a/api/src/repositories/download/download-repository.ts
+++ b/api/src/repositories/download/download-repository.ts
@@ -575,7 +575,9 @@ export class DownloadRepository extends BaseRepository {
         jsonb_agg(a.object_key ORDER BY a.object_key) AS value
       FROM submission_feature_artifact sfa
       INNER JOIN submission_feature sf ON sf.submission_feature_id = sfa.submission_feature_id
-      INNER JOIN artifact a ON a.artifact_id = sfa.artifact_id
+      INNER JOIN artifact a
+        ON a.artifact_id = sfa.artifact_id
+        AND a.artifact_status = 'uploaded'
       INNER JOIN (
         SELECT
           ftp.feature_type_id,

--- a/api/src/repositories/expression-evaluation.test.ts
+++ b/api/src/repositories/expression-evaluation.test.ts
@@ -191,8 +191,10 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"content_edges"');
       expect(sql).to.include('"content_reach"');
       expect(sql).to.include('from "submission_feature_feature" as "sff"');
-      expect(sql).to.include('"source_sf"."record_end_date" is null');
-      expect(sql).to.include('"target_sf"."record_end_date" is null');
+      expect(sql).to.include('source_sf.record_effective_date <= now()');
+      expect(sql).to.include('now() < source_sf.record_end_date');
+      expect(sql).to.include('target_sf.record_effective_date <= now()');
+      expect(sql).to.include('now() < target_sf.record_end_date');
       // Depth bound and cycle guard on the recursive term.
       expect(sql).to.include('"content_reach"."depth" < 6');
       expect(sql).to.include('= ANY(content_reach.path)');
@@ -207,7 +209,8 @@ describe('expression-evaluation', () => {
       // The reachable selects are UNION-combined (dedup), and the anchor type is applied to the resolved targets.
       expect(sql).to.include(' union ');
       expect(sql).to.include('"ft"."name" = \'telemetry\'');
-      expect(sql).to.include('"sf"."record_end_date" is null');
+      expect(sql).to.include('sf.record_effective_date <= now()');
+      expect(sql).to.include('now() < sf.record_end_date');
 
       // The synthetic survey↔same-submission membership edge has been removed — content edges only.
       expect(sql).to.not.include('as "survey_sf"');
@@ -403,7 +406,8 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('from "submission_feature" as "sf"');
       expect(sql).to.include('inner join "feature_type" as "ft"');
       expect(sql).to.include('"ft"."name" = \'fish\'');
-      expect(sql).to.include('"sf"."record_end_date" is null');
+      expect(sql).to.include('sf.record_effective_date <= now()');
+      expect(sql).to.include('now() < sf.record_end_date');
       expect(sql).to.not.include('"ft"."record_end_date" is null');
       // Authenticated path uses isAccessibleToUser → security_scope_anchor + bound user id
       expect(sql).to.include('security_scope_anchor');

--- a/api/src/repositories/expression-evaluation.ts
+++ b/api/src/repositories/expression-evaluation.ts
@@ -8,7 +8,7 @@ import {
   NormalizedExpressionTreeExpression,
   NormalizedExpressionTreePredicate
 } from '../models/expression-tree-internal';
-import { buildSecurityFilter } from './sql-fragments';
+import { buildSecurityFilter, isSubmissionFeatureActive } from './sql-fragments';
 
 /**
  * Pure SQL builders that compile a normalized expression tree into Knex
@@ -79,7 +79,7 @@ export function buildBroadFeatureTypeSubquery(featureTypeName: string, systemUse
     .select('sf.submission_feature_id')
     .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
     .where('ft.name', featureTypeName)
-    .whereNull('sf.record_end_date');
+    .whereRaw(isSubmissionFeatureActive('sf'));
 
   const securityFilter = buildSecurityFilter(knex, systemUserId, 'sf.submission_feature_id');
   if (securityFilter) {
@@ -201,8 +201,10 @@ function buildPredicateEvidenceIdsQuery(
   let query = knex(`${tableName} as p`)
     .distinct()
     .select('p.submission_feature_id')
+    .join('submission_feature as sf', 'sf.submission_feature_id', 'p.submission_feature_id')
     .join('feature_type_property as ftp', 'ftp.feature_type_property_id', 'p.feature_type_property_id')
     .where('ftp.feature_property_id', clause.feature_property_id)
+    .whereRaw(isSubmissionFeatureActive('sf'))
     .whereNull('ftp.record_end_date');
 
   if (clause.feature_type_property_id !== null) {
@@ -333,7 +335,7 @@ function projectEvidenceToTargetIdsQuery(
     .join('submission_feature as sf', 'sf.submission_feature_id', 'reachable.submission_feature_id')
     .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id')
     .where('ft.name', anchorFeatureType)
-    .whereNull('sf.record_end_date');
+    .whereRaw(isSubmissionFeatureActive('sf'));
 
   const targetSecurityFilter = buildSecurityFilter(knex, systemUserId, 'sf.submission_feature_id');
   if (targetSecurityFilter) {
@@ -359,15 +361,15 @@ function buildContentEdgesQuery(knex: Knex): Knex.QueryBuilder {
     .select('sff.source_feature_id as from_feature_id', 'sff.target_feature_id as to_feature_id')
     .join('submission_feature as source_sf', 'source_sf.submission_feature_id', 'sff.source_feature_id')
     .join('submission_feature as target_sf', 'target_sf.submission_feature_id', 'sff.target_feature_id')
-    .whereNull('source_sf.record_end_date')
-    .whereNull('target_sf.record_end_date');
+    .whereRaw(isSubmissionFeatureActive('source_sf'))
+    .whereRaw(isSubmissionFeatureActive('target_sf'));
 
   const reverse = knex('submission_feature_feature as sff')
     .select('sff.target_feature_id as from_feature_id', 'sff.source_feature_id as to_feature_id')
     .join('submission_feature as source_sf', 'source_sf.submission_feature_id', 'sff.source_feature_id')
     .join('submission_feature as target_sf', 'target_sf.submission_feature_id', 'sff.target_feature_id')
-    .whereNull('source_sf.record_end_date')
-    .whereNull('target_sf.record_end_date');
+    .whereRaw(isSubmissionFeatureActive('source_sf'))
+    .whereRaw(isSubmissionFeatureActive('target_sf'));
 
   return forward.unionAll([reverse]);
 }

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -6,7 +6,7 @@ import { SearchFeatureResultWithRelevancy } from '../services/search-feature-ser
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 import { dependencies as expressionEvaluation } from './expression-evaluation';
-import { buildSecurityFilter, isEffectivelySecured } from './sql-fragments';
+import { buildSecurityFilter, isEffectivelySecured, isSubmissionFeatureActive } from './sql-fragments';
 
 /**
  * Repository for searching submission features by expression-tree criteria.
@@ -186,7 +186,7 @@ export class SearchFeatureRepository extends BaseRepository {
       .select('sf.submission_feature_id')
       .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
       .where('ft.name', anchorFeatureType)
-      .whereNull('sf.record_end_date');
+      .whereRaw(isSubmissionFeatureActive('sf'));
 
     if (expressionFeatureIds) {
       query.whereIn('sf.submission_feature_id', expressionFeatureIds);
@@ -244,7 +244,7 @@ export class SearchFeatureRepository extends BaseRepository {
       .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
       .joinRaw(this.buildTypedPropertiesLateralJoinSql())
       .where('ft.name', anchorFeatureType)
-      .whereNull('sf.record_end_date');
+      .whereRaw(isSubmissionFeatureActive('sf'));
 
     if (expressionFeatureIds) {
       expressionResults.whereIn('sf.submission_feature_id', expressionFeatureIds);
@@ -451,7 +451,7 @@ export class SearchFeatureRepository extends BaseRepository {
              AND fp.record_end_date IS NULL
             JOIN submission_feature referenced_sf
               ON referenced_sf.submission_feature_id = p.referenced_submission_feature_id
-             AND referenced_sf.record_end_date IS NULL
+             AND ${isSubmissionFeatureActive('referenced_sf')}
             WHERE p.submission_feature_id = sf.submission_feature_id
           ) AS property_values
           GROUP BY property_values.name

--- a/api/src/repositories/search-repository.ts
+++ b/api/src/repositories/search-repository.ts
@@ -13,6 +13,7 @@ import {
 import { SearchParams, WithCount } from '../services/search-service.interface';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
+import { isSubmissionFeatureActive } from './sql-fragments';
 
 export class SearchRepository extends BaseRepository {
   /**
@@ -79,7 +80,7 @@ export class SearchRepository extends BaseRepository {
       .from(matches.as('matches'))
       .join('submission_feature as sf', 'sf.submission_feature_id', 'matches.submission_feature_id')
       .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id')
-      .whereNull('sf.record_end_date')
+      .whereRaw(isSubmissionFeatureActive('sf'))
       .whereIn('ft.name', [...LANDING_PAGE_FEATURE_TYPES, 'dataset'])
       .groupBy('sf.submission_feature_id', 'sf.feature_type_id', 'ft.name')
       .select(
@@ -101,7 +102,7 @@ export class SearchRepository extends BaseRepository {
     const knex = getKnex();
     return knex('submission as s')
       .leftJoin('submission_feature as sf', function () {
-        this.on('sf.submission_id', 's.submission_id').andOnNull('sf.record_end_date');
+        this.on('sf.submission_id', 's.submission_id').andOn(knex.raw(isSubmissionFeatureActive('sf')));
       })
       .leftJoin('submission_feature_property_string as sfps', 'sfps.submission_feature_id', 'sf.submission_feature_id')
       .whereNull('s.record_end_date')
@@ -269,7 +270,9 @@ export class SearchRepository extends BaseRepository {
           FROM matching_ids m
          JOIN submission_feature sf ON sf.submission_feature_id = m.submission_feature_id
          JOIN feature_type ft ON ft.feature_type_id = sf.feature_type_id
-         WHERE sf.record_end_date IS NULL
+    `;
+    query.append(` WHERE ${isSubmissionFeatureActive('sf')}`);
+    query.append(SQL`
            AND ft.name = ANY(${allowedTypes}::text[])
       ),
       priority_types AS (
@@ -285,7 +288,7 @@ export class SearchRepository extends BaseRepository {
       GROUP BY pt.name, pt.feature_type_id
       HAVING COUNT(mf.submission_feature_id) > 0
       ORDER BY total DESC
-    `;
+    `);
 
     const result = await this.connection.sql(query, SearchSummaryFeature);
 

--- a/api/src/repositories/sql-fragments.test.ts
+++ b/api/src/repositories/sql-fragments.test.ts
@@ -1,8 +1,17 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { isAccessibleToUser, isEffectivelySecured } from './sql-fragments';
+import { isAccessibleToUser, isEffectivelySecured, isSubmissionFeatureActive } from './sql-fragments';
 
 describe('sql-fragments', () => {
+  describe('isSubmissionFeatureActive', () => {
+    it('requires an effective record that has not ended', () => {
+      const sql = isSubmissionFeatureActive('sf');
+
+      expect(sql).to.include('sf.record_effective_date <= now()');
+      expect(sql).to.include('(sf.record_end_date IS NULL OR now() < sf.record_end_date)');
+    });
+  });
+
   describe('isEffectivelySecured', () => {
     it('reads the precomputed closure ancestry instead of a recursive parent walk', () => {
       // Verifies: the closure-based fragment probes submission_feature_closure on the
@@ -20,6 +29,7 @@ describe('sql-fragments', () => {
       // Step 3: Verify the security join is on the closure target id and gated by effective date
       expect(sql).to.include('sfs.submission_feature_id = c.target_submission_feature_id');
       expect(sql).to.include('record_effective_date <= now()');
+      expect(sql).to.include('record_end_date is null or now() <');
 
       // Step 4: Verify it does NOT fall back to the recursive parent walk
       expect(sql).to.not.include('with recursive');

--- a/api/src/repositories/sql-fragments.ts
+++ b/api/src/repositories/sql-fragments.ts
@@ -9,6 +9,21 @@
 import { Knex } from 'knex';
 
 /**
+ * Active-window predicate for submission_feature rows that may surface on read
+ * paths or participate in access evaluation.
+ *
+ * A feature is active only after approval/publication sets record_effective_date
+ * and before any end date. NULL record_effective_date rows are drafts/pending
+ * review and must not be searchable, downloadable, or security anchors.
+ *
+ * @param alias SQL alias for submission_feature.
+ * @returns SQL predicate with zero placeholders.
+ */
+export function isSubmissionFeatureActive(alias: string): string {
+  return `${alias}.record_effective_date <= now() AND (${alias}.record_end_date IS NULL OR now() < ${alias}.record_end_date)`;
+}
+
+/**
  * Closure-based "effectively secured" check used on every security-resolving path —
  * the hot read paths (search / download) and the scope-anchor recompute write
  * path: a feature is effectively secured when it or an ancestor has an active security
@@ -48,7 +63,7 @@ export function isEffectivelySecured(featureIdExpr: string): string {
         AND c.is_ancestor = true
         AND sfs.record_end_date IS NULL
         AND sfs.status = 'active'
-        AND sf_sec.record_effective_date <= now()
+        AND ${isSubmissionFeatureActive('sf_sec')}
     )
     -- Fail closed: the reflexive self-loop (F, F) is written for every active feature when its upload's
     -- closure is built, so its absence means the closure is not built (recompute not yet run, or failed).

--- a/api/src/repositories/sql-fragments.ts
+++ b/api/src/repositories/sql-fragments.ts
@@ -65,7 +65,7 @@ export function isEffectivelySecured(featureIdExpr: string): string {
         AND sfs.status = 'active'
         AND ${isSubmissionFeatureActive('sf_sec')}
     )
-    -- Fail closed: the reflexive self-loop (F, F) is written for every active feature when its upload's
+    -- Fail closed: the reflexive self-loop (F, F) is written for every non-deleted feature when its upload's
     -- closure is built, so its absence means the closure is not built (recompute not yet run, or failed).
     -- We then cannot prove the feature is unsecured — treat it as secured rather than leak it. This is a
     -- direct primary-key probe ((source, target) is the PK).

--- a/api/src/repositories/submission-feature-closure-repository.test.ts
+++ b/api/src/repositories/submission-feature-closure-repository.test.ts
@@ -45,5 +45,16 @@ describe('SubmissionFeatureClosureRepository', () => {
 
       expect(result).to.equal(0);
     });
+
+    it('does not require record_effective_date when selecting features for closure', async () => {
+      const sqlSpy = sinon.spy(() => Promise.resolve(mockQueryResult([], 1)));
+      const repository = new SubmissionFeatureClosureRepository(getMockDBConnection({ sql: sqlSpy }));
+
+      await repository.computeClosureForUpload('11111111-1111-1111-1111-111111111111');
+
+      const sqlText = sqlSpy.firstCall.args[0].text;
+      expect(sqlText).to.include('record_end_date IS NULL');
+      expect(sqlText).to.not.include('record_effective_date <= now()');
+    });
   });
 });

--- a/api/src/repositories/submission-feature-closure-repository.ts
+++ b/api/src/repositories/submission-feature-closure-repository.ts
@@ -1,6 +1,5 @@
 import SQL from 'sql-template-strings';
 import { BaseRepository } from './base-repository';
-import { isSubmissionFeatureActive } from './sql-fragments';
 
 /**
  * Repository class for the derived submission feature closure table.
@@ -14,9 +13,9 @@ export class SubmissionFeatureClosureRepository extends BaseRepository {
    * Delete the closure rows for a single upload.
    *
    * Scoped by source: every closure row has BOTH endpoints in one upload (the edge CTEs in
-   * {@link computeClosureForUpload} join af_src AND af_tgt to the upload's active features), so matching
+   * {@link computeClosureForUpload} join af_src AND af_tgt to the upload's non-deleted features), so matching
    * by source already identifies all of the upload's rows — and it matches on the primary key, so no
-   * reverse index is needed. submission_feature is upload-wide (not active-only), so a deactivated
+   * reverse index is needed. submission_feature is upload-wide (not non-deleted-only), so a deleted
    * feature's stale rows are swept too.
    *
    * The service pairs this with {@link computeClosureForUpload} in one transaction (delete then insert);
@@ -50,7 +49,7 @@ export class SubmissionFeatureClosureRepository extends BaseRepository {
    * Insert only — the service deletes the upload's prior rows first (see {@link deleteClosureForUpload}),
    * so this runs against an empty slice for the upload and never accumulates duplicates.
    *
-   * Returns the number of closure rows written. An upload whose features are all inactive legitimately
+   * Returns the number of closure rows written. An upload whose features are all deleted legitimately
    * writes zero rows, so a count of 0 is a valid result, not a failure.
    *
    * @param {string} submissionUploadId The submission upload scope.
@@ -61,37 +60,35 @@ export class SubmissionFeatureClosureRepository extends BaseRepository {
     // Compute TWO closures and store every evidence edge: the ancestry closure (parent-only,
     // transitive) is the authorization reach; the evidence closure (parent + property, transitive) is
     // the search reach and a superset. is_ancestor is true iff the edge is also in the ancestry closure.
-    const sqlStatement = SQL``;
-
-    sqlStatement.append(`
+    const sqlStatement = SQL`
       WITH RECURSIVE
-      -- Active features in the upload (the universe for self-loops and the join filter).
-      active_features AS (
+      -- Non-ended features in the upload (the universe for self-loops and the join filter).
+      -- Closure is a derived graph for the upload and must be available before publication sets
+      -- record_effective_date, so drafts/pending rows are included here.
+      non_deleted_features AS (
         SELECT submission_feature_id
         FROM submission_feature
-        WHERE submission_upload_id = `);
-    sqlStatement.append(SQL`${submissionUploadId}`);
-    sqlStatement.append(`::uuid
-          AND ${isSubmissionFeatureActive('submission_feature')}
+        WHERE submission_upload_id = ${submissionUploadId}::uuid
+          AND record_end_date IS NULL
       ),
-      -- Reflexive self-loops (every active feature reaches itself) — the reflexive edges that seed the closure.
+      -- Reflexive self-loops (every non-ended feature reaches itself) — the reflexive edges that seed the closure.
       self_loops AS (
-        SELECT submission_feature_id AS source, submission_feature_id AS target FROM active_features
+        SELECT submission_feature_id AS source, submission_feature_id AS target FROM non_deleted_features
       ),
       -- Direct edges — parent (child -> parent, "up") / property (feature reference) — each filtered so
-      -- BOTH endpoints are intra-upload active features. Content edges are intentionally NOT included.
+      -- BOTH endpoints are intra-upload non-ended features. Content edges are intentionally NOT included.
       parent_edges AS (
         SELECT child.submission_feature_id AS source, child.parent_submission_feature_id AS target
         FROM submission_feature child
-        JOIN active_features af_src ON af_src.submission_feature_id = child.submission_feature_id
-        JOIN active_features af_tgt ON af_tgt.submission_feature_id = child.parent_submission_feature_id
+        JOIN non_deleted_features af_src ON af_src.submission_feature_id = child.submission_feature_id
+        JOIN non_deleted_features af_tgt ON af_tgt.submission_feature_id = child.parent_submission_feature_id
         WHERE child.parent_submission_feature_id IS NOT NULL
       ),
       property_edges AS (
         SELECT pf.submission_feature_id AS source, pf.referenced_submission_feature_id AS target
         FROM submission_feature_property_feature pf
-        JOIN active_features af_src ON af_src.submission_feature_id = pf.submission_feature_id
-        JOIN active_features af_tgt ON af_tgt.submission_feature_id = pf.referenced_submission_feature_id
+        JOIN non_deleted_features af_src ON af_src.submission_feature_id = pf.submission_feature_id
+        JOIN non_deleted_features af_tgt ON af_tgt.submission_feature_id = pf.referenced_submission_feature_id
       ),
       -- Ancestry base: self + parent only (the authorization reach, before transitive closure).
       ancestry_edges AS (
@@ -129,7 +126,7 @@ export class SubmissionFeatureClosureRepository extends BaseRepository {
       FROM closure cl
       LEFT JOIN ancestry_closure anc
         ON anc.source = cl.source AND anc.target = cl.target;
-    `);
+    `;
 
     const response = await this.connection.sql(sqlStatement);
 

--- a/api/src/repositories/submission-feature-closure-repository.ts
+++ b/api/src/repositories/submission-feature-closure-repository.ts
@@ -1,5 +1,6 @@
 import SQL from 'sql-template-strings';
 import { BaseRepository } from './base-repository';
+import { isSubmissionFeatureActive } from './sql-fragments';
 
 /**
  * Repository class for the derived submission feature closure table.
@@ -60,14 +61,18 @@ export class SubmissionFeatureClosureRepository extends BaseRepository {
     // Compute TWO closures and store every evidence edge: the ancestry closure (parent-only,
     // transitive) is the authorization reach; the evidence closure (parent + property, transitive) is
     // the search reach and a superset. is_ancestor is true iff the edge is also in the ancestry closure.
-    const response = await this.connection.sql(SQL`
+    const sqlStatement = SQL``;
+
+    sqlStatement.append(`
       WITH RECURSIVE
       -- Active features in the upload (the universe for self-loops and the join filter).
       active_features AS (
         SELECT submission_feature_id
         FROM submission_feature
-        WHERE submission_upload_id = ${submissionUploadId}::uuid
-          AND record_end_date IS NULL
+        WHERE submission_upload_id = `);
+    sqlStatement.append(SQL`${submissionUploadId}`);
+    sqlStatement.append(`::uuid
+          AND ${isSubmissionFeatureActive('submission_feature')}
       ),
       -- Reflexive self-loops (every active feature reaches itself) — the reflexive edges that seed the closure.
       self_loops AS (
@@ -125,6 +130,8 @@ export class SubmissionFeatureClosureRepository extends BaseRepository {
       LEFT JOIN ancestry_closure anc
         ON anc.source = cl.source AND anc.target = cl.target;
     `);
+
+    const response = await this.connection.sql(sqlStatement);
 
     return response.rowCount ?? 0;
   }

--- a/api/src/repositories/submission-feature-property-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-repository.test.ts
@@ -1,0 +1,56 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection } from '../__mocks__/db';
+import { SubmissionFeaturePropertyRepository } from './submission-feature-property-repository';
+
+chai.use(sinonChai);
+
+describe('SubmissionFeaturePropertyRepository', () => {
+  describe('getSubmissionFeatureProperties', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('reads canonical indexed property tables instead of submission_feature.data', async () => {
+      const sqlStub = sinon.stub().resolves({
+        rowCount: 1,
+        rows: [{ id: 'string:1', property: 'Species', value: 'Wolf' }]
+      });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const submissionFeaturePropertyRepository = new SubmissionFeaturePropertyRepository(mockDBConnection);
+
+      await submissionFeaturePropertyRepository.getSubmissionFeatureProperties(
+        10,
+        { page: 1, limit: 25, sort: 'property', order: 'asc' },
+        { search: 'wolf' }
+      );
+
+      const sqlText = sqlStub.firstCall.args[0].text;
+      expect(sqlText).to.include('submission_feature_property_string');
+      expect(sqlText).to.include('submission_feature_property_number');
+      expect(sqlText).to.include('submission_feature_property_timestamp');
+      expect(sqlText).to.include('submission_feature_artifact');
+      expect(sqlText).to.include('HAVING COUNT(*) = 1');
+      expect(sqlText).to.not.include('sf.data');
+      expect(sqlText).to.not.include('jsonb_each');
+    });
+
+    it('counts canonical indexed property rows instead of submission_feature.data', async () => {
+      const sqlStub = sinon.stub().resolves({ rowCount: 1, rows: [{ count: 3 }] });
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+      const submissionFeaturePropertyRepository = new SubmissionFeaturePropertyRepository(mockDBConnection);
+
+      const count = await submissionFeaturePropertyRepository.getSubmissionFeaturePropertiesCount(10, {
+        search: 'wolf'
+      });
+
+      const sqlText = sqlStub.firstCall.args[0].text;
+      expect(count).to.equal(3);
+      expect(sqlText).to.include('filtered_property_rows');
+      expect(sqlText).to.not.include('sf.data');
+      expect(sqlText).to.not.include('jsonb_each');
+    });
+  });
+});

--- a/api/src/repositories/submission-feature-property-repository.test.ts
+++ b/api/src/repositories/submission-feature-property-repository.test.ts
@@ -23,7 +23,7 @@ describe('SubmissionFeaturePropertyRepository', () => {
 
       await submissionFeaturePropertyRepository.getSubmissionFeatureProperties(
         10,
-        { page: 1, limit: 25, sort: 'property', order: 'asc' },
+        { page: 1, limit: 25, order: 'asc' },
         { search: 'wolf' }
       );
 
@@ -33,6 +33,9 @@ describe('SubmissionFeaturePropertyRepository', () => {
       expect(sqlText).to.include('submission_feature_property_timestamp');
       expect(sqlText).to.include('submission_feature_artifact');
       expect(sqlText).to.include('HAVING COUNT(*) = 1');
+      expect(sqlText).to.include('SELECT id, property, value');
+      expect(sqlText).to.include('ORDER BY sort asc NULLS LAST, property ASC, value ASC, id ASC');
+      expect(sqlText).to.include("a.artifact_status = 'uploaded'");
       expect(sqlText).to.not.include('sf.data');
       expect(sqlText).to.not.include('jsonb_each');
     });

--- a/api/src/repositories/submission-feature-property-repository.ts
+++ b/api/src/repositories/submission-feature-property-repository.ts
@@ -1,0 +1,357 @@
+import SQL, { SQLStatement } from 'sql-template-strings';
+import { z } from 'zod';
+import { SubmissionFeatureProperty } from '../models/feature-property';
+import { SubmissionFeaturePropertyFilters } from '../models/submission-feature';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
+import { BaseRepository } from './base-repository';
+import { isSubmissionFeatureActive } from './sql-fragments';
+
+/**
+ * Read repository for canonical indexed properties attached to submission features.
+ *
+ * This intentionally spans all typed/indexed property tables. It is not CRUD for the
+ * `submission_feature` table and must not read `submission_feature.data`.
+ */
+export class SubmissionFeaturePropertyRepository extends BaseRepository {
+  /**
+   * Get paginated and sorted indexed properties for a single submission feature.
+   *
+   * @param {number} submissionFeatureId
+   * @param {ApiPaginationOptions} pagination
+   * @param {SubmissionFeaturePropertyFilters} [filters]
+   * @returns {Promise<SubmissionFeatureProperty[]>}
+   * @memberof SubmissionFeaturePropertyRepository
+   */
+  async getSubmissionFeatureProperties(
+    submissionFeatureId: number,
+    pagination: ApiPaginationOptions,
+    filters?: SubmissionFeaturePropertyFilters
+  ): Promise<SubmissionFeatureProperty[]> {
+    const normalizedSearch = filters?.search?.trim().toLowerCase();
+    const sqlStatement = this._getSubmissionFeaturePropertiesQuery(submissionFeatureId, normalizedSearch, pagination);
+    const response = await this.connection.sql(sqlStatement, SubmissionFeatureProperty);
+
+    return response.rows;
+  }
+
+  /**
+   * Count indexed properties for a single submission feature with optional server-side search.
+   *
+   * @param {number} submissionFeatureId
+   * @param {SubmissionFeaturePropertyFilters} [filters]
+   * @returns {Promise<number>}
+   * @memberof SubmissionFeaturePropertyRepository
+   */
+  async getSubmissionFeaturePropertiesCount(
+    submissionFeatureId: number,
+    filters?: SubmissionFeaturePropertyFilters
+  ): Promise<number> {
+    const normalizedSearch = filters?.search?.trim().toLowerCase();
+    const sqlStatement = this._getSubmissionFeaturePropertiesCountQuery(submissionFeatureId, normalizedSearch);
+    const response = await this.connection.sql(sqlStatement, z.object({ count: z.number() }));
+
+    if (!response.rowCount) {
+      return 0;
+    }
+
+    return response.rows[0].count;
+  }
+
+  /**
+   * Build the count query for `getSubmissionFeaturePropertiesCount`.
+   *
+   * This reuses the same active-feature and indexed-property union CTE as the list query so count
+   * semantics stay aligned with the paginated result set.
+   *
+   * @param {number} submissionFeatureId The submission feature whose indexed properties are being counted.
+   * @param {string} [normalizedSearch] Optional trimmed/lowercase search term to apply to property names and values.
+   * @returns {SQLStatement} SQL statement that returns a single integer `count` row.
+   * @memberof SubmissionFeaturePropertyRepository
+   */
+  private _getSubmissionFeaturePropertiesCountQuery(
+    submissionFeatureId: number,
+    normalizedSearch?: string
+  ): SQLStatement {
+    const sqlStatement = this._getSubmissionFeaturePropertiesBaseQuery(submissionFeatureId, normalizedSearch);
+    sqlStatement.append(`
+      SELECT COUNT(*)::int AS count
+      FROM filtered_property_rows;
+    `);
+
+    return sqlStatement;
+  }
+
+  /**
+   * Build the paginated list query for `getSubmissionFeatureProperties`.
+   *
+   * Sort columns are constrained to the projected read-model fields before being appended as raw SQL.
+   * Limit and offset remain parameterized.
+   *
+   * @param {number} submissionFeatureId The submission feature whose indexed properties are being listed.
+   * @param {string | undefined} normalizedSearch Optional trimmed/lowercase search term to apply to property names and values.
+   * @param {ApiPaginationOptions} pagination Pagination and sort options from the request.
+   * @returns {SQLStatement} SQL statement that returns `id`, `property`, and `value` rows.
+   * @memberof SubmissionFeaturePropertyRepository
+   */
+  private _getSubmissionFeaturePropertiesQuery(
+    submissionFeatureId: number,
+    normalizedSearch: string | undefined,
+    pagination: ApiPaginationOptions
+  ): SQLStatement {
+    const sortColumnMap: Record<string, 'id' | 'property' | 'value'> = {
+      id: 'id',
+      property: 'property',
+      value: 'value'
+    };
+    const resolvedSort = pagination.sort ? (sortColumnMap[pagination.sort] ?? 'property') : 'property';
+    const resolvedOrder = pagination.order === 'desc' ? 'desc' : 'asc';
+    const limit = pagination.limit ?? 25;
+    const page = pagination.page ?? 1;
+    const offset = (page - 1) * limit;
+
+    const sqlStatement = this._getSubmissionFeaturePropertiesBaseQuery(submissionFeatureId, normalizedSearch);
+    sqlStatement.append(`
+      SELECT id, property, value
+      FROM filtered_property_rows
+      ORDER BY ${resolvedSort} ${resolvedOrder}, id ASC
+      LIMIT `);
+    sqlStatement.append(SQL`${limit}`);
+    sqlStatement.append(` OFFSET `);
+    sqlStatement.append(SQL`${offset}`);
+    sqlStatement.append(`;`);
+
+    return sqlStatement;
+  }
+
+  /**
+   * Build the shared active-feature and indexed-property CTEs used by the list and count queries.
+   *
+   * This is the only source of property values for this read path: it unions the typed/indexed property
+   * tables and artifact links, filters the root feature and feature-valued references to active
+   * `submission_feature` records, and intentionally does not read `submission_feature.data`.
+   *
+   * @param {number} submissionFeatureId The submission feature whose canonical indexed properties are being read.
+   * @param {string} [normalizedSearch] Optional trimmed/lowercase search term to apply to property names and values.
+   * @returns {SQLStatement} SQL statement prefix ending at the `filtered_property_rows` CTE.
+   * @memberof SubmissionFeaturePropertyRepository
+   */
+  private _getSubmissionFeaturePropertiesBaseQuery(
+    submissionFeatureId: number,
+    normalizedSearch?: string
+  ): SQLStatement {
+    const sqlStatement = SQL``;
+
+    sqlStatement.append(`
+      WITH active_feature AS (
+        SELECT sf.submission_feature_id, sf.feature_type_id
+        FROM submission_feature sf
+        WHERE sf.submission_feature_id = `);
+    sqlStatement.append(SQL`${submissionFeatureId}`);
+    sqlStatement.append(`
+          AND ${isSubmissionFeatureActive('sf')}
+      ),
+      property_rows AS (
+        SELECT
+          'string:' || p.submission_feature_property_string_id::text AS id,
+          fp.display_name AS property,
+          p.value::text AS value,
+          ftp.sort
+        FROM submission_feature_property_string p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+
+        UNION ALL
+
+        SELECT
+          'number:' || p.submission_feature_property_number_id::text AS id,
+          fp.display_name AS property,
+          p.value::text AS value,
+          ftp.sort
+        FROM submission_feature_property_number p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+
+        UNION ALL
+
+        SELECT
+          'boolean:' || p.submission_feature_property_boolean_id::text AS id,
+          fp.display_name AS property,
+          p.value::text AS value,
+          ftp.sort
+        FROM submission_feature_property_boolean p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+
+        UNION ALL
+
+        SELECT
+          'timestamp:' || p.submission_feature_property_timestamp_id::text AS id,
+          fp.display_name AS property,
+          COALESCE(
+            CASE
+              WHEN p.date_value IS NOT NULL AND p.time_value IS NOT NULL
+                THEN to_char(p.date_value, 'YYYY-MM-DD') || 'T' || to_char(p.time_value, 'HH24:MI:SS')
+              WHEN p.date_value IS NOT NULL THEN to_char(p.date_value, 'YYYY-MM-DD')
+              ELSE to_char(p.time_value, 'HH24:MI:SS')
+            END,
+            ''
+          ) AS value,
+          ftp.sort
+        FROM submission_feature_property_timestamp p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+
+        UNION ALL
+
+        SELECT
+          'code:' || p.submission_feature_property_code_id::text AS id,
+          fp.display_name AS property,
+          ccc.label::text AS value,
+          ftp.sort
+        FROM submission_feature_property_code p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+        JOIN contributor_codeset_code ccc
+          ON ccc.contributor_codeset_code_id = p.contributor_codeset_code_id
+         AND ccc.record_end_date IS NULL
+
+        UNION ALL
+
+        SELECT
+          'taxon:' || p.submission_feature_property_taxon_id::text AS id,
+          fp.display_name AS property,
+          COALESCE(t.itis_scientific_name, t.common_name, t.bc_taxon_code, t.itis_tsn::text) AS value,
+          ftp.sort
+        FROM submission_feature_property_taxon p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+        JOIN taxon t
+          ON t.taxon_id = p.taxon_id
+         AND t.record_end_date IS NULL
+
+        UNION ALL
+
+        SELECT
+          'geometry:' || p.submission_feature_property_geometry_id::text AS id,
+          fp.display_name AS property,
+          public.ST_AsGeoJSON(p.value)::text AS value,
+          ftp.sort
+        FROM submission_feature_property_geometry p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+
+        UNION ALL
+
+        SELECT
+          'feature:' || p.submission_feature_property_feature_id::text AS id,
+          fp.display_name AS property,
+          referenced_sf.urn::text AS value,
+          ftp.sort
+        FROM submission_feature_property_feature p
+        JOIN active_feature sf ON sf.submission_feature_id = p.submission_feature_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = p.feature_type_property_id
+         AND ftp.feature_type_id = sf.feature_type_id
+         AND ftp.record_end_date IS NULL
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+         AND fp.record_end_date IS NULL
+        JOIN submission_feature referenced_sf
+          ON referenced_sf.submission_feature_id = p.referenced_submission_feature_id
+         AND ${isSubmissionFeatureActive('referenced_sf')}
+
+        UNION ALL
+
+        SELECT
+          'artifact_key:' || sfa.submission_feature_artifact_id::text AS id,
+          fp.display_name AS property,
+          a.object_key::text AS value,
+          ftp.sort
+        FROM submission_feature_artifact sfa
+        JOIN active_feature sf ON sf.submission_feature_id = sfa.submission_feature_id
+        JOIN artifact a ON a.artifact_id = sfa.artifact_id
+        JOIN (
+          SELECT
+            ftp.feature_type_id,
+            MIN(ftp.feature_type_property_id) AS feature_type_property_id
+          FROM feature_type_property ftp
+          JOIN feature_property fp
+            ON fp.feature_property_id = ftp.feature_property_id
+           AND fp.record_end_date IS NULL
+          JOIN feature_property_type fpt
+            ON fpt.feature_property_type_id = fp.feature_property_type_id
+           AND fpt.name = 'artifact_key'
+           AND fpt.record_end_date IS NULL
+          WHERE ftp.record_end_date IS NULL
+          GROUP BY ftp.feature_type_id
+          HAVING COUNT(*) = 1
+        ) artifact_ftp
+          ON artifact_ftp.feature_type_id = sf.feature_type_id
+        JOIN feature_type_property ftp
+          ON ftp.feature_type_property_id = artifact_ftp.feature_type_property_id
+        JOIN feature_property fp
+          ON fp.feature_property_id = ftp.feature_property_id
+      ),
+      filtered_property_rows AS (
+        SELECT id, property, value, sort
+        FROM property_rows
+    `);
+
+    if (normalizedSearch) {
+      sqlStatement.append(SQL`
+        WHERE (
+          LOWER(property) LIKE ${`%${normalizedSearch}%`}
+          OR LOWER(value) LIKE ${`%${normalizedSearch}%`}
+        )
+      `);
+    }
+
+    sqlStatement.append(`
+      )
+    `);
+
+    return sqlStatement;
+  }
+}

--- a/api/src/repositories/submission-feature-property-repository.ts
+++ b/api/src/repositories/submission-feature-property-repository.ts
@@ -103,7 +103,7 @@ export class SubmissionFeaturePropertyRepository extends BaseRepository {
       property: 'property',
       value: 'value'
     };
-    const resolvedSort = pagination.sort ? (sortColumnMap[pagination.sort] ?? 'property') : 'property';
+    const resolvedSort = pagination.sort ? sortColumnMap[pagination.sort] ?? 'property' : 'property';
     const resolvedOrder = pagination.order === 'desc' ? 'desc' : 'asc';
     const limit = pagination.limit ?? 25;
     const page = pagination.page ?? 1;

--- a/api/src/repositories/submission-feature-property-repository.ts
+++ b/api/src/repositories/submission-feature-property-repository.ts
@@ -85,6 +85,7 @@ export class SubmissionFeaturePropertyRepository extends BaseRepository {
    * Build the paginated list query for `getSubmissionFeatureProperties`.
    *
    * Sort columns are constrained to the projected read-model fields before being appended as raw SQL.
+   * When no public sort is requested, the feature-type-property `sort` column drives the default order.
    * Limit and offset remain parameterized.
    *
    * @param {number} submissionFeatureId The submission feature whose indexed properties are being listed.
@@ -98,29 +99,43 @@ export class SubmissionFeaturePropertyRepository extends BaseRepository {
     normalizedSearch: string | undefined,
     pagination: ApiPaginationOptions
   ): SQLStatement {
-    const sortColumnMap: Record<string, 'id' | 'property' | 'value'> = {
-      id: 'id',
-      property: 'property',
-      value: 'value'
-    };
-    const resolvedSort = pagination.sort ? sortColumnMap[pagination.sort] ?? 'property' : 'property';
-    const resolvedOrder = pagination.order === 'desc' ? 'desc' : 'asc';
-    const limit = pagination.limit ?? 25;
-    const page = pagination.page ?? 1;
-    const offset = (page - 1) * limit;
-
     const sqlStatement = this._getSubmissionFeaturePropertiesBaseQuery(submissionFeatureId, normalizedSearch);
     sqlStatement.append(`
       SELECT id, property, value
       FROM filtered_property_rows
-      ORDER BY ${resolvedSort} ${resolvedOrder}, id ASC
-      LIMIT `);
+    `);
+    this.applySortingAndPagination(sqlStatement, pagination);
+
+    return sqlStatement;
+  }
+
+  /**
+   * Append sorting and pagination to the submission-feature property list query.
+   *
+   * Public sort requests may only target returned fields. The internal `sort`
+   * column from `feature_type_property` is reserved for the default display order.
+   *
+   * @param {SQLStatement} sqlStatement Query being built.
+   * @param {ApiPaginationOptions} pagination Pagination and sort options from the request.
+   */
+  private applySortingAndPagination(sqlStatement: SQLStatement, pagination: ApiPaginationOptions): void {
+    const publicSortColumn =
+      pagination.sort === 'id' || pagination.sort === 'property' || pagination.sort === 'value'
+        ? pagination.sort
+        : undefined;
+    const resolvedOrder = pagination.order === 'desc' ? 'desc' : 'asc';
+    const limit = pagination.limit ?? 25;
+    const page = pagination.page ?? 1;
+    const offset = (page - 1) * limit;
+    const primaryOrderBy = publicSortColumn
+      ? `${publicSortColumn} ${resolvedOrder}`
+      : `sort ${resolvedOrder} NULLS LAST`;
+
+    sqlStatement.append(`ORDER BY ${primaryOrderBy}, property ASC, value ASC, id ASC LIMIT `);
     sqlStatement.append(SQL`${limit}`);
     sqlStatement.append(` OFFSET `);
     sqlStatement.append(SQL`${offset}`);
     sqlStatement.append(`;`);
-
-    return sqlStatement;
   }
 
   /**
@@ -311,7 +326,9 @@ export class SubmissionFeaturePropertyRepository extends BaseRepository {
           ftp.sort
         FROM submission_feature_artifact sfa
         JOIN active_feature sf ON sf.submission_feature_id = sfa.submission_feature_id
-        JOIN artifact a ON a.artifact_id = sfa.artifact_id
+        JOIN artifact a
+          ON a.artifact_id = sfa.artifact_id
+         AND a.artifact_status = 'uploaded'
         JOIN (
           SELECT
             ftp.feature_type_id,

--- a/api/src/repositories/submission-feature-repository.ts
+++ b/api/src/repositories/submission-feature-repository.ts
@@ -210,5 +210,4 @@ export class SubmissionFeatureRepository extends BaseRepository {
     const response = await this.connection.sql(sqlStatement, RelatedSubmissionFeature);
     return response.rows;
   }
-
 }

--- a/api/src/repositories/submission-feature-repository.ts
+++ b/api/src/repositories/submission-feature-repository.ts
@@ -1,11 +1,7 @@
-import SQL, { SQLStatement } from 'sql-template-strings';
-import { z } from 'zod';
-import { getKnex } from '../database/db';
+import SQL from 'sql-template-strings';
 import { ApiExecuteSQLError } from '../errors/api-error';
-import { SubmissionFeatureProperty } from '../models/feature-property';
-import { SubmissionFeaturePropertyFilters } from '../models/submission-feature';
-import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
+import { isSubmissionFeatureActive } from './sql-fragments';
 import { RelatedSubmissionFeature, SubmissionFeature, SubmissionFeatureRecord } from './submission-repository';
 
 /**
@@ -119,8 +115,9 @@ export class SubmissionFeatureRepository extends BaseRepository {
       FROM
         submission_feature
       WHERE
-        uuid = ${submissionUuid};
+        uuid = ${submissionUuid}
     `;
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('submission_feature')};`);
 
     const response = await this.connection.sql(sqlStatement, SubmissionFeatureRecord);
 
@@ -168,8 +165,9 @@ export class SubmissionFeatureRepository extends BaseRepository {
       JOIN
         submission s ON s.submission_id = sf.submission_id
       WHERE
-        sf.submission_feature_id = ${submissionFeatureId};
+        sf.submission_feature_id = ${submissionFeatureId}
     `;
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('sf')};`);
 
     const response = await this.connection.sql(sqlStatement, SubmissionFeature);
 
@@ -205,120 +203,12 @@ export class SubmissionFeatureRepository extends BaseRepository {
         UNION
         SELECT target_feature_id FROM submission_feature_feature
         WHERE source_feature_id = ${submissionFeatureId}
-      );
+      )
     `;
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('sf')};`);
 
     const response = await this.connection.sql(sqlStatement, RelatedSubmissionFeature);
     return response.rows;
   }
 
-  /**
-   * Get paginated and sorted properties for a single submission feature.
-   *
-   * @param {number} submissionFeatureId
-   * @param {ApiPaginationOptions} pagination
-   * @param {SubmissionFeaturePropertyFilters} [filters]
-   * @returns {Promise<SubmissionFeatureProperty[]>}
-   * @memberof SubmissionFeatureRepository
-   */
-  async getSubmissionFeatureProperties(
-    submissionFeatureId: number,
-    pagination: ApiPaginationOptions,
-    filters?: SubmissionFeaturePropertyFilters
-  ): Promise<SubmissionFeatureProperty[]> {
-    const knex = getKnex();
-    const normalizedSearch = filters?.search?.trim().toLowerCase();
-
-    const sortColumnMap: Record<string, 'id' | 'property' | 'value'> = {
-      id: 'id',
-      property: 'property',
-      value: 'value'
-    };
-
-    const requestedSort = pagination.sort ? sortColumnMap[pagination.sort] : undefined;
-    const resolvedSort = requestedSort ?? 'property';
-    const resolvedOrder = pagination.order === 'desc' ? 'desc' : 'asc';
-
-    const queryBuilder = knex('submission_feature as sf')
-      .where('sf.submission_feature_id', submissionFeatureId)
-      .crossJoin(knex.raw(`LATERAL jsonb_each_text(COALESCE(sf.data, '{}'::jsonb)) AS prop(key, value)`))
-      .select([
-        knex.raw('prop.key AS id'),
-        knex.raw(`REPLACE(prop.key, '_', ' ') AS property`),
-        knex.raw('prop.value AS value')
-      ]);
-
-    if (normalizedSearch) {
-      queryBuilder.andWhere(function () {
-        this.whereRaw(`LOWER(REPLACE(prop.key, '_', ' ')) LIKE ?`, [`%${normalizedSearch}%`]).orWhereRaw(
-          `LOWER(prop.value) LIKE ?`,
-          [`%${normalizedSearch}%`]
-        );
-      });
-    }
-
-    this.applyPagination(queryBuilder, {
-      ...pagination,
-      sort: resolvedSort,
-      order: resolvedOrder
-    });
-
-    const response = await this.connection.knex(queryBuilder, SubmissionFeatureProperty);
-
-    return response.rows;
-  }
-
-  /**
-   * Count properties for a single submission feature with optional server-side search.
-   *
-   * @param {number} submissionFeatureId
-   * @param {SubmissionFeaturePropertyFilters} [filters]
-   * @returns {Promise<number>}
-   * @memberof SubmissionFeatureRepository
-   */
-  async getSubmissionFeaturePropertiesCount(
-    submissionFeatureId: number,
-    filters?: SubmissionFeaturePropertyFilters
-  ): Promise<number> {
-    const normalizedSearch = filters?.search?.trim().toLowerCase();
-    const sqlStatement = this._getSubmissionFeaturePropertiesCountQuery(submissionFeatureId, normalizedSearch);
-    const response = await this.connection.sql(sqlStatement, z.object({ count: z.number() }));
-
-    if (!response.rowCount) {
-      return 0;
-    }
-
-    return response.rows[0].count;
-  }
-
-  /**
-   * Build SQL to count submission feature properties with optional normalized search.
-   *
-   * @param {number} submissionFeatureId
-   * @param {string} [normalizedSearch]
-   * @returns {SQLStatement}
-   * @memberof SubmissionFeatureRepository
-   */
-  private _getSubmissionFeaturePropertiesCountQuery(
-    submissionFeatureId: number,
-    normalizedSearch?: string
-  ): SQLStatement {
-    const sqlStatement = SQL`
-      SELECT COUNT(*)::int AS count
-      FROM submission_feature sf
-      CROSS JOIN LATERAL jsonb_each_text(COALESCE(sf.data, '{}'::jsonb)) AS prop(key, value)
-      WHERE sf.submission_feature_id = ${submissionFeatureId}
-    `;
-
-    if (normalizedSearch) {
-      sqlStatement.append(SQL`
-        AND (
-          LOWER(REPLACE(prop.key, '_', ' ')) LIKE ${`%${normalizedSearch}%`}
-          OR LOWER(prop.value) LIKE ${`%${normalizedSearch}%`}
-        )
-      `);
-    }
-
-    return sqlStatement;
-  }
 }

--- a/api/src/repositories/submission-repository.ts
+++ b/api/src/repositories/submission-repository.ts
@@ -8,6 +8,7 @@ import { SubmissionFeatureFilters } from '../models/submission-feature';
 import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { BaseRepository } from './base-repository';
 import { SECURITY_APPLIED_STATUS } from './security-repository';
+import { isSubmissionFeatureActive } from './sql-fragments';
 
 export interface ISubmissionFeature {
   id: string | null;
@@ -1122,6 +1123,9 @@ export class SubmissionRepository extends BaseRepository {
         submission_feature_security.status = 'active'
       WHERE
         submission_id = ${submissionId}
+    `;
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('submission_feature')}`);
+    sqlStatement.append(`
       GROUP BY
         submission_feature.submission_feature_id,
         feature_type.name,
@@ -1129,7 +1133,7 @@ export class SubmissionRepository extends BaseRepository {
         feature_type.sort
       ORDER BY
         feature_type.sort ASC;
-    `;
+    `);
 
     const response = await this.connection.sql(sqlStatement, SubmissionFeatureRecordWithTypeAndSecurity);
     return response.rows;
@@ -1689,8 +1693,9 @@ export class SubmissionRepository extends BaseRepository {
       WHERE
         submission_id = ${submissionId}
       and
-        parent_submission_feature_id is null;
+        parent_submission_feature_id is null
     `;
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('submission_feature')};`);
 
     const response = await this.connection.sql(sqlStatement, SubmissionFeatureRecord);
 
@@ -1735,6 +1740,9 @@ export class SubmissionRepository extends BaseRepository {
         parent_submission_feature_id IS null
       AND
         s.submission_id = ${submissionId}
+    `;
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('sf')}`);
+    sqlStatement.append(SQL`
 
       UNION ALL
 
@@ -1757,6 +1765,9 @@ export class SubmissionRepository extends BaseRepository {
       ft.feature_type_id = sf.feature_type_id
       where
         sf.submission_id = ${submissionId}
+    `);
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('sf')}`);
+    sqlStatement.append(SQL`
     )
     SELECT
       w_submission_feature.submission_feature_id,
@@ -1775,7 +1786,7 @@ export class SubmissionRepository extends BaseRepository {
     ORDER BY
       level,
       submission_feature_id;
-    `;
+    `);
 
     const response = await this.connection.sql(sqlStatement, SubmissionFeatureDownloadRecord);
 
@@ -1826,6 +1837,9 @@ export class SubmissionRepository extends BaseRepository {
         parent_submission_feature_id IS null
       AND
         s.submission_id = ${submissionId}
+    `;
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('sf')}`);
+    sqlStatement.append(SQL`
       AND sfs.submission_feature_security_id IS NULL
 
       UNION ALL
@@ -1855,6 +1869,9 @@ export class SubmissionRepository extends BaseRepository {
         sfs.status = 'active'
       WHERE
         sf.submission_id = ${submissionId}
+    `);
+    sqlStatement.append(` AND ${isSubmissionFeatureActive('sf')}`);
+    sqlStatement.append(SQL`
       AND sfs.submission_feature_security_id IS NULL
     )
     SELECT
@@ -1874,7 +1891,7 @@ export class SubmissionRepository extends BaseRepository {
     ORDER BY
       level,
       submission_feature_id;
-    `;
+    `);
 
     const response = await this.connection.sql(sqlStatement, SubmissionFeatureDownloadRecord);
 
@@ -1913,7 +1930,8 @@ export class SubmissionRepository extends BaseRepository {
       `)
       )
       .leftJoin('feature_type', 'feature_type.feature_type_id', 'submission_feature.feature_type_id')
-      .where('submission_feature.submission_id', submissionId);
+      .where('submission_feature.submission_id', submissionId)
+      .whereRaw(isSubmissionFeatureActive('submission_feature'));
 
     const normalizedSearch = filters?.search?.trim().toLowerCase();
     if (normalizedSearch) {

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -389,9 +389,9 @@ export class DownloadPipelineService extends DBService {
    * Fetches values from typed `submission_feature_property_*` tables via the
    * repository, then assembles them into `ParquetFeatureData` records.
    *
-   * Properties without typed tables (array, object, artifact_key) fall back to
-   * `submission_feature.data.properties` — these types have dynamic internal
-   * structure that can't be represented as a single typed value.
+   * Properties without indexed storage are emitted as null. The hydrator must
+   * not read `submission_feature.data`; that JSONB is pre-indexing input and
+   * can differ from the canonical indexed values.
    *
    * @param {BaseFeatureRow[]} baseBatch - Base feature rows from a cursor stream.
    * @param {CsvPropertyDefinition[]} properties - Schema property definitions.
@@ -402,12 +402,11 @@ export class DownloadPipelineService extends DBService {
     baseBatch: BaseFeatureRow[],
     properties: CsvPropertyDefinition[]
   ): Promise<ParquetFeatureData[]> {
-    // Types that live in the JSONB blob rather than typed tables
-    const JSONB_FALLBACK_TYPES = new Set(['array', 'object', 'artifact_key']);
+    const unsupportedPropertyTypes = new Set(['array', 'object']);
 
     // Determine which typed tables need querying
     const typedPropertyTypes = [
-      ...new Set(properties.map((p) => p.feature_property_type_name).filter((t) => !JSONB_FALLBACK_TYPES.has(t)))
+      ...new Set(properties.map((p) => p.feature_property_type_name).filter((t) => !unsupportedPropertyTypes.has(t)))
     ];
 
     const submissionFeatureIds = baseBatch.map((row) => row.submission_feature_id);
@@ -435,9 +434,8 @@ export class DownloadPipelineService extends DBService {
       for (const prop of properties) {
         const propName = prop.feature_property_name;
 
-        if (JSONB_FALLBACK_TYPES.has(prop.feature_property_type_name)) {
-          // Array/object/artifact_key: fall back to JSONB data.properties
-          data[propName] = baseRow.data?.properties?.[propName] ?? null;
+        if (unsupportedPropertyTypes.has(prop.feature_property_type_name)) {
+          data[propName] = null;
         } else if (prop.feature_property_type_name === 'datetime') {
           // `datetime` properties are projected as two synthetic rows by
           // `fetchTypedPropertyRows` with suffixed `name` values

--- a/api/src/services/submission-feature-property-service.ts
+++ b/api/src/services/submission-feature-property-service.ts
@@ -1,0 +1,44 @@
+import { IDBConnection } from '../database/db';
+import { SubmissionFeatureProperty } from '../models/feature-property';
+import { SubmissionFeaturePropertyFilters } from '../models/submission-feature';
+import { SubmissionFeaturePropertyRepository } from '../repositories/submission-feature-property-repository';
+import { ApiPaginationOptions } from '../zod-schema/pagination';
+import { DBService } from './db-service';
+
+/**
+ * Service for reading canonical indexed properties attached to submission features.
+ *
+ * @export
+ * @class SubmissionFeaturePropertyService
+ * @extends {DBService}
+ */
+export class SubmissionFeaturePropertyService extends DBService {
+  submissionFeaturePropertyRepository: SubmissionFeaturePropertyRepository;
+
+  constructor(connection: IDBConnection) {
+    super(connection);
+    this.submissionFeaturePropertyRepository = new SubmissionFeaturePropertyRepository(connection);
+  }
+
+  /**
+   * Get paginated, searchable feature properties for a single active submission feature.
+   *
+   * @param {number} submissionFeatureId
+   * @param {ApiPaginationOptions} pagination
+   * @param {SubmissionFeaturePropertyFilters} [filters]
+   * @returns {Promise<{ properties: SubmissionFeatureProperty[]; total: number }>}
+   * @memberof SubmissionFeaturePropertyService
+   */
+  async getSubmissionFeatureProperties(
+    submissionFeatureId: number,
+    pagination: ApiPaginationOptions,
+    filters?: SubmissionFeaturePropertyFilters
+  ): Promise<{ properties: SubmissionFeatureProperty[]; total: number }> {
+    const [properties, total] = await Promise.all([
+      this.submissionFeaturePropertyRepository.getSubmissionFeatureProperties(submissionFeatureId, pagination, filters),
+      this.submissionFeaturePropertyRepository.getSubmissionFeaturePropertiesCount(submissionFeatureId, filters)
+    ]);
+
+    return { properties, total };
+  }
+}

--- a/api/src/services/submission-feature-service.ts
+++ b/api/src/services/submission-feature-service.ts
@@ -1,13 +1,10 @@
 import { IDBConnection } from '../database/db';
-import { SubmissionFeatureProperty } from '../models/feature-property';
-import { SubmissionFeaturePropertyFilters } from '../models/submission-feature';
 import { SubmissionFeatureRepository } from '../repositories/submission-feature-repository';
 import {
   RelatedSubmissionFeature,
   SubmissionFeature,
   SubmissionFeatureRecord
 } from '../repositories/submission-repository';
-import { ApiPaginationOptions } from '../zod-schema/pagination';
 import { DBService } from './db-service';
 
 /**
@@ -89,27 +86,5 @@ export class SubmissionFeatureService extends DBService {
    */
   async getRelatedSubmissionFeatures(submissionFeatureId: number): Promise<RelatedSubmissionFeature[]> {
     return this.submissionFeatureRepository.getRelatedSubmissionFeatures(submissionFeatureId);
-  }
-
-  /**
-   * Get paginated, searchable feature properties for a single submission feature.
-   *
-   * @param {number} submissionFeatureId
-   * @param {ApiPaginationOptions} pagination
-   * @param {SubmissionFeaturePropertyFilters} [filters]
-   * @returns {Promise<{ properties: SubmissionFeatureProperty[]; total: number }>}
-   * @memberof SubmissionFeatureService
-   */
-  async getSubmissionFeatureProperties(
-    submissionFeatureId: number,
-    pagination: ApiPaginationOptions,
-    filters?: SubmissionFeaturePropertyFilters
-  ): Promise<{ properties: SubmissionFeatureProperty[]; total: number }> {
-    const [properties, total] = await Promise.all([
-      this.submissionFeatureRepository.getSubmissionFeatureProperties(submissionFeatureId, pagination, filters),
-      this.submissionFeatureRepository.getSubmissionFeaturePropertiesCount(submissionFeatureId, filters)
-    ]);
-
-    return { properties, total };
   }
 }


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1080

## Description of Changes

- Improves feature visibility controls so not-yet-active features stay hidden from regular users in search, downloads, and security-sensitive paths.
- Keeps draft/pending features flowing through backend processing, including closure calculation, so they are ready when published.
- Excludes only actually deleted features from closure processing.
- Improves security behavior by relying on precomputed closure data for access checks and failing closed when closure data is missing.
- Makes artifact-key handling more deterministic by avoiding ambiguous mappings when multiple artifact-key properties exist.
- Consolidates active-feature SQL filtering in shared repository helpers to reduce inconsistent visibility behavior.
- Preserves existing migration history; no migration changes are included in this branch.

## Testing Notes

- Submit a tarball
- Confirm that it succeeded
- Confirm that you cannot see the tarball's features as search results
- Approve the submission
- Confirm that you *can* see the tarball's features