### PR TITLE
SIMSBIOHUB-1093: Show Keycloak Display Name instead of IDIR

### DIFF
--- a/api/src/models/system-user.ts
+++ b/api/src/models/system-user.ts
@@ -32,7 +32,8 @@ export type SystemUserExtended = z.infer<typeof SystemUserExtended>;
 
 export const AvailableUser = z.object({
   system_user_id: z.number(),
-  user_identifier: z.string()
+  user_identifier: z.string(),
+  display_name: z.string().nullable()
 });
 
 export type AvailableUser = z.infer<typeof AvailableUser>;

--- a/api/src/models/team-member.ts
+++ b/api/src/models/team-member.ts
@@ -12,6 +12,7 @@ export const TeamMemberWithUser = z.object({
   team_member_id: z.string().uuid(),
   system_user_id: z.number().int(),
   user_identifier: z.string(),
+  display_name: z.string().nullable(),
   email: z.string().nullable()
 });
 

--- a/api/src/openapi/schemas/team-member.ts
+++ b/api/src/openapi/schemas/team-member.ts
@@ -7,7 +7,7 @@ import { paginationResponseSchema } from './pagination';
 export const TeamMemberSchema: OpenAPIV3.SchemaObject = {
   title: 'TeamMember',
   type: 'object',
-  required: ['team_member_id', 'system_user_id', 'user_identifier', 'email'],
+  required: ['team_member_id', 'system_user_id', 'user_identifier', 'display_name', 'email'],
   properties: {
     team_member_id: {
       type: 'string',
@@ -21,6 +21,11 @@ export const TeamMemberSchema: OpenAPIV3.SchemaObject = {
     user_identifier: {
       type: 'string',
       description: 'Username or identifier from identity provider'
+    },
+    display_name: {
+      type: 'string',
+      nullable: true,
+      description: 'Keycloak display name for the user'
     },
     email: {
       type: 'string',
@@ -68,7 +73,7 @@ export const TeamMemberByUserRequestSchema: OpenAPIV3.SchemaObject = {
 export const AvailableUserSchema: OpenAPIV3.SchemaObject = {
   title: 'AvailableUser',
   type: 'object',
-  required: ['system_user_id', 'user_identifier'],
+  required: ['system_user_id', 'user_identifier', 'display_name'],
   properties: {
     system_user_id: {
       type: 'integer',
@@ -77,6 +82,11 @@ export const AvailableUserSchema: OpenAPIV3.SchemaObject = {
     user_identifier: {
       type: 'string',
       description: 'Username or identifier from identity provider'
+    },
+    display_name: {
+      type: 'string',
+      nullable: true,
+      description: 'Keycloak display name for the user'
     }
   }
 };

--- a/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
+++ b/api/src/paths/administrative/teams/{teamId}/member/index.test.ts
@@ -40,7 +40,13 @@ describe('getTeamMembers', () => {
 
   it('should return 200 with paginated team members', async () => {
     const mockMembers: TeamMemberWithUser[] = [
-      { team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice', email: 'a@test.com' }
+      {
+        team_member_id: 'tm-1',
+        system_user_id: 1,
+        user_identifier: 'alice',
+        display_name: 'Wonderland, Alice WLRS:EX',
+        email: 'a@test.com'
+      }
     ];
     const mockResponse = {
       members: mockMembers,
@@ -77,6 +83,7 @@ describe('getTeamMembers', () => {
       team_member_id: 'tm-1',
       system_user_id: 42,
       user_identifier: 'user_42',
+      display_name: 'User, FortyTwo WLRS:EX',
       email: 'user_42@test.com'
     };
     const createStub = sinon.stub(TeamMemberService.prototype, 'createTeamMember').resolves(createdTeamMember);
@@ -94,6 +101,7 @@ describe('getTeamMembers', () => {
       team_member_id: 'tm-1',
       system_user_id: 42,
       user_identifier: 'user_42',
+      display_name: 'User, FortyTwo WLRS:EX',
       email: 'user_42@test.com'
     });
   });

--- a/api/src/paths/administrative/users/index.test.ts
+++ b/api/src/paths/administrative/users/index.test.ts
@@ -66,7 +66,7 @@ describe('getAvailableUsers', () => {
   });
 
   it('should return 200 with users matching search parameter', async () => {
-    const mockUsers = [{ system_user_id: 1, user_identifier: 'alice' }];
+    const mockUsers = [{ system_user_id: 1, user_identifier: 'alice', display_name: 'Wonderland, Alice WLRS:EX' }];
 
     const mockDBConnection = getMockDBConnection({ knex: async () => ({ rows: mockUsers } as any) });
     sinon.stub(db.dbDependencies, 'getDBConnection').returns(mockDBConnection);
@@ -83,8 +83,8 @@ describe('getAvailableUsers', () => {
 
   it('should handle empty search parameter', async () => {
     const mockUsers = [
-      { system_user_id: 1, user_identifier: 'alice' },
-      { system_user_id: 2, user_identifier: 'bob' }
+      { system_user_id: 1, user_identifier: 'alice', display_name: 'Wonderland, Alice WLRS:EX' },
+      { system_user_id: 2, user_identifier: 'bob', display_name: null }
     ];
 
     const mockDBConnection = getMockDBConnection({ knex: async () => ({ rows: mockUsers } as any) });
@@ -102,8 +102,8 @@ describe('getAvailableUsers', () => {
 
   it('should handle whitespace-only search parameter', async () => {
     const mockUsers = [
-      { system_user_id: 1, user_identifier: 'alice' },
-      { system_user_id: 2, user_identifier: 'bob' }
+      { system_user_id: 1, user_identifier: 'alice', display_name: 'Wonderland, Alice WLRS:EX' },
+      { system_user_id: 2, user_identifier: 'bob', display_name: null }
     ];
 
     const mockDBConnection = getMockDBConnection({ knex: async () => ({ rows: mockUsers } as any) });

--- a/api/src/paths/administrative/users/index.ts
+++ b/api/src/paths/administrative/users/index.ts
@@ -31,7 +31,7 @@ GET.apiDoc = {
       in: 'query',
       name: 'search',
       schema: { type: 'string' },
-      description: 'Search term to filter users by user_identifier (case-insensitive partial match)'
+      description: 'Search term to filter users by user_identifier or display_name (case-insensitive partial match)'
     }
   ],
   responses: {

--- a/api/src/paths/user/list.ts
+++ b/api/src/paths/user/list.ts
@@ -73,6 +73,11 @@ GET.apiDoc = {
                       type: 'string',
                       description: 'The GUID for the user.'
                     },
+                    display_name: {
+                      type: 'string',
+                      nullable: true,
+                      description: 'Keycloak display name for the user.'
+                    },
                     record_end_date: {
                       type: 'string',
                       nullable: true

--- a/api/src/paths/user/{userId}/get.ts
+++ b/api/src/paths/user/{userId}/get.ts
@@ -65,6 +65,11 @@ GET.apiDoc = {
                 description: 'The unique user identifier',
                 type: 'string'
               },
+              display_name: {
+                description: 'Keycloak display name for the user',
+                type: 'string',
+                nullable: true
+              },
               record_end_date: {
                 description: 'Determines if the user record has expired',
                 type: 'string'

--- a/api/src/repositories/authorization/team-member-repository.ts
+++ b/api/src/repositories/authorization/team-member-repository.ts
@@ -232,14 +232,13 @@ export class TeamMemberRepository extends BaseRepository {
   }
 
   /**
-   * Get a single team member with user details for a team and system user.
+   * Find a single team member with user details for a team and system user.
    *
-   * @param {string} teamId - The ID of the team.
-   * @param {number} systemUserId - The system user ID.
+   * @param {TeamMemberByUserFilter} teamMemberData - The team and system user identifiers.
    * @return {Promise<TeamMemberWithUser | null>}
    * @memberof TeamMemberRepository
    */
-  async getTeamMemberWithUser(teamMemberData: TeamMemberByUserFilter): Promise<TeamMemberWithUser | null> {
+  async findTeamMemberWithUser(teamMemberData: TeamMemberByUserFilter): Promise<TeamMemberWithUser | null> {
     const knex = getKnex();
     const query = knex
       .table('team_member as tm')

--- a/api/src/repositories/authorization/team-member-repository.ts
+++ b/api/src/repositories/authorization/team-member-repository.ts
@@ -217,7 +217,7 @@ export class TeamMemberRepository extends BaseRepository {
     const sortField = sortFieldMap[pagination?.sort || ''] || 'su.user_identifier';
     const query = knex
       .table('team_member as tm')
-      .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier', 'su.email'])
+      .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier', 'su.display_name', 'su.email'])
       .innerJoin('system_user as su', 'tm.system_user_id', 'su.system_user_id')
       .where('tm.team_id', teamId)
       .whereNull('tm.record_end_date')
@@ -243,7 +243,7 @@ export class TeamMemberRepository extends BaseRepository {
     const knex = getKnex();
     const query = knex
       .table('team_member as tm')
-      .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier', 'su.email'])
+      .select(['tm.team_member_id', 'tm.system_user_id', 'su.user_identifier', 'su.display_name', 'su.email'])
       .innerJoin('system_user as su', 'tm.system_user_id', 'su.system_user_id')
       .where('tm.team_id', teamMemberData.team_id)
       .where('tm.system_user_id', teamMemberData.system_user_id)

--- a/api/src/repositories/user-repository.test.ts
+++ b/api/src/repositories/user-repository.test.ts
@@ -284,6 +284,66 @@ describe('UserRepository', () => {
     });
   });
 
+  describe('getAvailableUsers', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return available users including display_name', async () => {
+      const mockResponse = [
+        { system_user_id: 1, user_identifier: 'testuser', display_name: 'User, Test WLRS:EX' },
+        { system_user_id: 2, user_identifier: 'anotheruser', display_name: null }
+      ];
+      const mockQueryResponse = { rowCount: 2, rows: mockResponse } as any as Promise<QueryResult<any>>;
+
+      const mockDBConnection = getMockDBConnection({
+        knex: async () => {
+          return mockQueryResponse;
+        }
+      });
+
+      const userRepository = new UserRepository(mockDBConnection);
+
+      const response = await userRepository.getAvailableUsers();
+
+      expect(response).to.equal(mockResponse);
+    });
+
+    it('should filter by user_identifier or display_name and order by display label', async () => {
+      const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
+
+      const knexStub = sinon.stub().resolves(mockQueryResponse);
+
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const userRepository = new UserRepository(mockDBConnection);
+
+      await userRepository.getAvailableUsers('bryan');
+
+      const generatedQuery = knexStub.getCall(0).args[0].toString().toLowerCase();
+
+      expect(generatedQuery).to.contain(`"su"."user_identifier" ilike '%bryan%'`);
+      expect(generatedQuery).to.contain(`"su"."display_name" ilike '%bryan%'`);
+      expect(generatedQuery).to.contain('coalesce(su.display_name, su.user_identifier)');
+    });
+
+    it('should not apply a search filter when search is undefined', async () => {
+      const mockQueryResponse = { rowCount: 0, rows: [] } as any as Promise<QueryResult<any>>;
+
+      const knexStub = sinon.stub().resolves(mockQueryResponse);
+
+      const mockDBConnection = getMockDBConnection({ knex: knexStub });
+
+      const userRepository = new UserRepository(mockDBConnection);
+
+      await userRepository.getAvailableUsers();
+
+      const generatedQuery = knexStub.getCall(0).args[0].toString().toLowerCase();
+
+      expect(generatedQuery).to.not.contain('ilike');
+    });
+  });
+
   describe('getSystemUsersCount', () => {
     afterEach(() => {
       sinon.restore();

--- a/api/src/repositories/user-repository.ts
+++ b/api/src/repositories/user-repository.ts
@@ -508,7 +508,7 @@ export class UserRepository extends BaseRepository {
   /**
    * Get available users for team membership (excludes SYSTEM and DATABASE users).
    *
-   * @param {string} [search] - Optional search term to filter by user_identifier.
+   * @param {string} [search] - Optional search term to filter by user_identifier or display_name.
    * @return {Promise<AvailableUser[]>}
    * @memberof UserRepository
    */
@@ -516,15 +516,16 @@ export class UserRepository extends BaseRepository {
     const knex = getKnex();
     const query = knex
       .table('system_user as su')
-      .select(['su.system_user_id', 'su.user_identifier'])
+      .select(['su.system_user_id', 'su.user_identifier', 'su.display_name'])
       .innerJoin('user_identity_source as uis', 'su.user_identity_source_id', 'uis.user_identity_source_id')
       .whereNull('su.record_end_date')
       .whereNotIn('uis.name', [SYSTEM_IDENTITY_SOURCE.SYSTEM, SYSTEM_IDENTITY_SOURCE.DATABASE])
-      .orderBy('su.user_identifier', 'asc')
+      .orderByRaw('COALESCE(su.display_name, su.user_identifier) ASC')
       .limit(MAX_AVAILABLE_USERS_LIMIT);
 
     if (search?.trim()) {
-      query.whereILike('su.user_identifier', `%${search.trim()}%`);
+      const term = `%${search.trim()}%`;
+      query.where((builder) => builder.whereILike('su.user_identifier', term).orWhereILike('su.display_name', term));
     }
 
     const response = await this.connection.knex(query, AvailableUser);

--- a/api/src/services/access-policy/team-member-service.test.ts
+++ b/api/src/services/access-policy/team-member-service.test.ts
@@ -39,6 +39,7 @@ describe('TeamMemberService', () => {
         team_member_id: '11111111-1111-1111-1111-111111111111',
         system_user_id: 1,
         user_identifier: 'user_1',
+        display_name: 'User, One WLRS:EX',
         email: 'user_1@test.com'
       };
 
@@ -70,6 +71,7 @@ describe('TeamMemberService', () => {
         team_member_id: '11111111-1111-1111-1111-111111111111',
         system_user_id: 1,
         user_identifier: 'user_1',
+        display_name: 'User, One WLRS:EX',
         email: 'user_1@test.com'
       };
 

--- a/api/src/services/access-policy/team-member-service.test.ts
+++ b/api/src/services/access-policy/team-member-service.test.ts
@@ -44,7 +44,7 @@ describe('TeamMemberService', () => {
       };
 
       const getWithUserStub = sinon
-        .stub(TeamMemberRepository.prototype, 'getTeamMemberWithUser')
+        .stub(TeamMemberRepository.prototype, 'findTeamMemberWithUser')
         .onFirstCall()
         .resolves(null)
         .onSecondCall()
@@ -75,7 +75,7 @@ describe('TeamMemberService', () => {
         email: 'user_1@test.com'
       };
 
-      sinon.stub(TeamMemberRepository.prototype, 'getTeamMemberWithUser').resolves(existingTeamMember);
+      sinon.stub(TeamMemberRepository.prototype, 'findTeamMemberWithUser').resolves(existingTeamMember);
       const insertStub = sinon.stub(TeamMemberRepository.prototype, 'insertTeamMember').resolves({} as TeamMember);
 
       const input: CreateTeamMember = {

--- a/api/src/services/access-policy/team-member-service.ts
+++ b/api/src/services/access-policy/team-member-service.ts
@@ -26,7 +26,7 @@ export class TeamMemberService extends DBService {
    * @memberof TeamMemberService
    */
   async createTeamMember(teamMemberData: CreateTeamMember): Promise<TeamMemberWithUser> {
-    const existing = await this.teamMemberRepository.getTeamMemberWithUser(teamMemberData);
+    const existing = await this.teamMemberRepository.findTeamMemberWithUser(teamMemberData);
 
     if (existing) {
       return existing;
@@ -34,7 +34,7 @@ export class TeamMemberService extends DBService {
 
     await this.teamMemberRepository.insertTeamMember(teamMemberData);
 
-    const created = await this.teamMemberRepository.getTeamMemberWithUser(teamMemberData);
+    const created = await this.teamMemberRepository.findTeamMemberWithUser(teamMemberData);
 
     if (!created) {
       throw new Error('Failed to create team member');

--- a/api/src/services/access-policy/team-service.test.ts
+++ b/api/src/services/access-policy/team-service.test.ts
@@ -60,6 +60,7 @@ describe('TeamService', () => {
       team_member_id: '22222222-2222-2222-2222-222222222222',
       system_user_id: 1,
       user_identifier: 'user_1',
+      display_name: 'User, One WLRS:EX',
       email: 'user_1@test.com'
     };
 

--- a/api/src/services/data-request-service.test.ts
+++ b/api/src/services/data-request-service.test.ts
@@ -45,6 +45,7 @@ describe('DataRequestService', () => {
     team_member_id: 'd4e5f6a7-b8c9-0123-defa-234567890123',
     system_user_id: 1,
     user_identifier: 'user_1',
+    display_name: 'User, One WLRS:EX',
     email: 'user_1@test.com'
   };
 

--- a/app/src/features/admin/policies/components/AddTeamForm.test.tsx
+++ b/app/src/features/admin/policies/components/AddTeamForm.test.tsx
@@ -114,8 +114,8 @@ describe('AddTeamForm', () => {
 
     it('allows array of member user objects', async () => {
       const users = [
-        { system_user_id: 1, user_identifier: 'alice' },
-        { system_user_id: 2, user_identifier: 'bob' }
+        { system_user_id: 1, user_identifier: 'alice', display_name: null },
+        { system_user_id: 2, user_identifier: 'bob', display_name: null }
       ];
       const result = await AddTeamFormYupSchema.validate({
         name: 'Team',

--- a/app/src/features/admin/policies/components/TeamMemberSelect.test.tsx
+++ b/app/src/features/admin/policies/components/TeamMemberSelect.test.tsx
@@ -8,9 +8,9 @@ vi.mock('../../../../hooks/useApi');
 const mockBiohubApi = useApi as Mock;
 
 const mockUsers = [
-  { system_user_id: 1, user_identifier: 'alice' },
-  { system_user_id: 2, user_identifier: 'bob' },
-  { system_user_id: 3, user_identifier: 'charlie' }
+  { system_user_id: 1, user_identifier: 'alice', display_name: 'Wonderland, Alice WLRS:EX' },
+  { system_user_id: 2, user_identifier: 'bob', display_name: null },
+  { system_user_id: 3, user_identifier: 'charlie', display_name: '' }
 ];
 
 const mockGetAvailableUsers = vi.fn().mockResolvedValue({ users: mockUsers });
@@ -63,24 +63,24 @@ describe('TeamMemberSelect', () => {
     });
   });
 
-  it('displays selected users as chips', async () => {
+  it('displays selected users as chips using the display label with fallback', async () => {
     const mockOnChange = vi.fn();
     const selectedUsers = [
-      { system_user_id: 1, user_identifier: 'alice' },
-      { system_user_id: 2, user_identifier: 'bob' }
+      { system_user_id: 1, user_identifier: 'alice', display_name: 'Wonderland, Alice WLRS:EX' },
+      { system_user_id: 2, user_identifier: 'bob', display_name: null }
     ];
 
     const { getByText } = render(<TeamMemberSelect selectedUsers={selectedUsers} onChange={mockOnChange} />);
 
     await waitFor(() => {
-      expect(getByText('alice')).toBeVisible();
+      expect(getByText('Wonderland, Alice WLRS:EX')).toBeVisible();
       expect(getByText('bob')).toBeVisible();
     });
   });
 
-  it('displays user_identifier for selected users', async () => {
+  it('falls back to user_identifier when display_name is empty', async () => {
     const mockOnChange = vi.fn();
-    const selectedUsers = [{ system_user_id: 3, user_identifier: 'charlie' }];
+    const selectedUsers = [{ system_user_id: 3, user_identifier: 'charlie', display_name: '' }];
 
     const { getByText } = render(<TeamMemberSelect selectedUsers={selectedUsers} onChange={mockOnChange} />);
 
@@ -112,15 +112,16 @@ describe('TeamMemberSelect', () => {
 
     const listbox = getByRole('listbox');
     const options = within(listbox).getAllByRole('option');
+    // Options are sorted by display label, so 'bob' sorts before 'Wonderland, Alice WLRS:EX'
     fireEvent.click(options[0]);
 
-    // Verify onChange was called with the full user object
+    // Verify onChange was called with the full user object, including display_name
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenCalledWith([{ system_user_id: 1, user_identifier: 'alice' }]);
+      expect(mockOnChange).toHaveBeenCalledWith([{ system_user_id: 2, user_identifier: 'bob', display_name: null }]);
     });
   });
 
-  it('displays user_identifier in dropdown options', async () => {
+  it('displays the display label in dropdown options', async () => {
     const mockOnChange = vi.fn();
 
     const { getByLabelText, getByRole, getByText } = render(
@@ -143,16 +144,16 @@ describe('TeamMemberSelect', () => {
       expect(listbox).toBeVisible();
     });
 
-    // Verify user_identifier is displayed
-    expect(getByText('alice')).toBeVisible();
+    // Verify the display label (or user_identifier fallback) is displayed
+    expect(getByText('Wonderland, Alice WLRS:EX')).toBeVisible();
     expect(getByText('bob')).toBeVisible();
   });
 
   it('removes user when chip is deleted', async () => {
     const mockOnChange = vi.fn();
     const selectedUsers = [
-      { system_user_id: 1, user_identifier: 'alice' },
-      { system_user_id: 2, user_identifier: 'bob' }
+      { system_user_id: 1, user_identifier: 'alice', display_name: 'Wonderland, Alice WLRS:EX' },
+      { system_user_id: 2, user_identifier: 'bob', display_name: null }
     ];
 
     const { getAllByTestId, getByText } = render(
@@ -161,7 +162,7 @@ describe('TeamMemberSelect', () => {
 
     // Wait for chips to render
     await waitFor(() => {
-      expect(getByText('alice')).toBeVisible();
+      expect(getByText('Wonderland, Alice WLRS:EX')).toBeVisible();
       expect(getByText('bob')).toBeVisible();
     });
 
@@ -171,7 +172,7 @@ describe('TeamMemberSelect', () => {
 
     // Verify onChange was called without the removed user
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenCalledWith([{ system_user_id: 2, user_identifier: 'bob' }]);
+      expect(mockOnChange).toHaveBeenCalledWith([{ system_user_id: 2, user_identifier: 'bob', display_name: null }]);
     });
   });
 
@@ -206,7 +207,7 @@ describe('TeamMemberSelect', () => {
     mockGetAvailableUsers.mockResolvedValueOnce({ users: mockUsers });
 
     const mockOnChange = vi.fn();
-    const selectedUsers = [{ system_user_id: 1, user_identifier: 'alice' }];
+    const selectedUsers = [{ system_user_id: 1, user_identifier: 'alice', display_name: 'Wonderland, Alice WLRS:EX' }];
 
     const { getAllByText, getByLabelText, queryByRole } = render(
       <TeamMemberSelect selectedUsers={selectedUsers} onChange={mockOnChange} />
@@ -223,7 +224,7 @@ describe('TeamMemberSelect', () => {
 
     // Mock a search that returns different users (not including alice)
     mockGetAvailableUsers.mockResolvedValueOnce({
-      users: [{ system_user_id: 4, user_identifier: 'david' }]
+      users: [{ system_user_id: 4, user_identifier: 'david', display_name: null }]
     });
 
     // Type a search that wouldn't normally include alice
@@ -240,7 +241,30 @@ describe('TeamMemberSelect', () => {
 
     // Alice should still be visible as a chip because she's selected
     // Use getAllByText since alice may appear as chip and in dropdown
-    const aliceElements = getAllByText('alice');
+    const aliceElements = getAllByText('Wonderland, Alice WLRS:EX');
     expect(aliceElements.length).toBeGreaterThan(0);
+  });
+
+  it('sorts dropdown options by display label', async () => {
+    const mockOnChange = vi.fn();
+
+    const { getByLabelText, getByRole } = render(<TeamMemberSelect selectedUsers={[]} onChange={mockOnChange} />);
+
+    // Wait for users to load
+    await waitFor(() => {
+      expect(mockGetAvailableUsers).toHaveBeenCalled();
+    });
+
+    // Open the dropdown
+    const input = getByLabelText('Team Members');
+    fireEvent.click(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(getByRole('listbox')).toBeVisible();
+    });
+
+    const options = within(getByRole('listbox')).getAllByRole('option');
+    expect(options.map((option) => option.textContent)).toEqual(['bob', 'charlie', 'Wonderland, Alice WLRS:EX']);
   });
 });

--- a/app/src/features/admin/policies/components/TeamMemberSelect.tsx
+++ b/app/src/features/admin/policies/components/TeamMemberSelect.tsx
@@ -9,6 +9,7 @@ import useDataLoader from 'hooks/useDataLoader';
 import { IAvailableUser } from 'interfaces/useTeamsApi.interface';
 import { debounce } from 'lodash-es';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getUserLabel } from 'utils/Utils';
 
 /**
  * Props for TeamMemberSelect component.
@@ -91,7 +92,7 @@ export const TeamMemberSelect = ({ selectedUsers, onChange }: ITeamMemberSelectP
       }
     }
 
-    return Array.from(optionsMap.values()).sort((a, b) => a.user_identifier.localeCompare(b.user_identifier));
+    return Array.from(optionsMap.values()).sort((a, b) => getUserLabel(a).localeCompare(getUserLabel(b)));
   }, [usersDataLoader.data?.users, selectedUsers]);
 
   /**
@@ -111,7 +112,7 @@ export const TeamMemberSelect = ({ selectedUsers, onChange }: ITeamMemberSelectP
       value={selectedUsers}
       inputValue={inputValue}
       loading={usersDataLoader.isLoading}
-      getOptionLabel={(user) => user.user_identifier}
+      getOptionLabel={(user) => getUserLabel(user)}
       isOptionEqualToValue={(option, value) => option.system_user_id === value.system_user_id}
       onInputChange={handleInputChange}
       onChange={handleChange}
@@ -129,7 +130,7 @@ export const TeamMemberSelect = ({ selectedUsers, onChange }: ITeamMemberSelectP
           <li key={key} {...otherProps}>
             <Box display="flex" alignItems="center" gap={1}>
               <Icon path={mdiAccountOutline} size={0.875} />
-              <Typography>{user.user_identifier}</Typography>
+              <Typography>{getUserLabel(user)}</Typography>
             </Box>
           </li>
         );

--- a/app/src/features/admin/policies/components/TeamsContainer.test.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.test.tsx
@@ -54,13 +54,13 @@ const mockTeams: ITeam[] = [
 ];
 
 const mockAvailableUsers = [
-  { system_user_id: 1, user_identifier: 'alice' },
-  { system_user_id: 2, user_identifier: 'bob' }
+  { system_user_id: 1, user_identifier: 'alice', display_name: null },
+  { system_user_id: 2, user_identifier: 'bob', display_name: null }
 ];
 
 const mockTeamMembers = [
-  { team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' },
-  { team_member_id: 'tm-2', system_user_id: 2, user_identifier: 'bob' }
+  { team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice', display_name: null },
+  { team_member_id: 'tm-2', system_user_id: 2, user_identifier: 'bob', display_name: null }
 ];
 
 const mockCreateTeam = vi.fn();
@@ -290,7 +290,7 @@ describe('TeamsContainer', () => {
       // When a team has 1 member (was 2), the update payload sends [1].
       // The backend diff removes the absent member (2) — subtractive sync.
       mockGetTeamMembers.mockResolvedValueOnce({
-        members: [{ team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice' }]
+        members: [{ team_member_id: 'tm-1', system_user_id: 1, user_identifier: 'alice', display_name: null }]
       });
       mockUpdateTeam.mockResolvedValueOnce({});
       const mockRefresh = vi.fn();

--- a/app/src/features/admin/policies/components/TeamsContainer.tsx
+++ b/app/src/features/admin/policies/components/TeamsContainer.tsx
@@ -156,7 +156,11 @@ export const TeamsContainer = (props: ITeamsContainerProps) => {
     try {
       const { members } = await biohubApi.teams.getTeamMembers(team.team_id);
       setEditingTeamMembers(
-        members.map((m) => ({ system_user_id: m.system_user_id, user_identifier: m.user_identifier }))
+        members.map((m) => ({
+          system_user_id: m.system_user_id,
+          user_identifier: m.user_identifier,
+          display_name: m.display_name
+        }))
       );
     } catch (error) {
       const apiError = error as APIError;

--- a/app/src/features/admin/tickets/components/dialog/system-user/TicketSystemUserDialog.tsx
+++ b/app/src/features/admin/tickets/components/dialog/system-user/TicketSystemUserDialog.tsx
@@ -8,6 +8,7 @@ import useDebounce from 'hooks/useDebounce';
 import { useOptimisticDataLoader } from 'hooks/useOptimisticDataLoader';
 import { ITicketSystemUser } from 'interfaces/useTicketsApi.interface';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getUserLabel } from 'utils/Utils';
 import { TicketSystemUserDialogYup } from './TicketSystemUserDialogYup';
 import { ITicketSystemUserFormValues, TicketSystemUserForm } from './form/TicketSystemUserForm';
 
@@ -70,7 +71,7 @@ export const TicketSystemUserDialog = (props: ITicketSystemUserDialogProps) => {
         status: ticketSystemUser.status,
         system_user: {
           system_user_id: ticketSystemUser.system_user_id,
-          display_name: null,
+          display_name: ticketSystemUser.display_name,
           user_identifier: ticketSystemUser.user_identifier,
           email: null
         }
@@ -125,7 +126,7 @@ export const TicketSystemUserDialog = (props: ITicketSystemUserDialogProps) => {
     () =>
       availableUsers.map((user) => ({
         value: user.system_user_id,
-        label: user.user_identifier
+        label: getUserLabel(user)
       })),
     [availableUsers]
   );
@@ -198,6 +199,7 @@ export const TicketSystemUserDialog = (props: ITicketSystemUserDialogProps) => {
         element: (
           <TicketSystemUserForm
             options={options}
+            availableUsers={availableUsers}
             isLoadingUsers={availableUsersLoader.isLoading}
             isSubmitting={isSubmitting}
             onSearchUsers={debouncedAvailableUserRefresh}

--- a/app/src/features/admin/tickets/components/dialog/system-user/form/TicketSystemUserCard.tsx
+++ b/app/src/features/admin/tickets/components/dialog/system-user/form/TicketSystemUserCard.tsx
@@ -10,7 +10,7 @@ import { TicketSystemUserStatus } from 'interfaces/useTicketsApi.interface';
 
 interface ITicketSystemUserCardProps {
   systemUserId: number;
-  userIdentifier: string;
+  label: string;
   status: TicketSystemUserStatus;
   statusOptions: Array<{ value: TicketSystemUserStatus; label: string; iconPath: string }>;
   isSubmitting: boolean;
@@ -25,15 +25,7 @@ interface ITicketSystemUserCardProps {
  * @return {*}
  */
 export const TicketSystemUserCard = (props: ITicketSystemUserCardProps) => {
-  const {
-    systemUserId,
-    userIdentifier,
-    status,
-    statusOptions,
-    isSubmitting,
-    onChangeStatus,
-    onRemoveTicketSystemUser
-  } = props;
+  const { systemUserId, label, status, statusOptions, isSubmitting, onChangeStatus, onRemoveTicketSystemUser } = props;
   const statusOptionGroups: IDropdownMenuItemGroup[] = [
     {
       groupId: 'status-options',
@@ -56,7 +48,7 @@ export const TicketSystemUserCard = (props: ITicketSystemUserCardProps) => {
         justifyContent: 'space-between',
         gap: 2
       }}>
-      <Typography sx={{ fontWeight: 500 }}>{userIdentifier}</Typography>
+      <Typography sx={{ fontWeight: 500 }}>{label}</Typography>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
         <DropdownButton
           value={status}
@@ -67,7 +59,7 @@ export const TicketSystemUserCard = (props: ITicketSystemUserCardProps) => {
         />
         <IconButton
           size="small"
-          aria-label={`remove ${userIdentifier}`}
+          aria-label={`remove ${label}`}
           onClick={onRemoveTicketSystemUser}
           disabled={isSubmitting}>
           <Icon path={mdiClose} size={0.65} />

--- a/app/src/features/admin/tickets/components/dialog/system-user/form/TicketSystemUserForm.tsx
+++ b/app/src/features/admin/tickets/components/dialog/system-user/form/TicketSystemUserForm.tsx
@@ -4,20 +4,24 @@ import { SearchAutocomplete } from 'components/search/SearchAutocomplete';
 import { SearchOption } from 'components/search/SearchAutocomplete.interface';
 import { TICKET_SYSTEM_USER_STATUS_PRESENTATION } from 'constants/ticket';
 import { ArrayHelpers, FieldArray, getIn, useFormikContext } from 'formik';
+import { IAvailableUser } from 'interfaces/useTeamsApi.interface';
 import { TicketSystemUserStatus } from 'interfaces/useTicketsApi.interface';
 import { useMemo } from 'react';
+import { getUserLabel } from 'utils/Utils';
 import { TicketSystemUserCard } from './TicketSystemUserCard';
 
 export interface ITicketSystemUserFormValues {
   ticketSystemUsers: {
     system_user_id: number;
     user_identifier: string;
+    display_name: string | null;
     status: TicketSystemUserStatus;
   }[];
 }
 
 interface ITicketSystemUserFormProps {
   options: SearchOption[];
+  availableUsers: IAvailableUser[];
   isLoadingUsers: boolean;
   isSubmitting: boolean;
   onSearchUsers: (search: string) => void;
@@ -30,7 +34,7 @@ interface ITicketSystemUserFormProps {
  * @return {*}
  */
 export const TicketSystemUserForm = (props: ITicketSystemUserFormProps) => {
-  const { options, isLoadingUsers, isSubmitting, onSearchUsers } = props;
+  const { options, availableUsers, isLoadingUsers, isSubmitting, onSearchUsers } = props;
   const { values, errors, touched } = useFormikContext<ITicketSystemUserFormValues>();
   const statusOptions = useMemo<Array<{ value: TicketSystemUserStatus; label: string; iconPath: string }>>(
     () =>
@@ -57,9 +61,16 @@ export const TicketSystemUserForm = (props: ITicketSystemUserFormProps) => {
       return;
     }
 
-    arrayHelpers.push({
+    const selectedUser = availableUsers.find((user) => user.system_user_id === selectedUserId) ?? {
       system_user_id: selectedUserId,
       user_identifier: option.label,
+      display_name: null
+    };
+
+    arrayHelpers.push({
+      system_user_id: selectedUser.system_user_id,
+      user_identifier: selectedUser.user_identifier,
+      display_name: selectedUser.display_name,
       status: 'requested'
     });
   };
@@ -106,7 +117,7 @@ export const TicketSystemUserForm = (props: ITicketSystemUserFormProps) => {
                   <TicketSystemUserCard
                     key={ticketSystemUser.system_user_id}
                     systemUserId={ticketSystemUser.system_user_id}
-                    userIdentifier={ticketSystemUser.user_identifier}
+                    label={getUserLabel(ticketSystemUser)}
                     status={ticketSystemUser.status}
                     statusOptions={statusOptions}
                     isSubmitting={isSubmitting}

--- a/app/src/features/admin/tickets/components/dialog/team/TicketTeamDialog.tsx
+++ b/app/src/features/admin/tickets/components/dialog/team/TicketTeamDialog.tsx
@@ -8,6 +8,7 @@ import useDataLoader from 'hooks/useDataLoader';
 import useDebounce from 'hooks/useDebounce';
 import { ITeamMember } from 'interfaces/useTeamsApi.interface';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getUserLabel } from 'utils/Utils';
 
 interface ITicketTeamDialogProps {
   open: boolean;
@@ -60,7 +61,7 @@ export const TicketTeamDialog = (props: ITicketTeamDialogProps) => {
     () =>
       availableUsers.map((user) => ({
         value: user.system_user_id,
-        label: user.user_identifier
+        label: getUserLabel(user)
       })),
     [availableUsers]
   );
@@ -80,11 +81,18 @@ export const TicketTeamDialog = (props: ITicketTeamDialogProps) => {
         return;
       }
 
+      const selectedUser = availableUsers.find((user) => user.system_user_id === selectedUserId) ?? {
+        system_user_id: selectedUserId,
+        user_identifier: option.label,
+        display_name: null
+      };
+
       const optimisticTeamMemberId = `optimistic-${selectedUserId}-${Date.now()}`;
       const optimisticMember: ITeamMember = {
         team_member_id: optimisticTeamMemberId,
-        system_user_id: selectedUserId,
-        user_identifier: option.label
+        system_user_id: selectedUser.system_user_id,
+        user_identifier: selectedUser.user_identifier,
+        display_name: selectedUser.display_name
       };
 
       try {
@@ -102,7 +110,7 @@ export const TicketTeamDialog = (props: ITicketTeamDialogProps) => {
         setIsSubmitting(false);
       }
     },
-    [api.teams, memberSystemUserIds, onMemberAdd, onMemberRemove, showApiError, teamId]
+    [api.teams, availableUsers, memberSystemUserIds, onMemberAdd, onMemberRemove, showApiError, teamId]
   );
 
   const handleRemoveUser = useCallback(
@@ -129,7 +137,7 @@ export const TicketTeamDialog = (props: ITicketTeamDialogProps) => {
     () =>
       members.map((member) => ({
         id: member.team_member_id,
-        label: member.user_identifier
+        label: getUserLabel(member)
       })),
     [members]
   );

--- a/app/src/features/admin/tickets/detail/sidebar/TicketSidebarSystemUserCard.tsx
+++ b/app/src/features/admin/tickets/detail/sidebar/TicketSidebarSystemUserCard.tsx
@@ -8,6 +8,7 @@ import { ContextMenuButton, IContextMenuItem } from 'components/ContextMenuButto
 import { TICKET_SYSTEM_USER_STATUS_PRESENTATION } from 'constants/ticket';
 import { ITicketSystemUser, TicketSystemUserStatus } from 'interfaces/useTicketsApi.interface';
 import { useMemo } from 'react';
+import { getUserLabel } from 'utils/Utils';
 
 interface ITicketSidebarSystemUserCardProps {
   ticketSystemUser: ITicketSystemUser;
@@ -39,7 +40,7 @@ export const TicketSidebarSystemUserCard = (props: ITicketSidebarSystemUserCardP
     []
   );
 
-  const displayLabel = ticketSystemUser.system_user.display_name ?? ticketSystemUser.system_user.user_identifier;
+  const displayLabel = getUserLabel(ticketSystemUser.system_user);
   const statusContextMenuItems: IContextMenuItem[] = statusOptions.map((statusOption) => ({
     label: statusOption.label,
     icon: <Icon path={statusOption.icon} size={0.7} />,

--- a/app/src/features/admin/tickets/detail/sidebar/TicketSidebarTeam.tsx
+++ b/app/src/features/admin/tickets/detail/sidebar/TicketSidebarTeam.tsx
@@ -4,6 +4,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { LoadingGuard } from 'components/loading/LoadingGuard';
 import { ITeamMember } from 'interfaces/useTeamsApi.interface';
+import { getUserLabel } from 'utils/Utils';
 import { TicketSidebarItem } from './TicketSidebarItem';
 import { TicketSidebarSection } from './TicketSidebarSection';
 
@@ -46,7 +47,7 @@ export const TicketSidebarTeam = (props: ITicketSidebarTeamProps) => {
           {visibleMembers.map((member) => (
             <TicketSidebarItem
               key={member.team_member_id}
-              label={member.user_identifier}
+              label={getUserLabel(member)}
               onRemove={() => onRemoveUser(member.team_member_id)}
             />
           ))}

--- a/app/src/features/admin/users/ActiveUsersList.test.tsx
+++ b/app/src/features/admin/users/ActiveUsersList.test.tsx
@@ -92,6 +92,30 @@ describe('ActiveUsersList', () => {
     });
   });
 
+  it('shows the display name as the primary label with the identifier as a secondary caption', async () => {
+    const { getByText } = renderContainer({
+      rows: [
+        {
+          system_user_id: 1,
+          user_identifier: 'lbryan',
+          user_guid: 'user-guid',
+          record_end_date: null,
+          identity_source: 'idir',
+          role_ids: [1],
+          role_names: ['role 1'],
+          display_name: 'Bryan, Luke WLRS:EX',
+          email: null
+        }
+      ],
+      rowCount: 1
+    });
+
+    await waitFor(() => {
+      expect(getByText('Bryan, Luke WLRS:EX')).toBeVisible();
+      expect(getByText('lbryan')).toBeVisible();
+    });
+  });
+
   it('shows a table row for a user with no assigned role', async () => {
     const { getByTestId } = renderContainer({
       rows: [

--- a/app/src/features/admin/users/ActiveUsersList.tsx
+++ b/app/src/features/admin/users/ActiveUsersList.tsx
@@ -14,6 +14,7 @@ import { IGetRoles } from 'interfaces/useAdminApi.interface';
 import { ISystemUser } from 'interfaces/useUserApi.interface';
 import { useMemo } from 'react';
 import { IServerPaginationProps } from 'types/pagination';
+import { getUserLabel } from 'utils/Utils';
 
 export interface IUsersListRowActions {
   onChangeRole: (user: ISystemUser, roleId: number, roleName: string) => void;
@@ -55,14 +56,25 @@ const ActiveUsersList: React.FC<IActiveUsersListProps> = (props) => {
     () => [
       {
         field: 'user_identifier',
-        headerName: 'Username',
+        headerName: 'Name',
         minWidth: 220,
         flex: 1,
-        renderCell: (params) => (
-          <Typography variant="body2" noWrap title={params.value || ''}>
-            {params.value || 'No identifier'}
-          </Typography>
-        )
+        renderCell: (params) => {
+          const label = getUserLabel(params.row);
+
+          return (
+            <Stack>
+              <Typography variant="body2" noWrap title={label || 'No identifier'}>
+                {label || 'No identifier'}
+              </Typography>
+              {params.row.display_name?.trim() ? (
+                <Typography variant="caption" color="textSecondary" noWrap title={params.row.user_identifier}>
+                  {params.row.user_identifier}
+                </Typography>
+              ) : null}
+            </Stack>
+          );
+        }
       },
       {
         field: 'identity_source',

--- a/app/src/features/data-request/components/CreateDataRequestDialog.tsx
+++ b/app/src/features/data-request/components/CreateDataRequestDialog.tsx
@@ -6,6 +6,7 @@ import { useDialogContext } from 'hooks/useContext';
 import useDataLoader from 'hooks/useDataLoader';
 import useDebounce from 'hooks/useDebounce';
 import { useEffect, useMemo } from 'react';
+import { getUserLabel } from 'utils/Utils';
 import { CreateDataRequestDialogYup } from './CreateDataRequestDialogYup';
 import { CreateDataRequestForm, ICreateDataRequestFormValues } from './form/CreateDataRequestForm';
 
@@ -55,13 +56,14 @@ export const CreateDataRequestDialog = (props: ICreateDataRequestDialogProps) =>
     availableUsersLoader.load();
   }, [open, availableUsersLoader]);
 
+  const availableUsers = useMemo(() => availableUsersLoader.data?.users ?? [], [availableUsersLoader.data?.users]);
   const userOptions = useMemo<SearchOption[]>(
     () =>
-      (availableUsersLoader.data?.users ?? []).map((user) => ({
+      availableUsers.map((user) => ({
         value: user.system_user_id,
-        label: user.user_identifier
+        label: getUserLabel(user)
       })),
-    [availableUsersLoader.data?.users]
+    [availableUsers]
   );
 
   const debouncedAvailableUserRefresh = useDebounce((search: string) => {
@@ -78,6 +80,7 @@ export const CreateDataRequestDialog = (props: ICreateDataRequestDialogProps) =>
         element: (
           <CreateDataRequestForm
             options={userOptions}
+            availableUsers={availableUsers}
             isLoadingUsers={availableUsersLoader.isLoading}
             isSubmitting={isSubmitting}
             onSearchUsers={debouncedAvailableUserRefresh}

--- a/app/src/features/data-request/components/form/CreateDataRequestForm.tsx
+++ b/app/src/features/data-request/components/form/CreateDataRequestForm.tsx
@@ -4,9 +4,11 @@ import CustomTextFieldFormik from 'components/fields/CustomTextFieldFormik';
 import { SearchOption } from 'components/search/SearchAutocomplete.interface';
 import { useFormikContext } from 'formik';
 import { IAvailableUser } from 'interfaces/useTeamsApi.interface';
+import { getUserLabel } from 'utils/Utils';
 
 interface ICreateDataRequestFormProps {
   options: SearchOption[];
+  availableUsers: IAvailableUser[];
   isLoadingUsers: boolean;
   isSubmitting: boolean;
   onSearchUsers: (search: string) => void;
@@ -32,12 +34,12 @@ export interface ICreateDataRequestFormValues {
  * @returns {JSX.Element}
  */
 export const CreateDataRequestForm = (props: ICreateDataRequestFormProps) => {
-  const { options, isLoadingUsers, isSubmitting, onSearchUsers } = props;
+  const { options, availableUsers, isLoadingUsers, isSubmitting, onSearchUsers } = props;
   const { values, setFieldValue } = useFormikContext<ICreateDataRequestFormValues>();
 
   const users = values.system_users.map((user) => ({
     id: String(user.system_user_id),
-    label: user.user_identifier
+    label: getUserLabel(user)
   }));
 
   const handleSelectUser = (option: SearchOption | null) => {
@@ -50,13 +52,13 @@ export const CreateDataRequestForm = (props: ICreateDataRequestFormProps) => {
       return;
     }
 
-    const nextSystemUsers: IAvailableUser[] = [
-      ...values.system_users,
-      {
-        system_user_id: selectedUserId,
-        user_identifier: option.label
-      }
-    ];
+    const selectedUser = availableUsers.find((user) => user.system_user_id === selectedUserId) ?? {
+      system_user_id: selectedUserId,
+      user_identifier: option.label,
+      display_name: null
+    };
+
+    const nextSystemUsers: IAvailableUser[] = [...values.system_users, selectedUser];
 
     setFieldValue('system_users', nextSystemUsers);
   };

--- a/app/src/features/portal/detail/sidebar/PortalTicketSidebar.tsx
+++ b/app/src/features/portal/detail/sidebar/PortalTicketSidebar.tsx
@@ -9,6 +9,7 @@ import useDataLoader from 'hooks/useDataLoader';
 import { ITeamMember } from 'interfaces/useTeamsApi.interface';
 import { ITicketSystemUser } from 'interfaces/useTicketsApi.interface';
 import { useEffect } from 'react';
+import { getUserLabel } from 'utils/Utils';
 
 interface IPortalTicketSidebarProps {
   teamId: string;
@@ -45,9 +46,9 @@ export const PortalTicketSidebar = (props: IPortalTicketSidebarProps) => {
             {ticketSystemUsers.map((ticketSystemUser) => (
               <TicketSidebarItem
                 key={ticketSystemUser.ticket_system_user_id}
-                label={`${
-                  ticketSystemUser.system_user.display_name ?? ticketSystemUser.system_user.user_identifier
-                } (${getTicketSystemUserStatusLabel(ticketSystemUser.status)})`}
+                label={`${getUserLabel(ticketSystemUser.system_user)} (${getTicketSystemUserStatusLabel(
+                  ticketSystemUser.status
+                )})`}
               />
             ))}
           </Stack>
@@ -66,7 +67,7 @@ export const PortalTicketSidebar = (props: IPortalTicketSidebarProps) => {
           hasNoDataFallback={<Typography variant="body2">No participants</Typography>}>
           <Stack spacing={0.75}>
             {members.map((member) => (
-              <TicketSidebarItem key={member.team_member_id} label={member.user_identifier} />
+              <TicketSidebarItem key={member.team_member_id} label={getUserLabel(member)} />
             ))}
           </Stack>
         </LoadingGuard>

--- a/app/src/interfaces/useTeamsApi.interface.ts
+++ b/app/src/interfaces/useTeamsApi.interface.ts
@@ -7,6 +7,7 @@ export interface ITeamMember {
   team_member_id: string;
   system_user_id: number;
   user_identifier: string;
+  display_name: string | null;
   email?: string | null;
 }
 
@@ -52,6 +53,7 @@ export interface IUpdateTeamRequest {
 export interface IAvailableUser {
   system_user_id: number;
   user_identifier: string;
+  display_name: string | null;
 }
 
 /**

--- a/app/src/utils/Utils.test.ts
+++ b/app/src/utils/Utils.test.ts
@@ -11,6 +11,7 @@ import {
   getFormattedDateRangeString,
   getFormattedFileSize,
   getFormattedIdentitySource,
+  getUserLabel,
   isObject,
   jsonParseObjectProperties,
   jsonStringifyObjectProperties,
@@ -478,5 +479,29 @@ describe('getFormattedIdentitySource', () => {
       const response = firstOrNull(arr);
       expect(response).toEqual({ id: 1 });
     });
+  });
+});
+
+describe('getUserLabel', () => {
+  it('returns the display name when present', () => {
+    expect(getUserLabel({ display_name: 'Bryan, Luke WLRS:EX', user_identifier: 'lbryan' })).toEqual(
+      'Bryan, Luke WLRS:EX'
+    );
+  });
+
+  it('falls back to the user identifier when display name is null', () => {
+    expect(getUserLabel({ display_name: null, user_identifier: 'lbryan' })).toEqual('lbryan');
+  });
+
+  it('falls back to the user identifier when display name is undefined', () => {
+    expect(getUserLabel({ user_identifier: 'lbryan' })).toEqual('lbryan');
+  });
+
+  it('falls back to the user identifier when display name is empty', () => {
+    expect(getUserLabel({ display_name: '', user_identifier: 'lbryan' })).toEqual('lbryan');
+  });
+
+  it('falls back to the user identifier when display name is whitespace-only', () => {
+    expect(getUserLabel({ display_name: '   ', user_identifier: 'lbryan' })).toEqual('lbryan');
   });
 });

--- a/app/src/utils/Utils.ts
+++ b/app/src/utils/Utils.ts
@@ -434,6 +434,17 @@ export const getFormattedIdentitySource = (identitySource: SYSTEM_IDENTITY_SOURC
 };
 
 /**
+ * Get the human-readable label for a user: the Keycloak display name (ex: `Bryan, Luke WLRS:EX`) when
+ * available, otherwise the raw user identifier (ex: IDIR username).
+ *
+ * @param {{ display_name?: string | null; user_identifier: string }} user The user to label
+ * @returns {*} {string} the display label for the user
+ */
+export const getUserLabel = (user: { display_name?: string | null; user_identifier: string }): string => {
+  return user.display_name?.trim() || user.user_identifier;
+};
+
+/**
  * same implementation as Object.keys but with correct typings for interable
  *
  * @template Obj

--- a/database/src/seeds/01_db_system_users.ts
+++ b/database/src/seeds/01_db_system_users.ts
@@ -46,14 +46,14 @@ const systemUsers: SystemUserSeed[] = [
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
     user_guid: '543C3CE2F4DE472DB3A569FD0024B244',
-    display_name: 'Thompson, Anissa WLRS:EX'
+    display_name: 'Thompson, Andrew WLRS:EX'
   },
   {
     identifier: 'ameijer',
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
     user_guid: '74231b32026141a7acec6bcc0284f038',
-    display_name: 'Meijer, Aidan WLRS:EX'
+    display_name: 'Meijer, Annika WLRS:EX'
   },
   {
     identifier: 'dylrogow',

--- a/database/src/seeds/01_db_system_users.ts
+++ b/database/src/seeds/01_db_system_users.ts
@@ -22,6 +22,8 @@ interface SystemUserSeed {
   type: SYSTEM_IDENTITY_SOURCE;
   role_name: SYSTEM_USER_ROLE_NAME;
   user_guid: string;
+  /** Keycloak display name. Optional: omit to exercise the user_identifier fallback in the app. */
+  display_name?: string;
 }
 
 const systemUsers: SystemUserSeed[] = [
@@ -29,33 +31,39 @@ const systemUsers: SystemUserSeed[] = [
     identifier: 'achirico',
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
-    user_guid: 'E3A279530D164485BF43C6FE7A49E175'
+    user_guid: 'E3A279530D164485BF43C6FE7A49E175',
+    display_name: 'Chirico, Albert WLRS:EX'
   },
   {
     identifier: 'mauberti',
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
-    user_guid: '62EC624E50844486A046DC9709854F8D'
+    user_guid: '62EC624E50844486A046DC9709854F8D',
+    display_name: 'Aubertin-Young, Macgregor WLRS:EX'
   },
   {
     identifier: 'anthomps',
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
-    user_guid: '543C3CE2F4DE472DB3A569FD0024B244'
+    user_guid: '543C3CE2F4DE472DB3A569FD0024B244',
+    display_name: 'Thompson, Anissa WLRS:EX'
   },
   {
     identifier: 'ameijer',
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
-    user_guid: '74231b32026141a7acec6bcc0284f038'
+    user_guid: '74231b32026141a7acec6bcc0284f038',
+    display_name: 'Meijer, Aidan WLRS:EX'
   },
   {
     identifier: 'dylrogow',
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
-    user_guid: '473C7CDAC46D402AA79AE980DDDB85C3'
+    user_guid: '473C7CDAC46D402AA79AE980DDDB85C3',
+    display_name: 'Rogowsky, Dylan WLRS:EX'
   },
   {
+    // No display_name: exercises the user_identifier fallback in user selectors.
     identifier: 'dahogan',
     type: SYSTEM_IDENTITY_SOURCE.IDIR,
     role_name: SYSTEM_USER_ROLE_NAME.SYSTEM_ADMINISTRATOR,
@@ -141,6 +149,7 @@ const insertSystemUserSQL = (systemUser: SystemUserSeed) => `
     user_identity_source_id,
     user_identifier,
     user_guid,
+    display_name,
     record_effective_date,
     create_date,
     create_user
@@ -149,6 +158,7 @@ const insertSystemUserSQL = (systemUser: SystemUserSeed) => `
     user_identity_source_id,
     '${systemUser.identifier}',
     LOWER('${systemUser.user_guid}'),
+    ${systemUser.display_name ? `'${systemUser.display_name.replace(/'/g, "''")}'` : 'NULL'},
     now(),
     now(),
     (SELECT system_user_id from "system_user" where LOWER(user_identifier) = LOWER('${DB_ADMIN}'))


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1093](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1093)

## Description of Changes

User autocomplete fields and form user selectors now display the readable Keycloak display label (e.g. `Bryan, Luke WLRS:EX`) instead of the raw IDIR username (`LBRYAN`), so users can confidently identify the correct person. When a display label is missing, null, or empty, the UI falls back to the existing username / IDIR. Submitted values are unchanged — forms still send the stable `system_user_id`.

`system_user.display_name` already exists in the database (populated from the Keycloak token on login via `PUT /user/self`); this PR surfaces it through the user-option APIs and the selector UI.

**Backend (`api/`)**

- `getAvailableUsers` and the team-member queries now select `su.display_name`. The `AvailableUser` / `TeamMemberWithUser` models and the `AvailableUserSchema` / `TeamMemberSchema` OpenAPI schemas include it (required, nullable).
- Available-users search now matches `user_identifier` **or** `display_name` (case-insensitive), and results are ordered by `COALESCE(display_name, user_identifier)` — so typing what you see (e.g. "Bryan") finds the user whose identifier is `LBRYAN`.
- Documented the already-returned `display_name` field on the `GET /user` and `GET /user/{userId}` response schemas.

**Frontend (`app/`)**

- New shared `getUserLabel(user)` helper (`utils/Utils.ts`) returns `display_name` when present, otherwise `user_identifier` (handles null / empty / whitespace).
- Every user selector, selected chip, sidebar, and card now uses it: policy team-member select, ticket participants dialog + sidebar, ticket assignee dialog + cards + sidebar, the data-request dialog, and the portal ticket sidebar. Selecting an option carries the full user object (looked up by `system_user_id`) so the stored `user_identifier` stays correct while the visible label is the display name.
- Admin → Users table: the user column (dev's recently-merged DataGrid) is renamed **Username → Name** and renders the display label as the primary value, with the raw identifier as a secondary caption when a display label exists.
- `IAvailableUser` and `ITeamMember` interfaces gain `display_name: string | null`.

**Seed data (`database/`)**

- Dev system users are seeded with realistic display names (one intentionally left without one to exercise the fallback). Applies on a fresh database.

## Testing Notes

- Display names are read from the Keycloak token on login, so your own account populates automatically. For other users on an existing local DB, seed a value directly — e.g. `UPDATE biohub.system_user SET display_name = 'Bryan, Luke WLRS:EX' WHERE user_identifier = 'mauberti';` — and leave at least one user `NULL` (optionally one `''`) to confirm the username fallback. A fresh DB (`make clean && make web`) picks up the seeded names.
- Verify each selector shows the display label in **both** the dropdown options and the selected chips/cards:
  - Manage Policies → create / edit a team (typing part of a display name, e.g. "Bryan", finds the user via server-side search)
  - Ticket detail → Participants dialog + sidebar
  - Ticket detail → Assign Ticket dialog + assignee cards / sidebar (a newly assigned user shows the label immediately, with no flash of the identifier)
  - Create Data Request dialog
  - Admin → Users table (**Name** column with the identifier caption)
  - Portal ticket sidebar (read-only)
- Confirm submitted payloads are unchanged: `POST /api/administrative/teams/{teamId}/member`, data-request, and assignee requests still send only `system_user_id`s.
- API spot-check: `GET /api/administrative/users?search=bryan` returns each option with `display_name`, ordered by the display label.
- Unit tests: `cd api && npm test` and `cd app && npm test` — new coverage for `getUserLabel`, `getAvailableUsers` search/ordering, and the selector label rendering.

