### PR TITLE
SIMSBIOHUB-1095: Optimize github workflow, add retry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,26 +100,10 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
 
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
-
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry
         run: |
           echo ${{ secrets.TOOLS_SA_TOKEN }} | docker login -u unused --password-stdin ${{ vars.OPENSHIFT_REGISTRY }}
-
-      # Scale down any existing OpenShift pods for this PR deployment
-      # Why? The new pods will be deployed before the existing pods are terminated, and twice the resources will be needed
-      # in that moment. If not enough resources are available to spin up the new pods, then they may fail to deploy.
-      - name: Scale down app pods
-        run: oc get Deployment --namespace ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev --selector env-id=$PR_NUMBER,app-name=$APP_NAME -o name | awk '{print "oc scale --replicas=0 " $1}' | bash
 
       # Build and push the app image
       - name: Build and Push App Image
@@ -172,26 +156,10 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
 
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
-
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry
         run: |
           echo ${{ secrets.TOOLS_SA_TOKEN }} | docker login -u unused --password-stdin ${{ vars.OPENSHIFT_REGISTRY }}
-
-      # Scale down any existing OpenShift pods for this PR deployment
-      # Why? The new pods will be deployed before the existing pods are terminated, and twice the resources will be needed
-      # in that moment. If not enough resources are available to spin up the new pods, then they may fail to deploy.
-      - name: Scale down database pods
-        run: oc get Deployment --namespace ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev --selector env-id=$PR_NUMBER,app-name=$APP_NAME -o name | awk '{print "oc scale --replicas=0 " $1}' | bash
 
       # Build and push the database image using Docker
       - name: Build and Push Database Image
@@ -243,16 +211,6 @@ jobs:
       - name: Checkout Target Branch
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
-
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
 
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry
@@ -310,26 +268,10 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
 
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
-
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry
         run: |
           echo ${{ secrets.TOOLS_SA_TOKEN }} | docker login -u unused --password-stdin ${{ vars.OPENSHIFT_REGISTRY }}
-
-      # Scale down any existing OpenShift pods for this PR deployment
-      # Why? The new pods will be deployed before the existing pods are terminated, and twice the resources will be needed
-      # in that moment. If not enough resources are available to spin up the new pods, then they may fail to deploy.
-      - name: Scale down API pods
-        run: oc get Deployment --namespace ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev --selector env-id=$PR_NUMBER,app-name=$APP_NAME -o name | awk '{print "oc scale --replicas=0 " $1}' | bash
 
       # Build and push the API image
       - name: Build and Push API Image
@@ -400,6 +342,12 @@ jobs:
           cache-dir: ${{ env.OC_CACHE_DIR }}
           login: "true"
           namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev
+
+      # Scale down this PR's existing pods before deploying.
+      # Why? Helm creates the new pods before the old ones terminate, and twice the resources would be needed in that
+      # moment. Scaling to zero first avoids deploy failures when the namespace is near its resource quota.
+      - name: Scale down PR pods
+        run: oc get deployment --namespace ${{ vars.OPENSHIFT_LICENSE_PLATE }}-dev --selector env-id=$PR_NUMBER -o name | xargs -r -n1 oc scale --replicas=0
 
       # Deploy the Helm chart
       - name: Deploy Helm Chart

--- a/.github/workflows/deployStatic.yml
+++ b/.github/workflows/deployStatic.yml
@@ -96,16 +96,6 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
 
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
-
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry
         run: |
@@ -145,16 +135,6 @@ jobs:
       - name: Checkout Target Branch
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
-
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
 
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry
@@ -196,16 +176,6 @@ jobs:
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
 
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
-
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry
         run: |
@@ -245,16 +215,6 @@ jobs:
       - name: Checkout Target Branch
         if: steps.cache-repo.outputs.cache-hit != 'true'
         uses: actions/checkout@v6
-
-      # Install oc (see .github/actions/setup-openshift-cli). Fork PRs have no secrets — oc commands will fail.
-      - uses: ./.github/actions/setup-openshift-cli
-        env:
-          OPENSHIFT_TOKEN: ${{ secrets.TOOLS_SA_TOKEN }}
-        with:
-          oc-version: ${{ env.OC_VERSION }}
-          cache-dir: ${{ env.OC_CACHE_DIR }}
-          login: "true"
-          namespace: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-${{ env.BRANCH }}
 
       # Authenticate Docker with OpenShift registry
       - name: Authenticate Docker with OpenShift registry

--- a/.github/workflows/retryFailedJobs.yml
+++ b/.github/workflows/retryFailedJobs.yml
@@ -1,0 +1,65 @@
+# Auto-retry workflow runs that failed due to the intermittent OpenShift API connection
+# timeout (source-IP dependent SYN drops from some GitHub-hosted runner egress IPs).
+#
+# Why this exists: in-job retry loops never recover from the timeout because the runner's
+# egress IP is fixed for the life of the job — every retry re-sends from the same blocked IP.
+# Re-running the *job* lands it on a fresh runner (fresh egress IP), which is the only retry
+# that works. This workflow watches for failed runs, checks whether the failure was the
+# connection timeout (and not a genuine build/deploy error), and re-runs only the failed jobs.
+#
+# See SIMSBIOHUB-1079.
+name: Retry Jobs Failed on OpenShift Connection Timeout
+
+on:
+  workflow_run:
+    workflows:
+      - "PR-Based Deploy on OpenShift"
+      - "Static Deploy on OpenShift"
+      - "Clean PR Artifacts"
+      - "Draft Scale Down"
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    name: Re-run failed jobs on a fresh runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # run_attempt < 4 → up to 3 automatic re-runs (4 attempts total) before giving up.
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 4
+    steps:
+      # Only retry if a failed job's log shows the API connection timeout. Genuine build,
+      # test, or deploy failures are left alone for a human to look at.
+      - name: Detect OpenShift connection timeout in failed jobs
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          found=false
+          for job_id in $(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+              --jq '.jobs[] | select(.conclusion == "failure") | .id'); do
+            if gh api "repos/${REPO}/actions/jobs/${job_id}/logs" 2>/dev/null \
+                | grep -q ':6443: i/o timeout'; then
+              echo "Job ${job_id} failed on the OpenShift API connection timeout."
+              found=true
+              break
+            fi
+          done
+          echo "timeout_failure=${found}" >> "${GITHUB_OUTPUT}"
+
+      - name: Re-run failed jobs
+        if: steps.detect.outputs.timeout_failure == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          echo "Attempt ${ATTEMPT} of run ${RUN_ID} failed on the connection timeout; re-running failed jobs."
+          gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"


### PR DESCRIPTION
## Links to Jira Tickets

- [SIMSBIOHUB-1095](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1095)
- Related: [SIMSBIOHUB-1079](https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1079) (connection-timeout investigation / probe step)

## Description of Changes

**Background:** GitHub-hosted runners intermittently fail `oc login` to the Silver API (`dial tcp 142.34.194.119:6443: i/o timeout`). Probe evidence shows the failure is source-IP dependent: some runner egress IPs are silently dropped before auth, and the IP is fixed for a job's lifetime — so in-job retries never recover, but re-running the job on a fresh runner (fresh IP) does. Every `oc login` in a workflow is an independent draw at a possibly-blocked IP. This PR minimizes the draws and automates the only retry that works.

- **`deploy.yml`** — removed the `oc` install/login and per-app scale-down steps from the four build jobs. They never needed the API: `docker login`/`push` targets the registry route (open apps ingress) using `TOOLS_SA_TOKEN` directly. The scale-down moved into `Deploy Helm Chart` as a single step using the `env-id=$PR_NUMBER` selector, running right before `helm upgrade`. Result: **5 logins per run → 1**.
  - Behavior deltas: the queue deployment is now also scaled down (previously missed); the old db-setup scale-down was always a no-op (it's a Job, not a Deployment). Deployments have no image triggers, so pods don't restart on image push — the delayed scale-down preserves the "avoid 2× resource peak" intent with less PR-env downtime.
- **`deployStatic.yml`** — removed the `oc` install/login from the four build jobs, which ran zero `oc` commands (the logins were pure waste). Result: **6 logins per run → 2** (helm deploy + image-tag prune keep theirs).
- **`retryFailedJobs.yml` (new)** — a `workflow_run` watcher for the four `oc`-using workflows. When a run fails, it greps the failed jobs' logs for `:6443: i/o timeout` and, only on a match, calls the `rerun-failed-jobs` API — landing the failed jobs on fresh runners/IPs within the same run, so a successful retry turns the PR check green. Genuine build/test/deploy failures are never auto-retried. Caps at 3 automatic re-runs (4 attempts total).

**Note:** the watcher only activates once this merges — `workflow_run` triggers are read from the default branch, so it cannot fire for this PR's own runs.

## Testing Notes

- This PR's own deploy run ([run 29200799720](https://github.com/bcgov/biohubbc-platform/actions/runs/29200799720)) demonstrates the refactor under a real timeout: all four build jobs passed with no API contact; only `Deploy Helm Chart` drew a blocked IP and failed. Re-running failed jobs (the same API call the watcher makes, invoked manually) re-ran just the deploy job, reusing the already-pushed images — no rebuild.
- Watcher preconditions were verified against that real failure: workflow-name filter matches, `conclusion: failure`, `run_attempt` under the cap, and the log grep matches the failed job's output exactly once.
- Post-merge, on the first timeout in any covered workflow: confirm a "Retry Jobs Failed on OpenShift Connection Timeout" run appears and re-runs only the failed jobs. If the rerun call is rejected under org token policy (403), swap `GH_TOKEN` in the watcher for a fine-grained PAT with Actions read/write.
- `deployStatic.yml` validates on merge: build jobs green with no login steps; helm deploy and prune unchanged. In the PR-env deploy, confirm the `Scale down PR pods` step lists the app/db/api/queue deployments before `helm upgrade`.
