### PR TITLE
SIMSBIOHUB-1085: Remove recursive reachability query when evaluating expression

### DIFF
--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -46,7 +46,6 @@
 
 import { expect } from 'chai';
 import SQL from 'sql-template-strings';
-import { MAX_SEARCH_GRAPH_DEPTH } from '../../constants/expression';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
 import {
   NormalizedExpressionTreeExpression,
@@ -1072,51 +1071,6 @@ describe('expression-evaluation (integration)', function () {
       );
 
       expect(ids.has(q)).to.equal(false);
-    });
-
-    /**
-     * Depth cap = MAX_SEARCH_GRAPH_DEPTH (6). A linear content chain n1→…→n8 (7 edges). n1 is depth 0; the
-     * deepest reachable node is 6 edges from the seed (depth 6 included, depth 7 excluded). n7 (animal) sits
-     * at depth 6 and is reachable; n8 (telemetry) sits at depth 7 and is truncated. n1..n6 are sample_site so
-     * the animal/telemetry anchors isolate n7 and n8.
-     */
-    it('15: depth cap — node at depth 6 reachable, node at depth 7 truncated', async () => {
-      expect(MAX_SEARCH_GRAPH_DEPTH).to.equal(6);
-
-      const submissionId = await createTestSubmission(connection);
-      const uploadId = await createTestUpload(connection, submissionId);
-
-      // Chain of 8 nodes: indices 0-5 sample_site, 6 animal, 7 telemetry — the animal/telemetry anchors
-      // isolate the node at depth 6 (reachable) from the node at depth 7 (truncated).
-      const nodeTypes = [...Array.from({ length: 6 }, () => 'sample_site'), 'animal', 'telemetry'];
-      const nodes: number[] = [];
-      for (const featureTypeName of nodeTypes) {
-        nodes.push(await insertFeatureRow({ submissionId, submissionUploadId: uploadId, featureTypeName }));
-      }
-      for (let i = 0; i < nodes.length - 1; i++) {
-        await insertContentEdge(nodes[i], nodes[i + 1]);
-      }
-      await indexNameProperty(nodes[0], 'depth', SAMPLE_SITE_NAME_FTP_ID);
-
-      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
-
-      const tree: NormalizedExpressionTreeExpression = {
-        type: 'expression',
-        operator: 'AND',
-        clauses: [namePredicate('depth', SAMPLE_SITE_NAME_FTP_ID)]
-      };
-
-      // n7 (index 6) is depth 6 — exactly at the cap — so it is reachable.
-      const animalIds = await runSubquery(
-        buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId())
-      );
-      expect(animalIds.has(nodes[6])).to.equal(true);
-
-      // n8 (index 7) is depth 7 — one past the cap — so it is truncated.
-      const telemetryIds = await runSubquery(
-        buildExpressionTreeFeatureIdsSubquery('telemetry', tree, connection.systemUserId())
-      );
-      expect(telemetryIds.has(nodes[7])).to.equal(false);
     });
   });
 });

--- a/api/src/__integration__/db/expression-evaluation.integration.ts
+++ b/api/src/__integration__/db/expression-evaluation.integration.ts
@@ -2,35 +2,28 @@
 // submission_feature_id sets against a real schema, including the security filter applied for an
 // authenticated user.
 //
-// SEMANTICS UNDER TEST — closure + recursive content walk:
-// The evaluator resolves a predicate's evidence features (security-filtered on the evidence side) and
-// then expands them to the anchor feature type through two reachability sources combined with UNION:
+// SEMANTICS UNDER TEST — anchor-first closure projection:
+// The evaluator resolves a predicate's direct evidence features (security-filtered on the evidence side)
+// and then tests candidate anchors of the requested feature type against that evidence:
 //
-//   content_reach  = a bounded recursive walk SEEDED FROM the evidence (depth 0), following the BIDIRECTIONAL
-//                    submission_feature_feature content edges the closure omits (both endpoints active) — cap
-//                    depth < 6 in the recursive step (deepest node reached is 6 edges from the seed),
-//                    cycle-guarded by the visited path. content_reach ALWAYS includes the evidence itself.
-//   reachable      = content_reach
-//                    ∪ closureForward = { c.target : c.source ∈ content_reach }  (ancestors + referenced)
-//                    ∪ closureReverse = { c.source : c.target ∈ content_reach }  (descendants + referencing)
-//   result         = { sf ∈ reachable : sf is of anchorFeatureType, sf active, sf passes TARGET security }
+//   evidence       = active features that directly carry a typed property row matching the predicate
+//   same-type      = evidence.feature_type == anchor.feature_type AND evidence.id == anchor.id
+//   different-type = evidence.feature_type != anchor.feature_type AND closure connects anchor and evidence
+//                    in either direction
+//   result         = active anchors of anchorFeatureType that satisfy one of the above and pass target security
 //
 // The closure (submission_feature_closure) is UPLOAD-SCOPED and precomputes parent-ancestry and
 // property-reference reach. A parent edge stores (source=child, target=parent); a property edge stores
 // (source=feature, target=referenced). It is built by SubmissionFeatureClosureService.computeClosureForUpload
 // AFTER seeding and BEFORE running the subquery. Closure relatedness therefore REQUIRES a shared upload.
-// Content edges are excluded from the closure and are walked at read time; they need neither a shared
-// upload nor a closure rebuild.
+// Content edges are excluded from the closure and are no longer walked at read time.
 //
 // Key consequences pinned by these tests:
-//   1. Evidence is always in content_reach, so a reflexive match (anchor = evidence's own type) returns
-//      the evidence even with an empty closure and no content edges.
+//   1. Reflexive same-type matches return only the evidence row itself, not siblings connected through a
+//      shared parent or upload.
 //   2. Ancestor / descendant / property reach REQUIRES a shared upload + computeClosureForUpload.
-//   3. Content reach is a RECURSIVE multi-hop walk (not one-hop).
-//   4. content→closure chains: a content neighbour M of E contributes M's closure ancestors/descendants,
-//      because M ∈ content_reach and the closure is probed from content_reach.
-//   5. ACCEPTED, INTENTIONAL GAP: the reverse order (closure-ancestor of E, then THAT ancestor's content
-//      edge) is NOT recovered — the content walk seeds only from evidence, not from closure results.
+//   3. Content edges, including multi-hop content chains and content->closure chains, do not produce matches.
+//   4. Target security is applied after projection so related secured anchors do not leak.
 //
 // UO#5 / API-shape acceptance rows are exercised at the route layer and are out of scope for this
 // evaluator suite, which pins the emitted-SQL reachability semantics directly.
@@ -73,7 +66,7 @@ const SURVEY_NAME_FTP_ID = 70;
  * `feature_property_id` stays 31 (the shared `name` feature_property); `featureTypePropertyId` selects
  * the typed slot to filter on (45 = sample_site.name, 70 = survey.name). The predicate is intentionally
  * target-feature agnostic — it only identifies EVIDENCE features that carry the matching string row; the
- * evaluator then projects that evidence to the anchor type through the closure + content walk.
+ * evaluator then projects anchor candidates against that evidence.
  */
 function namePredicate(
   value: string,
@@ -120,7 +113,7 @@ describe('expression-evaluation (integration)', function () {
    * of the same upload, so a parent and its children must share one submission_upload_id. createTestFeature
    * mints its OWN upload per call and cannot place a parent + child under one upload, so the closure-driven
    * fixtures insert features directly here. `recordEndDate` marks a feature inactive (excluded from the
-   * active universe, dropped from the closure and the content walk's active-endpoint guard).
+   * active universe and dropped from the closure.
    *
    * @returns The new submission_feature_id.
    */
@@ -219,10 +212,10 @@ describe('expression-evaluation (integration)', function () {
   /**
    * Insert a single content edge (submission_feature_feature) source -> target.
    *
-   * Content edges are walked at read time (bidirectionally) and are NOT part of the closure, so this
-   * helper drives the recursive-content-walk assertions. The table has a unique index on
+   * Content edges are NOT part of the closure and are no longer walked by expression evaluation. The
+   * helper drives negative assertions that content-only relatedness does not produce matches. The table has a unique index on
    * (LEAST(source, target), GREATEST(source, target)), so only ONE direction per unordered pair may be
-   * inserted — the evaluator makes the walk bidirectional regardless of stored direction.
+   * inserted.
    */
   async function insertContentEdge(sourceFeatureId: number, targetFeatureId: number): Promise<void> {
     const systemUserId = connection.systemUserId();
@@ -321,7 +314,7 @@ describe('expression-evaluation (integration)', function () {
   /**
    * Run an emitted Knex subquery and return the resulting SET of submission_feature_id values. Set
    * equality is what every reachability test asserts on; ordering is irrelevant. NOTE: a Set hides
-   * duplicates — use runCount for the UNION-dedup assertion.
+   * duplicates — use runCount where duplicate suppression matters.
    */
   async function runSubquery(subquery: any): Promise<Set<number>> {
     const { sql, bindings } = subquery.toSQL().toNative();
@@ -331,8 +324,7 @@ describe('expression-evaluation (integration)', function () {
 
   /**
    * Count the rows the emitted subquery returns by wrapping it as a derived table. Needed where a Set
-   * would collapse duplicates — the evaluator UNIONs (not UNION ALL) its reachability sources, so a
-   * feature reachable by more than one path must surface exactly once.
+   * would collapse duplicates.
    */
   async function runCount(subquery: any): Promise<number> {
     const { sql, bindings } = subquery.toSQL().toNative();
@@ -344,7 +336,7 @@ describe('expression-evaluation (integration)', function () {
   }
 
   /**
-   * Seed a `survey → animal → capture` parent chain under ONE upload, index `name` on the survey, and
+   * Seed a `survey -> animal -> capture` parent chain under ONE upload, index `name` on the survey, and
    * rebuild the closure. The common fixture for closure descendant/ancestor reach tests anchored on the
    * survey name.
    */
@@ -447,13 +439,12 @@ describe('expression-evaluation (integration)', function () {
     });
   });
 
-  // === self-match: evidence ∈ content_reach guards the set-op combinator and evidence security =========
+  // === self-match: same-type evidence must be the anchor row itself ================================
 
-  describe('buildExpressionTreeFeatureIdsSubquery — self-match (evidence ∈ content_reach)', () => {
+  describe('buildExpressionTreeFeatureIdsSubquery — same-type self-match', () => {
     it('AND tree returns only features matching every predicate', async () => {
-      // Self-match: anchor type == evidence type, so the result is the evidence itself (content_reach
-      // always contains the evidence) with no closure or content edges needed. Isolated submissions keep
-      // the target and decoy from sharing any reach.
+      // Self-match: anchor type == evidence type, so the result is the evidence itself with no closure or
+      // content edges needed. Isolated submissions keep the target and decoy from sharing any reach.
       const submissionTarget = await createTestSubmission(connection);
       const target = await createTestFeature(connection, submissionTarget, 'sample_site', { name: 'AND-target' });
       await indexNameProperty(target, 'AND-target');
@@ -481,7 +472,7 @@ describe('expression-evaluation (integration)', function () {
 
     it('OR tree returns the union of predicate matches', async () => {
       // Self-match OR: the UNION combinator over two predicate branches; each candidate is its own
-      // evidence in content_reach. Each in its own submission to keep reach narrow.
+      // evidence. Each in its own submission to keep reach narrow.
       const submissionA = await createTestSubmission(connection);
       const a = await createTestFeature(connection, submissionA, 'sample_site', { name: 'OR-A' });
       await indexNameProperty(a, 'OR-A');
@@ -555,14 +546,52 @@ describe('expression-evaluation (integration)', function () {
       expect(ids.has(open)).to.equal(true);
       expect(ids.has(secured)).to.equal(false);
     });
+
+    it('same-type evidence does not pull in sibling anchors through a shared parent', async () => {
+      const submissionId = await createTestSubmission(connection);
+      const uploadId = await createTestUpload(connection, submissionId);
+
+      const survey = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'survey'
+      });
+      const matchingObservation = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: survey
+      });
+      const siblingObservation = await insertFeatureRow({
+        submissionId,
+        submissionUploadId: uploadId,
+        featureTypeName: 'sample_site',
+        parentFeatureId: survey
+      });
+
+      await indexNameProperty(matchingObservation, 'high-elevation-observation', SAMPLE_SITE_NAME_FTP_ID);
+      await new SubmissionFeatureClosureService(connection).computeClosureForUpload(uploadId);
+
+      const tree: NormalizedExpressionTreeExpression = {
+        type: 'expression',
+        operator: 'AND',
+        clauses: [namePredicate('high-elevation-observation', SAMPLE_SITE_NAME_FTP_ID)]
+      };
+      const ids = await runSubquery(
+        buildExpressionTreeFeatureIdsSubquery('sample_site', tree, connection.systemUserId())
+      );
+
+      expect(ids.has(matchingObservation)).to.equal(true);
+      expect(ids.has(siblingObservation)).to.equal(false);
+    });
   });
 
-  // === closure + recursive content-walk reachability =====================================
+  // === closure reachability without recursive content walking =============================
 
-  describe('buildExpressionTreeFeatureIdsSubquery — closure + content-walk reachability', () => {
+  describe('buildExpressionTreeFeatureIdsSubquery — anchor-first closure reachability', () => {
     /**
-     * Descendant reach (load-bearing reverse closure probe). D(survey) ← A(animal) ← C(capture) under one
-     * upload; evidence = D (survey.name). content_reach = {D}; closureReverse(D) = D's descendants = {A, C}.
+     * Descendant reach (load-bearing reverse closure probe). D(survey) <- A(animal) <- C(capture) under one
+     * upload; evidence = D (survey.name). closureReverse(D) = D's descendants = {A, C}.
      * Anchor=capture isolates C. A FORWARD-ONLY probe would return EMPTY here — descendant reach exists only
      * because the closure is probed in BOTH directions.
      */
@@ -580,8 +609,8 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Ancestor reach (forward closure probe). D(survey) ← S(sample_site) under one upload; evidence = S.
-     * content_reach = {S}; closureForward(S) = S's ancestors = {D}. Anchor=survey isolates D.
+     * Ancestor reach (forward closure probe). D(survey) <- S(sample_site) under one upload; evidence = S.
+     * closureForward(S) = S's ancestors = {D}. Anchor=survey isolates D.
      */
     it('2: ancestor reach — anchor above evidence is recovered via closureForward', async () => {
       const submissionId = await createTestSubmission(connection);
@@ -609,9 +638,9 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Property-reference reach in BOTH directions. F(sample_site) → G(animal) via a property edge, NO parent
-     * link. Forward: evidence=F, closureForward(F)→G, anchor=animal returns G (the referenced feature).
-     * Reverse: evidence=G, closureReverse(G)→F, anchor=sample_site returns F (the referencing feature).
+     * Property-reference reach in BOTH directions. F(sample_site) -> G(animal) via a property edge, NO parent
+     * link. Forward: evidence=F, closureForward(F)->G, anchor=animal returns G (the referenced feature).
+     * Reverse: evidence=G, closureReverse(G)->F, anchor=sample_site returns F (the referencing feature).
      */
     it('3: property-reference reach — referenced (forward) and referencing (reverse) both recovered', async () => {
       const submissionId = await createTestSubmission(connection);
@@ -653,8 +682,8 @@ describe('expression-evaluation (integration)', function () {
 
     /**
      * Defense-in-depth: the security filter is re-applied to PROJECTED targets, not just evidence. evidence
-     * (sample_site, unsecured) and securedTarget (sample_site, parent=evidence) share one upload, so the
-     * closure connects them (parent edge securedTarget→evidence ⇒ closureReverse(evidence) reaches it). With
+     * (sample_site, unsecured) and securedTarget (animal, parent=evidence) share one upload, so the closure
+     * connects them (parent edge securedTarget->evidence => closureReverse(evidence) reaches it). With
      * systemUserId=null the secured target must NOT leak; with a privileged user (scope-granted) it appears.
      */
     it('4: secured projected target is filtered for anonymous and visible to a granted user', async () => {
@@ -669,7 +698,7 @@ describe('expression-evaluation (integration)', function () {
       const securedTarget = await insertFeatureRow({
         submissionId,
         submissionUploadId: uploadId,
-        featureTypeName: 'sample_site',
+        featureTypeName: 'animal',
         parentFeatureId: evidence
       });
       await indexNameProperty(evidence, 'evidence-row', SAMPLE_SITE_NAME_FTP_ID);
@@ -684,21 +713,20 @@ describe('expression-evaluation (integration)', function () {
       };
 
       // Anonymous: evidence (unsecured) is kept; the secured descendant must not leak.
-      const anonymousIds = await runSubquery(buildExpressionTreeFeatureIdsSubquery('sample_site', tree, null));
-      expect(anonymousIds.has(evidence)).to.equal(true);
+      const anonymousIds = await runSubquery(buildExpressionTreeFeatureIdsSubquery('animal', tree, null));
       expect(anonymousIds.has(securedTarget)).to.equal(false);
 
       // Granted: stand up the scope-grant chain on the secured target, then the privileged user sees it.
       await grantPrivilegedAccess(securedTarget);
       const grantedIds = await runSubquery(
-        buildExpressionTreeFeatureIdsSubquery('sample_site', tree, connection.systemUserId())
+        buildExpressionTreeFeatureIdsSubquery('animal', tree, connection.systemUserId())
       );
       expect(grantedIds.has(securedTarget)).to.equal(true);
     });
 
     /**
-     * Reflexive reach. A single feature E(sample_site) with an empty closure and no content edges still
-     * returns itself, because content_reach is seeded from the evidence and always contains it.
+     * Reflexive reach. A single feature E(sample_site) returns itself because same-type evidence directly
+     * matches the anchor row.
      */
     it('5: reflexive — evidence returns itself with empty closure and no edges', async () => {
       const submissionId = await createTestSubmission(connection);
@@ -722,9 +750,9 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * UNION dedup. F is reachable from evidence E both as a referenced feature (closureForward, via a
-     * property edge E→F) AND as a descendant (closureReverse, via parent F→E). UNION (not UNION ALL) must
-     * collapse the two paths so F appears EXACTLY ONCE — a downstream count(*) wrap must not double-count.
+     * Duplicate suppression. F is reachable from evidence E both as a referenced feature (closureForward, via a
+     * property edge E->F) AND as a descendant (closureReverse, via parent F->E). F must appear EXACTLY ONCE
+     * so a downstream count(*) wrap does not double-count.
      */
     it('6: UNION dedup — a multi-path target appears exactly once', async () => {
       const submissionId = await createTestSubmission(connection);
@@ -756,11 +784,10 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Content-only reach is preserved (no closure path). F(sample_site) ─content→ G(telemetry); G2(telemetry)
-     * has NO edge. The closure adds only self loops, so G is reached purely by the content walk; G2 (the
-     * control) proves it is the content edge doing the work, not incidental same-upload reach.
+     * Content-only reach is intentionally absent. F(sample_site) -content-> G(telemetry); G2(telemetry)
+     * has NO edge. The closure adds only self loops, so neither telemetry row is connected through closure.
      */
-    it('7: content-only — content neighbour reached, unconnected same-type decoy not', async () => {
+    it('7: content-only — content neighbour is not reached', async () => {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
 
@@ -781,14 +808,14 @@ describe('expression-evaluation (integration)', function () {
         buildExpressionTreeFeatureIdsSubquery('telemetry', tree, connection.systemUserId())
       );
 
-      expect(ids.has(g)).to.equal(true);
+      expect(ids.has(g)).to.equal(false);
       expect(ids.has(g2)).to.equal(false);
     });
 
     /**
      * Survey membership fan-out has been removed. D(survey) with a real descendant Y(animal, parent=D) and an
      * UNCONNECTED same-submission X(animal, no parent). Evidence=D reaches Y via closureReverse (Y is D's
-     * descendant) but no longer reaches X — the synthetic survey→every-feature-in-submission membership edge is
+     * descendant) but no longer reaches X — the synthetic survey->every-feature-in-submission membership edge is
      * gone, so an unconnected same-submission feature is unreachable from survey evidence.
      */
     it('8: survey evidence reaches descendants via closure but not unconnected same-submission features', async () => {
@@ -820,14 +847,13 @@ describe('expression-evaluation (integration)', function () {
 
     /**
      * Empty-closure behaviour, two halves, evaluated on the authenticated path.
-     * (a) uploadA gets NO closure: A(sample_site) ← E(sample_site), evidence=E, anchor=sample_site → A
+     * (a) uploadA gets NO closure: A(sample_site) <- E(sample_site), evidence=E, anchor=sample_site -> A
      *     ABSENT. With no ancestry rows the parent A is unreachable from E, and (post fail-closed) E itself
      *     reads as secured and is stripped — either way A does not appear.
-     * (b) uploadB's closure is rebuilt to self-loops only (no e2→m ancestor edge), so M stays reachable
-     *     SOLELY via the content walk while reading as a visible unsecured feature: E2(sample_site)
-     *     ─content→ M(animal), evidence=E2, anchor=animal → M PRESENT. Distinct uploads keep the halves clean.
+     * (b) uploadB's closure is rebuilt to self-loops only (no e2->m ancestor edge). E2(sample_site)
+     *     -content-> M(animal), evidence=E2, anchor=animal remains ABSENT because content edges are not walked.
      */
-    it('9: empty closure — closure ancestor reach absent, content reach still works', async () => {
+    it('9: empty closure — closure ancestor reach absent, content reach absent', async () => {
       const submissionId = await createTestSubmission(connection);
 
       // (a) closure ancestor reach needs the closure — do NOT rebuild it.
@@ -855,10 +881,8 @@ describe('expression-evaluation (integration)', function () {
       );
       expect(ancestorIds.has(ancestorSite)).to.equal(false);
 
-      // (b) The content WALK still reaches m without any closure ancestry — but the security filter now
-      // fails closed on a feature with no closure rows, so rebuild uploadB's closure to give e2 and m their
-      // self-loops. m is NOT e2's child, so no e2→m ancestor edge is created: the content edge remains the
-      // ONLY thing that reaches m, while the self-loop lets the filter read m as a visible (unsecured) feature.
+      // (b) Rebuild uploadB's closure to give e2 and m their self-loops. m is NOT e2's child, so no e2->m
+      // ancestor edge is created. The content edge alone must not reach m.
       const uploadB = await createTestUpload(connection, submissionId);
       const e2 = await insertFeatureRow({ submissionId, submissionUploadId: uploadB, featureTypeName: 'sample_site' });
       const m = await insertFeatureRow({ submissionId, submissionUploadId: uploadB, featureTypeName: 'animal' });
@@ -874,12 +898,12 @@ describe('expression-evaluation (integration)', function () {
       const contentIds = await runSubquery(
         buildExpressionTreeFeatureIdsSubquery('animal', contentTree, connection.systemUserId())
       );
-      expect(contentIds.has(m)).to.equal(true);
+      expect(contentIds.has(m)).to.equal(false);
     });
 
     /**
      * AND/OR compose over closure-related features. Two surveys in separate submissions each have a child
-     * sample_site: D1 ← S1, D2 ← S2. An OR of [D1.name, D2.name] anchored at sample_site UNIONs the two
+     * sample_site: D1 <- S1, D2 <- S2. An OR of [D1.name, D2.name] anchored at sample_site UNIONs the two
      * descendant reaches (S1 and S2). An AND INTERSECTs them — no sample_site is a descendant of both surveys,
      * so the intersection is empty. The raw combinator is already pinned by the self-match AND/OR tests; this
      * guards that it composes correctly when leaves resolve THROUGH closure relatedness.
@@ -944,9 +968,9 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Cross-type anchor filter. D(survey) ← A(animal) ← C(capture) under one upload; evidence=D reaches
-     * {A, C} via closureReverse plus D itself. Anchor=animal returns ONLY A — not C (capture), not D
-     * (survey). The anchor type is the sole result filter over the reachable set.
+     * Cross-type anchor filter. D(survey) <- A(animal) <- C(capture) under one upload; evidence=D is
+     * connected to both descendants through closureReverse. Anchor=animal returns ONLY A, not C (capture)
+     * or D (survey).
      */
     it('11: anchor type filters the reachable set to one type', async () => {
       const { d, a, c } = await seedSurveyAnimalCaptureChain('cross-type');
@@ -964,11 +988,10 @@ describe('expression-evaluation (integration)', function () {
     });
 
     /**
-     * Multi-hop content chain (CRITICAL). Content edges A→B and B→C only (no A→C). Evidence=A; the recursive
-     * walk reaches C across TWO content hops (A→B→C). Anchor=telemetry returns C and not the unconnected
-     * decoy. This result would be EMPTY under a one-hop probe — that is the point of the recursive walk.
+     * Multi-hop content chain. Content edges A->B and B->C only (no A->C). Evidence=A; because expression
+     * evaluation no longer walks content edges, anchor=telemetry returns neither C nor the unconnected decoy.
      */
-    it('12: multi-hop content chain — target reached across two content hops', async () => {
+    it('12: multi-hop content chain — target is not reached across content hops', async () => {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
 
@@ -995,16 +1018,16 @@ describe('expression-evaluation (integration)', function () {
         buildExpressionTreeFeatureIdsSubquery('telemetry', tree, connection.systemUserId())
       );
 
-      expect(ids.has(c)).to.equal(true);
+      expect(ids.has(c)).to.equal(false);
       expect(ids.has(cDecoy)).to.equal(false);
     });
 
     /**
-     * content→closure chain. E ─content→ M, and M's parent is P (closure: M→P ancestor). Evidence=E;
-     * content_reach={E, M}; closureForward(M)→P. Anchor=capture returns P (and not the unconnected Pdecoy):
-     * a content neighbour contributes ITS closure ancestors because the closure is probed from content_reach.
+     * content->closure chain. E -content-> M, and M's parent is P (closure: M->P ancestor). Evidence=E;
+     * because content edges are not walked, M is never used as bridge evidence and anchor=capture returns
+     * neither P nor the unconnected Pdecoy.
      */
-    it('13: content→closure chain — content neighbour contributes its closure ancestor', async () => {
+    it('13: content->closure chain — content neighbour does not contribute its closure ancestor', async () => {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
 
@@ -1033,18 +1056,16 @@ describe('expression-evaluation (integration)', function () {
       };
       const ids = await runSubquery(buildExpressionTreeFeatureIdsSubquery('capture', tree, connection.systemUserId()));
 
-      expect(ids.has(p)).to.equal(true);
+      expect(ids.has(p)).to.equal(false);
       expect(ids.has(pDecoy)).to.equal(false);
     });
 
     /**
-     * ACCEPTED INTENTIONAL GAP (negative). A(capture) is rootless; E(sample_site, parent=A) so the closure
-     * gives E→A ancestor. A ─content→ Q (NOT E→Q). Evidence=E; content_reach={E} (E has no content edge).
-     * closureForward(E)→A, but A is reached via the CLOSURE, not content_reach, so A's content neighbour Q is
-     * never walked — the walk seeds only from evidence, not from closure results. Q must be ABSENT. This is a
-     * deliberate one-way design choice (closure-then-content is not recovered), not a bug.
+     * Closure-then-content remains absent. A(capture) is rootless; E(sample_site, parent=A) so the closure
+     * gives E->A ancestor. A -content-> Q (NOT E->Q). Evidence=E; closureForward(E)->A, but A's content
+     * neighbour Q is never walked.
      */
-    it('14: accepted gap — closure-ancestor then ITS content edge is not recovered', async () => {
+    it('14: closure-ancestor then its content edge is not recovered', async () => {
       const submissionId = await createTestSubmission(connection);
       const uploadId = await createTestUpload(connection, submissionId);
 

--- a/api/src/constants/expression.ts
+++ b/api/src/constants/expression.ts
@@ -2,15 +2,6 @@ import type { PredicateOperator } from '../models/expression-predicate';
 import { FEATURE_PROPERTY_TYPE } from '../models/feature-property';
 
 /**
- * Maximum hop count for the recursive content-edge (`data.content`) walk in expression search.
- *
- * The closure precomputes parent-ancestry and property-reference reach, so the only run-time
- * recursion left is the bounded walk over `submission_feature_feature` content edges. This caps
- * that walk.
- */
-export const MAX_SEARCH_GRAPH_DEPTH = 6;
-
-/**
  * Shared operator registry keyed by resolved feature property type.
  *
  * Used after structural parsing to validate predicate semantics and expose expression-builder metadata.

--- a/api/src/repositories/expression-evaluation.test.ts
+++ b/api/src/repositories/expression-evaluation.test.ts
@@ -76,8 +76,8 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('submission_feature_property_string');
       expect(sql).to.include('inner join "feature_type_property" as "ftp"');
       expect(sql).to.include('"ftp"."feature_property_id"');
-      expect(sql).to.include('"ft"."name" = \'survey\'');
-      expect(sql).to.include('from (with recursive "evidence"');
+      expect(sql).to.include('"anchor_ft"."name" = \'survey\'');
+      expect(sql).to.include('from (with "evidence"');
       expect(sql).to.include('intersect');
       expect(sql).to.include('feature_property_id');
     });
@@ -125,9 +125,6 @@ describe('expression-evaluation', () => {
     });
 
     it('should also apply security filtering to projected target features (defense in depth)', () => {
-      // Filtering only the predicate evidence is not enough: graph traversal can reach a secured
-      // *target* feature from an unsecured evidence feature, so consumers that use the subquery
-      // directly (e.g. the download pipeline cursor) would otherwise leak that target id.
       const expressionTree: NormalizedExpressionTreeExpression = {
         type: 'expression',
         operator: 'AND',
@@ -143,10 +140,8 @@ describe('expression-evaluation', () => {
 
       const sql = buildExpressionTreeFeatureIdsSubquery('survey', expressionTree, 42).toString();
 
-      // The target-side filter is keyed on `sf.submission_feature_id`, distinct from the
-      // evidence-side filter on `p.submission_feature_id`.
-      expect(sql).to.include('"sf"."submission_feature_id"');
-      expect(sql).to.match(/security_scope_anchor[\s\S]*"sf"\."submission_feature_id"/);
+      expect(sql).to.include('"anchor_sf"."submission_feature_id"');
+      expect(sql).to.match(/security_scope_anchor[\s\S]*"anchor_sf"\."submission_feature_id"/);
     });
 
     it('should narrow predicate evidence by feature_type_property_id when provided', () => {
@@ -170,7 +165,7 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('"p"."feature_type_property_id" = 123');
     });
 
-    it('should project related predicate evidence to anchor feature ids through the content walk and closure probes', () => {
+    it('should project related predicate evidence to anchor feature ids through closure probes', () => {
       const expressionTree: NormalizedExpressionTreeExpression = {
         type: 'expression',
         operator: 'AND',
@@ -187,40 +182,36 @@ describe('expression-evaluation', () => {
 
       const sql = buildExpressionTreeFeatureIdsSubquery('telemetry', expressionTree, null).toString();
 
-      // Evidence CTE seeds the recursive content walk (WITH RECURSIVE is restored by the content-edge recursion).
       expect(sql).to.include('submission_feature_property_taxon');
-      expect(sql).to.include('with recursive "evidence" as');
+      expect(sql).to.include('with "evidence" as');
 
-      // Bounded recursive content walk over submission_feature_feature edges.
-      expect(sql).to.include('"content_edges"');
-      expect(sql).to.include('"content_reach"');
-      expect(sql).to.include('from "submission_feature_feature" as "sff"');
-      expect(sql).to.include('source_sf.record_effective_date <= now()');
-      expect(sql).to.include('now() < source_sf.record_end_date');
-      expect(sql).to.include('target_sf.record_effective_date <= now()');
-      expect(sql).to.include('now() < target_sf.record_end_date');
-      // Depth bound and cycle guard on the recursive term.
-      expect(sql).to.include('"content_reach"."depth" < 6');
-      expect(sql).to.include('= ANY(content_reach.path)');
+      expect(sql).to.include('from "submission_feature" as "anchor_sf"');
+      expect(sql).to.include('inner join "feature_type" as "anchor_ft"');
+      expect(sql).to.include('"anchor_ft"."name" = \'telemetry\'');
+      expect(sql).to.include('anchor_sf.record_effective_date <= now()');
+      expect(sql).to.include('now() < anchor_sf.record_end_date');
 
-      // Closure probed from every content-reached node — forward (by source) and reverse (by target).
-      expect(sql).to.include('from "submission_feature_closure" as "c"');
-      expect(sql).to.include('"cr"."feature_id" = "c"."source_submission_feature_id"');
-      expect(sql).to.include('"cr"."feature_id" = "c"."target_submission_feature_id"');
-      expect(sql).to.include('"c"."target_submission_feature_id" as "submission_feature_id"');
-      expect(sql).to.include('"c"."source_submission_feature_id" as "submission_feature_id"');
+      expect(sql).to.include('from "evidence"');
+      expect(sql).to.include('inner join "submission_feature" as "evidence_sf"');
+      expect(sql).to.include('inner join "feature_type" as "evidence_ft"');
+      expect(sql).to.include('evidence_sf.record_effective_date <= now()');
+      expect(sql).to.include('now() < evidence_sf.record_end_date');
 
-      // The reachable selects are UNION-combined (dedup), and the anchor type is applied to the resolved targets.
-      expect(sql).to.include(' union ');
-      expect(sql).to.include('"ft"."name" = \'telemetry\'');
-      expect(sql).to.include('sf.record_effective_date <= now()');
-      expect(sql).to.include('now() < sf.record_end_date');
+      expect(sql).to.include('evidence_ft.name = anchor_ft.name');
+      expect(sql).to.include('evidence_sf.submission_feature_id = anchor_sf.submission_feature_id');
+      expect(sql).to.include('evidence_ft.name <> anchor_ft.name');
 
-      // The synthetic survey↔same-submission membership edge has been removed — content edges only.
-      expect(sql).to.not.include('as "survey_sf"');
-      expect(sql).to.not.include('"related_sf"."submission_id" = "survey_sf"."submission_id"');
+      expect(sql).to.include('from "submission_feature_closure" as "c_forward"');
+      expect(sql).to.include('c_forward.source_submission_feature_id = anchor_sf.submission_feature_id');
+      expect(sql).to.include('c_forward.target_submission_feature_id = evidence_sf.submission_feature_id');
 
-      // The old graph-edge union machinery is gone (parent/child reach now comes from the closure).
+      expect(sql).to.include('from "submission_feature_closure" as "c_reverse"');
+      expect(sql).to.include('c_reverse.source_submission_feature_id = evidence_sf.submission_feature_id');
+      expect(sql).to.include('c_reverse.target_submission_feature_id = anchor_sf.submission_feature_id');
+
+      expect(sql).to.not.include('"content_edges"');
+      expect(sql).to.not.include('"content_reach"');
+      expect(sql).to.not.include('from "submission_feature_feature" as "sff"');
       expect(sql).to.not.include('connected_features');
       expect(sql).to.not.include('graph_edges');
       expect(sql).to.not.include('parent_submission_feature_id as');
@@ -253,7 +244,7 @@ describe('expression-evaluation', () => {
 
       expect(sql).to.include(' union ');
       expect(sql).to.not.include(' intersect ');
-      expect(sql).to.include('"ft"."name" = \'species_observation\'');
+      expect(sql).to.include('"anchor_ft"."name" = \'species_observation\'');
     });
 
     it('should recursively compose nested expression target sets', () => {
@@ -295,7 +286,7 @@ describe('expression-evaluation', () => {
 
       expect(sql).to.include(' intersect ');
       expect(sql).to.include(' union ');
-      expect(sql).to.include('"ft"."name" = \'species_observation\'');
+      expect(sql).to.include('"anchor_ft"."name" = \'species_observation\'');
     });
 
     it('should use feature-level NotEquals evidence semantics for multi-value properties', () => {
@@ -368,7 +359,7 @@ describe('expression-evaluation', () => {
       expect(sql).to.not.include('p.value');
     });
 
-    it('should project predicate evidence to species_observation targets through the content walk and closure probes', () => {
+    it('should project predicate evidence to species_observation targets through same-type matching and closure probes', () => {
       const expressionTree: NormalizedExpressionTreeExpression = {
         type: 'expression',
         operator: 'AND',
@@ -387,17 +378,17 @@ describe('expression-evaluation', () => {
 
       expect(sql).to.include('submission_feature_property_string');
       expect(sql).to.include('"ftp"."feature_property_id" = 46');
-      expect(sql).to.include('with recursive "evidence" as');
-      expect(sql).to.include('"content_reach"');
-      expect(sql).to.include('"content_edges"');
-      expect(sql).to.include('from "submission_feature_feature" as "sff"');
-      expect(sql).to.include('from "submission_feature_closure" as "c"');
-      expect(sql).to.include('"cr"."feature_id" = "c"."source_submission_feature_id"');
-      expect(sql).to.include('"cr"."feature_id" = "c"."target_submission_feature_id"');
-      expect(sql).to.include('"content_reach"."depth" < 6');
-      expect(sql).to.include(' union ');
-      expect(sql).to.include('"ft"."name" = \'species_observation\'');
-      expect(sql).to.not.include('as "survey_sf"');
+      expect(sql).to.include('with "evidence" as');
+      expect(sql).to.include('from "submission_feature" as "anchor_sf"');
+      expect(sql).to.include('from "evidence"');
+      expect(sql).to.include('evidence_ft.name = anchor_ft.name');
+      expect(sql).to.include('evidence_sf.submission_feature_id = anchor_sf.submission_feature_id');
+      expect(sql).to.include('from "submission_feature_closure" as "c_forward"');
+      expect(sql).to.include('from "submission_feature_closure" as "c_reverse"');
+      expect(sql).to.include('"anchor_ft"."name" = \'species_observation\'');
+      expect(sql).to.not.include('"content_reach"');
+      expect(sql).to.not.include('"content_edges"');
+      expect(sql).to.not.include('from "submission_feature_feature" as "sff"');
       expect(sql).to.not.include('connected_features');
     });
   });
@@ -413,7 +404,6 @@ describe('expression-evaluation', () => {
       expect(sql).to.include('sf.record_effective_date <= now()');
       expect(sql).to.include('now() < sf.record_end_date');
       expect(sql).to.not.include('"ft"."record_end_date" is null');
-      // Authenticated path uses isAccessibleToUser → security_scope_anchor + bound user id
       expect(sql).to.include('security_scope_anchor');
       expect(sql).to.include('team_security_scope');
       expect(sql).to.include('42');
@@ -423,7 +413,6 @@ describe('expression-evaluation', () => {
       const sql = buildBroadFeatureTypeSubquery('fish', null).toString();
 
       expect(sql).to.include('"ft"."name" = \'fish\'');
-      // Anonymous: emits NOT EXISTS (uppercase, raw SQL fragment) with no scope-anchor branch
       expect(sql.toLowerCase()).to.include('not exists');
       expect(sql).to.not.include('security_scope_anchor');
     });
@@ -446,7 +435,7 @@ describe('expression-evaluation', () => {
     it('emits the same expression criteria as the filtered variant', () => {
       const sql = buildUnfilteredExpressionTreeFeatureIdsSubquery('dataset', expressionTree).toString();
 
-      expect(sql).to.include('"ft"."name" = \'dataset\'');
+      expect(sql).to.include('"anchor_ft"."name" = \'dataset\'');
       expect(sql).to.include('submission_feature_property_number');
       expect(sql).to.include('"p"."submission_feature_id"');
     });
@@ -454,7 +443,6 @@ describe('expression-evaluation', () => {
     it('applies NO security/access filter (the candidate set before access filtering)', () => {
       const sql = buildUnfilteredExpressionTreeFeatureIdsSubquery('dataset', expressionTree).toString();
 
-      // Neither the authenticated scope-grant probe nor the anonymous NOT-secured probe is emitted.
       expect(sql).to.not.include('security_scope_anchor');
       expect(sql).to.not.include('team_security_scope');
       expect(sql).to.not.include('submission_feature_security');

--- a/api/src/repositories/expression-evaluation.ts
+++ b/api/src/repositories/expression-evaluation.ts
@@ -1,5 +1,4 @@
 import { Knex } from 'knex';
-import { MAX_SEARCH_GRAPH_DEPTH } from '../constants/expression';
 import { getKnex } from '../database/db';
 import { ApiBuildSQLError } from '../errors/api-error';
 import { InternalTypedPredicate, TimestampInternalPredicate } from '../models/expression-predicate';
@@ -189,11 +188,26 @@ function wrapTargetIdsQuery(query: Knex.QueryBuilder, knex: Knex, alias: string)
 /**
  * Builds a target submission_feature_id query for one typed expression predicate.
  *
- * @param {string} anchorFeatureType - Feature type name that result IDs must belong to.
+ * The predicate is evaluated in two steps:
+ *
+ * 1. Build the evidence set: features that directly carry a typed property row
+ *    matching the predicate.
+ * 2. Project that evidence set back to matching features of `anchorFeatureType`.
+ *
+ * `projectEvidenceToTargetIdsQuery` owns the anchor-projection semantics:
+ *
+ * - same feature type evidence must match the anchor row directly;
+ * - different feature type evidence may match an anchor row through
+ *   `submission_feature_closure` in either direction.
+ *
+ * This keeps `buildPredicateTargetIdsQuery` small and prevents predicate evaluation
+ * from becoming broad graph expansion.
+ *
+ * @param {string} anchorFeatureType - The route/result feature type to return.
  * @param {NormalizedExpressionTreePredicate} clause - Normalized predicate clause to compile.
- * @param {Knex} knex - Knex instance used to build the subquery.
- * @param {number | null} [systemUserId] - Security context (null = anonymous).
- * @return {Knex.QueryBuilder} Unexecuted subquery returning target submission_feature_id rows.
+ * @param {Knex} knex - Knex instance used to build the SQL query.
+ * @param {number | null} [systemUserId] - Security context. `null` represents anonymous access.
+ * @return {Knex.QueryBuilder} Unexecuted query returning distinct matching anchor `submission_feature_id` rows.
  */
 function buildPredicateTargetIdsQuery(
   anchorFeatureType: string,
@@ -202,6 +216,7 @@ function buildPredicateTargetIdsQuery(
   systemUserId?: number | null
 ): Knex.QueryBuilder {
   const evidenceQuery = buildPredicateEvidenceIdsQuery(clause, knex, systemUserId);
+
   return projectEvidenceToTargetIdsQuery(anchorFeatureType, evidenceQuery, knex, systemUserId);
 }
 
@@ -266,40 +281,36 @@ function buildPredicateEvidenceIdsQuery(
 }
 
 /**
- * Projects evidence feature IDs to the requested target feature type.
+ * Projects predicate evidence feature IDs to matching anchor feature IDs.
  *
- * Relatedness is the union of two reachability sources:
- *   (a) the precomputed `submission_feature_closure` reachability — parent-ancestry plus property-reference, in
- *       BOTH directions; and
- *   (b) a bounded recursive walk over the `submission_feature_feature` content (`data.content`) edges the closure
- *       deliberately omits — excluded from the closure because closing over them would make the closure the
- *       complete O(N^2) same-upload digraph.
+ * A predicate is first evaluated directly against typed property rows, producing
+ * an `evidence` set: features that directly carry a property matching the predicate.
  *
- * The walk starts from the evidence features and follows those edges out to MAX_SEARCH_GRAPH_DEPTH hops,
- * cycle-guarded by the visited path. Every content-reached node is then probed against the closure in BOTH
- * directions (forward by source: its ancestors + referenced features; reverse by target: its descendants +
- * referencing features), so a predicate that filters one feature type resolves results deeper or shallower in the
- * hierarchy, and content cross-references chain transitively into the closure reach. A forward-only or one-hop
- * probe would silently drop the common "filter the container, return the contained" search and multi-hop content
- * chains. Because `content_reach` is seeded from the evidence, probing the closure from `content_reach` already
- * covers the closure reach of the evidence features themselves — no separate evidence-to-closure probe is needed.
+ * This function returns only features of `anchorFeatureType`.
  *
- * `is_ancestor` is NOT consulted here. That flag marks the authorization (parent-ancestry) subset only; search
- * relatedness uses the full reachability set, so every closure row counts.
+ * Projection semantics:
  *
- * The three reachability selects are combined with UNION (not UNION ALL) so a feature reachable through more than
- * one path is counted once — a downstream count(*) wrap must not double-count it.
+ * - If an evidence feature has the same feature type as the anchor, the anchor
+ *   must be the evidence feature itself. This handles direct filters such as
+ *   `telemetry.elevation < 66` and prevents sibling leakage through a shared
+ *   dataset or parent.
  *
- * The security filter is re-applied to the resolved target rows, not only the evidence. Relatedness can reach a
- * secured target feature from unsecured evidence, which would leak the target id to any consumer that uses this
- * subquery directly (e.g. the download pipeline). Applying it here protects every consumer of this shared
- * subquery — search and download alike — with the same target-level security boundary.
+ * - If an evidence feature has a different feature type than the anchor, an
+ *   anchor matches when it is connected to the evidence feature through
+ *   `submission_feature_closure` in either direction. This supports searches
+ *   like `telemetry where animal.species = caribou` and
+ *   `telemetry where dataset.species = caribou`.
  *
- * @param {string} anchorFeatureType - Feature type name that projected target IDs must belong to.
- * @param {Knex.QueryBuilder} evidenceQuery - Query returning evidence submission_feature_id rows.
- * @param {Knex} knex - Knex instance used to build the projection query.
- * @param {number | null} [systemUserId] - Security context (null = anonymous).
- * @return {Knex.QueryBuilder} Unexecuted subquery returning projected target submission_feature_id rows.
+ * This is a candidate-anchor semi-join, not broad evidence graph expansion.
+ * Do not walk `submission_feature_feature` content edges here and do not expand
+ * from evidence outward before filtering back to the anchor type, because that
+ * can pull in non-matching sibling anchors.
+ *
+ * @param {string} anchorFeatureType - The route/result feature type to return.
+ * @param {Knex.QueryBuilder} evidenceQuery - Query returning direct predicate evidence `submission_feature_id` rows.
+ * @param {Knex} knex - Knex instance used to build the SQL query.
+ * @param {number | null} [systemUserId] - Security context. `null` represents anonymous access.
+ * @return {Knex.QueryBuilder} Unexecuted query returning distinct matching anchor `submission_feature_id` rows.
  */
 function projectEvidenceToTargetIdsQuery(
   anchorFeatureType: string,
@@ -307,98 +318,61 @@ function projectEvidenceToTargetIdsQuery(
   knex: Knex,
   systemUserId?: number | null
 ): Knex.QueryBuilder {
-  // reachable set: the content-reached nodes themselves, plus the closure probed in both directions from every
-  // content-reached node. Inlined here (not a top-level CTE) because it must reference the content_reach CTE.
-  // UNION (not UNION ALL) dedups a feature reachable via more than one path — a count(*) wrap must not double-count.
-  const reachable = knex
-    .select('content_reach.feature_id as submission_feature_id')
-    .from('content_reach')
-    .union([
-      // closure forward: ancestors + referenced features of every content-reached node
-      knex
-        .select('c.target_submission_feature_id as submission_feature_id')
-        .from('submission_feature_closure as c')
-        .join('content_reach as cr', 'cr.feature_id', 'c.source_submission_feature_id'),
-      // closure reverse: descendants + referencing features of every content-reached node
-      knex
-        .select('c.source_submission_feature_id as submission_feature_id')
-        .from('submission_feature_closure as c')
-        .join('content_reach as cr', 'cr.feature_id', 'c.target_submission_feature_id')
-    ]);
-
   const query = knex
     .queryBuilder()
     .with('evidence', evidenceQuery.clone())
-    // edges the closure deliberately omits, walked here: bidirectional content (data.content) edges.
-    // The builder is active-guarded.
-    .with('content_edges', (qb) => {
-      qb.select('from_feature_id', 'to_feature_id').from(buildContentEdgesQuery(knex).as('content_feature_edges'));
-    })
-    // recursive content walk: from each evidence feature, follow content edges out to MAX_SEARCH_GRAPH_DEPTH hops,
-    // cycle-guarded by the visited path. parent/property transitivity is NOT walked here — the closure handles it.
-    .withRecursive('content_reach', (qb) => {
-      qb.select(
-        'evidence.submission_feature_id as feature_id',
-        knex.raw('ARRAY[evidence.submission_feature_id] as path'),
-        knex.raw('0 as depth')
-      )
-        .from('evidence')
-        .unionAll([
-          knex
-            .select(
-              'content_edges.to_feature_id as feature_id',
-              knex.raw('content_reach.path || content_edges.to_feature_id as path'),
-              knex.raw('content_reach.depth + 1 as depth')
-            )
-            .from('content_reach')
-            .join('content_edges', 'content_edges.from_feature_id', 'content_reach.feature_id')
-            .where('content_reach.depth', '<', MAX_SEARCH_GRAPH_DEPTH)
-            .whereRaw('NOT content_edges.to_feature_id = ANY(content_reach.path)')
-        ]);
-    })
     .distinct()
-    .select('sf.submission_feature_id')
-    .from(reachable.as('reachable'))
-    .join('submission_feature as sf', 'sf.submission_feature_id', 'reachable.submission_feature_id')
-    .join('feature_type as ft', 'ft.feature_type_id', 'sf.feature_type_id')
-    .where('ft.name', anchorFeatureType)
-    .whereRaw(isSubmissionFeatureActive('sf'));
+    .select('anchor_sf.submission_feature_id')
+    .from('submission_feature as anchor_sf')
+    .join('feature_type as anchor_ft', 'anchor_ft.feature_type_id', 'anchor_sf.feature_type_id')
+    .where('anchor_ft.name', anchorFeatureType)
+    .whereRaw(isSubmissionFeatureActive('anchor_sf'))
+    .whereNull('anchor_ft.record_end_date')
+    .whereExists(
+      knex
+        .select(knex.raw('1'))
+        .from('evidence')
+        .join(
+          'submission_feature as evidence_sf',
+          'evidence_sf.submission_feature_id',
+          'evidence.submission_feature_id'
+        )
+        .join('feature_type as evidence_ft', 'evidence_ft.feature_type_id', 'evidence_sf.feature_type_id')
+        .whereRaw(isSubmissionFeatureActive('evidence_sf'))
+        .whereNull('evidence_ft.record_end_date')
+        .where((qb) => {
+          qb.where((sameType) => {
+            sameType
+              .whereRaw('evidence_ft.name = anchor_ft.name')
+              .whereRaw('evidence_sf.submission_feature_id = anchor_sf.submission_feature_id');
+          }).orWhere((differentType) => {
+            differentType.whereRaw('evidence_ft.name <> anchor_ft.name').where((connected) => {
+              connected
+                .whereExists(
+                  knex
+                    .select(knex.raw('1'))
+                    .from('submission_feature_closure as c_forward')
+                    .whereRaw('c_forward.source_submission_feature_id = anchor_sf.submission_feature_id')
+                    .whereRaw('c_forward.target_submission_feature_id = evidence_sf.submission_feature_id')
+                )
+                .orWhereExists(
+                  knex
+                    .select(knex.raw('1'))
+                    .from('submission_feature_closure as c_reverse')
+                    .whereRaw('c_reverse.source_submission_feature_id = evidence_sf.submission_feature_id')
+                    .whereRaw('c_reverse.target_submission_feature_id = anchor_sf.submission_feature_id')
+                );
+            });
+          });
+        })
+    );
 
-  const targetSecurityFilter = buildSecurityFilter(knex, systemUserId, 'sf.submission_feature_id');
+  const targetSecurityFilter = buildSecurityFilter(knex, systemUserId, 'anchor_sf.submission_feature_id');
   if (targetSecurityFilter) {
     query.whereRaw(targetSecurityFilter);
   }
 
   return query;
-}
-
-/**
- * Builds the bidirectional content (`data.content`) edges that the closure deliberately omits, so the search-time
- * recursion can walk them, emitted as from_feature_id -> to_feature_id.
- *
- * `submission_feature_feature` stores direct content edges only and has no record_end_date column. Active-record
- * filtering is applied to the source and target submission_feature rows instead, because either endpoint may
- * reference a soft-deleted feature.
- *
- * @param {Knex} knex - Knex instance used to build the edge query.
- * @return {Knex.QueryBuilder} Unexecuted query returning from_feature_id/to_feature_id content edges.
- */
-function buildContentEdgesQuery(knex: Knex): Knex.QueryBuilder {
-  const forward = knex('submission_feature_feature as sff')
-    .select('sff.source_feature_id as from_feature_id', 'sff.target_feature_id as to_feature_id')
-    .join('submission_feature as source_sf', 'source_sf.submission_feature_id', 'sff.source_feature_id')
-    .join('submission_feature as target_sf', 'target_sf.submission_feature_id', 'sff.target_feature_id')
-    .whereRaw(isSubmissionFeatureActive('source_sf'))
-    .whereRaw(isSubmissionFeatureActive('target_sf'));
-
-  const reverse = knex('submission_feature_feature as sff')
-    .select('sff.target_feature_id as from_feature_id', 'sff.source_feature_id as to_feature_id')
-    .join('submission_feature as source_sf', 'source_sf.submission_feature_id', 'sff.source_feature_id')
-    .join('submission_feature as target_sf', 'target_sf.submission_feature_id', 'sff.target_feature_id')
-    .whereRaw(isSubmissionFeatureActive('source_sf'))
-    .whereRaw(isSubmissionFeatureActive('target_sf'));
-
-  return forward.unionAll([reverse]);
 }
 
 /**

--- a/api/src/repositories/expression-evaluation.ts
+++ b/api/src/repositories/expression-evaluation.ts
@@ -14,11 +14,11 @@ import { buildSecurityFilter, isSubmissionFeatureActive } from './sql-fragments'
  * subqueries returning matching submission_feature_id values for an anchor
  * feature type.
  *
- * Each predicate compiles into a bounded recursive content walk plus closure
- * probes: a `WITH RECURSIVE` CTE walks the `submission_feature_feature` content
- * (`data.content`) edges the closure deliberately omits, and the precomputed
- * `submission_feature_closure` table is probed from every content-reached node
- * to resolve parent-ancestry and property-reference reach with indexed joins.
+ * Each predicate first resolves direct evidence features from typed property
+ * rows, then projects candidate anchor features against that evidence. Same-type
+ * evidence must be the anchor row itself; different-type evidence may be
+ * connected through the precomputed `submission_feature_closure` table in either
+ * direction. The projection does not recursively walk content edges.
  *
  * Read-time evaluator shared by the search wrapper (POST /api/search/feature)
  * and the download pipeline (POST /api/download). Both paths consume the same
@@ -173,7 +173,7 @@ function buildExpressionTargetIdsQuery(
 /**
  * Wraps target ID queries before set operations.
  *
- * Predicate clauses carry a `WITH RECURSIVE` CTE (the bounded content-edge walk). PostgreSQL accepts a WITH-bearing
+ * Predicate clauses carry a WITH-bearing evidence CTE. PostgreSQL accepts a WITH-bearing
  * query inside a derived table, but not directly as a parenthesized INTERSECT/UNION operand, so the wrap is required.
  *
  * @param {Knex.QueryBuilder} query - Target ID query to wrap as a derived table.
@@ -207,7 +207,7 @@ function wrapTargetIdsQuery(query: Knex.QueryBuilder, knex: Knex, alias: string)
  * @param {NormalizedExpressionTreePredicate} clause - Normalized predicate clause to compile.
  * @param {Knex} knex - Knex instance used to build the SQL query.
  * @param {number | null} [systemUserId] - Security context. `null` represents anonymous access.
- * @return {Knex.QueryBuilder} Unexecuted query returning distinct matching anchor `submission_feature_id` rows.
+ * @return {Knex.QueryBuilder} Unexecuted query returning matching anchor `submission_feature_id` rows.
  */
 function buildPredicateTargetIdsQuery(
   anchorFeatureType: string,
@@ -310,7 +310,7 @@ function buildPredicateEvidenceIdsQuery(
  * @param {Knex.QueryBuilder} evidenceQuery - Query returning direct predicate evidence `submission_feature_id` rows.
  * @param {Knex} knex - Knex instance used to build the SQL query.
  * @param {number | null} [systemUserId] - Security context. `null` represents anonymous access.
- * @return {Knex.QueryBuilder} Unexecuted query returning distinct matching anchor `submission_feature_id` rows.
+ * @return {Knex.QueryBuilder} Unexecuted query returning matching anchor `submission_feature_id` rows.
  */
 function projectEvidenceToTargetIdsQuery(
   anchorFeatureType: string,
@@ -321,7 +321,6 @@ function projectEvidenceToTargetIdsQuery(
   const query = knex
     .queryBuilder()
     .with('evidence', evidenceQuery.clone())
-    .distinct()
     .select('anchor_sf.submission_feature_id')
     .from('submission_feature as anchor_sf')
     .join('feature_type as anchor_ft', 'anchor_ft.feature_type_id', 'anchor_sf.feature_type_id')


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1085

## Description of Changes

- Updated expression search so results are always limited to the requested feature type.
- Changed predicate matching to use related features as evidence for selecting results, rather than returning every feature connected to that evidence.
- Added direct matching for predicates on the same feature type, so a feature can match on its own properties without needing a self-reference in the closure table.
- No longer uses `submission_feature_feature` (the `content` property of a feature) when finding related features
- Use the closure table only when the predicate is on a different feature type than the one being returned.
- Prevented unrelated sibling records from being returned just because they share a parent, dataset, submission, or other relationship with a matching feature.

## Examples

- Example: searching telemetry by animal species
  - If the user searches for `telemetry` where the related `animal.species = caribou`, the query should return the matching telemetry records.
  - It should not return the animal record itself, the dataset, or unrelated telemetry records from other animals.

- Example: telemetry matching on its own property
  - If the user searches for `telemetry` where `telemetry.temperature > 20`, the telemetry record can match directly on its own property.
  - It does not need a self-referencing row in the closure table to be returned.

- Example: preventing sibling leakage
  - If one animal in a dataset matches the search criteria, the query should not return telemetry for every other animal in that same dataset.
  - Only telemetry records connected to the matching animal should be returned.

- Example: “big fish”
  - If the user searches for `fish` where a related observation or sample has `subcount_comment = big fish`, the query should return the relevant fish features.
  - It should not return every feature reachable from that observation or sample, and it should not pull in unrelated fish just because they share a parent dataset.

- Example: secured matches
  - The normal search returns only records the user can access.
  - The unfiltered check can still detect that additional secured records match the same search, so the UI can say there are hidden secured results.


## Testing Notes

## Testing Notes

- Search with an expression and confirm every returned result is the requested anchor feature type.
- Confirm results match the expression criteria, including predicates on related feature types.
- Confirm related predicates return only the relevant anchor features, not unrelated siblings from the same parent, dataset, or submission.
- Confirm same-type predicates work without requiring a self-referencing closure row.
- Confirm secured matching results are hidden from the normal result set but still counted for `has_more_secured_features`.

<img width="957" height="676" alt="image" src="https://github.com/user-attachments/assets/f26271e1-bd48-4935-9d68-99d291407155" />

