### PR TITLE
SIMSBIOHUB-1087: Show Gallery Downloads on Home Page

### DIFF
--- a/api/src/__integration__/db/gallery-download-repository.integration.ts
+++ b/api/src/__integration__/db/gallery-download-repository.integration.ts
@@ -4,6 +4,13 @@
 // active version resolution), both-side (gd + download) active filtering, and
 // deterministic membership ordering.
 //
+// Also covers the public landing-page read (getEligibleGalleryDownloads +
+// getEligibleGalleryDownloadsCount — latest-active-version status eligibility,
+// public-scope filter, hybrid pin/newest ordering, feature_count round-trip,
+// count/list parity) and the slug-addressed service gate
+// (GalleryDownloadService.getPublicGalleryDownloadsBySlug — private/missing
+// indistinguishable 404s, public happy path).
+//
 // Uses a transaction that is ROLLED BACK after each test, so no data is persisted.
 //
 // Run: make test-db
@@ -14,13 +21,15 @@ import { describe } from 'mocha';
 import { randomUUID } from 'node:crypto';
 import SQL from 'sql-template-strings';
 import { defaultPoolConfig, getAPIUserDBConnection, IDBConnection, initDBPool } from '../../database/db';
+import { HTTP404 } from '../../errors/http-error';
 import { DownloadStatusEnum } from '../../models/download-status';
-import { GalleryRecord } from '../../models/gallery';
+import { GalleryRecord, GalleryVisibility } from '../../models/gallery';
 import { DownloadVersionRepository } from '../../repositories/download/download-version-repository';
 import { GalleryDownloadRepository } from '../../repositories/gallery/gallery-download-repository';
 import { GalleryRepository } from '../../repositories/gallery/gallery-repository';
 import { DownloadPolicyService } from '../../services/download/download-policy-service';
 import { DownloadService } from '../../services/download/download-service';
+import { GalleryDownloadService } from '../../services/gallery/gallery-download-service';
 
 function unique(prefix: string): string {
   return `${prefix} ${randomUUID().slice(0, 8)}`;
@@ -35,6 +44,7 @@ describe('GalleryDownloadRepository (integration)', function () {
   let policyService: DownloadPolicyService;
   let downloadService: DownloadService;
   let versionRepo: DownloadVersionRepository;
+  let galleryDownloadService: GalleryDownloadService;
 
   before(() => {
     initDBPool(defaultPoolConfig);
@@ -50,6 +60,7 @@ describe('GalleryDownloadRepository (integration)', function () {
     policyService = new DownloadPolicyService(connection);
     downloadService = new DownloadService(connection);
     versionRepo = new DownloadVersionRepository(connection);
+    galleryDownloadService = new GalleryDownloadService(connection);
   });
 
   afterEach(async () => {
@@ -59,13 +70,13 @@ describe('GalleryDownloadRepository (integration)', function () {
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 
-  /** Create an active gallery with unique name + slug. */
-  function seedGallery(): Promise<GalleryRecord> {
+  /** Create an active gallery with unique name + slug (public unless overridden). */
+  function seedGallery(opts?: { visibility?: GalleryVisibility }): Promise<GalleryRecord> {
     const suffix = randomUUID().slice(0, 8);
     return galleryRepo.createGallery({
       name: `Gallery ${suffix}`,
       slug: `gallery-${suffix}`,
-      visibility: 'public',
+      visibility: opts?.visibility ?? 'public',
       description: null
     });
   }
@@ -76,10 +87,15 @@ describe('GalleryDownloadRepository (integration)', function () {
    * invisible to getGalleryDownloads' INNER JOIN LATERAL, so all three links are
    * required for the member to surface. Mirrors download-service.integration.ts's
    * createPolicyDownload helper, using the same shared connection.
+   *
+   * `requestedBy` defaults to the connection's system user (a user-scoped export);
+   * pass an explicit `null` for a public-scope export, which is the only kind the
+   * eligible landing read advertises.
    */
   async function createPolicyDownload(opts?: {
     name?: string;
     description?: string | null;
+    requestedBy?: number | null;
   }): Promise<{ download_id: string; policy_id: string; download_version_id: string }> {
     const { policy_id } = await policyService.createDownloadPolicy({
       name: opts?.name ?? unique('Policy'),
@@ -89,10 +105,61 @@ describe('GalleryDownloadRepository (integration)', function () {
     const { download_id } = await downloadService.createDownload({
       policyId: policy_id,
       format: 'parquet',
-      requestedBy: connection.systemUserId()
+      requestedBy: opts?.requestedBy === undefined ? connection.systemUserId() : opts.requestedBy
     });
     const version = await versionRepo.createDownloadVersion(download_id);
     return { download_id, policy_id, download_version_id: version.download_version_id };
+  }
+
+  /**
+   * Seed a download that the public landing read considers advertisable:
+   * public-scope (`requested_by IS NULL`) with its version transitioned to
+   * `ready` (optionally carrying a stored feature_count).
+   */
+  async function createEligibleDownload(opts?: {
+    name?: string;
+    featureCount?: number;
+  }): Promise<{ download_id: string; policy_id: string; download_version_id: string }> {
+    const download = await createPolicyDownload({ name: opts?.name, requestedBy: null });
+    await versionRepo.updateDownloadVersionStatus(
+      download.download_version_id,
+      DownloadStatusEnum.READY,
+      opts?.featureCount === undefined ? undefined : { feature_count: opts.featureCount }
+    );
+    return download;
+  }
+
+  /**
+   * Insert an additional download_version with an explicit create_date offset.
+   * Versions default to the transaction-frozen now() (so same-transaction inserts
+   * tie on create_date and fall through to a nondeterministic UUID tie-break), and
+   * the audit trigger makes create_date immutable on UPDATE — so controlled
+   * version recency must be set at INSERT time via raw SQL.
+   */
+  async function insertVersionAt(downloadId: string, status: DownloadStatusEnum, offset: string): Promise<string> {
+    const result = await connection.sql(SQL`
+      INSERT INTO download_version (download_id, status, create_date)
+      VALUES (${downloadId}, ${status}, now() + ${offset}::interval)
+      RETURNING download_version_id;
+    `);
+    return result.rows[0].download_version_id;
+  }
+
+  /**
+   * Insert a gallery membership with an explicit create_date offset — same
+   * frozen-now() rationale as insertVersionAt: membership recency ordering can
+   * only be exercised with create_date set at INSERT time.
+   */
+  async function addMembershipAt(
+    galleryId: number,
+    downloadId: string,
+    sort: number | null,
+    offset: string
+  ): Promise<void> {
+    await connection.sql(SQL`
+      INSERT INTO gallery_download (gallery_id, download_id, sort, create_date)
+      VALUES (${galleryId}, ${downloadId}, ${sort}, now() + ${offset}::interval);
+    `);
   }
 
   /** Count of ACTIVE gallery_download rows for a (gallery, download) pair. */
@@ -334,6 +401,195 @@ describe('GalleryDownloadRepository (integration)', function () {
 
       const members = await repo.getGalleryDownloads(gallery.gallery_id);
       expect(members).to.eql([]);
+    });
+  });
+
+  // ── getEligibleGalleryDownloads / getEligibleGalleryDownloadsCount ───────
+  // The public landing-page read: latest-active-version status eligibility,
+  // public-scope filter, hybrid pin/newest ordering, and count/list parity.
+
+  describe('getEligibleGalleryDownloads / getEligibleGalleryDownloadsCount', () => {
+    it('returns only memberships whose latest version is ready or downloaded, round-trips feature_count, and the count matches', async () => {
+      const gallery = await seedGallery();
+
+      const ready = await createEligibleDownload({ name: 'ready', featureCount: 17412 });
+      const downloaded = await createPolicyDownload({ name: 'downloaded', requestedBy: null });
+      await versionRepo.updateDownloadVersionStatus(downloaded.download_version_id, DownloadStatusEnum.DOWNLOADED);
+      const pending = await createPolicyDownload({ name: 'pending', requestedBy: null }); // versions are born pending
+      const failed = await createPolicyDownload({ name: 'failed', requestedBy: null });
+      await versionRepo.updateDownloadVersionStatus(failed.download_version_id, DownloadStatusEnum.FAILED);
+
+      for (const download of [ready, downloaded, pending, failed]) {
+        await repo.addDownloadToGallery(gallery.gallery_id, download.download_id, null);
+      }
+
+      const rows = await repo.getEligibleGalleryDownloads(gallery.gallery_id);
+      expect(rows.map((row) => row.download_id)).to.have.members([ready.download_id, downloaded.download_id]);
+
+      // The stored feature_count survives the LATERAL projection + Zod parse intact.
+      const readyRow = rows.find((row) => row.download_id === ready.download_id);
+      expect(readyRow?.feature_count).to.equal(17412);
+
+      // Filter parity: the filtered-out pending/failed rows must not inflate the total.
+      expect(await repo.getEligibleGalleryDownloadsCount(gallery.gallery_id)).to.equal(2);
+    });
+
+    it('excludes a user-scoped download (requested_by set) from both list and count even when its latest version is ready', async () => {
+      const gallery = await seedGallery();
+
+      // requested_by is the security identity the parquet was built with — a
+      // user-scoped export must never be advertised publicly, whatever its status.
+      const userScoped = await createPolicyDownload({ requestedBy: connection.systemUserId() });
+      await versionRepo.updateDownloadVersionStatus(userScoped.download_version_id, DownloadStatusEnum.READY);
+      await repo.addDownloadToGallery(gallery.gallery_id, userScoped.download_id, null);
+
+      expect(await repo.getEligibleGalleryDownloads(gallery.gallery_id)).to.eql([]);
+      expect(await repo.getEligibleGalleryDownloadsCount(gallery.gallery_id)).to.equal(0);
+    });
+
+    it('excludes a download whose latest active version is failed even when an older version was ready', async () => {
+      const gallery = await seedGallery();
+
+      // Older version ready (frozen now()); strictly newer version failed. Eligibility
+      // is judged on the most recent active version only — the LATERAL resolves the
+      // latest first, then the status filter judges that one row, so the older ready
+      // version can never resurrect the download.
+      const download = await createEligibleDownload();
+      await insertVersionAt(download.download_id, DownloadStatusEnum.FAILED, '1 second');
+      await repo.addDownloadToGallery(gallery.gallery_id, download.download_id, null);
+
+      expect(await repo.getEligibleGalleryDownloads(gallery.gallery_id)).to.eql([]);
+      expect(await repo.getEligibleGalleryDownloadsCount(gallery.gallery_id)).to.equal(0);
+    });
+
+    it('includes a download whose newest version is soft-deleted when its newest ACTIVE version is ready', async () => {
+      const gallery = await seedGallery();
+
+      // Newest version soft-deleted; the LATERAL only considers active versions,
+      // so the older still-active ready version keeps the download advertisable.
+      const download = await createEligibleDownload();
+      const newerVersionId = await insertVersionAt(download.download_id, DownloadStatusEnum.FAILED, '1 second');
+      await connection.sql(
+        SQL`UPDATE download_version SET record_end_date = now() WHERE download_version_id = ${newerVersionId};`
+      );
+      await repo.addDownloadToGallery(gallery.gallery_id, download.download_id, null);
+
+      const rows = await repo.getEligibleGalleryDownloads(gallery.gallery_id);
+      expect(rows.map((row) => row.download_id)).to.eql([download.download_id]);
+      expect(await repo.getEligibleGalleryDownloadsCount(gallery.gallery_id)).to.equal(1);
+    });
+
+    it('orders pinned memberships first, then unpinned newest-membership-first (gd.create_date DESC)', async () => {
+      const gallery = await seedGallery();
+
+      const pinned = await createEligibleDownload({ name: 'pinned' });
+      const oldest = await createEligibleDownload({ name: 'unpinned-oldest' });
+      const middle = await createEligibleDownload({ name: 'unpinned-middle' });
+      const newest = await createEligibleDownload({ name: 'unpinned-newest' });
+
+      // The pin has the OLDEST membership create_date — it must still lead, proving
+      // sort wins over recency. Unpinned rows follow newest membership first:
+      // "newest" is the membership's create_date (newly curated), not the download's.
+      await addMembershipAt(gallery.gallery_id, pinned.download_id, 1, '-3 seconds');
+      await addMembershipAt(gallery.gallery_id, oldest.download_id, null, '-2 seconds');
+      await addMembershipAt(gallery.gallery_id, middle.download_id, null, '-1 second');
+      await addMembershipAt(gallery.gallery_id, newest.download_id, null, '0 seconds');
+
+      const orderedIds = (await repo.getEligibleGalleryDownloads(gallery.gallery_id)).map((row) => row.download_id);
+      expect(orderedIds).to.eql([pinned.download_id, newest.download_id, middle.download_id, oldest.download_id]);
+    });
+
+    it('breaks same-timestamp membership ties by gallery_download_id DESC (later insert first, deterministic)', async () => {
+      const gallery = await seedGallery();
+
+      const first = await createEligibleDownload({ name: 'inserted-first' });
+      const second = await createEligibleDownload({ name: 'inserted-second' });
+
+      // Both memberships share the transaction-frozen now() create_date, so the
+      // ordering falls through to the identity-column tie-break: the later insert
+      // (higher gallery_download_id) comes first under DESC.
+      await repo.addDownloadToGallery(gallery.gallery_id, first.download_id, null);
+      await repo.addDownloadToGallery(gallery.gallery_id, second.download_id, null);
+
+      const orderedIds = (await repo.getEligibleGalleryDownloads(gallery.gallery_id)).map((row) => row.download_id);
+      expect(orderedIds).to.eql([second.download_id, first.download_id]);
+    });
+
+    it('returns feature_count: null for a ready version materialized before counting existed', async () => {
+      const gallery = await seedGallery();
+
+      const download = await createPolicyDownload({ requestedBy: null });
+      await versionRepo.updateDownloadVersionStatus(download.download_version_id, DownloadStatusEnum.READY);
+      await repo.addDownloadToGallery(gallery.gallery_id, download.download_id, null);
+
+      const rows = await repo.getEligibleGalleryDownloads(gallery.gallery_id);
+      expect(rows).to.have.length(1);
+      expect(rows[0].feature_count).to.be.null;
+    });
+
+    it('paginates ({ limit: 9, page: 2 } over 10 eligible → 1 row) while the count reports the full eligible total', async () => {
+      const gallery = await seedGallery();
+
+      const downloads = [];
+      for (let i = 0; i < 10; i++) {
+        const download = await createEligibleDownload({ name: `tile-${i}` });
+        await repo.addDownloadToGallery(gallery.gallery_id, download.download_id, null);
+        downloads.push(download);
+      }
+
+      const pageTwo = await repo.getEligibleGalleryDownloads(gallery.gallery_id, { limit: 9, page: 2 });
+
+      // Same-frozen-now() memberships order gallery_download_id DESC, so the
+      // first-inserted membership is the single row left on page 2.
+      expect(pageTwo.map((row) => row.download_id)).to.eql([downloads[0].download_id]);
+      expect(await repo.getEligibleGalleryDownloadsCount(gallery.gallery_id)).to.equal(10);
+    });
+  });
+
+  // ── GalleryDownloadService.getPublicGalleryDownloadsBySlug ───────────────
+  // Service-level: the slug-addressed visibility gate on top of the eligible read.
+
+  describe('GalleryDownloadService.getPublicGalleryDownloadsBySlug', () => {
+    it('throws identical HTTP404s for a private gallery and a missing slug (a private gallery must be indistinguishable from a missing one)', async () => {
+      const privateGallery = await seedGallery({ visibility: 'private' });
+
+      let privateError: unknown;
+      try {
+        await galleryDownloadService.getPublicGalleryDownloadsBySlug(privateGallery.slug);
+        expect.fail('Expected HTTP404 for a private gallery');
+      } catch (error) {
+        privateError = error;
+      }
+
+      let missingError: unknown;
+      try {
+        await galleryDownloadService.getPublicGalleryDownloadsBySlug(`missing-${randomUUID().slice(0, 8)}`);
+        expect.fail('Expected HTTP404 for a missing slug');
+      } catch (error) {
+        missingError = error;
+      }
+
+      expect(privateError).to.be.instanceOf(HTTP404);
+      expect(missingError).to.be.instanceOf(HTTP404);
+      // The indistinguishability contract: a distinct status or message would
+      // disclose that a hidden gallery exists.
+      expect((privateError as HTTP404).status).to.equal((missingError as HTTP404).status);
+      expect((privateError as HTTP404).message).to.equal((missingError as HTTP404).message);
+    });
+
+    it('returns the eligible tiles and count for a public gallery slug', async () => {
+      const gallery = await seedGallery();
+
+      const eligible = await createEligibleDownload({ name: 'advertised', featureCount: 42 });
+      const ineligible = await createPolicyDownload({ name: 'still-pending', requestedBy: null });
+      await repo.addDownloadToGallery(gallery.gallery_id, eligible.download_id, null);
+      await repo.addDownloadToGallery(gallery.gallery_id, ineligible.download_id, null);
+
+      const result = await galleryDownloadService.getPublicGalleryDownloadsBySlug(gallery.slug);
+
+      expect(result.count).to.equal(1);
+      expect(result.downloads.map((row) => row.download_id)).to.eql([eligible.download_id]);
+      expect(result.downloads[0].feature_count).to.equal(42);
     });
   });
 });

--- a/api/src/__mocks__/gallery-download.ts
+++ b/api/src/__mocks__/gallery-download.ts
@@ -1,0 +1,15 @@
+import { GalleryDownloadTileRecord } from '../models/gallery-download';
+import { createMockDownloadRecord } from './download';
+
+/**
+ * Test factory: build a GalleryDownloadTileRecord (a download detail row plus the
+ * latest version's stored `feature_count`). Defaults to a counted version; tests
+ * exercising the pre-counting NULL contract override `feature_count: null`.
+ */
+export const createMockGalleryDownloadTileRecord = (
+  overrides?: Partial<GalleryDownloadTileRecord>
+): GalleryDownloadTileRecord => ({
+  ...createMockDownloadRecord(),
+  feature_count: 9,
+  ...overrides
+});

--- a/api/src/models/gallery-download.ts
+++ b/api/src/models/gallery-download.ts
@@ -25,6 +25,12 @@ export interface AddGalleryDownloadRequestBody {
  * must not fail the whole list parse.
  */
 export const GalleryDownloadTileRecord = DownloadDetailRecord.extend({
-  feature_count: z.number().nullable()
+  feature_count: z.number().int().nullable()
 });
 export type GalleryDownloadTileRecord = z.infer<typeof GalleryDownloadTileRecord>;
+
+/**
+ * Read shape for the `SELECT EXISTS (...)` membership check.
+ */
+export const GalleryDownloadExists = z.object({ exists: z.boolean() });
+export type GalleryDownloadExists = z.infer<typeof GalleryDownloadExists>;

--- a/api/src/models/gallery-download.ts
+++ b/api/src/models/gallery-download.ts
@@ -1,3 +1,6 @@
+import { z } from 'zod';
+import { DownloadDetailRecord } from './download';
+
 /**
  * HTTP request body for adding a download to a gallery.
  *
@@ -14,3 +17,14 @@ export interface AddGalleryDownloadRequestBody {
   downloadId: string;
   sort?: number | null;
 }
+
+/**
+ * Landing-tile read shape: a gallery download detail row plus the latest
+ * version's stored feature count. `feature_count` must stay `.nullable()` —
+ * versions materialized before counting existed carry NULL, and one stale row
+ * must not fail the whole list parse.
+ */
+export const GalleryDownloadTileRecord = DownloadDetailRecord.extend({
+  feature_count: z.number().nullable()
+});
+export type GalleryDownloadTileRecord = z.infer<typeof GalleryDownloadTileRecord>;

--- a/api/src/openapi/schemas/gallery-download.ts
+++ b/api/src/openapi/schemas/gallery-download.ts
@@ -23,47 +23,74 @@ export const AddGalleryDownloadRequestSchema: OpenAPIV3.SchemaObject = {
 };
 
 /**
+ * A single gallery download row — the download detail row shape; exports are
+ * fetched through the download/export endpoints when needed.
+ */
+export const GalleryDownloadResponseSchema: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'download_id',
+    'download_version_id',
+    'download_status',
+    'format',
+    'metadata',
+    'started_at',
+    'completed_at',
+    'downloaded_at',
+    'create_date',
+    'name',
+    'description'
+  ],
+  properties: {
+    download_id: { type: 'string', format: 'uuid' },
+    download_version_id: {
+      type: 'string',
+      format: 'uuid',
+      description: 'The most-recent materialized version of this download.'
+    },
+    download_status: {
+      type: 'string',
+      enum: ['pending', 'processing', 'ready', 'failed', 'downloaded']
+    },
+    format: { type: 'string', description: 'Export wire format.' },
+    metadata: { type: 'object', additionalProperties: true, nullable: true },
+    started_at: { type: 'string', nullable: true },
+    completed_at: { type: 'string', nullable: true },
+    downloaded_at: { type: 'string', nullable: true },
+    create_date: { type: 'string' },
+    name: { type: 'string', description: "The owning policy's display name." },
+    description: { type: 'string', nullable: true, description: "The owning policy's description." }
+  }
+};
+
+/**
  * Response schema for GET /gallery/{galleryId}/download — gallery download
- * records. Each item matches the download detail row shape; exports are fetched
- * through the download/export endpoints when needed.
+ * records.
  */
 export const GalleryDownloadListResponseSchema: OpenAPIV3.SchemaObject = {
   type: 'array',
+  items: GalleryDownloadResponseSchema
+};
+
+/**
+ * Response schema for GET /gallery/slug/{slug}/download — landing-tile rows.
+ * Extends the gallery download row with the latest version's stored
+ * `feature_count` (null for versions materialized before counting existed).
+ */
+export const GalleryDownloadTileListResponseSchema: OpenAPIV3.SchemaObject = {
+  type: 'array',
   items: {
-    type: 'object',
-    additionalProperties: false,
-    required: [
-      'download_id',
-      'download_version_id',
-      'download_status',
-      'format',
-      'metadata',
-      'started_at',
-      'completed_at',
-      'downloaded_at',
-      'create_date',
-      'name',
-      'description'
-    ],
+    ...GalleryDownloadResponseSchema,
+    required: [...(GalleryDownloadResponseSchema.required ?? []), 'feature_count'],
     properties: {
-      download_id: { type: 'string', format: 'uuid' },
-      download_version_id: {
-        type: 'string',
-        format: 'uuid',
-        description: 'The most-recent materialized version of this download.'
-      },
-      download_status: {
-        type: 'string',
-        enum: ['pending', 'processing', 'ready', 'failed', 'downloaded']
-      },
-      format: { type: 'string', description: 'Export wire format.' },
-      metadata: { type: 'object', additionalProperties: true, nullable: true },
-      started_at: { type: 'string', nullable: true },
-      completed_at: { type: 'string', nullable: true },
-      downloaded_at: { type: 'string', nullable: true },
-      create_date: { type: 'string' },
-      name: { type: 'string', description: "The owning policy's display name." },
-      description: { type: 'string', nullable: true, description: "The owning policy's description." }
+      ...GalleryDownloadResponseSchema.properties,
+      feature_count: {
+        type: 'integer',
+        nullable: true,
+        description:
+          "Total features in the download's latest materialized version; null when materialized before counting existed."
+      }
     }
   }
 };

--- a/api/src/paths/gallery/slug/{slug}/download/index.test.ts
+++ b/api/src/paths/gallery/slug/{slug}/download/index.test.ts
@@ -1,0 +1,111 @@
+import chai, { expect } from 'chai';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { getPublicGalleryDownloadsBySlug } from '.';
+import { getMockDBConnection, getRequestHandlerMocks } from '../../../../../__mocks__/db';
+import { createMockGalleryDownloadTileRecord } from '../../../../../__mocks__/gallery-download';
+import * as db from '../../../../../database/db';
+import { HTTP404 } from '../../../../../errors/http-error';
+import { GalleryDownloadTileRecord } from '../../../../../models/gallery-download';
+import { GalleryDownloadService } from '../../../../../services/gallery/gallery-download-service';
+
+chai.use(sinonChai);
+
+describe('paths/gallery/slug/{slug}/download/index', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getPublicGalleryDownloadsBySlug', () => {
+    it('uses the API-user connection, forwards the raw slug and pagination, and returns downloads with pagination', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      const apiUserStub = sinon.stub(db.dbDependencies, 'getAPIUserDBConnection').returns(dbConnectionObj);
+      const dbConnStub = sinon.stub(db.dbDependencies, 'getDBConnection');
+
+      const tiles: GalleryDownloadTileRecord[] = [createMockGalleryDownloadTileRecord()];
+      const getBySlugStub = sinon
+        .stub(GalleryDownloadService.prototype, 'getPublicGalleryDownloadsBySlug')
+        .resolves({ downloads: tiles, count: 1 });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params = { slug: 'home' };
+      mockReq.query = { page: '2', limit: '10', sort: 'create_date', order: 'desc' };
+
+      const requestHandler = getPublicGalleryDownloadsBySlug();
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      // Public endpoint: shared API-user connection, never the authenticated getter.
+      expect(apiUserStub).to.have.been.calledOnce;
+      expect(dbConnStub).to.not.have.been.called;
+      // Slug is forwarded as the raw string — never Number()-coerced like id params.
+      expect(getBySlugStub).to.have.been.calledOnceWith('home', {
+        page: 2,
+        limit: 10,
+        sort: 'create_date',
+        order: 'desc'
+      });
+      expect(mockRes.statusValue).to.equal(200);
+      expect(mockRes.jsonValue.downloads).to.eql(tiles);
+      expect(mockRes.jsonValue.pagination).to.eql({
+        total: 1,
+        per_page: 10,
+        current_page: 2,
+        last_page: 1,
+        sort: 'create_date',
+        order: 'desc'
+      });
+      // Tile shape fence: the landing rows carry the stored feature count.
+      expect(mockRes.jsonValue.downloads[0]).to.have.property('feature_count');
+    });
+
+    it('returns 200 with empty downloads and default pagination when the gallery has no eligible records', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+      sinon
+        .stub(GalleryDownloadService.prototype, 'getPublicGalleryDownloadsBySlug')
+        .resolves({ downloads: [], count: 0 });
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params = { slug: 'home' };
+
+      const requestHandler = getPublicGalleryDownloadsBySlug();
+      await requestHandler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.statusValue).to.equal(200);
+      expect(mockRes.jsonValue).to.eql({
+        downloads: [],
+        pagination: {
+          total: 0,
+          per_page: 25,
+          current_page: 1,
+          last_page: 1,
+          sort: undefined,
+          order: undefined
+        }
+      });
+    });
+
+    it('propagates 404 when the gallery is private or missing (distinct from the empty-array case)', async () => {
+      const dbConnectionObj = getMockDBConnection();
+      sinon.stub(db.dbDependencies, 'getAPIUserDBConnection').returns(dbConnectionObj);
+
+      sinon
+        .stub(GalleryDownloadService.prototype, 'getPublicGalleryDownloadsBySlug')
+        .rejects(new HTTP404('Gallery not found'));
+
+      const { mockReq, mockRes, mockNext } = getRequestHandlerMocks();
+      mockReq.params = { slug: 'hidden-gallery' };
+
+      const requestHandler = getPublicGalleryDownloadsBySlug();
+
+      try {
+        await requestHandler(mockReq, mockRes, mockNext);
+        expect.fail();
+      } catch (error) {
+        expect(error).to.be.instanceOf(HTTP404);
+      }
+    });
+  });
+});

--- a/api/src/paths/gallery/slug/{slug}/download/index.test.ts
+++ b/api/src/paths/gallery/slug/{slug}/download/index.test.ts
@@ -39,11 +39,13 @@ describe('paths/gallery/slug/{slug}/download/index', () => {
       expect(apiUserStub).to.have.been.calledOnce;
       expect(dbConnStub).to.not.have.been.called;
       // Slug is forwarded as the raw string — never Number()-coerced like id params.
+      // Client sort/order are stripped: the landing order is a product invariant, and
+      // the pagination response must not echo a sort the read didn't honor.
       expect(getBySlugStub).to.have.been.calledOnceWith('home', {
         page: 2,
         limit: 10,
-        sort: 'create_date',
-        order: 'desc'
+        sort: undefined,
+        order: undefined
       });
       expect(mockRes.statusValue).to.equal(200);
       expect(mockRes.jsonValue.downloads).to.eql(tiles);
@@ -52,8 +54,8 @@ describe('paths/gallery/slug/{slug}/download/index', () => {
         per_page: 10,
         current_page: 2,
         last_page: 1,
-        sort: 'create_date',
-        order: 'desc'
+        sort: undefined,
+        order: undefined
       });
       // Tile shape fence: the landing rows carry the stored feature count.
       expect(mockRes.jsonValue.downloads[0]).to.have.property('feature_count');

--- a/api/src/paths/gallery/slug/{slug}/download/index.ts
+++ b/api/src/paths/gallery/slug/{slug}/download/index.ts
@@ -1,0 +1,83 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { getAPIUserDBConnection } from '../../../../../database/db';
+import { GalleryDownloadTileListResponseSchema } from '../../../../../openapi/schemas/gallery-download';
+import { defaultErrorResponses } from '../../../../../openapi/schemas/http-responses';
+import { paginationRequestQueryParamSchema, paginationResponseSchema } from '../../../../../openapi/schemas/pagination';
+import { GalleryDownloadService } from '../../../../../services/gallery/gallery-download-service';
+import { getLogger } from '../../../../../utils/logger';
+import { makePaginationOptionsFromRequest, makePaginationResponse } from '../../../../../utils/pagination';
+
+const defaultLog = getLogger('paths/gallery/slug/{slug}/download');
+
+export const GET: Operation = [getPublicGalleryDownloadsBySlug()];
+
+GET.apiDoc = {
+  description: 'Get the publicly advertisable download tiles for a slug-addressed gallery.',
+  tags: ['gallery'],
+  security: [{ OptionalBearer: [] }],
+  parameters: [
+    {
+      in: 'path',
+      name: 'slug',
+      required: true,
+      schema: { type: 'string' },
+      description: 'Gallery slug.'
+    },
+    ...paginationRequestQueryParamSchema
+  ],
+  responses: {
+    200: {
+      description: 'Paginated gallery download tile records',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['downloads', 'pagination'],
+            properties: {
+              downloads: GalleryDownloadTileListResponseSchema,
+              pagination: paginationResponseSchema
+            }
+          }
+        }
+      }
+    },
+    ...defaultErrorResponses
+  }
+};
+
+/**
+ * Get the publicly advertisable download tiles for a slug-addressed gallery.
+ *
+ * Public: the landing page addresses its curated gallery by slug (stable across
+ * environments, unlike ids), so an unauthenticated caller reads on the shared
+ * API-user connection. The service enforces the visibility gate — private and
+ * missing galleries are both a 404.
+ *
+ * @returns {RequestHandler}
+ */
+export function getPublicGalleryDownloadsBySlug(): RequestHandler {
+  return async (req, res) => {
+    const connection = getAPIUserDBConnection();
+
+    try {
+      const slug = req.params.slug;
+
+      await connection.open();
+
+      const galleryDownloadService = new GalleryDownloadService(connection);
+      const pagination = makePaginationOptionsFromRequest(req);
+      const { downloads, count } = await galleryDownloadService.getPublicGalleryDownloadsBySlug(slug, pagination);
+
+      await connection.commit();
+
+      return res.status(200).json({ downloads, pagination: makePaginationResponse(count, pagination) });
+    } catch (error) {
+      defaultLog.error({ label: 'getPublicGalleryDownloadsBySlug', message: 'error', error });
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/gallery/slug/{slug}/download/index.ts
+++ b/api/src/paths/gallery/slug/{slug}/download/index.ts
@@ -13,7 +13,8 @@ const defaultLog = getLogger('paths/gallery/slug/{slug}/download');
 export const GET: Operation = [getPublicGalleryDownloadsBySlug()];
 
 GET.apiDoc = {
-  description: 'Get the publicly advertisable download tiles for a slug-addressed gallery.',
+  description:
+    'Get the publicly advertisable download tiles for a slug-addressed gallery. The landing order (curator pins first, then newest memberships) is a product invariant — client `sort`/`order` params are ignored.',
   tags: ['gallery'],
   security: [{ OptionalBearer: [] }],
   parameters: [
@@ -21,7 +22,7 @@ GET.apiDoc = {
       in: 'path',
       name: 'slug',
       required: true,
-      schema: { type: 'string' },
+      schema: { type: 'string', maxLength: 100 },
       description: 'Gallery slug.'
     },
     ...paginationRequestQueryParamSchema
@@ -66,10 +67,15 @@ export function getPublicGalleryDownloadsBySlug(): RequestHandler {
       await connection.open();
 
       const galleryDownloadService = new GalleryDownloadService(connection);
-      const pagination = makePaginationOptionsFromRequest(req);
+      // Landing order is a product invariant (curator pins + newest memberships), so a
+      // client `sort`/`order` is never applied — strip it here so the pagination
+      // response doesn't echo a sort the read didn't honor.
+      const pagination = { ...makePaginationOptionsFromRequest(req), sort: undefined, order: undefined };
       const { downloads, count } = await galleryDownloadService.getPublicGalleryDownloadsBySlug(slug, pagination);
 
       await connection.commit();
+
+      res.setHeader('Cache-Control', 'public, max-age=90');
 
       return res.status(200).json({ downloads, pagination: makePaginationResponse(count, pagination) });
     } catch (error) {

--- a/api/src/queue/jobs/process-download-job.test.ts
+++ b/api/src/queue/jobs/process-download-job.test.ts
@@ -227,6 +227,75 @@ describe('process-download-job', () => {
       expect(transitionStub.secondCall.args[1]).to.equal(DownloadStatusEnum.READY);
     });
 
+    it('sums per-feature-type row counts and passes featureCount on the READY transition only', async () => {
+      setupMockConnection();
+
+      sinon
+        .stub(DownloadVersionRepository.prototype, 'getDownloadVersionStatusById')
+        .resolves(createMockDownloadVersionStatusRecord());
+
+      const transitionStub = sinon
+        .stub(DownloadPipelineService.prototype, 'transitionDownloadVersionStatus')
+        .resolves();
+      sinon
+        .stub(DownloadRepository.prototype, 'getDownloadSource')
+        .resolves({ policy_id: '11111111-1111-1111-1111-111111111111', requested_by: 1 });
+
+      const schemaLookup = new Map<string, CsvPropertyDefinition[]>();
+      schemaLookup.set('a', []);
+      schemaLookup.set('b', []);
+      schemaLookup.set('c', []);
+      sinon.stub(DownloadPipelineService.prototype, 'resolveParquetSchema').resolves({
+        schemaLookup,
+        featureTypes: ['a', 'b', 'c'],
+        statements: [createMockStatement('a'), createMockStatement('b'), createMockStatement('c')]
+      });
+
+      // Each per-type write reports the rows it materialized; the handler sums them.
+      const writeStub = sinon.stub(DownloadPipelineService.prototype, 'writeFeatureTypeParquet');
+      writeStub.onCall(0).resolves(2);
+      writeStub.onCall(1).resolves(3);
+      writeStub.onCall(2).resolves(5);
+
+      await processDownloadJobHandler([createMockJob(DOWNLOAD_VERSION_ID)]);
+
+      // The PROCESSING transition carries no metadata; the READY transition carries the sum.
+      expect(transitionStub).to.have.been.calledTwice;
+      expect(transitionStub.firstCall.args[1]).to.equal(DownloadStatusEnum.PROCESSING);
+      expect(transitionStub.firstCall.args[3]).to.be.undefined;
+      expect(transitionStub.secondCall.args[1]).to.equal(DownloadStatusEnum.READY);
+      expect(transitionStub.secondCall.args[3]).to.deep.equal({ featureCount: 10 });
+    });
+
+    it('passes featureCount 0 to READY when there are no statements (explicit 0, not skipped metadata)', async () => {
+      setupMockConnection();
+
+      sinon
+        .stub(DownloadVersionRepository.prototype, 'getDownloadVersionStatusById')
+        .resolves(createMockDownloadVersionStatusRecord());
+      const transitionStub = sinon
+        .stub(DownloadPipelineService.prototype, 'transitionDownloadVersionStatus')
+        .resolves();
+      sinon
+        .stub(DownloadRepository.prototype, 'getDownloadSource')
+        .resolves({ policy_id: '11111111-1111-1111-1111-111111111111', requested_by: 1 });
+      sinon.stub(DownloadPipelineService.prototype, 'resolveParquetSchema').resolves({
+        schemaLookup: new Map<string, CsvPropertyDefinition[]>(),
+        featureTypes: [],
+        statements: []
+      });
+
+      const writeStub = sinon.stub(DownloadPipelineService.prototype, 'writeFeatureTypeParquet').resolves(0);
+
+      await processDownloadJobHandler([createMockJob(DOWNLOAD_VERSION_ID)]);
+
+      // No writes ran, but the version still materialized (as empty) — READY records an
+      // explicit 0, distinguishing "counted, empty" from the pre-counting NULL.
+      expect(writeStub).to.not.have.been.called;
+      expect(transitionStub.secondCall.args[1]).to.equal(DownloadStatusEnum.READY);
+      expect(transitionStub.secondCall.args[3]).to.deep.equal({ featureCount: 0 });
+    });
+
     it('enters processing cleanly when a mid-job retry finds the version already in PROCESSING', async () => {
       setupMockConnection();
 

--- a/api/src/queue/jobs/process-download-job.ts
+++ b/api/src/queue/jobs/process-download-job.ts
@@ -114,11 +114,16 @@ export const processDownloadJobHandler: PgBoss.WorkHandler<IProcessDownloadJobDa
       // and the artifact + download_artifact inserts use ON CONFLICT DO NOTHING. The
       // statement is threaded in so the per-type evaluator (expression vs broad) is
       // resolved up front and not re-queried per type.
+      //
+      // The per-run accumulator sums the rows each write reports; a mid-job retry
+      // re-runs the whole loop, so the total is always re-accumulated from scratch
+      // (S3/DB idempotence makes the re-writes converge to the same state).
+      let totalFeatureCount = 0;
       for (const statement of statements) {
         await withConnection(async (connection) => {
           const featureTypeName = statement.urn_feature_type;
           const properties = schemaLookup.get(featureTypeName) ?? [];
-          await new DownloadPipelineService(connection).writeFeatureTypeParquet({
+          totalFeatureCount += await new DownloadPipelineService(connection).writeFeatureTypeParquet({
             downloadId,
             downloadVersionId,
             source,
@@ -133,7 +138,8 @@ export const processDownloadJobHandler: PgBoss.WorkHandler<IProcessDownloadJobDa
         await new DownloadPipelineService(connection).transitionDownloadVersionStatus(
           downloadVersionId,
           DownloadStatusEnum.READY,
-          [DownloadStatusEnum.PROCESSING]
+          [DownloadStatusEnum.PROCESSING],
+          { featureCount: totalFeatureCount }
         );
       });
 

--- a/api/src/repositories/download/download-version-repository.test.ts
+++ b/api/src/repositories/download/download-version-repository.test.ts
@@ -177,9 +177,6 @@ describe('DownloadVersionRepository', () => {
       const sqlValues = sqlStub.firstCall.args[0].values;
       const nullBinds = sqlValues.filter((value: unknown) => value === null);
       expect(nullBinds).to.have.length(1);
-      // Bind order mirrors the SET list: status, started_at, completed_at, materialized_at,
-      // error_message, feature_count, download_version_id.
-      expect(sqlValues[5]).to.equal(null);
     });
 
     it('throws ApiExecuteSQLError when rowCount is not 1', async () => {

--- a/api/src/repositories/download/download-version-repository.test.ts
+++ b/api/src/repositories/download/download-version-repository.test.ts
@@ -134,6 +134,54 @@ describe('DownloadVersionRepository', () => {
       expect(sqlValues).to.include(VERSION_ID);
     });
 
+    it('includes feature_count = COALESCE and binds the provided count', async () => {
+      // Verifies: the materialized feature count is written through the same set-once-
+      // preserve-later COALESCE pattern as the timestamps, and the provided value is bound.
+
+      const sqlStub = sinon.stub().resolves(mockQueryResult([], 1));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repo = new DownloadVersionRepository(mockDBConnection);
+
+      await repo.updateDownloadVersionStatus(VERSION_ID, DownloadStatusEnum.READY, {
+        completed_at: '2026-01-01T00:01:00.000Z',
+        materialized_at: '2026-01-01T00:01:00.000Z',
+        feature_count: 42
+      });
+
+      const sqlText = sqlStub.firstCall.args[0].text;
+      expect(sqlText).to.include('feature_count = COALESCE');
+
+      const sqlValues = sqlStub.firstCall.args[0].values;
+      expect(sqlValues).to.include(42);
+    });
+
+    it('binds null for feature_count when absent so COALESCE preserves the stored value', async () => {
+      // Verifies: a transition that doesn't own the count (here: FAILED) binds null into
+      // feature_count's COALESCE, so an already-materialized count is never cleared.
+
+      const sqlStub = sinon.stub().resolves(mockQueryResult([], 1));
+      const mockDBConnection = getMockDBConnection({ sql: sqlStub });
+
+      const repo = new DownloadVersionRepository(mockDBConnection);
+
+      // Every sibling metadata field carries a real value so the ONLY null bind left is
+      // feature_count's — a bare `.include(null)` would be satisfied by any sibling COALESCE.
+      await repo.updateDownloadVersionStatus(VERSION_ID, DownloadStatusEnum.FAILED, {
+        started_at: '2026-01-01T00:00:00.000Z',
+        completed_at: '2026-01-01T00:01:00.000Z',
+        materialized_at: '2026-01-01T00:01:00.000Z',
+        error_message: 'boom'
+      });
+
+      const sqlValues = sqlStub.firstCall.args[0].values;
+      const nullBinds = sqlValues.filter((value: unknown) => value === null);
+      expect(nullBinds).to.have.length(1);
+      // Bind order mirrors the SET list: status, started_at, completed_at, materialized_at,
+      // error_message, feature_count, download_version_id.
+      expect(sqlValues[5]).to.equal(null);
+    });
+
     it('throws ApiExecuteSQLError when rowCount is not 1', async () => {
       // Verifies: an UPDATE that matched no version row is surfaced as an error
 

--- a/api/src/repositories/download/download-version-repository.ts
+++ b/api/src/repositories/download/download-version-repository.ts
@@ -57,12 +57,13 @@ export class DownloadVersionRepository extends BaseRepository {
    * COALESCE preserves an already-set field when a later transition passes only the
    * fields it owns (e.g. the READY transition sets completed_at + materialized_at
    * without clearing the started_at written at PROCESSING; an error_message set on
-   * FAILED is never cleared by a subsequent update).
+   * FAILED — or a feature_count set on READY — is never cleared by a subsequent
+   * update).
    *
    * @param {string} downloadVersionId - The download version ID.
    * @param {DownloadStatusEnum} status - The new lifecycle status.
-   * @param {{ started_at?: string; completed_at?: string; materialized_at?: string; error_message?: string }} [metadata]
-   *   Optional timestamps / error to set alongside the status.
+   * @param {{ started_at?: string; completed_at?: string; materialized_at?: string; error_message?: string; feature_count?: number }} [metadata]
+   *   Optional timestamps / error / materialized feature count to set alongside the status.
    * @return {Promise<void>}
    * @throws {ApiExecuteSQLError} when no version matches the given ID (rowCount !== 1).
    * @memberof DownloadVersionRepository
@@ -75,6 +76,7 @@ export class DownloadVersionRepository extends BaseRepository {
       completed_at?: string;
       materialized_at?: string;
       error_message?: string;
+      feature_count?: number;
     }
   ): Promise<void> {
     const sql = SQL`
@@ -84,7 +86,8 @@ export class DownloadVersionRepository extends BaseRepository {
         started_at = COALESCE(${metadata?.started_at ?? null}::timestamptz, started_at),
         completed_at = COALESCE(${metadata?.completed_at ?? null}::timestamptz, completed_at),
         materialized_at = COALESCE(${metadata?.materialized_at ?? null}::timestamptz, materialized_at),
-        error_message = COALESCE(${metadata?.error_message ?? null}, error_message)
+        error_message = COALESCE(${metadata?.error_message ?? null}, error_message),
+        feature_count = COALESCE(${metadata?.feature_count ?? null}, feature_count)
       WHERE download_version_id = ${downloadVersionId};
     `;
 

--- a/api/src/repositories/gallery/gallery-download-repository.test.ts
+++ b/api/src/repositories/gallery/gallery-download-repository.test.ts
@@ -3,6 +3,7 @@ import { describe } from 'mocha';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getMockDBConnection, mockQueryResult } from '../../__mocks__/db';
+import { DownloadStatusEnum } from '../../models/download-status';
 import { GalleryDownloadRepository } from './gallery-download-repository';
 
 chai.use(sinonChai);
@@ -179,6 +180,93 @@ describe('GalleryDownloadRepository', () => {
       expect(sqlText).to.match(/exists/i);
       expect(sqlText).to.include('"dv"."record_end_date" is null');
       expect(sqlText).to.include('count(*)');
+    });
+  });
+
+  describe('getEligibleGalleryDownloads', () => {
+    it('binds the gallery id, filters to ready/downloaded, selects feature_count, and applies the fixed landing order', async () => {
+      const knexStub = sinon.stub().resolves(mockQueryResult([], 0));
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const repo = new GalleryDownloadRepository(mockDBConnection);
+
+      await repo.getEligibleGalleryDownloads(42);
+
+      expect(knexStub).to.have.been.calledOnce;
+      const sqlText = knexStub.firstCall.args[0].toString();
+      expect(sqlText).to.include('"gd"."gallery_id" = 42');
+      expect(sqlText).to.include(`'${DownloadStatusEnum.READY}'`);
+      expect(sqlText).to.include(`'${DownloadStatusEnum.DOWNLOADED}'`);
+      // Public-scope security filter — user-scoped exports (requested_by set) reflect that
+      // user's privileged visibility and must never be advertised on the public landing page.
+      expect(sqlText).to.include('"d"."requested_by" is null');
+      const lateralSql = sqlText.slice(sqlText.indexOf('INNER JOIN LATERAL'), sqlText.indexOf(') dv ON true'));
+      expect(lateralSql).to.include('feature_count');
+      // The landing order is unconditional — applied even with no pagination in play
+      expect(sqlText).to.include('gd.sort ASC NULLS LAST, gd.create_date DESC, gd.gallery_download_id DESC');
+    });
+
+    it('ignores caller-provided sort/order — the landing order is a product invariant', async () => {
+      const knexStub = sinon.stub().resolves(mockQueryResult([], 0));
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const repo = new GalleryDownloadRepository(mockDBConnection);
+
+      await repo.getEligibleGalleryDownloads(42, { page: 1, limit: 9, sort: 'create_date', order: 'asc' });
+
+      const sqlText = knexStub.firstCall.args[0].toString();
+      expect(sqlText).to.include('gd.sort ASC NULLS LAST, gd.create_date DESC, gd.gallery_download_id DESC');
+      expect(sqlText).to.not.include('order by "create_date" asc');
+    });
+
+    it('honors pagination limit/offset while still applying the fixed landing order', async () => {
+      const knexStub = sinon.stub().resolves(mockQueryResult([], 0));
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const repo = new GalleryDownloadRepository(mockDBConnection);
+
+      await repo.getEligibleGalleryDownloads(42, { page: 2, limit: 10 });
+
+      const sqlText = knexStub.firstCall.args[0].toString();
+      expect(sqlText).to.include('limit 10');
+      expect(sqlText).to.include('offset 10');
+      expect(sqlText).to.include('gd.sort ASC NULLS LAST, gd.create_date DESC, gd.gallery_download_id DESC');
+    });
+
+    it('keeps the status filter outside the LATERAL so the latest version is resolved first, then judged', async () => {
+      // A status filter pushed down into the LATERAL would resurrect an older ready
+      // version when the latest one is failed — the filter must judge the resolved row.
+      const knexStub = sinon.stub().resolves(mockQueryResult([], 0));
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const repo = new GalleryDownloadRepository(mockDBConnection);
+
+      await repo.getEligibleGalleryDownloads(42);
+
+      const sqlText = knexStub.firstCall.args[0].toString();
+      const lateralSql = sqlText.slice(sqlText.indexOf('INNER JOIN LATERAL'), sqlText.indexOf(') dv ON true'));
+      expect(lateralSql.toLowerCase()).to.not.include('status in');
+      expect(sqlText).to.include('"dv"."status" in');
+    });
+  });
+
+  describe('getEligibleGalleryDownloadsCount', () => {
+    it('returns the eligible count using the same latest-version LATERAL as the list read', async () => {
+      const knexStub = sinon.stub().resolves(mockQueryResult([{ count: 7 }], 1));
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+      const repo = new GalleryDownloadRepository(mockDBConnection);
+
+      const result = await repo.getEligibleGalleryDownloadsCount(42);
+
+      expect(result).to.equal(7);
+      const sqlText = knexStub.firstCall.args[0].toString();
+      expect(sqlText).to.include('"gd"."gallery_id" = 42');
+      expect(sqlText).to.include('ORDER BY create_date DESC');
+      expect(sqlText).to.include('LIMIT 1');
+      expect(sqlText).to.include(`'${DownloadStatusEnum.READY}'`);
+      expect(sqlText).to.include(`'${DownloadStatusEnum.DOWNLOADED}'`);
+      // Parity with the list read's public-scope filter — the count must not include
+      // user-scoped rows the list excludes.
+      expect(sqlText).to.include('"d"."requested_by" is null');
+      // Must not use the sibling's whereExists any-active-version shape — that would
+      // count downloads the list read filters out.
+      expect(sqlText.toLowerCase()).to.not.include('exists');
     });
   });
 });

--- a/api/src/repositories/gallery/gallery-download-repository.ts
+++ b/api/src/repositories/gallery/gallery-download-repository.ts
@@ -1,15 +1,13 @@
+import { Knex } from 'knex';
 import SQL from 'sql-template-strings';
-import { z } from 'zod';
 import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { CountResult } from '../../models/count';
 import { DownloadDetailRecord } from '../../models/download';
 import { DownloadStatusEnum } from '../../models/download-status';
-import { GalleryDownloadTileRecord } from '../../models/gallery-download';
+import { GalleryDownloadExists, GalleryDownloadTileRecord } from '../../models/gallery-download';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
-
-const GalleryDownloadExists = z.object({ exists: z.boolean() });
 
 /**
  * A repository class for accessing the gallery↔download join (`gallery_download`).
@@ -231,9 +229,7 @@ export class GalleryDownloadRepository extends BaseRepository {
     galleryId: number,
     pagination?: ApiPaginationOptions
   ): Promise<GalleryDownloadTileRecord[]> {
-    const knex = getKnex();
-
-    const query = knex
+    const query = this._buildEligibleGalleryDownloadsQuery(galleryId)
       .select([
         'd.download_id',
         'dv.download_version_id',
@@ -248,23 +244,7 @@ export class GalleryDownloadRepository extends BaseRepository {
         'p.name',
         'p.description'
       ])
-      .from('gallery_download as gd')
-      .innerJoin('download as d', 'd.download_id', 'gd.download_id')
-      .joinRaw(
-        `INNER JOIN LATERAL (
-          SELECT download_version_id, status, started_at, completed_at, feature_count
-          FROM download_version
-          WHERE download_id = d.download_id AND record_end_date IS NULL
-          ORDER BY create_date DESC, download_version_id DESC
-          LIMIT 1
-        ) dv ON true`
-      )
-      .leftJoin('policy as p', 'p.policy_id', 'd.policy_id')
-      .where('gd.gallery_id', galleryId)
-      .whereNull('gd.record_end_date')
-      .whereNull('d.record_end_date')
-      .whereNull('d.requested_by')
-      .whereIn('dv.status', [DownloadStatusEnum.READY, DownloadStatusEnum.DOWNLOADED]);
+      .leftJoin('policy as p', 'p.policy_id', 'd.policy_id');
 
     if (pagination) {
       // Landing order is a product invariant — apply limit/offset only, never client sort.
@@ -286,11 +266,10 @@ export class GalleryDownloadRepository extends BaseRepository {
   /**
    * Count active gallery download records eligible for public landing-page display.
    *
-   * Must apply the same eligibility filters as `getEligibleGalleryDownloads` — the
-   * same latest-active-version `LATERAL`, not the any-active-version `whereExists`
-   * check used by `getGalleryDownloadsCount`, plus the same public-scope filter
-   * (`requested_by IS NULL`) — so a filtered-out download never inflates the
-   * pagination total.
+   * Applies the same eligibility filters as `getEligibleGalleryDownloads` — both
+   * are built from `_buildEligibleGalleryDownloadsQuery`, so a filtered-out
+   * download never inflates the pagination total. Deliberately NOT the
+   * any-active-version `whereExists` shape used by `getGalleryDownloadsCount`.
    *
    * @param {number} galleryId - The gallery ID.
    * @return {Promise<number>}
@@ -299,12 +278,35 @@ export class GalleryDownloadRepository extends BaseRepository {
   async getEligibleGalleryDownloadsCount(galleryId: number): Promise<number> {
     const knex = getKnex();
 
-    const query = knex
+    const query = this._buildEligibleGalleryDownloadsQuery(galleryId)
+      .select(knex.raw('coalesce(count(*), 0)::integer as count'))
+      .first();
+
+    const response = await this.connection.knex(query, CountResult);
+
+    return response.rows[0].count;
+  }
+
+  /**
+   * Build the shared advertisability scaffolding for the public landing read:
+   * the membership + download joins, the latest-active-version `LATERAL`, and
+   * the eligibility filters. The list and count queries are both built from this
+   * one base so their filter parity is structural — a download filtered out of
+   * the list can never inflate the pagination total.
+   *
+   * @param {number} galleryId - The gallery ID.
+   * @return {Knex.QueryBuilder}
+   * @memberof GalleryDownloadRepository
+   */
+  private _buildEligibleGalleryDownloadsQuery(galleryId: number): Knex.QueryBuilder {
+    const knex = getKnex();
+
+    return knex
       .from('gallery_download as gd')
       .innerJoin('download as d', 'd.download_id', 'gd.download_id')
       .joinRaw(
         `INNER JOIN LATERAL (
-          SELECT status
+          SELECT download_version_id, status, started_at, completed_at, feature_count
           FROM download_version
           WHERE download_id = d.download_id AND record_end_date IS NULL
           ORDER BY create_date DESC, download_version_id DESC
@@ -315,12 +317,6 @@ export class GalleryDownloadRepository extends BaseRepository {
       .whereNull('gd.record_end_date')
       .whereNull('d.record_end_date')
       .whereNull('d.requested_by')
-      .whereIn('dv.status', [DownloadStatusEnum.READY, DownloadStatusEnum.DOWNLOADED])
-      .select(knex.raw('coalesce(count(*), 0)::integer as count'))
-      .first();
-
-    const response = await this.connection.knex(query, CountResult);
-
-    return response.rows[0].count;
+      .whereIn('dv.status', [DownloadStatusEnum.READY, DownloadStatusEnum.DOWNLOADED]);
   }
 }

--- a/api/src/repositories/gallery/gallery-download-repository.ts
+++ b/api/src/repositories/gallery/gallery-download-repository.ts
@@ -4,6 +4,8 @@ import { getKnex } from '../../database/db';
 import { ApiExecuteSQLError } from '../../errors/api-error';
 import { CountResult } from '../../models/count';
 import { DownloadDetailRecord } from '../../models/download';
+import { DownloadStatusEnum } from '../../models/download-status';
+import { GalleryDownloadTileRecord } from '../../models/gallery-download';
 import { ApiPaginationOptions } from '../../zod-schema/pagination';
 import { BaseRepository } from '../base-repository';
 
@@ -188,6 +190,132 @@ export class GalleryDownloadRepository extends BaseRepository {
           .whereRaw('dv.download_id = d.download_id')
           .whereNull('dv.record_end_date');
       })
+      .select(knex.raw('coalesce(count(*), 0)::integer as count'))
+      .first();
+
+    const response = await this.connection.knex(query, CountResult);
+
+    return response.rows[0].count;
+  }
+
+  /**
+   * List active gallery download records eligible for public landing-page display,
+   * with their policy display fields and the latest version's stored `feature_count`.
+   *
+   * Eligibility is judged on the most recent active version's status
+   * (`ready`/`downloaded`), not "any ready version ever" — a download whose current
+   * materialization is broken must not be advertised, even if an older version
+   * succeeded. The `LATERAL` subquery resolves the latest active version first;
+   * the status filter then judges that one row on the outside (`dv.status`), so a
+   * pushed-down filter can never resurrect an older ready version.
+   *
+   * Both the membership row (`gd`) and the download row (`d`) are filtered to
+   * `record_end_date IS NULL`, so a soft-deleted download never leaks into the
+   * landing list even if its gallery_download link is still active.
+   *
+   * Only downloads materialized under the public/anonymous security scope
+   * (`requested_by IS NULL`) are advertisable. `requested_by` is the security
+   * identity the parquet was built with — a user-scoped export's artifacts (and
+   * even its feature count) reflect that user's privileged visibility, so it must
+   * never be advertised on the public landing page regardless of which gallery it
+   * was curated into. This makes the method public-advertisability-specific: a
+   * future private-gallery read must not reuse it unchanged, since user-scoped
+   * downloads are legitimate members of private galleries.
+   *
+   * @param {number} galleryId - The gallery ID.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination (limit/offset only; sort is ignored).
+   * @return {Promise<GalleryDownloadTileRecord[]>}
+   * @memberof GalleryDownloadRepository
+   */
+  async getEligibleGalleryDownloads(
+    galleryId: number,
+    pagination?: ApiPaginationOptions
+  ): Promise<GalleryDownloadTileRecord[]> {
+    const knex = getKnex();
+
+    const query = knex
+      .select([
+        'd.download_id',
+        'dv.download_version_id',
+        'dv.status as download_status',
+        'd.format',
+        'd.metadata',
+        'dv.started_at',
+        'dv.completed_at',
+        'dv.feature_count',
+        'd.downloaded_at',
+        'd.create_date',
+        'p.name',
+        'p.description'
+      ])
+      .from('gallery_download as gd')
+      .innerJoin('download as d', 'd.download_id', 'gd.download_id')
+      .joinRaw(
+        `INNER JOIN LATERAL (
+          SELECT download_version_id, status, started_at, completed_at, feature_count
+          FROM download_version
+          WHERE download_id = d.download_id AND record_end_date IS NULL
+          ORDER BY create_date DESC, download_version_id DESC
+          LIMIT 1
+        ) dv ON true`
+      )
+      .leftJoin('policy as p', 'p.policy_id', 'd.policy_id')
+      .where('gd.gallery_id', galleryId)
+      .whereNull('gd.record_end_date')
+      .whereNull('d.record_end_date')
+      .whereNull('d.requested_by')
+      .whereIn('dv.status', [DownloadStatusEnum.READY, DownloadStatusEnum.DOWNLOADED]);
+
+    if (pagination) {
+      // Landing order is a product invariant — apply limit/offset only, never client sort.
+      // Honoring a client `sort` would let a query param silently demote curator pins.
+      this.applyPagination(query, { ...pagination, sort: undefined, order: undefined });
+    }
+
+    // Curator-pinned rows (`sort` set) keep their positions; unpinned rows show newest
+    // membership first so fresh curation surfaces without re-ordering the pins. Ordering
+    // uses the membership's `create_date`, not the download's — "newest" means newly
+    // curated, not newly created.
+    query.orderByRaw('gd.sort ASC NULLS LAST, gd.create_date DESC, gd.gallery_download_id DESC');
+
+    const response = await this.connection.knex(query, GalleryDownloadTileRecord);
+
+    return response.rows;
+  }
+
+  /**
+   * Count active gallery download records eligible for public landing-page display.
+   *
+   * Must apply the same eligibility filters as `getEligibleGalleryDownloads` — the
+   * same latest-active-version `LATERAL`, not the any-active-version `whereExists`
+   * check used by `getGalleryDownloadsCount`, plus the same public-scope filter
+   * (`requested_by IS NULL`) — so a filtered-out download never inflates the
+   * pagination total.
+   *
+   * @param {number} galleryId - The gallery ID.
+   * @return {Promise<number>}
+   * @memberof GalleryDownloadRepository
+   */
+  async getEligibleGalleryDownloadsCount(galleryId: number): Promise<number> {
+    const knex = getKnex();
+
+    const query = knex
+      .from('gallery_download as gd')
+      .innerJoin('download as d', 'd.download_id', 'gd.download_id')
+      .joinRaw(
+        `INNER JOIN LATERAL (
+          SELECT status
+          FROM download_version
+          WHERE download_id = d.download_id AND record_end_date IS NULL
+          ORDER BY create_date DESC, download_version_id DESC
+          LIMIT 1
+        ) dv ON true`
+      )
+      .where('gd.gallery_id', galleryId)
+      .whereNull('gd.record_end_date')
+      .whereNull('d.record_end_date')
+      .whereNull('d.requested_by')
+      .whereIn('dv.status', [DownloadStatusEnum.READY, DownloadStatusEnum.DOWNLOADED])
       .select(knex.raw('coalesce(count(*), 0)::integer as count'))
       .first();
 

--- a/api/src/services/download/download-export-pipeline-service.ts
+++ b/api/src/services/download/download-export-pipeline-service.ts
@@ -154,8 +154,10 @@ export class DownloadExportPipelineService extends DBService {
    * pg-boss DLQ.
    *
    * `errorMetadata.error` is re-keyed to `error_message` to match the repo's
-   * column name while keeping the caller surface consistent with
-   * `DownloadPipelineService.transitionDownloadVersionStatus`.
+   * column name, mirroring the error-metadata handling of
+   * `DownloadPipelineService.transitionDownloadVersionStatus` (whose metadata
+   * bag additionally carries a READY-only `featureCount` that has no group
+   * equivalent).
    */
   async transitionGroupStatus(
     groupId: string,

--- a/api/src/services/download/download-pipeline-service.test.ts
+++ b/api/src/services/download/download-pipeline-service.test.ts
@@ -170,6 +170,91 @@ describe('DownloadPipelineService', () => {
       expect(metadata.completed_at).to.be.a('string');
       expect(metadata.materialized_at).to.be.undefined;
     });
+
+    it('maps featureCount to feature_count on processing→ready alongside the timestamps', async () => {
+      // Verifies: the READY transition re-keys metadata.featureCount → the repo's feature_count
+      // column while still stamping completed_at + materialized_at.
+
+      // Step 1: Stub the version-status read to return a PROCESSING version
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      sinon
+        .stub(DownloadVersionRepository.prototype, 'getDownloadVersionStatusById')
+        .resolves(createMockDownloadVersionStatusRecord({ status: DownloadStatusEnum.PROCESSING }));
+      const updateStub = sinon.stub(DownloadVersionRepository.prototype, 'updateDownloadVersionStatus').resolves();
+
+      // Step 2: Perform the ready transition with the materialized feature count
+      await service.transitionDownloadVersionStatus(
+        versionId,
+        DownloadStatusEnum.READY,
+        [DownloadStatusEnum.PROCESSING],
+        { featureCount: 42 }
+      );
+
+      // Step 3: Verify the count landed under the repo key and the timestamps are still set
+      const metadata = updateStub.firstCall.args[2] as {
+        completed_at?: string;
+        materialized_at?: string;
+        feature_count?: number;
+      };
+      expect(metadata.feature_count).to.equal(42);
+      expect(metadata.completed_at).to.be.a('string');
+      expect(metadata.materialized_at).to.be.a('string');
+    });
+
+    it('passes featureCount 0 through to the repo (strict undefined check, not truthiness)', async () => {
+      // Verifies: a legitimate count of 0 (empty policy scope) is persisted — a truthiness
+      // guard on featureCount would silently drop it.
+
+      // Step 1: Stub the version-status read to return a PROCESSING version
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      sinon
+        .stub(DownloadVersionRepository.prototype, 'getDownloadVersionStatusById')
+        .resolves(createMockDownloadVersionStatusRecord({ status: DownloadStatusEnum.PROCESSING }));
+      const updateStub = sinon.stub(DownloadVersionRepository.prototype, 'updateDownloadVersionStatus').resolves();
+
+      // Step 2: Perform the ready transition with a zero count
+      await service.transitionDownloadVersionStatus(
+        versionId,
+        DownloadStatusEnum.READY,
+        [DownloadStatusEnum.PROCESSING],
+        { featureCount: 0 }
+      );
+
+      // Step 3: Verify the zero landed (strictly) under the repo key
+      const metadata = updateStub.firstCall.args[2] as { feature_count?: number };
+      expect(metadata.feature_count).to.equal(0);
+    });
+
+    it('omits feature_count when featureCount is absent (FAILED transition with error only)', async () => {
+      // Verifies: transitions that don't own the count (e.g. the DLQ's FAILED transition) leave
+      // feature_count out of the update bag entirely, so the repo COALESCE preserves any stored value.
+
+      // Step 1: Stub the version-status read to return a PROCESSING version
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+
+      sinon
+        .stub(DownloadVersionRepository.prototype, 'getDownloadVersionStatusById')
+        .resolves(createMockDownloadVersionStatusRecord({ status: DownloadStatusEnum.PROCESSING }));
+      const updateStub = sinon.stub(DownloadVersionRepository.prototype, 'updateDownloadVersionStatus').resolves();
+
+      // Step 2: Perform the failing transition with error metadata only
+      await service.transitionDownloadVersionStatus(
+        versionId,
+        DownloadStatusEnum.FAILED,
+        [DownloadStatusEnum.PENDING, DownloadStatusEnum.PROCESSING],
+        { error: 'job failed after all retries' }
+      );
+
+      // Step 3: Verify no feature_count key was passed
+      const metadata = updateStub.firstCall.args[2] as { error_message?: string; feature_count?: number };
+      expect(metadata.error_message).to.equal('job failed after all retries');
+      expect(metadata.feature_count).to.be.undefined;
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -844,6 +929,103 @@ describe('DownloadPipelineService', () => {
       expect(linkStub.firstCall.args[1]).to.equal('bbbb0000-0000-0000-0000-000000000001');
       expect(linkStub.firstCall.args[2]).to.equal('observation');
       expect(linkStub).to.have.been.calledAfter(insertArtifactStub);
+    });
+
+    // Minimal hydrated feature for the row-count tests — shape matches what
+    // hydrateFeatureBatch assembles (ParquetFeatureData).
+    const hydratedFeature = (id: number) => ({
+      submission_feature_id: id,
+      uuid: `uuid-${id}`,
+      feature_type_name: 'observation',
+      data: { species: 'moose' },
+      parent_uuid: null
+    });
+
+    it('returns the accumulated hydrated row count across cursor batches', async () => {
+      // Verifies: the count is accumulated during the streaming write (2 batches → 2 + 1
+      // hydrated rows → 3) so the caller can persist the version's total at materialization
+      // time instead of computing a live COUNT later.
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+      const { mockWriter } = stubParquetPipeline();
+
+      sinon.stub(expressionEvaluation, 'buildBroadFeatureTypeSubquery').returns(subqueryStub('SELECT broad', []));
+      sinon
+        .stub(DownloadRepository.prototype, 'streamFeatureBaseBySearchQueryAndType')
+        .returns(
+          mockBaseCursor([[{ submission_feature_id: 1 }, { submission_feature_id: 2 }], [{ submission_feature_id: 3 }]])
+        );
+
+      const hydrateStub = sinon.stub(DownloadPipelineService.prototype, 'hydrateFeatureBatch');
+      hydrateStub.onCall(0).resolves([hydratedFeature(1), hydratedFeature(2)]);
+      hydrateStub.onCall(1).resolves([hydratedFeature(3)]);
+
+      const result = await service.writeFeatureTypeParquet({
+        downloadId: TEST_DOWNLOAD_ID,
+        downloadVersionId: TEST_DOWNLOAD_VERSION_ID,
+        source: TEST_SOURCE,
+        properties: mockProperties,
+        featureTypeName: 'observation',
+        statement: stmt('observation', null)
+      });
+
+      expect(result).to.equal(3);
+      expect(mockWriter.appendRow).to.have.been.calledThrice;
+    });
+
+    it('counts HYDRATED rows, not base cursor rows', async () => {
+      // Verifies: the count reflects what actually lands in the Parquet file — the hydrated
+      // rows written through appendRow — not the raw base cursor batch size.
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+      const { mockWriter } = stubParquetPipeline();
+
+      sinon.stub(expressionEvaluation, 'buildBroadFeatureTypeSubquery').returns(subqueryStub('SELECT broad', []));
+      // Base batch has 3 rows...
+      sinon
+        .stub(DownloadRepository.prototype, 'streamFeatureBaseBySearchQueryAndType')
+        .returns(
+          mockBaseCursor([[{ submission_feature_id: 1 }, { submission_feature_id: 2 }, { submission_feature_id: 3 }]])
+        );
+      // ...but hydration resolves only 2.
+      sinon
+        .stub(DownloadPipelineService.prototype, 'hydrateFeatureBatch')
+        .resolves([hydratedFeature(1), hydratedFeature(2)]);
+
+      const result = await service.writeFeatureTypeParquet({
+        downloadId: TEST_DOWNLOAD_ID,
+        downloadVersionId: TEST_DOWNLOAD_VERSION_ID,
+        source: TEST_SOURCE,
+        properties: mockProperties,
+        featureTypeName: 'observation',
+        statement: stmt('observation', null)
+      });
+
+      expect(result).to.equal(2);
+      expect(mockWriter.appendRow).to.have.been.calledTwice;
+    });
+
+    it('returns 0 (not undefined/NaN) for an empty cursor', async () => {
+      // Verifies: a feature type with no visible rows still reports an explicit numeric 0 so
+      // the caller's sum stays a number.
+      const mockDBConnection = getMockDBConnection();
+      const service = new DownloadPipelineService(mockDBConnection);
+      const { mockWriter } = stubParquetPipeline();
+
+      sinon.stub(expressionEvaluation, 'buildBroadFeatureTypeSubquery').returns(subqueryStub('SELECT broad', []));
+      sinon.stub(DownloadRepository.prototype, 'streamFeatureBaseBySearchQueryAndType').returns(mockBaseCursor([]));
+
+      const result = await service.writeFeatureTypeParquet({
+        downloadId: TEST_DOWNLOAD_ID,
+        downloadVersionId: TEST_DOWNLOAD_VERSION_ID,
+        source: TEST_SOURCE,
+        properties: mockProperties,
+        featureTypeName: 'observation',
+        statement: stmt('observation', null)
+      });
+
+      expect(result).to.equal(0);
+      expect(mockWriter.appendRow).to.not.have.been.called;
     });
   });
 

--- a/api/src/services/download/download-pipeline-service.ts
+++ b/api/src/services/download/download-pipeline-service.ts
@@ -119,7 +119,9 @@ export class DownloadPipelineService extends DBService {
    * @param {string} downloadVersionId - The download version ID.
    * @param {DownloadStatusEnum} nextStatus - Target status.
    * @param {DownloadStatusEnum[]} allowedCurrentStatuses - Statuses from which `nextStatus` is reachable.
-   * @param {{ error?: string }} [errorMetadata] - Optional error metadata (used for FAILED transitions).
+   * @param {{ error?: string; featureCount?: number }} [metadata] - Optional transition metadata: `error`
+   *   is used for FAILED transitions; `featureCount` (the total features materialized into the version's
+   *   artifacts) is only ever passed on the READY transition.
    * @return {Promise<void>}
    * @throws {ApiNotFoundError} if the download version does not exist.
    * @throws {ApiConflictError} if the current status is not in `allowedCurrentStatuses`.
@@ -129,7 +131,7 @@ export class DownloadPipelineService extends DBService {
     downloadVersionId: string,
     nextStatus: DownloadStatusEnum,
     allowedCurrentStatuses: DownloadStatusEnum[],
-    errorMetadata?: { error?: string }
+    metadata?: { error?: string; featureCount?: number }
   ): Promise<void> {
     const version = await this.downloadVersionRepository.getDownloadVersionStatusById(downloadVersionId);
 
@@ -141,23 +143,33 @@ export class DownloadPipelineService extends DBService {
     );
 
     const now = new Date().toISOString();
-    const metadata: { started_at?: string; completed_at?: string; materialized_at?: string; error_message?: string } =
-      {};
+    const updateFields: {
+      started_at?: string;
+      completed_at?: string;
+      materialized_at?: string;
+      error_message?: string;
+      feature_count?: number;
+    } = {};
     if (nextStatus === DownloadStatusEnum.PROCESSING) {
-      metadata.started_at = now;
+      updateFields.started_at = now;
     }
     if (nextStatus === DownloadStatusEnum.READY || nextStatus === DownloadStatusEnum.FAILED) {
-      metadata.completed_at = now;
+      updateFields.completed_at = now;
     }
     // materialized_at is the data watermark — when this version's snapshot was captured.
     if (nextStatus === DownloadStatusEnum.READY) {
-      metadata.materialized_at = now;
+      updateFields.materialized_at = now;
     }
-    if (errorMetadata?.error !== undefined) {
-      metadata.error_message = errorMetadata.error;
+    if (metadata?.error !== undefined) {
+      updateFields.error_message = metadata.error;
+    }
+    // Strict undefined check — a legitimate count of 0 (empty policy scope) must
+    // still be persisted; a truthiness guard would silently drop it.
+    if (metadata?.featureCount !== undefined) {
+      updateFields.feature_count = metadata.featureCount;
     }
 
-    await this.downloadVersionRepository.updateDownloadVersionStatus(downloadVersionId, nextStatus, metadata);
+    await this.downloadVersionRepository.updateDownloadVersionStatus(downloadVersionId, nextStatus, updateFields);
   }
 
   /**
@@ -232,10 +244,13 @@ export class DownloadPipelineService extends DBService {
    * @param {CsvPropertyDefinition[]} payload.properties - Schema property definitions for this feature type.
    * @param {string} payload.featureTypeName - The feature type to stream.
    * @param {EffectiveDownloadStatement} payload.statement - The effective policy statement for this feature type.
-   * @return {Promise<void>}
+   * @return {Promise<number>} The number of hydrated feature rows written to the Parquet file. Counted
+   *   during the streaming write so the caller can store the version's total feature count at
+   *   materialization time — computing it live per landing view would put a large COUNT over the policy
+   *   scope on a public request path.
    * @memberof DownloadPipelineService
    */
-  async writeFeatureTypeParquet(payload: WriteFeatureTypeParquetPayload): Promise<void> {
+  async writeFeatureTypeParquet(payload: WriteFeatureTypeParquetPayload): Promise<number> {
     const { downloadId, downloadVersionId, source, properties, featureTypeName, statement } = payload;
 
     const spatialColumns = properties
@@ -308,6 +323,7 @@ export class DownloadPipelineService extends DBService {
       s3Key
     );
 
+    let rowCount = 0;
     let streamingSucceeded = false;
     try {
       // PassThrough implements write()/end() but @dsnp/parquetjs types expect
@@ -326,8 +342,10 @@ export class DownloadPipelineService extends DBService {
       }
 
       // Stream: cursor → hydrate typed properties → convert to Parquet row → write.
+      // Count hydrated rows (what actually lands in the file), not base cursor rows.
       for await (const baseBatch of cursor) {
         const hydrated = await this.hydrateFeatureBatch(baseBatch, properties);
+        rowCount += hydrated.length;
         for (const feature of hydrated) {
           await writer.appendRow(featureToRow(feature, properties));
         }
@@ -381,6 +399,8 @@ export class DownloadPipelineService extends DBService {
     });
 
     await this.downloadVersionRepository.createDownloadVersionArtifact(downloadVersionId, artifact_id, featureTypeName);
+
+    return rowCount;
   }
 
   /**

--- a/api/src/services/gallery/gallery-download-service.test.ts
+++ b/api/src/services/gallery/gallery-download-service.test.ts
@@ -5,8 +5,9 @@ import sinonChai from 'sinon-chai';
 import { getMockDBConnection } from '../../__mocks__/db';
 import { createMockDownloadRecord } from '../../__mocks__/download';
 import { createMockGalleryRecord } from '../../__mocks__/gallery';
+import { createMockGalleryDownloadTileRecord } from '../../__mocks__/gallery-download';
 import { ApiNotFoundError } from '../../errors/api-error';
-import { HTTP409 } from '../../errors/http-error';
+import { HTTP404, HTTP409 } from '../../errors/http-error';
 import { DownloadRepository } from '../../repositories/download/download-repository';
 import { GalleryDownloadRepository } from '../../repositories/gallery/gallery-download-repository';
 import { GalleryRepository } from '../../repositories/gallery/gallery-repository';
@@ -257,6 +258,92 @@ describe('GalleryDownloadService', () => {
 
       // Step 4: The member order is preserved
       expect(result.downloads.map((member) => member.download_id)).to.eql(['first', 'second']);
+    });
+  });
+
+  describe('getPublicGalleryDownloadsBySlug', () => {
+    it('throws HTTP404 and fetches nothing when no active gallery matches the slug', async () => {
+      // The slug guard runs first: a missing gallery short-circuits before any
+      // eligible-download work.
+
+      // Step 1: Stub the slug lookup to find nothing
+      const findStub = sinon.stub(GalleryRepository.prototype, 'findActiveGalleryBySlug').resolves(null);
+      const downloadsStub = sinon.stub(GalleryDownloadRepository.prototype, 'getEligibleGalleryDownloads');
+      const countStub = sinon.stub(GalleryDownloadRepository.prototype, 'getEligibleGalleryDownloadsCount');
+
+      // Step 2: Create the service
+      const mockDBConnection = getMockDBConnection();
+      const service = new GalleryDownloadService(mockDBConnection);
+
+      // Step 3: Attempt to read a nonexistent gallery
+      try {
+        await service.getPublicGalleryDownloadsBySlug('nonexistent');
+        expect.fail('expected HTTP404');
+      } catch (error) {
+        // Step 4: The 404 propagates and no further work runs
+        expect(error).to.be.instanceOf(HTTP404);
+        expect((error as HTTP404).message).to.equal('Gallery not found');
+        expect(findStub).to.have.been.calledOnceWith('nonexistent');
+        expect(downloadsStub).to.not.have.been.called;
+        expect(countStub).to.not.have.been.called;
+      }
+    });
+
+    it('throws the identical HTTP404 for a private gallery (indistinguishable from missing)', async () => {
+      // Anti-disclosure: the private and missing paths must not drift into an
+      // oracle — same error type, same exact message, same no-fetch behavior.
+
+      // Step 1: Stub the slug lookup to find a private gallery
+      sinon
+        .stub(GalleryRepository.prototype, 'findActiveGalleryBySlug')
+        .resolves(createMockGalleryRecord({ visibility: 'private' }));
+      const downloadsStub = sinon.stub(GalleryDownloadRepository.prototype, 'getEligibleGalleryDownloads');
+      const countStub = sinon.stub(GalleryDownloadRepository.prototype, 'getEligibleGalleryDownloadsCount');
+
+      // Step 2: Create the service
+      const mockDBConnection = getMockDBConnection();
+      const service = new GalleryDownloadService(mockDBConnection);
+
+      // Step 3: Attempt to read the private gallery
+      try {
+        await service.getPublicGalleryDownloadsBySlug('test-gallery');
+        expect.fail('expected HTTP404');
+      } catch (error) {
+        // Step 4: Byte-identical to the missing-gallery response; fetchers never run
+        expect(error).to.be.instanceOf(HTTP404);
+        expect((error as HTTP404).message).to.equal('Gallery not found');
+        expect(downloadsStub).to.not.have.been.called;
+        expect(countStub).to.not.have.been.called;
+      }
+    });
+
+    it('resolves the slug to the gallery id and returns eligible downloads with the count', async () => {
+      // Step 1: Stub the slug lookup to a public gallery and the eligible reads
+      sinon
+        .stub(GalleryRepository.prototype, 'findActiveGalleryBySlug')
+        .resolves(createMockGalleryRecord({ gallery_id: 7 }));
+      const downloads = [
+        createMockGalleryDownloadTileRecord({ download_id: 'first' }),
+        createMockGalleryDownloadTileRecord({ download_id: 'second', feature_count: null })
+      ];
+      const downloadsStub = sinon
+        .stub(GalleryDownloadRepository.prototype, 'getEligibleGalleryDownloads')
+        .resolves(downloads);
+      const countStub = sinon.stub(GalleryDownloadRepository.prototype, 'getEligibleGalleryDownloadsCount').resolves(9);
+
+      // Step 2: Create the service
+      const mockDBConnection = getMockDBConnection();
+      const service = new GalleryDownloadService(mockDBConnection);
+      const pagination = { page: 2, limit: 10, sort: 'create_date', order: 'desc' as const };
+
+      // Step 3: Read the public gallery by slug
+      const result = await service.getPublicGalleryDownloadsBySlug('test-gallery', pagination);
+
+      // Step 4: Both eligible reads receive the resolved gallery id; rows (including
+      // a NULL feature_count) pass through untouched
+      expect(result).to.eql({ downloads, count: 9 });
+      expect(downloadsStub).to.have.been.calledOnceWith(7, pagination);
+      expect(countStub).to.have.been.calledOnceWith(7);
     });
   });
 });

--- a/api/src/services/gallery/gallery-download-service.ts
+++ b/api/src/services/gallery/gallery-download-service.ts
@@ -1,6 +1,7 @@
 import { IDBConnection } from '../../database/db';
-import { HTTP409 } from '../../errors/http-error';
+import { HTTP404, HTTP409 } from '../../errors/http-error';
 import { DownloadDetailRecord } from '../../models/download';
+import { GalleryDownloadTileRecord } from '../../models/gallery-download';
 import { DownloadRepository } from '../../repositories/download/download-repository';
 import { GalleryDownloadRepository } from '../../repositories/gallery/gallery-download-repository';
 import { GalleryRepository } from '../../repositories/gallery/gallery-repository';
@@ -105,6 +106,46 @@ export class GalleryDownloadService extends DBService {
     const [downloads, count] = await Promise.all([
       this.galleryDownloadRepository.getGalleryDownloads(galleryId, pagination),
       this.galleryDownloadRepository.getGalleryDownloadsCount(galleryId)
+    ]);
+
+    return { downloads, count };
+  }
+
+  /**
+   * List the publicly advertisable download tiles for a slug-addressed gallery.
+   *
+   * The visibility gate lives here, not in the repository: whether a gallery may
+   * be shown to the anonymous public is a business rule, and the repository's
+   * slug lookup stays a plain active-row read. Private and missing galleries
+   * throw from the single guard below with an identical 404 — a private gallery
+   * must be indistinguishable from a missing one, since a distinct response
+   * would disclose that a hidden gallery exists.
+   *
+   * An existing public gallery with zero eligible downloads is the empty list
+   * (a valid state, distinct from not-found). Eligibility (latest active version
+   * ready/downloaded, public-scope exports only) is enforced by the repository
+   * reads.
+   *
+   * @param {string} slug - The gallery slug.
+   * @param {ApiPaginationOptions} [pagination] - Optional pagination options.
+   * @return {Promise<{ downloads: GalleryDownloadTileRecord[]; count: number }>}
+   * @throws {HTTP404} when no active gallery matches the slug, or the matching
+   * gallery is not public.
+   * @memberof GalleryDownloadService
+   */
+  async getPublicGalleryDownloadsBySlug(
+    slug: string,
+    pagination?: ApiPaginationOptions
+  ): Promise<{ downloads: GalleryDownloadTileRecord[]; count: number }> {
+    const gallery = await this.galleryRepository.findActiveGalleryBySlug(slug);
+
+    if (!gallery || gallery.visibility !== 'public') {
+      throw new HTTP404('Gallery not found');
+    }
+
+    const [downloads, count] = await Promise.all([
+      this.galleryDownloadRepository.getEligibleGalleryDownloads(gallery.gallery_id, pagination),
+      this.galleryDownloadRepository.getEligibleGalleryDownloadsCount(gallery.gallery_id)
     ]);
 
     return { downloads, count };

--- a/api/src/services/gallery/gallery-download-service.ts
+++ b/api/src/services/gallery/gallery-download-service.ts
@@ -139,7 +139,7 @@ export class GalleryDownloadService extends DBService {
   ): Promise<{ downloads: GalleryDownloadTileRecord[]; count: number }> {
     const gallery = await this.galleryRepository.findActiveGalleryBySlug(slug);
 
-    if (!gallery || gallery.visibility !== 'public') {
+    if (gallery?.visibility !== 'public') {
       throw new HTTP404('Gallery not found');
     }
 

--- a/app/src/features/search/SearchPage.tsx
+++ b/app/src/features/search/SearchPage.tsx
@@ -3,6 +3,7 @@ import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useEffect, useMemo } from 'react';
 import { SearchContainer } from './container/SearchContainer';
+import { FeaturedDownloadsSection } from './gallery/FeaturedDownloadsSection';
 import { buildSearchFeatureTypeLinks } from './utils/search-feature-type-links';
 
 /**
@@ -39,6 +40,7 @@ export const SearchPage = () => {
           <SearchContainer links={featureTypeLinks} isLoading={isLoading} />
         </Stack>
       </Paper>
+      <FeaturedDownloadsSection />
     </Container>
   );
 };

--- a/app/src/features/search/gallery/FeaturedDownloadTile.tsx
+++ b/app/src/features/search/gallery/FeaturedDownloadTile.tsx
@@ -1,0 +1,53 @@
+import { Card, CardActionArea, Stack, Typography } from '@mui/material';
+import { GalleryDownloadTile } from 'interfaces/useGalleryApi.interface';
+import { useNavigate } from 'react-router';
+import { formatFeatureCount } from 'utils/Utils';
+
+interface FeaturedDownloadTileProps {
+  /** Gallery download represented by this tile. */
+  download: GalleryDownloadTile;
+}
+
+/**
+ * A single featured-download card in the landing page's "Featured Downloads" grid. Clicking
+ * anywhere on the card navigates to the download's public landing page.
+ *
+ * The count line is derived via `formatFeatureCount` and rendered only when it returns a
+ * string: versions materialized before counting existed carry a NULL `feature_count`, and the
+ * tile omits the line entirely rather than rendering a broken value.
+ *
+ * @param {FeaturedDownloadTileProps} props - Gallery download to display.
+ * @returns {JSX.Element} Featured download tile.
+ */
+export const FeaturedDownloadTile = ({ download }: FeaturedDownloadTileProps) => {
+  const navigate = useNavigate();
+  const countLine = formatFeatureCount(download.feature_count);
+
+  return (
+    <Card variant="outlined" sx={{ height: 1 }}>
+      <CardActionArea onClick={() => navigate(`/download/${download.download_id}`)} sx={{ height: 1, p: 2 }}>
+        <Stack gap={1}>
+          <Typography variant="h4">{download.name}</Typography>
+          {download.description ? (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden'
+              }}>
+              {download.description}
+            </Typography>
+          ) : null}
+          {countLine ? (
+            <Typography variant="body2" color="text.secondary" fontWeight={700}>
+              {countLine}
+            </Typography>
+          ) : null}
+        </Stack>
+      </CardActionArea>
+    </Card>
+  );
+};

--- a/app/src/features/search/gallery/FeaturedDownloadsSection.test.tsx
+++ b/app/src/features/search/gallery/FeaturedDownloadsSection.test.tsx
@@ -1,0 +1,197 @@
+import { cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { GalleryDownloadTile } from 'interfaces/useGalleryApi.interface';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { render } from 'test-helpers/test-utils';
+import { FeaturedDownloadsSection } from './FeaturedDownloadsSection';
+
+const mockGetGalleryDownloadsBySlug = vi.fn();
+
+vi.mock('hooks/useApi', () => ({
+  useApi: () => ({
+    gallery: { getGalleryDownloadsBySlug: mockGetGalleryDownloadsBySlug }
+  })
+}));
+
+const mockPagination = (overrides = {}) => ({ total: 1, current_page: 1, last_page: 1, ...overrides });
+
+const makeTile = (overrides: Partial<GalleryDownloadTile> = {}): GalleryDownloadTile => ({
+  download_id: 'd1',
+  download_version_id: 'ver-d1',
+  download_status: 'ready',
+  format: 'parquet',
+  metadata: null,
+  started_at: '2026-01-01T00:00:00Z',
+  completed_at: '2026-01-01T01:00:00Z',
+  downloaded_at: null,
+  create_date: '2026-01-01T00:00:00Z',
+  name: 'Bears in BC',
+  description: 'All bear observations within BC',
+  feature_count: 412,
+  ...overrides
+});
+
+const renderSection = () =>
+  render(
+    <MemoryRouter>
+      <FeaturedDownloadsSection />
+    </MemoryRouter>
+  );
+
+describe('FeaturedDownloadsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('fetches the home gallery by slug with page 1 and the fixed tile limit on mount', async () => {
+    mockGetGalleryDownloadsBySlug.mockResolvedValue({
+      downloads: [makeTile()],
+      pagination: mockPagination()
+    });
+
+    renderSection();
+
+    await waitFor(() => {
+      expect(mockGetGalleryDownloadsBySlug).toHaveBeenCalledWith('home', { page: 1, limit: 9 });
+    });
+  });
+
+  it('fails closed on a fetch error: renders nothing — no heading, no shell', async () => {
+    const notFound = new Error('status 404') as Error & { status: number };
+    notFound.status = 404;
+    mockGetGalleryDownloadsBySlug.mockRejectedValue(notFound);
+
+    const { container, queryByText } = renderSection();
+
+    await waitFor(() => {
+      expect(mockGetGalleryDownloadsBySlug).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+    expect(queryByText('Featured Downloads')).not.toBeInTheDocument();
+  });
+
+  it('fails closed on zero downloads: a resolved empty result renders nothing', async () => {
+    mockGetGalleryDownloadsBySlug.mockResolvedValue({
+      downloads: [],
+      pagination: mockPagination({ total: 0 })
+    });
+
+    const { container } = renderSection();
+
+    await waitFor(() => {
+      expect(mockGetGalleryDownloadsBySlug).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('fails closed while loading: container is empty synchronously after render', () => {
+    mockGetGalleryDownloadsBySlug.mockReturnValue(new Promise(() => {}));
+
+    const { container } = renderSection();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the heading and a tile per download; a null description renders no stray text', async () => {
+    mockGetGalleryDownloadsBySlug.mockResolvedValue({
+      downloads: [
+        makeTile({ download_id: 'd1', name: 'Bears in BC' }),
+        makeTile({ download_id: 'd2', name: 'Moose in BC', description: null })
+      ],
+      pagination: mockPagination({ total: 2 })
+    });
+
+    const { getByText, queryByText } = renderSection();
+
+    await waitFor(() => {
+      expect(getByText('Featured Downloads')).toBeVisible();
+    });
+    expect(getByText('Bears in BC')).toBeVisible();
+    expect(getByText('Moose in BC')).toBeVisible();
+    expect(queryByText(/null/)).toBeNull();
+  });
+
+  it('routes feature_count through the formatter: formatted line shown, null count omits the line', async () => {
+    mockGetGalleryDownloadsBySlug.mockResolvedValue({
+      downloads: [
+        makeTile({ download_id: 'd1', name: 'Alpha', description: 'First dataset', feature_count: 17412 }),
+        makeTile({ download_id: 'd2', name: 'Beta', description: 'Second dataset', feature_count: null })
+      ],
+      pagination: mockPagination({ total: 2 })
+    });
+
+    const { getByText, getAllByText, queryByText } = renderSection();
+
+    await waitFor(() => {
+      expect(getByText('17.4k features')).toBeVisible();
+    });
+    expect(queryByText('null features')).toBeNull();
+    expect(getAllByText(/features/)).toHaveLength(1);
+  });
+
+  it('navigates to the download landing page when a tile is clicked', async () => {
+    mockGetGalleryDownloadsBySlug.mockResolvedValue({
+      downloads: [makeTile({ download_id: 'abc-123', name: 'Bears in BC' })],
+      pagination: mockPagination()
+    });
+
+    const { getByText, getByTestId } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<FeaturedDownloadsSection />} />
+          <Route path="/download/:downloadId" element={<div data-testid="download-page-probe" />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getByText('Bears in BC')).toBeVisible();
+    });
+
+    fireEvent.click(getByText('Bears in BC'));
+
+    await waitFor(() => {
+      expect(getByTestId('download-page-probe')).toBeInTheDocument();
+    });
+  });
+
+  it('hides the pager when there is only one page', async () => {
+    mockGetGalleryDownloadsBySlug.mockResolvedValue({
+      downloads: [makeTile()],
+      pagination: mockPagination({ last_page: 1 })
+    });
+
+    const { getByText, queryByRole } = renderSection();
+
+    await waitFor(() => {
+      expect(getByText('Featured Downloads')).toBeVisible();
+    });
+    expect(queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it('shows the pager across multiple pages and refetches with the new page number', async () => {
+    mockGetGalleryDownloadsBySlug.mockResolvedValue({
+      downloads: [makeTile()],
+      pagination: mockPagination({ total: 25, last_page: 3 })
+    });
+
+    const { getByRole } = renderSection();
+
+    await waitFor(() => {
+      expect(getByRole('navigation')).toBeVisible();
+    });
+
+    fireEvent.click(getByRole('button', { name: /go to page 2/i }));
+
+    await waitFor(() => {
+      expect(mockGetGalleryDownloadsBySlug).toHaveBeenCalledWith('home', { page: 2, limit: 9 });
+    });
+  });
+});

--- a/app/src/features/search/gallery/FeaturedDownloadsSection.tsx
+++ b/app/src/features/search/gallery/FeaturedDownloadsSection.tsx
@@ -1,0 +1,64 @@
+import { Grid, Pagination, Stack, Typography } from '@mui/material';
+import { useApi } from 'hooks/useApi';
+import useDataLoader from 'hooks/useDataLoader';
+import { useEffect, useState } from 'react';
+import { FeaturedDownloadTile } from './FeaturedDownloadTile';
+
+/**
+ * Slug of the curated landing-page gallery. The gallery is addressed by slug — never by id —
+ * because gallery ids differ per environment while the slug is the stable handle.
+ */
+const HOME_GALLERY_SLUG = 'home';
+
+const TILES_PER_PAGE = 9;
+
+/**
+ * "Featured Downloads" grid rendered on the landing (search) page: a paged grid of tiles for
+ * the curated home gallery, each linking to that download's public landing page.
+ *
+ * Fails closed: the landing page is the app's front door — any fetch error (including a 404
+ * for a private or missing gallery), a pending first load, or an empty result renders nothing.
+ * Never an empty shell, a loading skeleton, or an error state.
+ */
+export const FeaturedDownloadsSection = () => {
+  const api = useApi();
+  const [page, setPage] = useState(1);
+
+  const galleryDataLoader = useDataLoader((pageToLoad: number) =>
+    api.gallery.getGalleryDownloadsBySlug(HOME_GALLERY_SLUG, { page: pageToLoad, limit: TILES_PER_PAGE })
+  );
+
+  // Fetches the current page; `galleryDataLoader.refresh` is an unstable ref, so it's omitted
+  // from the deps — the effect re-runs only when `page` changes (first render fetches page 1).
+  useEffect(() => {
+    galleryDataLoader.refresh(page);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page]);
+
+  const downloads = galleryDataLoader.data?.downloads ?? [];
+  const lastPage = galleryDataLoader.data?.pagination.last_page ?? 0;
+
+  // Fail closed BEFORE any layout (see component JSDoc): error, pending first load, and empty
+  // result all render nothing.
+  if (galleryDataLoader.error || downloads.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap={2} mt={5}>
+      <Typography variant="h3">Featured Downloads</Typography>
+      <Grid container spacing={3}>
+        {downloads.map((download) => (
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={download.download_id}>
+            <FeaturedDownloadTile download={download} />
+          </Grid>
+        ))}
+      </Grid>
+      {lastPage > 1 ? (
+        <Stack alignItems="center">
+          <Pagination count={lastPage} page={page} onChange={(_, newPage) => setPage(newPage)} shape="rounded" />
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+};

--- a/app/src/features/search/gallery/FeaturedDownloadsSection.tsx
+++ b/app/src/features/search/gallery/FeaturedDownloadsSection.tsx
@@ -1,4 +1,5 @@
 import { Grid, Pagination, Stack, Typography } from '@mui/material';
+import { LoadingGuard } from 'components/loading/LoadingGuard';
 import { useApi } from 'hooks/useApi';
 import useDataLoader from 'hooks/useDataLoader';
 import { useEffect, useState } from 'react';
@@ -38,27 +39,25 @@ export const FeaturedDownloadsSection = () => {
   const downloads = galleryDataLoader.data?.downloads ?? [];
   const lastPage = galleryDataLoader.data?.pagination.last_page ?? 0;
 
-  // Fail closed BEFORE any layout (see component JSDoc): error, pending first load, and empty
-  // result all render nothing.
-  if (galleryDataLoader.error || downloads.length === 0) {
-    return null;
-  }
-
+  // Fail closed (see component JSDoc): error, pending first load, and empty result all render
+  // nothing. `hasNoData` with no `hasNoDataFallback` makes LoadingGuard render nothing in each case.
   return (
-    <Stack gap={2} mt={5}>
-      <Typography variant="h3">Featured Downloads</Typography>
-      <Grid container spacing={3}>
-        {downloads.map((download) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={download.download_id}>
-            <FeaturedDownloadTile download={download} />
-          </Grid>
-        ))}
-      </Grid>
-      {lastPage > 1 ? (
-        <Stack alignItems="center">
-          <Pagination count={lastPage} page={page} onChange={(_, newPage) => setPage(newPage)} shape="rounded" />
-        </Stack>
-      ) : null}
-    </Stack>
+    <LoadingGuard hasNoData={Boolean(galleryDataLoader.error) || downloads.length === 0}>
+      <Stack gap={2} mt={5}>
+        <Typography variant="h3">Featured Downloads</Typography>
+        <Grid container spacing={3}>
+          {downloads.map((download) => (
+            <Grid size={{ xs: 12, sm: 6, md: 4 }} key={download.download_id}>
+              <FeaturedDownloadTile download={download} />
+            </Grid>
+          ))}
+        </Grid>
+        {lastPage > 1 ? (
+          <Stack alignItems="center">
+            <Pagination count={lastPage} page={page} onChange={(_, newPage) => setPage(newPage)} shape="rounded" />
+          </Stack>
+        ) : null}
+      </Stack>
+    </LoadingGuard>
   );
 };

--- a/app/src/hooks/api/useGalleryApi.test.ts
+++ b/app/src/hooks/api/useGalleryApi.test.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { GalleryDownloadsResponse } from 'interfaces/useGalleryApi.interface';
+import { useGalleryApi } from './useGalleryApi';
+
+describe('useGalleryApi', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe('getGalleryDownloadsBySlug', () => {
+    it('should send GET to /api/gallery/slug/<slug>/download and return response', async () => {
+      const mockResponse: GalleryDownloadsResponse = {
+        downloads: [
+          {
+            download_id: 'abc-123',
+            download_version_id: 'ver-abc-123',
+            download_status: 'ready',
+            format: 'parquet',
+            metadata: null,
+            started_at: '2026-03-01T00:01:00Z',
+            completed_at: '2026-03-01T00:02:00Z',
+            downloaded_at: null,
+            create_date: '2026-03-01T00:00:00Z',
+            name: 'Moose download',
+            description: 'Moose observations in the Skeena',
+            feature_count: 17412
+          }
+        ],
+        pagination: { total: 1, current_page: 1, last_page: 1 }
+      };
+
+      mock.onGet('/api/gallery/slug/my-gallery/download').reply(200, mockResponse);
+
+      const result = await useGalleryApi(axios).getGalleryDownloadsBySlug('my-gallery');
+
+      expect(result).toEqual(mockResponse);
+      expect(mock.history.get[0].url).toBe('/api/gallery/slug/my-gallery/download');
+    });
+
+    it('should pass pagination params as query string', async () => {
+      const mockResponse: GalleryDownloadsResponse = {
+        downloads: [],
+        pagination: { total: 0, current_page: 2, last_page: 3 }
+      };
+
+      mock.onGet('/api/gallery/slug/home/download').reply(200, mockResponse);
+
+      await useGalleryApi(axios).getGalleryDownloadsBySlug('home', { page: 2, limit: 9 });
+
+      expect(mock.history.get[0].params).toEqual({ page: 2, limit: 9 });
+    });
+
+    it('should propagate rejection on 404', async () => {
+      mock.onGet('/api/gallery/slug/home/download').reply(404, { message: 'Not found' });
+
+      await expect(useGalleryApi(axios).getGalleryDownloadsBySlug('home')).rejects.toThrow();
+    });
+  });
+});

--- a/app/src/hooks/api/useGalleryApi.ts
+++ b/app/src/hooks/api/useGalleryApi.ts
@@ -1,0 +1,30 @@
+import { AxiosInstance } from 'axios';
+import { GalleryDownloadsResponse } from 'interfaces/useGalleryApi.interface';
+import { ApiPaginationRequestOptions } from 'types/pagination';
+
+/**
+ * Returns API methods for gallery management.
+ *
+ * @param {AxiosInstance} axios
+ * @return {*} object whose properties are supported api methods.
+ */
+export const useGalleryApi = (axios: AxiosInstance) => {
+  /**
+   * Get paginated downloads for a public gallery by its slug.
+   *
+   * @param {string} slug
+   * @param {ApiPaginationRequestOptions} [pagination] - Optional pagination params (page, limit, sort, order).
+   * @return {Promise<GalleryDownloadsResponse>}
+   */
+  const getGalleryDownloadsBySlug = async (
+    slug: string,
+    pagination?: ApiPaginationRequestOptions
+  ): Promise<GalleryDownloadsResponse> => {
+    const { data } = await axios.get<GalleryDownloadsResponse>(`/api/gallery/slug/${slug}/download`, {
+      params: pagination
+    });
+    return data;
+  };
+
+  return { getGalleryDownloadsBySlug };
+};

--- a/app/src/hooks/useApi.ts
+++ b/app/src/hooks/useApi.ts
@@ -8,6 +8,7 @@ import { useDownloadExportApi } from './api/useDownloadExportApi';
 import useCodesApi from './api/useCodesApi';
 import { useDataRequestApi } from './api/useDataRequestApi';
 import { useFeaturesApi } from './api/useFeaturesApi';
+import { useGalleryApi } from './api/useGalleryApi';
 import { useObjectStorageApi } from './api/useObjectStorageApi';
 import usePoliciesApi from './api/usePoliciesApi';
 import { useSearchApi } from './api/useSearchApi';
@@ -58,6 +59,8 @@ export const useApi = () => {
 
   const downloadExport = useDownloadExportApi(apiAxios);
 
+  const gallery = useGalleryApi(apiAxios);
+
   const teamPolicies = useTeamPoliciesApi(apiAxios);
 
   const tickets = useTicketsApi(apiAxios);
@@ -83,6 +86,7 @@ export const useApi = () => {
     teams,
     download,
     downloadExport,
+    gallery,
     teamPolicies,
     tickets,
     dataRequest,

--- a/app/src/interfaces/useGalleryApi.interface.ts
+++ b/app/src/interfaces/useGalleryApi.interface.ts
@@ -1,0 +1,33 @@
+import { DownloadStatus } from 'interfaces/useDownloadApi.interface';
+import { ApiPaginationResponseParams } from 'types/pagination';
+
+/**
+ * A download tile as returned by GET /api/gallery/slug/:slug/download.
+ *
+ * The backend joins the owning policy to surface `name` (always present) and
+ * `description` (nullable). `feature_count` is nullable — versions materialized
+ * before counting existed carry no count, and the tile omits the count line.
+ */
+export interface GalleryDownloadTile {
+  download_id: string;
+  download_version_id: string;
+  download_status: DownloadStatus;
+  format: string;
+  metadata: Record<string, unknown> | null;
+  started_at: string | null;
+  completed_at: string | null;
+  downloaded_at: string | null;
+  create_date: string;
+  name: string;
+  description: string | null;
+  feature_count: number | null;
+}
+
+/**
+ * Response from GET /api/gallery/slug/:slug/download.
+ * Includes server-side pagination metadata alongside the data array.
+ */
+export interface GalleryDownloadsResponse {
+  downloads: GalleryDownloadTile[];
+  pagination: ApiPaginationResponseParams;
+}

--- a/app/src/utils/Utils.test.ts
+++ b/app/src/utils/Utils.test.ts
@@ -212,7 +212,7 @@ describe('getFormattedFileSize', () => {
 
 describe('formatFeatureCount', () => {
   it('returns null when count is null so the caller omits the line', () => {
-    expect(formatFeatureCount(null)).toEqual(null);
+    expect(formatFeatureCount(null)).toBeNull();
   });
 
   it('returns `0 features` when count is 0', () => {

--- a/app/src/utils/Utils.test.ts
+++ b/app/src/utils/Utils.test.ts
@@ -5,6 +5,7 @@ import {
   downloadFile,
   ensureProtocol,
   firstOrNull,
+  formatFeatureCount,
   getFormattedAmount,
   getFormattedDate,
   getFormattedDateRangeString,
@@ -206,6 +207,46 @@ describe('getFormattedFileSize', () => {
   it('returns answer in GB if fileSize >= 1000000000', async () => {
     const formattedFileSize = getFormattedFileSize(1000000000);
     expect(formattedFileSize).toEqual('1.0 GB');
+  });
+});
+
+describe('formatFeatureCount', () => {
+  it('returns null when count is null so the caller omits the line', () => {
+    expect(formatFeatureCount(null)).toEqual(null);
+  });
+
+  it('returns `0 features` when count is 0', () => {
+    expect(formatFeatureCount(0)).toEqual('0 features');
+  });
+
+  it('returns singular `1 feature` when count is 1', () => {
+    expect(formatFeatureCount(1)).toEqual('1 feature');
+  });
+
+  it('returns plain counts under 1000', () => {
+    expect(formatFeatureCount(2)).toEqual('2 features');
+    expect(formatFeatureCount(999)).toEqual('999 features');
+  });
+
+  it('returns `1k features` at the lower k boundary with trailing `.0` stripped', () => {
+    expect(formatFeatureCount(1000)).toEqual('1k features');
+  });
+
+  it('returns compact k form with one decimal', () => {
+    expect(formatFeatureCount(17412)).toEqual('17.4k features');
+  });
+
+  it('strips a trailing `.0` from mid-band k counts', () => {
+    expect(formatFeatureCount(17000)).toEqual('17k features');
+  });
+
+  it('returns compact M form for counts of a million or more', () => {
+    expect(formatFeatureCount(2500000)).toEqual('2.5M features');
+    expect(formatFeatureCount(1000000)).toEqual('1M features');
+  });
+
+  it('promotes a count that rounds up to 1000k into the M band', () => {
+    expect(formatFeatureCount(999999)).toEqual('1M features');
   });
 });
 

--- a/app/src/utils/Utils.ts
+++ b/app/src/utils/Utils.ts
@@ -185,12 +185,12 @@ export const formatFeatureCount = (count: number | null): string | null => {
     return `${count} ${pluralize(count, 'feature')}`;
   }
 
-  const thousands = parseFloat((count / 1000).toFixed(1));
+  const thousands = Number.parseFloat((count / 1000).toFixed(1));
   if (thousands < 1000) {
     return `${thousands}k features`;
   }
 
-  return `${parseFloat((count / 1000000).toFixed(1))}M features`;
+  return `${Number.parseFloat((count / 1000000).toFixed(1))}M features`;
 };
 
 /**

--- a/app/src/utils/Utils.ts
+++ b/app/src/utils/Utils.ts
@@ -161,6 +161,39 @@ export const getFormattedFileSize = (fileSize: number) => {
 };
 
 /**
+ * Format a feature count for display (e.g. on a download tile).
+ *
+ * Compact forms are for readability of large numbers only: counts under 1000 render plain
+ * (`412 features`, singular `1 feature`), while larger counts render with one decimal max and a
+ * trailing `.0` stripped (`17.4k features`, `17k features`, `2.5M features`). Lowercase `k` is
+ * deliberate — the desired display form is `17.4k`, whereas `Intl.NumberFormat` compact notation
+ * emits an uppercase `17.4K`. The band is chosen on the rounded thousands value, so a count that
+ * rounds up to 1000k promotes into the M band (999999 → `1M features`, never `1000k features`).
+ *
+ * A `null` count returns `null` so the caller hides the line entirely rather than rendering a
+ * broken value (e.g. versions materialized before counting existed carry no count).
+ *
+ * @param {number | null} count
+ * @return {*}  {(string | null)} formatted count string, or `null` when no count is stored
+ */
+export const formatFeatureCount = (count: number | null): string | null => {
+  if (count === null) {
+    return null;
+  }
+
+  if (count < 1000) {
+    return `${count} ${pluralize(count, 'feature')}`;
+  }
+
+  const thousands = parseFloat((count / 1000).toFixed(1));
+  if (thousands < 1000) {
+    return `${thousands}k features`;
+  }
+
+  return `${parseFloat((count / 1000000).toFixed(1))}M features`;
+};
+
+/**
  * Check if an unknown value is an object.
  *
  * @param {unknown} obj

--- a/database/src/migrations/20260709120000_add_feature_count_to_download_version.ts
+++ b/database/src/migrations/20260709120000_add_feature_count_to_download_version.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 
 /**
  * Adds `download_version.feature_count` — the total number of features materialized into the

--- a/database/src/migrations/20260709120000_add_feature_count_to_download_version.ts
+++ b/database/src/migrations/20260709120000_add_feature_count_to_download_version.ts
@@ -1,0 +1,38 @@
+import { Knex } from 'knex';
+
+/**
+ * Adds `download_version.feature_count` — the total number of features materialized into the
+ * version's artifacts, summed across all feature types.
+ *
+ * The count is written by the parquet pipeline when the version transitions to ready. Storing it
+ * at materialization time means public reads never compute a live COUNT over the policy scope.
+ * Nullable: versions materialized before counting existed stay NULL.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE download_version ADD COLUMN feature_count integer;
+
+    COMMENT ON COLUMN download_version.feature_count IS 'Total number of features materialized into this version''s artifacts, summed across all feature types. Written when the version transitions to ready; NULL for versions materialized before counting existed. Stored at materialization time so public reads never compute a live COUNT over the policy scope.';
+  `);
+}
+
+/**
+ * Reverses {@link up}: drops the column.
+ *
+ * @export
+ * @param {Knex} knex
+ * @return {*}  {Promise<void>}
+ */
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    ALTER TABLE download_version DROP COLUMN IF EXISTS feature_count;
+  `);
+}

--- a/database/src/seeds/10_gallery_download_data.ts
+++ b/database/src/seeds/10_gallery_download_data.ts
@@ -41,7 +41,11 @@ export async function seed(knex: Knex): Promise<void> {
     }
 
     // Resolve create_user for inserts (audit trigger may set it; fallback for environments where it does not)
-    const createUserRow = await trx('system_user').whereNull('record_end_date').select('system_user_id').first();
+    const createUserRow = await trx('system_user')
+      .whereNull('record_end_date')
+      .orderBy('system_user_id')
+      .select('system_user_id')
+      .first();
     const createUser = createUserRow?.system_user_id ?? 1;
 
     /**

--- a/database/src/seeds/10_gallery_download_data.ts
+++ b/database/src/seeds/10_gallery_download_data.ts
@@ -1,0 +1,151 @@
+import { Knex } from 'knex';
+
+const DB_SCHEMA = process.env.DB_SCHEMA;
+
+/**
+ * Seed the 'home' gallery with featured downloads for local and test environments only.
+ *
+ * Creates 12 gallery-eligible downloads (approved policy → download → ready version → gallery
+ * membership) plus 2 ineligible ones (a pending and a failed version) so the landing section's
+ * eligibility filter, hybrid pin/newest-first ordering, pagination, and feature-count formatting
+ * are all observable locally. Membership create dates are staggered one hour apart so newest-first
+ * ordering is deterministic, and the two oldest eligible memberships are pinned (sort 1 and 2) so
+ * pins visibly lead the grid despite being the oldest additions.
+ *
+ * Idempotent: if the home gallery already has any active gallery_download membership, the seed
+ * returns without inserting anything, so re-running adds nothing.
+ */
+export async function seed(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    await trx.raw('set search_path = ??;', [DB_SCHEMA]);
+
+    const gallery = await trx('gallery')
+      .select('gallery_id')
+      .where({ slug: 'home' })
+      .whereNull('record_end_date')
+      .first();
+
+    // The home gallery is created by the earlier gallery seed; without it there is nothing to populate.
+    if (!gallery) {
+      return;
+    }
+
+    const existingMembership = await trx('gallery_download')
+      .select('gallery_download_id')
+      .where({ gallery_id: gallery.gallery_id })
+      .whereNull('record_end_date')
+      .first();
+
+    if (existingMembership) {
+      return;
+    }
+
+    // Resolve create_user for inserts (audit trigger may set it; fallback for environments where it does not)
+    const createUserRow = await trx('system_user').whereNull('record_end_date').select('system_user_id').first();
+    const createUser = createUserRow?.system_user_id ?? 1;
+
+    /**
+     * Create one featured download and its full FK chain: an approved policy (one per download —
+     * the download_policy_unique constraint forbids sharing), the download itself, a version
+     * carrying the materialization status, and the gallery membership.
+     *
+     * The membership's create_date is set at INSERT time via raw SQL (now() minus ageHours) rather
+     * than a JS Date — the audit trigger freezes now() per transaction and makes create_date
+     * immutable on UPDATE, so staggering must happen in the INSERT and in database time.
+     */
+    const seedFeaturedDownload = async (options: {
+      name: string;
+      description: string;
+      versionStatus: 'ready' | 'pending' | 'failed';
+      featureCount: number | null;
+      sort: number | null;
+      ageHours: number;
+    }) => {
+      const [policy] = await trx('policy')
+        .insert({
+          name: options.name,
+          description: options.description,
+          status: 'approved',
+          create_user: createUser
+        })
+        .returning(['policy_id']);
+
+      const [download] = await trx('download')
+        .insert({
+          policy_id: policy.policy_id,
+          format: 'parquet',
+          requested_by: null,
+          create_user: createUser
+        })
+        .returning(['download_id']);
+
+      await trx('download_version').insert({
+        download_id: download.download_id,
+        status: options.versionStatus,
+        feature_count: options.featureCount,
+        completed_at: options.versionStatus === 'pending' ? null : trx.fn.now(),
+        materialized_at: options.versionStatus === 'ready' ? trx.fn.now() : null,
+        error_message: options.versionStatus === 'failed' ? 'Materialization failed during export' : null,
+        create_user: createUser
+      });
+
+      await trx('gallery_download').insert({
+        gallery_id: gallery.gallery_id,
+        download_id: download.download_id,
+        sort: options.sort,
+        create_date: trx.raw("now() - (? * interval '1 hour')", [options.ageHours]),
+        create_user: createUser
+      });
+    };
+
+    // Feature counts chosen to exercise the tile count formatter: singular (1), plain (412),
+    // thousands compaction (17412 → 17.4k), millions compaction (2500000 → 2.5M); rest arbitrary.
+    // The formatter cases sit at the newest (lowest age) positions so they land on page one.
+    const eligibleDownloads: { featureCount: number; description: string }[] = [
+      { featureCount: 17412, description: 'Moose aerial survey observations across the Skeena region' },
+      { featureCount: 412, description: 'Coastal amphibian call-count monitoring stations' },
+      { featureCount: 1, description: 'Single confirmed sighting of a northern spotted owl' },
+      { featureCount: 2500000, description: 'Province-wide acoustic bat telemetry detections' },
+      { featureCount: 96, description: 'Grizzly bear DNA hair-snag sampling sites' },
+      { featureCount: 1204, description: 'Fisher den box occupancy records from the central interior' },
+      { featureCount: 5300, description: 'Songbird point-count surveys in the Okanagan valley' },
+      { featureCount: 88213, description: 'Caribou GPS collar relocations for the Chilcotin herds' },
+      { featureCount: 342, description: 'Western toad breeding pond assessments' },
+      { featureCount: 7, description: 'Badger burrow observations along the Thompson corridor' },
+      { featureCount: 64000, description: 'Bull trout redd counts from long-term index streams' },
+      { featureCount: 950, description: 'Marbled murrelet nest platform habitat plots' }
+    ];
+
+    // Older memberships have larger ageHours. The two oldest are pinned (sort 1 and 2) so the
+    // curator-pin rule is visible locally: pins lead the grid even though they are the oldest.
+    for (let i = 0; i < eligibleDownloads.length; i++) {
+      await seedFeaturedDownload({
+        name: `Featured Dataset ${i + 1}`,
+        description: eligibleDownloads[i].description,
+        versionStatus: 'ready',
+        featureCount: eligibleDownloads[i].featureCount,
+        sort: i === 10 ? 1 : i === 11 ? 2 : null,
+        ageHours: i
+      });
+    }
+
+    // Ineligible memberships: versions that never reached 'ready' must not tile in the gallery.
+    await seedFeaturedDownload({
+      name: 'Ineligible Pending Dataset',
+      description: 'Still materializing; must not appear as a gallery tile',
+      versionStatus: 'pending',
+      featureCount: null,
+      sort: null,
+      ageHours: 12
+    });
+
+    await seedFeaturedDownload({
+      name: 'Ineligible Failed Dataset',
+      description: 'Materialization failed; must not appear as a gallery tile',
+      versionStatus: 'failed',
+      featureCount: null,
+      sort: null,
+      ageHours: 13
+    });
+  });
+}


### PR DESCRIPTION
## Links to Jira Tickets

[SIMSBIOHUB-1087](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1087)

## Description of Changes

As a BioHub user, I want curated downloads shown on the Biodiversity Data Search landing page, so that I can quickly find useful datasets without building a search first.

Acceptance Criteria

1. Show Gallery Download Tiles

WHEN a user opens the Biodiversity Data Search landing page,
THEN BioHub should show eligible gallery downloads as tiles.
WHEN no eligible gallery downloads are available,
THEN the page should still load normally without showing an empty or broken section.

2. Show Clear Tile Content

WHEN a gallery download tile is shown,
THEN the tile should include:
  - download name
  - download description
  - number of features
WHEN the number of features is shown,
THEN it should always be visible on the tile.
WHEN the feature count is large,
THEN it should be formatted compactly, such as `17.4k features`.

3. Show 9 Downloads Per Page

WHEN gallery download tiles are shown,
THEN BioHub should show up to 9 downloads per page.
WHEN more than 9 eligible gallery downloads are available,
THEN the user should be able to paginate through the remaining downloads.
WHEN the user changes pages,
THEN BioHub should show the next set of eligible gallery downloads.

4. Use A Responsive Tile Layout

WHEN the page is viewed on desktop,
THEN gallery download tiles should display three per row.
WHEN the page shows the default limit of 9 downloads on desktop,
THEN the tiles should display as up to three rows of three.
WHEN the page is viewed on smaller screens,
THEN the tiles should stack or resize appropriately.

5. Only Show Advertisable Downloads

WHEN gallery downloads are shown,
THEN they should only come from galleries the user is allowed to discover.
WHEN a gallery is private,
THEN its downloads should not be shown.
WHEN a gallery download is inactive,
THEN it should not be shown.
WHEN a download is inactive or unavailable,
THEN it should not be shown.

6. Show Newest Gallery Downloads First

WHEN multiple gallery downloads are available,
THEN the newest gallery download memberships should appear first.
WHEN sorting downloads,
THEN BioHub should use `gallery_download.create_date` descending.
Implementation Notes

Add a gallery download tile section to the Biodiversity Data Search landing page.

Each tile should make the download easy to understand at a glance by showing:

download name
download description
number of features

The feature count should always be shown. Large counts should use compact formatting, for example:

`17.4k features`

The gallery download section should be paginated with a limit of 9 downloads per page.

Gallery download tiles should be displayed below or near the main search entry point.

The section should only advertise downloads from galleries that are discoverable by the current user. Private galleries should not appear in this section.

The initial sort should use `gallery_download.create_date` descending so newly added gallery downloads appear first.

## Testing Notes

- {List any relevant testing considerations, necessary pre-reqs, and areas of the app to focus on. Specifically, include anything that will help the reviewers of this PR verify the code is functioning as expected.}
