### PR TITLE
SIMSBIOHUB-1068: Track Submission Feature Upserts

### DIFF
--- a/api/src/__integration__/db/submission-feature-reconciliation-service.integration.ts
+++ b/api/src/__integration__/db/submission-feature-reconciliation-service.integration.ts
@@ -137,14 +137,14 @@ describe('SubmissionFeatureReconciliationService — activation and submission_f
     // Upload A publishes a brand new feature: not a transition, so nothing is logged.
     const versionA = await publishVersion(submissionId, HASH_1);
     expect(versionA.counts).to.eql({ new: 1, unchanged: 0, superseded: 0, conflict: 0 });
-    expect(await getLogRows(submissionId)).to.have.length(0);
+    expect(await getLogRows(submissionId)).to.be.empty;
 
     // Upload B re-submits the same source with changed content: A is superseded by B.
     const versionB = await publishVersion(submissionId, HASH_2);
     expect(versionB.counts).to.eql({ new: 0, unchanged: 0, superseded: 1, conflict: 0 });
 
     const logRows = await getLogRows(submissionId);
-    expect(logRows).to.have.length(1);
+    expect(logRows).to.have.lengthOf(1);
     expect(logRows[0]).to.include({
       submission_id: submissionId,
       submission_upload_id: versionB.submissionUploadId,
@@ -167,13 +167,13 @@ describe('SubmissionFeatureReconciliationService — activation and submission_f
     // Re-approving the already-activated upload is a no-op: no new log rows.
     const reapprovalCounts = await service.reconcileAndActivateSubmissionUpload(versionB.submissionUploadId);
     expect(reapprovalCounts).to.eql({ new: 0, unchanged: 0, superseded: 0, conflict: 0 });
-    expect(await getLogRows(submissionId)).to.have.length(1);
+    expect(await getLogRows(submissionId)).to.have.lengthOf(1);
 
     // An unchanged re-submission (same content hash) leaves the active feature untouched
     // and is counted by the reconciliation summary, not the log.
     const versionC = await publishVersion(submissionId, HASH_2);
     expect(versionC.counts).to.eql({ new: 0, unchanged: 1, superseded: 0, conflict: 0 });
-    expect(await getLogRows(submissionId)).to.have.length(1);
+    expect(await getLogRows(submissionId)).to.have.lengthOf(1);
 
     const lifecycleBAfterC = await getFeatureLifecycle(versionB.submissionFeatureId);
     expect(lifecycleBAfterC.record_end_date).to.be.null;
@@ -187,7 +187,7 @@ describe('SubmissionFeatureReconciliationService — activation and submission_f
     const versionD = await publishVersion(submissionId, HASH_3);
 
     const logRows = await getLogRows(submissionId);
-    expect(logRows).to.have.length(2);
+    expect(logRows).to.have.lengthOf(2);
     expect(logRows.map((row) => [row.previous_submission_feature_id, row.new_submission_feature_id])).to.eql([
       [versionA.submissionFeatureId, versionB.submissionFeatureId],
       [versionB.submissionFeatureId, versionD.submissionFeatureId]
@@ -292,7 +292,7 @@ describe('SubmissionFeatureReconciliationService — activation and submission_f
     `);
 
     const logRows = await getLogRows(submissionId);
-    expect(logRows).to.have.length(1);
+    expect(logRows).to.have.lengthOf(1);
     expect(logRows[0]).to.include({
       action: 'removed',
       previous_submission_feature_id: feature1,

--- a/api/src/__integration__/db/submission-feature-reconciliation-service.integration.ts
+++ b/api/src/__integration__/db/submission-feature-reconciliation-service.integration.ts
@@ -1,0 +1,328 @@
+// Integration tests for SubmissionFeatureReconciliationService.reconcileAndActivateSubmissionUpload
+// and the append-only submission_feature_log, against a real database.
+//
+// Covers: superseded transitions are logged (linked old -> new with both hashes) while new,
+// unchanged, and re-approved uploads log nothing; multi-hop chain resolution; and the schema
+// guards (uk1 one-transition-per-predecessor, ck1 removed-row shape). Each test seeds its own
+// fixture and rolls back. Constraint-violation probes run LAST (a rejected statement poisons the
+// transaction) — see expectConstraintViolation.
+//
+// Run: docker compose exec api npm run test:mocha -- --no-config --extension ts \
+//        'src/__integration__/db/submission-feature-reconciliation-service.integration.ts'
+// Requires: database container running with seed data.
+
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import SQL from 'sql-template-strings';
+import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { ApiExecuteSQLError } from '../../errors/api-error';
+import { SubmissionFeatureReconciliationService } from '../../services/reconciliation/submission-feature-reconciliation-service';
+import { createTestSubmission, createTestUploadWithFeatures } from '../helpers/test-submission-helpers';
+
+const FEATURE_TYPE_NAME = 'survey';
+const SOURCE_ID = 'reconciliation-log-source-1';
+
+// content_hash is a 64-char SHA-256 hex digest; any 64-char value satisfies the column.
+const HASH_1 = 'a'.repeat(64);
+const HASH_2 = 'b'.repeat(64);
+const HASH_3 = 'c'.repeat(64);
+
+/**
+ * Assert a statement is rejected by the named constraint. Asserts OUTSIDE the catch so an
+ * unexpected success surfaces the constraint name, not a misleading instanceof error; the
+ * constraint is matched via the pg error message (the connection wrapper drops the code).
+ * The rejected statement poisons the transaction, so call this only as the test's last statement.
+ */
+async function expectConstraintViolation(statement: Promise<unknown>, constraintDescription: string) {
+  let caught: unknown;
+  try {
+    await statement;
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(caught, `expected the statement to be rejected by ${constraintDescription}`).to.not.be.undefined;
+  expect(caught).to.be.instanceOf(ApiExecuteSQLError);
+  const dbError = (caught as ApiExecuteSQLError).errors?.[0] as { message?: string };
+  expect(dbError.message).to.include(constraintDescription);
+}
+
+describe('SubmissionFeatureReconciliationService — activation and submission_feature_log (integration)', function () {
+  this.timeout(30000);
+
+  let connection: IDBConnection;
+  let service: SubmissionFeatureReconciliationService;
+
+  before(() => initDBPool(defaultPoolConfig));
+
+  beforeEach(async () => {
+    connection = getAPIUserDBConnection();
+    await connection.open();
+    service = new SubmissionFeatureReconciliationService(connection);
+  });
+
+  afterEach(async () => {
+    await connection.rollback();
+    connection.release();
+  });
+
+  // --- local fixture helpers -----------------------------------------------
+
+  /** Create an upload with pending features already at `indexed`, the status the activation guard requires. */
+  async function createIndexedUpload(
+    submissionId: number,
+    features: Array<{ source_id: string | null; content_hash?: string | null }>
+  ): Promise<string> {
+    return createTestUploadWithFeatures(connection, submissionId, FEATURE_TYPE_NAME, features, 'indexed');
+  }
+
+  /** Feature ids inserted under an upload, ascending. */
+  async function getFeatureIdsByUpload(submissionUploadId: string): Promise<number[]> {
+    const result = await connection.sql(SQL`
+      SELECT submission_feature_id
+      FROM submission_feature
+      WHERE submission_upload_id = ${submissionUploadId}::uuid
+      ORDER BY submission_feature_id;
+    `);
+    return result.rows.map((row) => row.submission_feature_id);
+  }
+
+  /**
+   * Create an indexed upload carrying one feature for SOURCE_ID with the given content hash,
+   * activate it, and return the ids involved plus the reconciliation outcome counts.
+   */
+  async function publishVersion(submissionId: number, contentHash: string) {
+    const submissionUploadId = await createIndexedUpload(submissionId, [
+      { source_id: SOURCE_ID, content_hash: contentHash }
+    ]);
+    const [submissionFeatureId] = await getFeatureIdsByUpload(submissionUploadId);
+    const counts = await service.reconcileAndActivateSubmissionUpload(submissionUploadId);
+    return { submissionUploadId, submissionFeatureId, counts };
+  }
+
+  /** All log rows for the fixture submission, ascending by id. */
+  async function getLogRows(submissionId: number) {
+    const result = await connection.sql(SQL`
+      SELECT
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        source_id,
+        action::text AS action,
+        previous_submission_feature_id,
+        new_submission_feature_id,
+        previous_content_hash,
+        new_content_hash
+      FROM submission_feature_log
+      WHERE submission_id = ${submissionId}
+      ORDER BY submission_feature_log_id;
+    `);
+    return result.rows;
+  }
+
+  async function getFeatureLifecycle(submissionFeatureId: number) {
+    const result = await connection.sql(SQL`
+      SELECT record_effective_date, record_end_date
+      FROM submission_feature
+      WHERE submission_feature_id = ${submissionFeatureId};
+    `);
+    return result.rows[0];
+  }
+
+  // --- tests ----------------------------------------------------------------
+
+  it('logs superseded transitions with full linkage, and nothing for new, re-approved, or unchanged features', async () => {
+    const submissionId = await createTestSubmission(connection);
+
+    // Upload A publishes a brand new feature: not a transition, so nothing is logged.
+    const versionA = await publishVersion(submissionId, HASH_1);
+    expect(versionA.counts).to.eql({ new: 1, unchanged: 0, superseded: 0, conflict: 0 });
+    expect(await getLogRows(submissionId)).to.have.length(0);
+
+    // Upload B re-submits the same source with changed content: A is superseded by B.
+    const versionB = await publishVersion(submissionId, HASH_2);
+    expect(versionB.counts).to.eql({ new: 0, unchanged: 0, superseded: 1, conflict: 0 });
+
+    const logRows = await getLogRows(submissionId);
+    expect(logRows).to.have.length(1);
+    expect(logRows[0]).to.include({
+      submission_id: submissionId,
+      submission_upload_id: versionB.submissionUploadId,
+      source_id: SOURCE_ID,
+      action: 'superseded',
+      previous_submission_feature_id: versionA.submissionFeatureId,
+      new_submission_feature_id: versionB.submissionFeatureId,
+      previous_content_hash: HASH_1,
+      new_content_hash: HASH_2
+    });
+    expect(logRows[0].feature_type_id).to.be.a('number');
+
+    // The predecessor row is preserved (soft-ended), the replacement is active.
+    const lifecycleA = await getFeatureLifecycle(versionA.submissionFeatureId);
+    expect(lifecycleA.record_end_date).to.not.be.null;
+    const lifecycleB = await getFeatureLifecycle(versionB.submissionFeatureId);
+    expect(lifecycleB.record_effective_date).to.not.be.null;
+    expect(lifecycleB.record_end_date).to.be.null;
+
+    // Re-approving the already-activated upload is a no-op: no new log rows.
+    const reapprovalCounts = await service.reconcileAndActivateSubmissionUpload(versionB.submissionUploadId);
+    expect(reapprovalCounts).to.eql({ new: 0, unchanged: 0, superseded: 0, conflict: 0 });
+    expect(await getLogRows(submissionId)).to.have.length(1);
+
+    // An unchanged re-submission (same content hash) leaves the active feature untouched
+    // and is counted by the reconciliation summary, not the log.
+    const versionC = await publishVersion(submissionId, HASH_2);
+    expect(versionC.counts).to.eql({ new: 0, unchanged: 1, superseded: 0, conflict: 0 });
+    expect(await getLogRows(submissionId)).to.have.length(1);
+
+    const lifecycleBAfterC = await getFeatureLifecycle(versionB.submissionFeatureId);
+    expect(lifecycleBAfterC.record_end_date).to.be.null;
+  });
+
+  it('resolves a multi-hop version chain from a historical feature to the current active feature', async () => {
+    const submissionId = await createTestSubmission(connection);
+
+    const versionA = await publishVersion(submissionId, HASH_1);
+    const versionB = await publishVersion(submissionId, HASH_2);
+    const versionD = await publishVersion(submissionId, HASH_3);
+
+    const logRows = await getLogRows(submissionId);
+    expect(logRows).to.have.length(2);
+    expect(logRows.map((row) => [row.previous_submission_feature_id, row.new_submission_feature_id])).to.eql([
+      [versionA.submissionFeatureId, versionB.submissionFeatureId],
+      [versionB.submissionFeatureId, versionD.submissionFeatureId]
+    ]);
+
+    // The chain walk documented on the table: follow previous -> new to the tip. The tip is
+    // the latest recorded replacement, not necessarily a live row (see the table comment) —
+    // the final assertions below prove it IS live in this deny-free scenario.
+    const resolved = await connection.sql(SQL`
+      WITH RECURSIVE chain AS (
+        SELECT l.new_submission_feature_id, 1 AS depth
+        FROM submission_feature_log l
+        WHERE l.previous_submission_feature_id = ${versionA.submissionFeatureId}
+          AND l.action = 'superseded'
+        UNION ALL
+        SELECT l.new_submission_feature_id, c.depth + 1
+        FROM submission_feature_log l
+        JOIN chain c ON l.previous_submission_feature_id = c.new_submission_feature_id
+        WHERE l.action = 'superseded'
+          AND c.depth < 1000
+      )
+      SELECT COALESCE(
+        (SELECT new_submission_feature_id FROM chain ORDER BY depth DESC LIMIT 1),
+        ${versionA.submissionFeatureId}
+      ) AS current_submission_feature_id;
+    `);
+    expect(resolved.rows[0].current_submission_feature_id).to.equal(versionD.submissionFeatureId);
+
+    // The chain tip is the live published row for the key.
+    const lifecycleD = await getFeatureLifecycle(versionD.submissionFeatureId);
+    expect(lifecycleD.record_effective_date).to.not.be.null;
+    expect(lifecycleD.record_end_date).to.be.null;
+  });
+
+  it('rejects a second terminal transition for the same predecessor (submission_feature_log_uk1)', async () => {
+    const submissionId = await createTestSubmission(connection);
+
+    const versionA = await publishVersion(submissionId, HASH_1);
+    const versionB = await publishVersion(submissionId, HASH_2);
+
+    // versionA's feature already has its one terminal transition; a second must be rejected.
+    await expectConstraintViolation(
+      connection.sql(SQL`
+        INSERT INTO submission_feature_log (
+          submission_id,
+          submission_upload_id,
+          feature_type_id,
+          source_id,
+          action,
+          previous_submission_feature_id,
+          new_submission_feature_id,
+          previous_content_hash,
+          new_content_hash
+        )
+        SELECT
+          ${submissionId},
+          ${versionB.submissionUploadId}::uuid,
+          feature_type_id,
+          ${SOURCE_ID},
+          'superseded'::submission_feature_log_action,
+          ${versionA.submissionFeatureId},
+          ${versionB.submissionFeatureId},
+          ${HASH_1},
+          ${HASH_2}
+        FROM submission_feature
+        WHERE submission_feature_id = ${versionA.submissionFeatureId};
+      `),
+      'unique constraint "submission_feature_log_uk1"'
+    );
+  });
+
+  it('accepts a well-formed removed row and rejects a removed row that names a replacement (ck1)', async () => {
+    const submissionId = await createTestSubmission(connection);
+
+    const uploadA = await createIndexedUpload(submissionId, [
+      { source_id: `${SOURCE_ID}-1`, content_hash: HASH_1 },
+      { source_id: `${SOURCE_ID}-2`, content_hash: HASH_2 }
+    ]);
+    const [feature1, feature2] = await getFeatureIdsByUpload(uploadA);
+    await service.reconcileAndActivateSubmissionUpload(uploadA);
+
+    // The future removal workflow's shape needs no schema change: no replacement row or
+    // hash; the owning upload is optional for removals (NULL here).
+    await connection.sql(SQL`
+      INSERT INTO submission_feature_log (
+        submission_id,
+        feature_type_id,
+        source_id,
+        action,
+        previous_submission_feature_id,
+        previous_content_hash
+      )
+      SELECT
+        ${submissionId},
+        feature_type_id,
+        ${`${SOURCE_ID}-1`},
+        'removed'::submission_feature_log_action,
+        ${feature1},
+        ${HASH_1}
+      FROM submission_feature
+      WHERE submission_feature_id = ${feature1};
+    `);
+
+    const logRows = await getLogRows(submissionId);
+    expect(logRows).to.have.length(1);
+    expect(logRows[0]).to.include({
+      action: 'removed',
+      previous_submission_feature_id: feature1,
+      new_submission_feature_id: null,
+      submission_upload_id: null,
+      new_content_hash: null
+    });
+
+    // A removed transition must not name a replacement.
+    await expectConstraintViolation(
+      connection.sql(SQL`
+        INSERT INTO submission_feature_log (
+          submission_id,
+          feature_type_id,
+          source_id,
+          action,
+          previous_submission_feature_id,
+          new_submission_feature_id
+        )
+        SELECT
+          ${submissionId},
+          feature_type_id,
+          ${`${SOURCE_ID}-2`},
+          'removed'::submission_feature_log_action,
+          ${feature2},
+          ${feature1}
+        FROM submission_feature
+        WHERE submission_feature_id = ${feature2};
+      `),
+      'check constraint "submission_feature_log_ck1"'
+    );
+  });
+});

--- a/api/src/__integration__/helpers/test-submission-helpers.ts
+++ b/api/src/__integration__/helpers/test-submission-helpers.ts
@@ -187,18 +187,22 @@ export async function createTestFeaturesInBulk(
 
 /**
  * Insert one `submission_upload` plus N `submission_feature` rows under it, each row
- * parameterized by `(source_id, record_end_date, data?)`.
+ * parameterized by `(source_id, record_end_date?, content_hash?, data?)`.
  *
  * Unlike `createTestFeaturesInBulk` — which inserts homogeneous features via
  * `generate_series` and is tuned for large counts — this helper supports
  * heterogeneous per-row data. Use it for tests that need control over
- * `source_id` and `record_end_date` to exercise NULL handling, soft-delete
- * semantics, or other per-row variation.
+ * `source_id`, `record_end_date`, and `content_hash` to exercise NULL handling,
+ * soft-delete semantics, reconciliation classification (a NULL `content_hash`
+ * always classifies as changed/superseded, never unchanged), or other per-row
+ * variation.
  *
  * @param connection Active database connection (transaction-scoped).
  * @param submissionId Submission to attach the upload and features to.
  * @param featureTypeName Feature type name (must exist in seed data).
  * @param features Per-row feature shapes. Empty array creates the upload with no features.
+ * @param status Optional `submission_upload.status` job status to set (e.g. 'indexed', which
+ *   upload activation requires). Defaults to the column default.
  * @returns The created `submission_upload_id`.
  */
 export async function createTestUploadWithFeatures(
@@ -208,8 +212,10 @@ export async function createTestUploadWithFeatures(
   features: Array<{
     source_id: string | null;
     record_end_date?: string | null;
+    content_hash?: string | null;
     data?: Record<string, unknown>;
-  }>
+  }>,
+  status?: string
 ): Promise<string> {
   const systemUserId = connection.systemUserId();
 
@@ -230,6 +236,14 @@ export async function createTestUploadWithFeatures(
   `);
   const submissionUploadId = bridgeResult.rows[0].submission_upload_id as string;
 
+  if (status) {
+    await connection.sql(SQL`
+      UPDATE submission_upload
+      SET status = ${status}
+      WHERE submission_upload_id = ${submissionUploadId}::uuid;
+    `);
+  }
+
   if (features.length === 0) {
     return submissionUploadId;
   }
@@ -248,6 +262,7 @@ export async function createTestUploadWithFeatures(
         feature_type_id,
         source_id,
         record_end_date,
+        content_hash,
         data,
         data_byte_size,
         create_user
@@ -258,6 +273,7 @@ export async function createTestUploadWithFeatures(
         ${featureTypeId},
         ${feature.source_id},
         ${feature.record_end_date ?? null},
+        ${feature.content_hash ?? null},
         ${dataJson}::jsonb,
         octet_length(${dataJson}::jsonb::text) + 500,
         ${systemUserId}

--- a/api/src/repositories/reconciliation/submission-feature-log-repository.test.ts
+++ b/api/src/repositories/reconciliation/submission-feature-log-repository.test.ts
@@ -1,0 +1,51 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getMockDBConnection, mockQueryResult } from '../../__mocks__/db';
+import { SubmissionFeatureLogRepository } from './submission-feature-log-repository';
+
+chai.use(sinonChai);
+
+const UPLOAD_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('SubmissionFeatureLogRepository', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('insertSupersededLogRecordsFromReconciliation', () => {
+    it('inserts one log row per superseded outcome and returns the count', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([], 2));
+      const repository = new SubmissionFeatureLogRepository(getMockDBConnection({ sql: sqlStub }));
+
+      const count = await repository.insertSupersededLogRecordsFromReconciliation(UPLOAD_ID);
+
+      expect(count).to.equal(2);
+      expect(sqlStub).to.have.been.calledOnce;
+
+      const sqlText = sqlStub.firstCall.args[0].text as string;
+      expect(sqlText).to.include('INSERT INTO submission_feature_log');
+      // Derived from the upload's superseded reconciliation outcomes only.
+      expect(sqlText).to.include("r.outcome = 'superseded'");
+      expect(sqlText).to.include("'superseded'::submission_feature_log_action");
+      // Links the ended predecessor to its published replacement.
+      expect(sqlText).to.include('prev_sf.submission_feature_id = r.previous_submission_feature_id');
+      expect(sqlText).to.include('new_sf.submission_feature_id = r.submission_feature_id');
+      // Snapshots both content hashes.
+      expect(sqlText).to.include('prev_sf.content_hash');
+      expect(sqlText).to.include('new_sf.content_hash');
+      // A submission_feature_log_uk1 violation is a chain conflict and must raise, not be swallowed.
+      expect(sqlText).to.not.include('ON CONFLICT');
+    });
+
+    it('returns 0 when the upload produced no superseded outcomes', async () => {
+      const sqlStub = sinon.stub().resolves(mockQueryResult([], 0));
+      const repository = new SubmissionFeatureLogRepository(getMockDBConnection({ sql: sqlStub }));
+
+      const count = await repository.insertSupersededLogRecordsFromReconciliation(UPLOAD_ID);
+
+      expect(count).to.equal(0);
+    });
+  });
+});

--- a/api/src/repositories/reconciliation/submission-feature-log-repository.ts
+++ b/api/src/repositories/reconciliation/submission-feature-log-repository.ts
@@ -1,0 +1,64 @@
+import SQL from 'sql-template-strings';
+import { BaseRepository } from '../base-repository';
+
+/**
+ * Repository for the append-only `submission_feature_log` table, which records terminal
+ * submission_feature transitions: `superseded` (a changed version replaces a published
+ * feature during reconciliation) and `removed` (reserved for a future workflow). New,
+ * unchanged, and pending-row soft-ends are never logged. Rows are permanent; the unique
+ * index on previous_submission_feature_id keeps version chains linear.
+ *
+ * @export
+ * @class SubmissionFeatureLogRepository
+ * @extends {BaseRepository}
+ */
+export class SubmissionFeatureLogRepository extends BaseRepository {
+  /**
+   * Write one `superseded` log row per superseded reconciliation outcome of the upload,
+   * linking each ended predecessor to its replacement and snapshotting both content hashes.
+   *
+   * Derived from `submission_upload_feature_reconciliation`, so an upload with no superseded
+   * outcomes (including idempotent re-approval) inserts nothing. A predecessor cannot be
+   * superseded twice — its record_end_date is never cleared — and `submission_feature_log_uk1`
+   * is the backstop: a violation must abort the approval rather than be swallowed.
+   *
+   * @param {string} submissionUploadId The submission upload scope.
+   * @returns {Promise<number>} Number of log rows inserted.
+   * @memberof SubmissionFeatureLogRepository
+   */
+  async insertSupersededLogRecordsFromReconciliation(submissionUploadId: string): Promise<number> {
+    const sqlStatement = SQL`
+      INSERT INTO submission_feature_log (
+        submission_id,
+        submission_upload_id,
+        feature_type_id,
+        source_id,
+        action,
+        previous_submission_feature_id,
+        new_submission_feature_id,
+        previous_content_hash,
+        new_content_hash
+      )
+      SELECT
+        new_sf.submission_id,
+        r.submission_upload_id,
+        r.feature_type_id,
+        r.source_id,
+        'superseded'::submission_feature_log_action,
+        r.previous_submission_feature_id,
+        r.submission_feature_id,
+        prev_sf.content_hash,
+        new_sf.content_hash
+      FROM submission_upload_feature_reconciliation r
+      JOIN submission_feature prev_sf
+        ON prev_sf.submission_feature_id = r.previous_submission_feature_id
+      JOIN submission_feature new_sf
+        ON new_sf.submission_feature_id = r.submission_feature_id
+      WHERE r.submission_upload_id = ${submissionUploadId}::uuid
+        AND r.outcome = 'superseded';
+    `;
+
+    const response = await this.connection.sql(sqlStatement);
+    return response.rowCount ?? 0;
+  }
+}

--- a/api/src/repositories/reconciliation/submission-feature-reconciliation-repository.ts
+++ b/api/src/repositories/reconciliation/submission-feature-reconciliation-repository.ts
@@ -34,7 +34,9 @@ export class SubmissionFeatureReconciliationRepository extends BaseRepository {
    * Delete any reconciliation outcome records previously written for the upload.
    *
    * Called before re-classification so re-activation of the same upload is idempotent.
-   * The journal trigger preserves the deleted rows' history.
+   * The journal trigger preserves the deleted rows' history. Append-only
+   * submission_feature_log rows are intentionally NOT deleted here: they are the durable
+   * lifecycle record, precisely because these outcome rows are not.
    *
    * @param {string} submissionUploadId The submission upload scope.
    * @returns {Promise<void>}

--- a/api/src/services/reconciliation/submission-feature-reconciliation-service.test.ts
+++ b/api/src/services/reconciliation/submission-feature-reconciliation-service.test.ts
@@ -3,9 +3,10 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, mockQueryResult } from '../../__mocks__/db';
-import { HTTP400, HTTP409 } from '../../errors/http-error';
+import { HTTP400, HTTP409, HTTP500 } from '../../errors/http-error';
 import { SubmissionUpload } from '../../models/submission-upload';
 import { SubmissionFeatureDerivedStateRepository } from '../../repositories/reconciliation/submission-feature-derived-state-repository';
+import { SubmissionFeatureLogRepository } from '../../repositories/reconciliation/submission-feature-log-repository';
 import { SubmissionFeatureReconciliationRepository } from '../../repositories/reconciliation/submission-feature-reconciliation-repository';
 import { SubmissionFeatureClosureService } from '../submission-feature-closure-service';
 import { SubmissionUploadService } from '../upload/submission-upload-service';
@@ -57,6 +58,9 @@ describe('SubmissionFeatureReconciliationService', () => {
         .stub(SubmissionFeatureReconciliationRepository.prototype, 'endConflictIncomingRows')
         .resolves(0),
       publish: sinon.stub(SubmissionFeatureReconciliationRepository.prototype, 'publishIncomingRows').resolves(3),
+      logSuperseded: sinon
+        .stub(SubmissionFeatureLogRepository.prototype, 'insertSupersededLogRecordsFromReconciliation')
+        .resolves(1),
       repointParents: sinon
         .stub(SubmissionFeatureDerivedStateRepository.prototype, 'repointParentLinksToActiveRows')
         .resolves(0),
@@ -112,11 +116,37 @@ describe('SubmissionFeatureReconciliationService', () => {
       expect(stubs.endUnchanged).to.have.been.calledBefore(stubs.publish);
       expect(stubs.endConflict).to.have.been.calledOnceWith(UPLOAD_ID);
       expect(stubs.endConflict).to.have.been.calledBefore(stubs.publish);
+      // The superseded log records completed transitions: after publish, before healing,
+      // so a chain-conflict unique violation aborts the approval before any healing work.
+      expect(stubs.logSuperseded).to.have.been.calledOnceWith(UPLOAD_ID);
+      expect(stubs.publish).to.have.been.calledBefore(stubs.logSuperseded);
+      expect(stubs.logSuperseded).to.have.been.calledBefore(stubs.repointParents);
       // Derived healing and closure run after publication, closure last.
       expect(stubs.publish).to.have.been.calledBefore(stubs.repointParents);
       expect(stubs.carryForward).to.have.been.calledOnceWith(UPLOAD_ID);
       expect(stubs.closure).to.have.been.calledOnceWith(42);
       expect(stubs.repointAnchors).to.have.been.calledBefore(stubs.closure);
+    });
+
+    it('throws HTTP500 and stops before healing when the superseded tallies diverge', async () => {
+      const stubs = stubHappyPath();
+      // Classification reports 1 superseded, but the soft-end pass claims 2 rows ended.
+      stubs.endSuperseded.resolves(2);
+      const service = new SubmissionFeatureReconciliationService(
+        getMockDBConnection({ sql: sinon.stub().resolves(mockQueryResult([], 1)) })
+      );
+
+      try {
+        await service.reconcileAndActivateSubmissionUpload(UPLOAD_ID);
+        expect.fail('Expected HTTP500');
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP500);
+        expect((error as HTTP500).message).to.equal('Superseded feature lifecycle records diverged during approval');
+      }
+
+      expect(stubs.logSuperseded).to.have.been.calledOnce;
+      expect(stubs.repointParents).not.to.have.been.called;
+      expect(stubs.closure).not.to.have.been.called;
     });
 
     it('throws HTTP400 before any writes when the upload is not indexed', async () => {
@@ -137,6 +167,7 @@ describe('SubmissionFeatureReconciliationService', () => {
       expect(stubs.deleteRecords).not.to.have.been.called;
       expect(stubs.classify).not.to.have.been.called;
       expect(stubs.publish).not.to.have.been.called;
+      expect(stubs.logSuperseded).not.to.have.been.called;
     });
 
     it('throws HTTP409 before any writes when pending rows share a reconciliation key', async () => {
@@ -160,6 +191,7 @@ describe('SubmissionFeatureReconciliationService', () => {
       expect(stubs.classify).not.to.have.been.called;
       expect(stubs.endSuperseded).not.to.have.been.called;
       expect(stubs.publish).not.to.have.been.called;
+      expect(stubs.logSuperseded).not.to.have.been.called;
       expect(stubs.closure).not.to.have.been.called;
     });
   });

--- a/api/src/services/reconciliation/submission-feature-reconciliation-service.ts
+++ b/api/src/services/reconciliation/submission-feature-reconciliation-service.ts
@@ -4,8 +4,9 @@ import {
   SUBMISSION_ACTIVE_STATE_LOCK_SEED
 } from '../../constants/database-lock-keys';
 import { IDBConnection } from '../../database/db';
-import { HTTP400, HTTP409 } from '../../errors/http-error';
+import { HTTP400, HTTP409, HTTP500 } from '../../errors/http-error';
 import { SubmissionFeatureDerivedStateRepository } from '../../repositories/reconciliation/submission-feature-derived-state-repository';
+import { SubmissionFeatureLogRepository } from '../../repositories/reconciliation/submission-feature-log-repository';
 import { SubmissionFeatureReconciliationRepository } from '../../repositories/reconciliation/submission-feature-reconciliation-repository';
 import { getLogger } from '../../utils/logger';
 import { DBService } from '../db-service';
@@ -40,6 +41,7 @@ export interface ReconciliationOutcomeCounts {
 export class SubmissionFeatureReconciliationService extends DBService {
   reconciliationRepository: SubmissionFeatureReconciliationRepository;
   derivedStateRepository: SubmissionFeatureDerivedStateRepository;
+  submissionFeatureLogRepository: SubmissionFeatureLogRepository;
   submissionUploadService: SubmissionUploadService;
   submissionFeatureClosureService: SubmissionFeatureClosureService;
 
@@ -53,6 +55,7 @@ export class SubmissionFeatureReconciliationService extends DBService {
     super(connection);
     this.reconciliationRepository = new SubmissionFeatureReconciliationRepository(connection);
     this.derivedStateRepository = new SubmissionFeatureDerivedStateRepository(connection);
+    this.submissionFeatureLogRepository = new SubmissionFeatureLogRepository(connection);
     this.submissionUploadService = new SubmissionUploadService(connection);
     this.submissionFeatureClosureService = new SubmissionFeatureClosureService(connection);
   }
@@ -70,10 +73,15 @@ export class SubmissionFeatureReconciliationService extends DBService {
    * 4. Soft-end superseded predecessors, soft-end unchanged and conflicted pending
    *    duplicates, then publish the new/superseded rows — in that order, so the
    *    one-published-row-per-key unique index holds at every statement boundary.
-   * 5. Heal derived state that referenced superseded rows (parent links, feature
+   * 5. Record append-only `superseded` rows in submission_feature_log, linking each ended
+   *    predecessor to its published replacement. Runs after publication so every log row
+   *    describes a completed transition; a unique-index violation (conflicting replacement
+   *    chain) or a classified/ended/logged tally mismatch aborts the approval before any
+   *    derived-state healing.
+   * 6. Heal derived state that referenced superseded rows (parent links, feature
    *    references, content relationships, security scope anchors) and carry active
    *    security rules forward onto replacement rows.
-   * 6. Recompute the submission's closure so search and authorization reach reflect the
+   * 7. Recompute the submission's closure so search and authorization reach reflect the
    *    new active state within the same transaction.
    *
    * Re-approving an already-activated upload is a no-op: classification only considers
@@ -83,6 +91,7 @@ export class SubmissionFeatureReconciliationService extends DBService {
    * @returns {Promise<ReconciliationOutcomeCounts>} Per-outcome feature counts for the upload.
    * @throws {HTTP400} If the upload has not reached the `indexed` status.
    * @throws {HTTP409} If the upload's pending rows contain duplicate reconciliation keys.
+   * @throws {HTTP500} If the classified, soft-ended, and logged superseded tallies diverge.
    * @memberof SubmissionFeatureReconciliationService
    */
   async reconcileAndActivateSubmissionUpload(submissionUploadId: string): Promise<ReconciliationOutcomeCounts> {
@@ -127,6 +136,18 @@ export class SubmissionFeatureReconciliationService extends DBService {
     const conflictEndedCount = await this.reconciliationRepository.endConflictIncomingRows(submissionUploadId);
     const publishedCount = await this.reconciliationRepository.publishIncomingRows(submissionUploadId);
 
+    const supersededLogCount = await this.submissionFeatureLogRepository.insertSupersededLogRecordsFromReconciliation(
+      submissionUploadId
+    );
+
+    // These three tallies derive from the same outcome rows; divergence would permanently
+    // record transitions that never happened (log rows are never deleted), so abort on drift.
+    if (supersededCount !== counts.superseded || supersededLogCount !== counts.superseded) {
+      throw new HTTP500('Superseded feature lifecycle records diverged during approval', [
+        `classified=${counts.superseded}, ended=${supersededCount}, logged=${supersededLogCount}`
+      ]);
+    }
+
     const parentRepointCount = await this.derivedStateRepository.repointParentLinksToActiveRows(submissionId);
     const referenceRepointCount = await this.derivedStateRepository.repointFeaturePropertyReferencesToActiveRows(
       submissionId
@@ -152,6 +173,7 @@ export class SubmissionFeatureReconciliationService extends DBService {
       unchangedEndedCount,
       conflictEndedCount,
       publishedCount,
+      supersededLogCount,
       parentRepointCount,
       referenceRepointCount,
       relationshipRepointCount,

--- a/database/src/migrations/20260707120000_submission_feature_log.ts
+++ b/database/src/migrations/20260707120000_submission_feature_log.ts
@@ -1,0 +1,155 @@
+import type { Knex } from 'knex';
+
+/**
+ * Adds `submission_feature_log`: an append-only record of terminal submission_feature
+ * lifecycle transitions.
+ *
+ * - `superseded`: written during upload reconciliation when a changed version replaces a
+ *   published feature. Links the soft-ended predecessor to its replacement and snapshots
+ *   both content hashes.
+ * - `removed`: reserved for a future removal workflow; enforced by CHECK but not yet written.
+ *
+ * Not logged: new insertions (already carried by submission_feature.submission_upload_id),
+ * unchanged re-uploads (counted by submission_upload_feature_reconciliation), and pending-row
+ * soft-ends (never published). The pre-reconciliation dedupe soft-ends from 20260706120000 are
+ * not backfilled — they lack an attributable upload and content hashes, so linking them would
+ * corrupt chain resolution.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    CREATE TYPE submission_feature_log_action AS ENUM (
+      'superseded',
+      'removed'
+    );
+
+    CREATE TABLE submission_feature_log (
+      submission_feature_log_id integer GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+      submission_id integer NOT NULL,
+      submission_upload_id uuid,
+      feature_type_id integer NOT NULL,
+      source_id varchar(200),
+      action submission_feature_log_action NOT NULL,
+      previous_submission_feature_id integer NOT NULL,
+      new_submission_feature_id integer,
+      previous_content_hash varchar(64),
+      new_content_hash varchar(64),
+      details jsonb,
+      create_date timestamptz(6) DEFAULT now() NOT NULL,
+      create_user integer NOT NULL,
+      update_date timestamptz(6),
+      update_user integer,
+      revision_count integer DEFAULT 0 NOT NULL,
+      CONSTRAINT submission_feature_log_pk PRIMARY KEY (submission_feature_log_id),
+      CONSTRAINT submission_feature_log_fk1
+        FOREIGN KEY (submission_id)
+        REFERENCES submission(submission_id),
+      CONSTRAINT submission_feature_log_fk2
+        FOREIGN KEY (submission_upload_id)
+        REFERENCES submission_upload(submission_upload_id),
+      CONSTRAINT submission_feature_log_fk3
+        FOREIGN KEY (feature_type_id)
+        REFERENCES feature_type(feature_type_id),
+      CONSTRAINT submission_feature_log_fk4
+        FOREIGN KEY (previous_submission_feature_id)
+        REFERENCES submission_feature(submission_feature_id),
+      CONSTRAINT submission_feature_log_fk5
+        FOREIGN KEY (new_submission_feature_id)
+        REFERENCES submission_feature(submission_feature_id),
+      CONSTRAINT submission_feature_log_ck1 CHECK (
+        (
+          action = 'superseded'
+          AND new_submission_feature_id IS NOT NULL
+          AND submission_upload_id IS NOT NULL
+          AND source_id IS NOT NULL
+        )
+        OR (
+          action = 'removed'
+          AND new_submission_feature_id IS NULL
+          AND new_content_hash IS NULL
+        )
+      ),
+      CONSTRAINT submission_feature_log_ck2 CHECK (
+        previous_submission_feature_id <> new_submission_feature_id
+      )
+    );
+
+    CREATE UNIQUE INDEX submission_feature_log_uk1
+      ON submission_feature_log (previous_submission_feature_id);
+
+    COMMENT ON INDEX submission_feature_log_uk1 IS
+      'At most one terminal transition per predecessor: version chains stay linear, and a conflicting replacement chain aborts the approval.';
+
+    CREATE INDEX submission_feature_log_idx1
+      ON submission_feature_log (new_submission_feature_id);
+    CREATE INDEX submission_feature_log_idx2
+      ON submission_feature_log (submission_id);
+    CREATE INDEX submission_feature_log_idx3
+      ON submission_feature_log (submission_upload_id);
+
+    COMMENT ON TABLE submission_feature_log IS
+      'Append-only log of terminal submission_feature transitions: superseded (a changed version replaced a published feature during reconciliation) and removed (reserved for a future workflow). New and unchanged features are not logged. Rows are never updated or deleted; corrections are new transitions from the active feature. Walk history via previous_submission_feature_id -> new_submission_feature_id; a removed row (new_submission_feature_id NULL) is terminal. The chain tip is NOT guaranteed live (denying an approved upload rewinds its rows without touching this log), so authoritative current state is always the active submission_feature row for the (submission_id, feature_type_id, source_id) key.';
+    COMMENT ON COLUMN submission_feature_log.submission_feature_log_id IS
+      'System generated surrogate primary key identifier.';
+    COMMENT ON COLUMN submission_feature_log.submission_id IS
+      'Foreign key to submission. Denormalized for submission-scoped history queries.';
+    COMMENT ON COLUMN submission_feature_log.submission_upload_id IS
+      'Foreign key to the submission_upload whose activation caused the transition. NULL allowed for removals not tied to an upload.';
+    COMMENT ON COLUMN submission_feature_log.feature_type_id IS
+      'Foreign key to the feature_type table.';
+    COMMENT ON COLUMN submission_feature_log.source_id IS
+      'Source-system identifier at transition time. Always set for superseded; nullable for removals of legacy rows without one.';
+    COMMENT ON COLUMN submission_feature_log.action IS
+      'Terminal transition kind: superseded (replaced by a changed version) or removed (no replacement; reserved for a future workflow).';
+    COMMENT ON COLUMN submission_feature_log.previous_submission_feature_id IS
+      'The soft-ended predecessor row that reached its terminal state.';
+    COMMENT ON COLUMN submission_feature_log.new_submission_feature_id IS
+      'The replacement row published in place of the predecessor. NOT NULL for superseded, NULL for removed.';
+    COMMENT ON COLUMN submission_feature_log.previous_content_hash IS
+      'content_hash of the predecessor at transition time. NULL for rows ingested before reconciliation support.';
+    COMMENT ON COLUMN submission_feature_log.new_content_hash IS
+      'content_hash of the replacement at transition time. NULL for removed, or replacements ingested before reconciliation support.';
+    COMMENT ON COLUMN submission_feature_log.details IS
+      'Optional structured context for the transition.';
+    COMMENT ON COLUMN submission_feature_log.create_date IS
+      'The datetime the record was created.';
+    COMMENT ON COLUMN submission_feature_log.create_user IS
+      'The id of the user who created the record.';
+    COMMENT ON COLUMN submission_feature_log.update_date IS
+      'The datetime the record was updated.';
+    COMMENT ON COLUMN submission_feature_log.update_user IS
+      'The id of the user who updated the record.';
+    COMMENT ON COLUMN submission_feature_log.revision_count IS
+      'Revision count used for concurrency control.';
+
+    CREATE TRIGGER audit_submission_feature_log
+      BEFORE INSERT OR UPDATE OR DELETE ON submission_feature_log
+      FOR EACH ROW EXECUTE PROCEDURE tr_audit_trigger();
+    CREATE TRIGGER journal_submission_feature_log
+      AFTER INSERT OR UPDATE OR DELETE ON submission_feature_log
+      FOR EACH ROW EXECUTE PROCEDURE tr_journal_trigger();
+  `);
+}
+
+/**
+ * Drops the submission_feature_log table and its action enum.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    DROP TRIGGER IF EXISTS journal_submission_feature_log ON submission_feature_log;
+    DROP TRIGGER IF EXISTS audit_submission_feature_log ON submission_feature_log;
+    DROP TABLE IF EXISTS submission_feature_log;
+    DROP TYPE IF EXISTS submission_feature_log_action;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1068](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1068)
- [SIMSBIOHUB-1060](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1060) - Dependency

## Description of Changes

- Adds `submission_feature_log`, an append-only table that records when an active feature is superseded during upload reconciliation. Each row links the old feature to its replacement and snapshots both content hashes.
- `removed` is reserved for a future removal workflow — the enum and CHECK support it, but nothing writes it yet.
- New and unchanged features are deliberately not logged; those are already covered by `submission_feature.submission_upload_id` and the reconciliation summary.
- Log rows are written in the reconciliation service right after features are published. A unique index on the previous feature id enforces one transition per version, and the approval aborts if the classified / soft-ended / logged superseded counts don't match.
- The table differs from the ticket's DDL sketch where it made sense to follow existing conventions: enum `action` + `details` jsonb (matching `submission_upload_feature_reconciliation`), varchar(64) hashes, uuid `submission_upload_id`, and the standard audit columns/triggers.

Worth calling out: the log captures transitions as they happen at approval, so the chain tip isn't guaranteed to be the live feature (e.g. denying an already-approved upload rewinds it without touching the log). Current state should still be read from active `submission_feature` rows — the table comment documents this.

## Testing Notes

- No API or response shape changes; the log is internal.
- Unit tests cover the new repository and the service wiring, including the count-divergence guard.
- Integration test (`submission-feature-reconciliation-service.integration.ts`) covers the end-to-end flow: a supersede writes one linked row, new/unchanged/re-approval write nothing, a multi-hop chain resolves to the current feature, and the uk1/ck1 constraints reject invalid rows.
