### PR TITLE
SIMSBIOHUB-1064: Allow access to route for secured features

### DIFF
--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/index.test.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/index.test.ts
@@ -94,5 +94,30 @@ describe('index', () => {
       expect(mockRes.statusValue).to.eql(200);
       expect(mockRes.jsonValue).to.eql({ feature: mockFeature, relatedFeatures: mockRelatedFeatures });
     });
+
+    it('uses the API user connection for anonymous (no token) requests', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      const getAPIUserDBConnectionStub = sinon
+        .stub(db.dbDependencies, 'getAPIUserDBConnection')
+        .returns(dbConnectionObj);
+      const getDBConnectionStub = sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon.stub(SubmissionFeatureService.prototype, 'getSubmissionFeatureById').resolves({} as SubmissionFeature);
+      sinon.stub(SubmissionFeatureService.prototype, 'getRelatedSubmissionFeatures').resolves([]);
+
+      const requestHandler = index.getSubmissionFeatureById();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      // No keycloak_token on the request => anonymous caller reading an unsecured feature.
+      mockReq.params = {
+        submissionFeatureId: '1'
+      };
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(getAPIUserDBConnectionStub).to.have.been.calledOnce;
+      expect(getDBConnectionStub).to.not.have.been.called;
+      expect(mockRes.statusValue).to.eql(200);
+    });
   });
 });

--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/index.ts
@@ -14,8 +14,7 @@ export const GET: Operation = [
     return {
       and: [
         {
-          discriminator: 'Team',
-          entity: 'submission_feature',
+          discriminator: 'Policy',
           submissionFeatureId: Number(req.params.submissionFeatureId),
           submissionId: Number(req.params.submissionId)
         }

--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/index.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/index.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
-import { getDBConnection } from '../../../../../database/db';
+import { getAPIUserDBConnection, getDBConnection } from '../../../../../database/db';
 import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
 import { authorizeRequestHandler } from '../../../../../request-handlers/security/authorization';
 import { GetSubmissionFeatureSchema } from '../../../../../schemas/submission-feature';
@@ -75,7 +75,10 @@ GET.apiDoc = {
  */
 export function getSubmissionFeatureById(): RequestHandler {
   return async (req, res) => {
-    const connection = getDBConnection(req.keycloak_token);
+    // Unsecured features are readable anonymously (see the closure-based authorization rule on this
+    // route); fall back to the API user connection when there is no keycloak token, mirroring the
+    // feature list endpoint.
+    const connection = req.keycloak_token ? getDBConnection(req.keycloak_token) : getAPIUserDBConnection();
 
     const submissionFeatureId = Number(req.params.submissionFeatureId);
 

--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.test.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.test.ts
@@ -85,5 +85,33 @@ describe('properties index', () => {
       ]);
       expect(mockRes.jsonValue.pagination.total).to.equal(2);
     });
+
+    it('uses the API user connection for anonymous (no token) requests', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      const getAPIUserDBConnectionStub = sinon
+        .stub(db.dbDependencies, 'getAPIUserDBConnection')
+        .returns(dbConnectionObj);
+      const getDBConnectionStub = sinon.stub(db.dbDependencies, 'getDBConnection').returns(dbConnectionObj);
+
+      sinon
+        .stub(SubmissionFeaturePropertyService.prototype, 'getSubmissionFeatureProperties')
+        .resolves({ properties: [], total: 0 });
+
+      const requestHandler = index.getSubmissionFeatureProperties();
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+
+      // No keycloak_token on the request => anonymous caller reading an unsecured feature.
+      mockReq.params = {
+        submissionId: '1',
+        submissionFeatureId: '10'
+      };
+      mockReq.query = { page: '1', limit: '10' };
+
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(getAPIUserDBConnectionStub).to.have.been.calledOnce;
+      expect(getDBConnectionStub).to.not.have.been.called;
+      expect(mockRes.statusValue).to.equal(200);
+    });
   });
 });

--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.ts
@@ -19,8 +19,7 @@ export const GET: Operation = [
     return {
       and: [
         {
-          discriminator: 'Team',
-          entity: 'submission_feature',
+          discriminator: 'Policy',
           submissionFeatureId: Number(req.params.submissionFeatureId),
           submissionId: Number(req.params.submissionId)
         }

--- a/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.ts
+++ b/api/src/paths/submission/{submissionId}/features/{submissionFeatureId}/properties/index.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
-import { getDBConnection } from '../../../../../../database/db';
+import { getAPIUserDBConnection, getDBConnection } from '../../../../../../database/db';
 import { SubmissionFeaturePropertyFilters } from '../../../../../../models/submission-feature';
 import { defaultErrorResponses } from '../../../../../../openapi/schemas/http-responses';
 import {
@@ -110,7 +110,10 @@ GET.apiDoc = {
  */
 export function getSubmissionFeatureProperties(): RequestHandler {
   return async (req, res) => {
-    const connection = getDBConnection(req.keycloak_token);
+    // Unsecured features are readable anonymously (see the closure-based authorization rule on this
+    // route); fall back to the API user connection when there is no keycloak token, mirroring the
+    // feature list endpoint.
+    const connection = req.keycloak_token ? getDBConnection(req.keycloak_token) : getAPIUserDBConnection();
     const submissionFeatureId = Number(req.params.submissionFeatureId);
     const pagination = makePaginationOptionsFromRequest(req);
     const filters = { search: req.query.search } as SubmissionFeaturePropertyFilters;

--- a/api/src/repositories/authorization/team-authorization-repository.test.ts
+++ b/api/src/repositories/authorization/team-authorization-repository.test.ts
@@ -129,5 +129,25 @@ describe('TeamAuthorizationRepository', () => {
       const repository = new TeamAuthorizationRepository(mockConnection);
       await repository.isSubmissionFeatureAccessibleToUser(1, 100, 200);
     });
+
+    it('applies the unsecured-only filter for anonymous users (no scope-anchor grant branch)', async () => {
+      const mockConnection = getMockDBConnection({
+        knex: async (query: any) => {
+          const sql = query.toSQL().sql.toLowerCase();
+          // still scoped and active-gated
+          expect(sql).to.include('"sf"."submission_id" = ?');
+          expect(sql).to.include('record_effective_date');
+          // anonymous: unsecured-only — closure ancestry walk, but no scope-anchor grant branch
+          expect(sql).to.include('submission_feature_closure');
+          expect(sql).to.not.include('security_scope_anchor');
+          return { rowCount: 1, rows: [{ '1': 1 }] } as unknown as QueryResult<any>;
+        }
+      });
+
+      const repository = new TeamAuthorizationRepository(mockConnection);
+      const result = await repository.isSubmissionFeatureAccessibleToUser(null, 100, 200);
+
+      expect(result).to.be.true;
+    });
   });
 });

--- a/api/src/repositories/authorization/team-authorization-repository.ts
+++ b/api/src/repositories/authorization/team-authorization-repository.ts
@@ -1,7 +1,7 @@
 import { getKnex } from '../../database/db';
 import { DataRequestRecord, TicketRecord } from '../../models/team-authorization';
 import { BaseRepository } from '../base-repository';
-import { isAccessibleToUser, isSubmissionFeatureActive } from '../sql-fragments';
+import { buildSecurityFilter, isSubmissionFeatureActive } from '../sql-fragments';
 
 /**
  * A repository class for team-scoped authorization queries.
@@ -70,19 +70,24 @@ export class TeamAuthorizationRepository extends BaseRepository {
 
   /**
    * Determine whether a submission feature is accessible to a user, using the same
-   * ancestry-aware, closure-based check as the search/download read paths
-   * (`isAccessibleToUser`): a feature is accessible when it is not effectively secured,
-   * or the user's team holds a security scope anchored on the feature or any of its
-   * ancestors. Only active features that belong to the given submission are considered.
+   * ancestry-aware, closure-based check as the search/download read paths: a feature is
+   * accessible when it is live (past its effective date and not ended) AND either it is not
+   * effectively secured (open to authenticated and anonymous users), or the user's team holds
+   * a security scope anchored on the feature or one of its ancestors.
    *
-   * @param {number} systemUserId
+   * Reuses `buildSecurityFilter` so feature-detail authorization matches search results exactly:
+   * a secured descendant of an accessible ancestor is granted, a secured feature under a parent
+   * the user cannot reach is denied, and (for `systemUserId === null`) anonymous users may still
+   * read unsecured features. Only features that belong to the given submission are considered.
+   *
+   * @param {number | null} systemUserId The authenticated user's id, or `null` for anonymous.
    * @param {number} submissionFeatureId
    * @param {number} submissionId The submission the feature must belong to.
-   * @return {Promise<boolean>}
+   * @return {Promise<boolean>} `true` if the feature is accessible to the user.
    * @memberof TeamAuthorizationRepository
    */
   async isSubmissionFeatureAccessibleToUser(
-    systemUserId: number,
+    systemUserId: number | null,
     submissionFeatureId: number,
     submissionId: number
   ): Promise<boolean> {
@@ -93,9 +98,15 @@ export class TeamAuthorizationRepository extends BaseRepository {
       .from('submission_feature as sf')
       .where('sf.submission_feature_id', submissionFeatureId)
       .where('sf.submission_id', submissionId)
+      // not-yet-effective / ended → forbidden
       .whereRaw(isSubmissionFeatureActive('sf'))
-      .whereRaw(isAccessibleToUser('sf.submission_feature_id'), [systemUserId])
       .limit(1);
+
+    // Pass `null` (not `undefined`) for anonymous so the unsecured-only filter is applied.
+    const securityFilter = buildSecurityFilter(knex, systemUserId, 'sf.submission_feature_id');
+    if (securityFilter) {
+      query.whereRaw(securityFilter);
+    }
 
     const response = await this.connection.knex(query);
     return response.rowCount === 1;

--- a/api/src/services/authorization/authorization-service.test.ts
+++ b/api/src/services/authorization/authorization-service.test.ts
@@ -93,6 +93,11 @@ describe('executeAuthorizeConfig', function () {
       },
       {
         discriminator: 'Contributor'
+      },
+      {
+        discriminator: 'Policy',
+        submissionFeatureId: 1,
+        submissionId: 2
       }
     ];
     const mockDBConnection = getMockDBConnection();
@@ -100,12 +105,13 @@ describe('executeAuthorizeConfig', function () {
     sinon.stub(AuthorizationService.prototype, 'authorizeBySystemRole').resolves(false);
     sinon.stub(AuthorizationService.prototype, 'authorizeBySystemUser').resolves(true);
     sinon.stub(AuthorizationService.prototype, 'authorizeByContributor').resolves(true);
+    sinon.stub(AuthorizationService.prototype, 'authorizeByPolicy').resolves(true);
 
     const authorizationService = new AuthorizationService(mockDBConnection);
 
     const authorizeResults = await authorizationService.executeAuthorizeConfig(mockAuthorizeRules);
 
-    expect(authorizeResults).to.eql([false, true, true]);
+    expect(authorizeResults).to.eql([false, true, true, true]);
   });
 });
 
@@ -526,28 +532,85 @@ describe('authorizeByTeam', function () {
 
     expect(result).to.be.false;
   });
+});
 
-  it('allows anonymous users to reach the submission_feature check with a null system user id', async function () {
+describe('authorizeByPolicy', function () {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const systemUser: SystemUser = {
+    system_user_id: 1,
+    user_identity_source_id: 2,
+    user_identifier: 'test-user',
+    user_guid: 'guid-123',
+    record_effective_date: '',
+    record_end_date: '',
+    create_date: '2023-01-01',
+    create_user: 1,
+    update_date: null,
+    update_user: null,
+    revision_count: 0,
+    display_name: null,
+    given_name: null,
+    family_name: null,
+    email: null,
+    agency: null,
+    notes: null
+  };
+
+  it('returns true when the feature is accessible, passing the authenticated user id and entity ids', async function () {
     const mockDBConnection = getMockDBConnection();
-    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(null);
-    const teamStub = sinon.stub(TeamAuthorizationService.prototype, 'isUserAuthorizedForTeamEntity').resolves(true);
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
+    const accessibleStub = sinon
+      .stub(TeamAuthorizationService.prototype, 'isSubmissionFeatureAccessibleToUser')
+      .resolves(true);
 
     const authorizationService = new AuthorizationService(mockDBConnection);
 
-    const result = await authorizationService.authorizeByTeam({
-      discriminator: 'Team',
-      entity: 'submission_feature',
-      submissionFeatureId: 1,
-      submissionId: 1
+    const result = await authorizationService.authorizeByPolicy({
+      discriminator: 'Policy',
+      submissionFeatureId: 2,
+      submissionId: 3
     });
 
     expect(result).to.be.true;
-    expect(teamStub).to.have.been.calledOnceWith(null, {
-      discriminator: 'Team',
-      entity: 'submission_feature',
-      submissionFeatureId: 1,
-      submissionId: 1
+    expect(accessibleStub).to.have.been.calledOnceWith(1, 2, 3);
+  });
+
+  it('returns false when the feature is not accessible to the user', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(systemUser);
+    sinon.stub(TeamAuthorizationService.prototype, 'isSubmissionFeatureAccessibleToUser').resolves(false);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByPolicy({
+      discriminator: 'Policy',
+      submissionFeatureId: 2,
+      submissionId: 3
     });
+
+    expect(result).to.be.false;
+  });
+
+  it('passes a null system user id through for anonymous requests', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(null);
+    const accessibleStub = sinon
+      .stub(TeamAuthorizationService.prototype, 'isSubmissionFeatureAccessibleToUser')
+      .resolves(true);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByPolicy({
+      discriminator: 'Policy',
+      submissionFeatureId: 2,
+      submissionId: 3
+    });
+
+    expect(result).to.be.true;
+    expect(accessibleStub).to.have.been.calledOnceWith(null, 2, 3);
   });
 });
 

--- a/api/src/services/authorization/authorization-service.test.ts
+++ b/api/src/services/authorization/authorization-service.test.ts
@@ -526,6 +526,29 @@ describe('authorizeByTeam', function () {
 
     expect(result).to.be.false;
   });
+
+  it('allows anonymous users to reach the submission_feature check with a null system user id', async function () {
+    const mockDBConnection = getMockDBConnection();
+    sinon.stub(AuthorizationService.prototype, 'getCachedSystemUser').resolves(null);
+    const teamStub = sinon.stub(TeamAuthorizationService.prototype, 'isUserAuthorizedForTeamEntity').resolves(true);
+
+    const authorizationService = new AuthorizationService(mockDBConnection);
+
+    const result = await authorizationService.authorizeByTeam({
+      discriminator: 'Team',
+      entity: 'submission_feature',
+      submissionFeatureId: 1,
+      submissionId: 1
+    });
+
+    expect(result).to.be.true;
+    expect(teamStub).to.have.been.calledOnceWith(null, {
+      discriminator: 'Team',
+      entity: 'submission_feature',
+      submissionFeatureId: 1,
+      submissionId: 1
+    });
+  });
 });
 
 describe('hasAtLeastOneValidValue', () => {

--- a/api/src/services/authorization/authorization-service.ts
+++ b/api/src/services/authorization/authorization-service.ts
@@ -223,11 +223,19 @@ export class AuthorizationService extends DBService {
     }
 
     const user = await this.getCachedSystemUser();
+    const teamAuthorizationService = new TeamAuthorizationService(this.connection);
+
+    // submission_feature supports anonymous access to unsecured features, so allow anonymous
+    // requests to reach the closure-based check with a null system user id.
+    if (authorizeRule.entity === 'submission_feature') {
+      return teamAuthorizationService.isUserAuthorizedForTeamEntity(user?.system_user_id ?? null, authorizeRule);
+    }
+
+    // All other team-scoped entities require an authenticated user.
     if (!user) {
       return false;
     }
 
-    const teamAuthorizationService = new TeamAuthorizationService(this.connection);
     return teamAuthorizationService.isUserAuthorizedForTeamEntity(user.system_user_id, authorizeRule);
   }
 

--- a/api/src/services/authorization/authorization-service.ts
+++ b/api/src/services/authorization/authorization-service.ts
@@ -46,16 +46,27 @@ export type TeamAuthorizationEntity =
   | {
       entity: 'data_request';
       dataRequestId: string;
-    }
-  | {
-      entity: 'submission_feature';
-      submissionFeatureId: number;
-      submissionId: number;
     };
 
 export type AuthorizeByTeam = TeamAuthorizationEntity & {
   discriminator: 'Team';
 };
+
+/**
+ * Authorization rule that checks policy/security-scope access to a submission feature.
+ *
+ * Unlike `Team` (a pure team-membership check), feature access is granted when the feature is open
+ * or when the user has access through the feature's security policy. Anonymous requests are allowed
+ * to reach this check (they can still read unsecured features).
+ *
+ * @export
+ * @interface AuthorizeByPolicy
+ */
+export interface AuthorizeByPolicy {
+  discriminator: 'Policy';
+  submissionFeatureId: number;
+  submissionId: number;
+}
 
 /**
  * Authorization rule that checks if a jwt token maps to a known contributor by client id.
@@ -67,7 +78,12 @@ export interface AuthorizeByContributor {
   discriminator: 'Contributor';
 }
 
-export type AuthorizeRule = AuthorizeBySystemRoles | AuthorizeBySystemUser | AuthorizeByContributor | AuthorizeByTeam;
+export type AuthorizeRule =
+  | AuthorizeBySystemRoles
+  | AuthorizeBySystemUser
+  | AuthorizeByContributor
+  | AuthorizeByTeam
+  | AuthorizeByPolicy;
 
 export type AuthorizeConfigOr = {
   [AuthorizeOperator.AND]?: never;
@@ -139,6 +155,9 @@ export class AuthorizationService extends DBService {
           break;
         case 'Team':
           authorizeResults.push(await this.authorizeByTeam(authorizeRule));
+          break;
+        case 'Policy':
+          authorizeResults.push(await this.authorizeByPolicy(authorizeRule));
           break;
       }
     }
@@ -223,20 +242,38 @@ export class AuthorizationService extends DBService {
     }
 
     const user = await this.getCachedSystemUser();
-    const teamAuthorizationService = new TeamAuthorizationService(this.connection);
-
-    // submission_feature supports anonymous access to unsecured features, so allow anonymous
-    // requests to reach the closure-based check with a null system user id.
-    if (authorizeRule.entity === 'submission_feature') {
-      return teamAuthorizationService.isUserAuthorizedForTeamEntity(user?.system_user_id ?? null, authorizeRule);
-    }
-
-    // All other team-scoped entities require an authenticated user.
     if (!user) {
       return false;
     }
 
+    const teamAuthorizationService = new TeamAuthorizationService(this.connection);
     return teamAuthorizationService.isUserAuthorizedForTeamEntity(user.system_user_id, authorizeRule);
+  }
+
+  /**
+   * Check whether the current request is authorized to access a submission feature.
+   *
+   * Access is granted when the feature is open, or when the authenticated user has access through
+   * the feature's security policy. Anonymous requests are permitted to reach this check (they can
+   * still read unsecured features), so the (possibly `null`) system user id is passed through.
+   *
+   * @param {AuthorizeByPolicy} authorizeRule
+   * @returns {Promise<boolean>}
+   */
+  async authorizeByPolicy(authorizeRule: AuthorizeByPolicy): Promise<boolean> {
+    if (!authorizeRule) {
+      return false;
+    }
+
+    const user = await this.getCachedSystemUser();
+
+    const teamAuthorizationService = new TeamAuthorizationService(this.connection);
+
+    return teamAuthorizationService.isSubmissionFeatureAccessibleToUser(
+      user?.system_user_id ?? null,
+      authorizeRule.submissionFeatureId,
+      authorizeRule.submissionId
+    );
   }
 
   /**

--- a/api/src/services/authorization/team-authorization-service.test.ts
+++ b/api/src/services/authorization/team-authorization-service.test.ts
@@ -105,7 +105,7 @@ describe('TeamAuthorizationService', () => {
     });
 
     describe('entity: submission_feature', () => {
-      it('returns true when the feature is accessible to the user, passing through the entity ids', async () => {
+      it('returns true when the closure-based check grants access, passing through the entity ids', async () => {
         const mockConnection = getMockDBConnection();
         const accessibleStub = sinon
           .stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser')
@@ -122,7 +122,7 @@ describe('TeamAuthorizationService', () => {
         expect(accessibleStub).to.have.been.calledOnceWith(1, 2, 3);
       });
 
-      it('returns false when the feature is not accessible to the user', async () => {
+      it('returns false when the closure-based check denies access', async () => {
         const mockConnection = getMockDBConnection();
         sinon.stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser').resolves(false);
 
@@ -134,6 +134,53 @@ describe('TeamAuthorizationService', () => {
         });
 
         expect(result).to.be.false;
+      });
+
+      it('passes a null system user id through for anonymous users', async () => {
+        const mockConnection = getMockDBConnection();
+        const accessibleStub = sinon
+          .stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser')
+          .resolves(true);
+
+        const service = new TeamAuthorizationService(mockConnection);
+        const result = await service.isUserAuthorizedForTeamEntity(null, {
+          entity: 'submission_feature',
+          submissionFeatureId: 2,
+          submissionId: 3
+        });
+
+        expect(result).to.be.true;
+        expect(accessibleStub).to.have.been.calledOnceWith(null, 2, 3);
+      });
+    });
+
+    describe('anonymous (null system user id)', () => {
+      it('returns false for ticket entities', async () => {
+        const mockConnection = getMockDBConnection();
+        const ticketStub = sinon.stub(TeamAuthorizationRepository.prototype, 'findTeamMembershipByTicket');
+
+        const service = new TeamAuthorizationService(mockConnection);
+        const result = await service.isUserAuthorizedForTeamEntity(null, {
+          entity: 'ticket',
+          ticketId: '11111111-1111-1111-1111-111111111111'
+        });
+
+        expect(result).to.be.false;
+        expect(ticketStub).to.not.have.been.called;
+      });
+
+      it('returns false for data_request entities', async () => {
+        const mockConnection = getMockDBConnection();
+        const dataRequestStub = sinon.stub(TeamAuthorizationRepository.prototype, 'findTeamMembershipByDataRequest');
+
+        const service = new TeamAuthorizationService(mockConnection);
+        const result = await service.isUserAuthorizedForTeamEntity(null, {
+          entity: 'data_request',
+          dataRequestId: 'dr-1'
+        });
+
+        expect(result).to.be.false;
+        expect(dataRequestStub).to.not.have.been.called;
       });
     });
   });

--- a/api/src/services/authorization/team-authorization-service.test.ts
+++ b/api/src/services/authorization/team-authorization-service.test.ts
@@ -103,85 +103,33 @@ describe('TeamAuthorizationService', () => {
         expect(result).to.be.false;
       });
     });
+  });
 
-    describe('entity: submission_feature', () => {
-      it('returns true when the closure-based check grants access, passing through the entity ids', async () => {
-        const mockConnection = getMockDBConnection();
-        const accessibleStub = sinon
-          .stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser')
-          .resolves(true);
+  describe('isSubmissionFeatureAccessibleToUser', () => {
+    it('delegates to the repository and returns its result, passing the ids through', async () => {
+      const mockConnection = getMockDBConnection();
+      const repoStub = sinon
+        .stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser')
+        .resolves(true);
 
-        const service = new TeamAuthorizationService(mockConnection);
-        const result = await service.isUserAuthorizedForTeamEntity(1, {
-          entity: 'submission_feature',
-          submissionFeatureId: 2,
-          submissionId: 3
-        });
+      const service = new TeamAuthorizationService(mockConnection);
+      const result = await service.isSubmissionFeatureAccessibleToUser(1, 2, 3);
 
-        expect(result).to.be.true;
-        expect(accessibleStub).to.have.been.calledOnceWith(1, 2, 3);
-      });
-
-      it('returns false when the closure-based check denies access', async () => {
-        const mockConnection = getMockDBConnection();
-        sinon.stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser').resolves(false);
-
-        const service = new TeamAuthorizationService(mockConnection);
-        const result = await service.isUserAuthorizedForTeamEntity(1, {
-          entity: 'submission_feature',
-          submissionFeatureId: 2,
-          submissionId: 3
-        });
-
-        expect(result).to.be.false;
-      });
-
-      it('passes a null system user id through for anonymous users', async () => {
-        const mockConnection = getMockDBConnection();
-        const accessibleStub = sinon
-          .stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser')
-          .resolves(true);
-
-        const service = new TeamAuthorizationService(mockConnection);
-        const result = await service.isUserAuthorizedForTeamEntity(null, {
-          entity: 'submission_feature',
-          submissionFeatureId: 2,
-          submissionId: 3
-        });
-
-        expect(result).to.be.true;
-        expect(accessibleStub).to.have.been.calledOnceWith(null, 2, 3);
-      });
+      expect(result).to.be.true;
+      expect(repoStub).to.have.been.calledOnceWith(1, 2, 3);
     });
 
-    describe('anonymous (null system user id)', () => {
-      it('returns false for ticket entities', async () => {
-        const mockConnection = getMockDBConnection();
-        const ticketStub = sinon.stub(TeamAuthorizationRepository.prototype, 'findTeamMembershipByTicket');
+    it('passes a null system user id through for anonymous users', async () => {
+      const mockConnection = getMockDBConnection();
+      const repoStub = sinon
+        .stub(TeamAuthorizationRepository.prototype, 'isSubmissionFeatureAccessibleToUser')
+        .resolves(false);
 
-        const service = new TeamAuthorizationService(mockConnection);
-        const result = await service.isUserAuthorizedForTeamEntity(null, {
-          entity: 'ticket',
-          ticketId: '11111111-1111-1111-1111-111111111111'
-        });
+      const service = new TeamAuthorizationService(mockConnection);
+      const result = await service.isSubmissionFeatureAccessibleToUser(null, 2, 3);
 
-        expect(result).to.be.false;
-        expect(ticketStub).to.not.have.been.called;
-      });
-
-      it('returns false for data_request entities', async () => {
-        const mockConnection = getMockDBConnection();
-        const dataRequestStub = sinon.stub(TeamAuthorizationRepository.prototype, 'findTeamMembershipByDataRequest');
-
-        const service = new TeamAuthorizationService(mockConnection);
-        const result = await service.isUserAuthorizedForTeamEntity(null, {
-          entity: 'data_request',
-          dataRequestId: 'dr-1'
-        });
-
-        expect(result).to.be.false;
-        expect(dataRequestStub).to.not.have.been.called;
-      });
+      expect(result).to.be.false;
+      expect(repoStub).to.have.been.calledOnceWith(null, 2, 3);
     });
   });
 });

--- a/api/src/services/authorization/team-authorization-service.ts
+++ b/api/src/services/authorization/team-authorization-service.ts
@@ -24,16 +24,31 @@ export class TeamAuthorizationService extends DBService {
    * Entity semantics:
    * - `ticket`: membership in the ticket visibility team.
    * - `data_request`: membership in the data-request visibility team.
-   * - `submission_feature`: the feature is not effectively secured, or the user's team
-   *   holds a security scope anchored on the feature or one of its ancestors (the same
-   *   ancestry-aware check the search/download read paths apply).
+   * - `submission_feature`: ancestry-aware, closure-based access shared with the search/download
+   *   read paths — the feature is unsecured, or the user's team holds a security scope anchored
+   *   on the feature or one of its ancestors. `systemUserId` may be `null` for anonymous users
+   *   (who can still access unsecured features).
    *
-   * @param {number} systemUserId
+   * @param {number | null} systemUserId The authenticated user's id, or `null` for anonymous.
    * @param {TeamAuthorizationEntity} entity
    * @return {Promise<boolean>}
    * @memberof TeamAuthorizationService
    */
-  async isUserAuthorizedForTeamEntity(systemUserId: number, entity: TeamAuthorizationEntity): Promise<boolean> {
+  async isUserAuthorizedForTeamEntity(systemUserId: number | null, entity: TeamAuthorizationEntity): Promise<boolean> {
+    // submission_feature uses closure-based access and supports anonymous (unsecured) access.
+    if (entity.entity === 'submission_feature') {
+      return this.teamAuthorizationRepository.isSubmissionFeatureAccessibleToUser(
+        systemUserId,
+        entity.submissionFeatureId,
+        entity.submissionId
+      );
+    }
+
+    // ticket / data_request require an authenticated user.
+    if (systemUserId === null) {
+      return false;
+    }
+
     let record: { record_end_date: string | null } | null;
 
     switch (entity.entity) {
@@ -47,16 +62,6 @@ export class TeamAuthorizationService extends DBService {
           entity.dataRequestId
         );
         break;
-
-      case 'submission_feature':
-        // Ancestry-aware access check shared with the search/download read paths: unsecured
-        // features are open; secured features require the user's team to hold a scope anchored
-        // on the feature or one of its ancestors.
-        return this.teamAuthorizationRepository.isSubmissionFeatureAccessibleToUser(
-          systemUserId,
-          entity.submissionFeatureId,
-          entity.submissionId
-        );
 
       default:
         return false;

--- a/api/src/services/authorization/team-authorization-service.ts
+++ b/api/src/services/authorization/team-authorization-service.ts
@@ -24,31 +24,13 @@ export class TeamAuthorizationService extends DBService {
    * Entity semantics:
    * - `ticket`: membership in the ticket visibility team.
    * - `data_request`: membership in the data-request visibility team.
-   * - `submission_feature`: ancestry-aware, closure-based access shared with the search/download
-   *   read paths — the feature is unsecured, or the user's team holds a security scope anchored
-   *   on the feature or one of its ancestors. `systemUserId` may be `null` for anonymous users
-   *   (who can still access unsecured features).
    *
-   * @param {number | null} systemUserId The authenticated user's id, or `null` for anonymous.
+   * @param {number} systemUserId
    * @param {TeamAuthorizationEntity} entity
    * @return {Promise<boolean>}
    * @memberof TeamAuthorizationService
    */
-  async isUserAuthorizedForTeamEntity(systemUserId: number | null, entity: TeamAuthorizationEntity): Promise<boolean> {
-    // submission_feature uses closure-based access and supports anonymous (unsecured) access.
-    if (entity.entity === 'submission_feature') {
-      return this.teamAuthorizationRepository.isSubmissionFeatureAccessibleToUser(
-        systemUserId,
-        entity.submissionFeatureId,
-        entity.submissionId
-      );
-    }
-
-    // ticket / data_request require an authenticated user.
-    if (systemUserId === null) {
-      return false;
-    }
-
+  async isUserAuthorizedForTeamEntity(systemUserId: number, entity: TeamAuthorizationEntity): Promise<boolean> {
     let record: { record_end_date: string | null } | null;
 
     switch (entity.entity) {
@@ -77,5 +59,31 @@ export class TeamAuthorizationService extends DBService {
     }
 
     return true;
+  }
+
+  /**
+   * Determine whether a submission feature is accessible to a user, using the ancestry-aware,
+   * closure-based security check shared with the search/download read paths: the feature is
+   * unsecured, or the user's team holds a security scope anchored on the feature or one of its
+   * ancestors.
+   *
+   * `systemUserId` may be `null` for anonymous users, who can still access unsecured features.
+   *
+   * @param {number | null} systemUserId The authenticated user's id, or `null` for anonymous.
+   * @param {number} submissionFeatureId
+   * @param {number} submissionId The submission the feature must belong to.
+   * @return {Promise<boolean>}
+   * @memberof TeamAuthorizationService
+   */
+  async isSubmissionFeatureAccessibleToUser(
+    systemUserId: number | null,
+    submissionFeatureId: number,
+    submissionId: number
+  ): Promise<boolean> {
+    return this.teamAuthorizationRepository.isSubmissionFeatureAccessibleToUser(
+      systemUserId,
+      submissionFeatureId,
+      submissionId
+    );
   }
 }


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1064](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1064)

## Description of Changes

A user with access to a secured **parent** feature could not open the secured **child/descendant** features belonging to it — the feature-detail page returned `403` and redirected to `/forbidden`. This was inconsistent with search and cart, which already grant access to any secured descendant of an accessible ancestor.

The root cause was **two parallel authorization systems**. Search/cart/download use the closure-based `isAccessibleToUser` / `buildSecurityFilter` (`api/src/repositories/sql-fragments.ts`), which grants access when a feature is unsecured or the user's team has a scope grant via a `security_scope_anchor` on the feature **or any ancestor** (walked through `submission_feature_closure`). The feature-detail path instead used a narrow exact-feature URN check that only matched the requested feature, so an ancestor grant did not cover its descendants.

This PR aligns feature-detail authorization with the same closure-based semantics — fixed in backend authorization logic, not with frontend exceptions.

- **`team-authorization-repository.ts`** — Replaced the narrow `findTeamPolicyBySubmissionFeature` (exact-URN match) with `isSubmissionFeatureAccessibleToUser(systemUserId, submissionFeatureId, submissionId?)`. It runs a single `SELECT EXISTS(...)` that:
  - gates liveness — `record_effective_date <= now() AND record_end_date IS NULL` → soft-deleted / not-yet-effective features are forbidden;
  - reuses `buildSecurityFilter`, so unsecured features are open to everyone (incl. anonymous via `null`), and secured features are granted only when an ancestor in `submission_feature_closure` is a reachable `security_scope_anchor`;
  - keeps the optional `submission_id` path-integrity guard.
- **`team-authorization-service.ts`** — `isUserAuthorizedForTeamEntity` now accepts `number | null`; the `submission_feature` case delegates directly to the new repository method. `ticket` / `data_request` still require an authenticated user.
- **`authorization-service.ts`** — `authorizeByTeam` now lets anonymous requests reach the `submission_feature` check with a `null` system user id (so unsecured features are viewable by non-authenticated users), while other entities still short-circuit to `false` for anonymous.
- Removed the now-dead `findTeamPolicyBySubmissionFeature` query and `TeamPolicyRecord` model; added a small `SubmissionFeatureAccessRecord` zod model for response validation (consistent with the sibling repository methods).
- Both endpoints routing through the `Team` / `submission_feature` scheme — feature detail (`/submission/{submissionId}/features/{submissionFeatureId}`) and its `/properties` — are fixed consistently.

## Testing Notes

Unit tests added/updated for the repository, service, and authorization-service layers (full API suite green).

End-to-end, against a seeded DB — for a user granted a secured **parent** feature:

1. Open the parent feature detail → loads (200).
2. Open a secured **child** of that parent → loads (200), **not** redirected to `/forbidden`.
3. Open a secured feature under a **different** parent the user lacks → `403` → `/forbidden`.
4. As **anonymous**: open an unsecured feature → loads; open a secured feature → `403`.
5. Open a soft-deleted (`record_end_date` set) or not-yet-effective (`record_effective_date > now()`) feature → `403`.
6. Repeat 1–3 against the feature `/properties` endpoint to confirm consistency.
