### PR TITLE
SIMSBIOHUB-1096: Only show non-null properties in search results

### DIFF
--- a/api/src/openapi/schemas/search/search-feature.ts
+++ b/api/src/openapi/schemas/search/search-feature.ts
@@ -143,6 +143,8 @@ export const featureSearchResponseSchema: OpenAPIV3.SchemaObject = {
     },
     properties: {
       type: 'array',
+      description:
+        'Metadata for properties with a non-null indexed value on at least one feature in the full filtered expression result. Independent of pagination.',
       items: featureSearchPropertySchema
     },
     pagination: paginationResponseSchema,

--- a/api/src/repositories/search-feature-repository.test.ts
+++ b/api/src/repositories/search-feature-repository.test.ts
@@ -265,7 +265,7 @@ describe('SearchFeatureRepository', () => {
   });
 
   describe('searchFeaturesByExpressionTreeProperties', () => {
-    it('should build a typed-property schema query over the filtered feature set', async () => {
+    it('should return metadata only for typed values belonging to features in the full filtered result', async () => {
       const knexSpy = Sinon.stub().resolves({ rowCount: 0, rows: [] });
       const mockDBConnection = getMockDBConnection({ knex: knexSpy });
       const repository = new SearchFeatureRepository(mockDBConnection);
@@ -278,10 +278,19 @@ describe('SearchFeatureRepository', () => {
       expect(sql).to.include('submission_feature_property_string');
       expect(sql).to.include('submission_feature_property_number');
       expect(sql).to.include('submission_feature_property_feature');
+      expect(sql).to.include('"p"."submission_feature_id", "p"."feature_type_property_id"');
+      expect(sql.match(/"matching_features"/g)).to.have.length(2);
+      expect(sql).to.include('"tpr"."submission_feature_id" = "mf"."submission_feature_id"');
+      expect(sql).to.include('"mf"."feature_type_id" = "matching_ftp"."feature_type_id"');
+      expect(sql).to.include('group by "tpr"."feature_type_property_id"');
+      expect(sql).to.include('from "present_property_ids" as "ppi"');
       expect(sql).to.include('"fpt"."name" as "type_name"');
       expect(sql).to.include('order by ftp.sort ASC NULLS LAST');
       expect(sql).to.not.include('jsonb_object_keys');
       expect(sql).to.not.include('typed_properties');
+      expect(sql).to.not.include('in (select "submission_feature_id" from "matching_features")');
+      expect(sql).to.not.include(' limit ');
+      expect(sql).to.not.include(' offset ');
     });
   });
 });

--- a/api/src/repositories/search-feature-repository.ts
+++ b/api/src/repositories/search-feature-repository.ts
@@ -134,7 +134,7 @@ export class SearchFeatureRepository extends BaseRepository {
       .whereRaw(isEffectivelySecured('mf.submission_feature_id'))
       .limit(1);
 
-    // Authenticated: a secured match is hidden when the caller cannot access it. Reuses the canonical
+    // Authenticated: a secured match is hidden when the caller cannot access it. Reuses the shared
     // isAccessibleToUser check (anchor-based, identical to the visible-results access filter) so the
     // banner stays consistent with which rows are actually shown. The candidate is already effectively
     // secured here, so isAccessibleToUser short-circuits to its team-scope-anchor branch.
@@ -149,12 +149,14 @@ export class SearchFeatureRepository extends BaseRepository {
   }
 
   /**
-   * Gets property metadata for properties that have typed values on the full filtered result set.
+   * Gets metadata for properties with at least one non-null typed value on the full filtered result set.
+   * Pagination is intentionally irrelevant. A typed row counts only when its property belongs to the
+   * matched feature's feature type, mirroring row-level property hydration.
    *
    * @param {string} anchorFeatureType - Target feature type returned by the search
    * @param {NormalizedExpressionTreeExpression | undefined} expressionTree - Expression tree criteria
    * @param {number | null} [systemUserId] - Security context
-   * @return {Promise<FeatureTypeProperty[]>} Active property metadata with at least one typed value row.
+   * @return {Promise<FeatureTypeProperty[]>} Active metadata for properties with at least one non-null value.
    */
   async searchFeaturesByExpressionTreeProperties(
     anchorFeatureType: string,
@@ -162,6 +164,9 @@ export class SearchFeatureRepository extends BaseRepository {
     systemUserId?: number | null
   ): Promise<FeatureTypeProperty[]> {
     const knex = getKnex();
+
+    // Compile the normalized expression into an unexecuted feature-id subquery. When there is no
+    // expression, the matching-feature query below uses all active features of the anchor type.
     const expressionFeatureIds = expressionTree
       ? expressionEvaluation.buildExpressionTreeFeatureIdsSubquery(
           anchorFeatureType,
@@ -169,24 +174,49 @@ export class SearchFeatureRepository extends BaseRepository {
           systemUserId ?? null
         )
       : null;
+
+    // Build the full, security-filtered result set as (submission_feature_id, feature_type_id).
+    // This intentionally has no LIMIT/OFFSET: top-level property metadata describes every feature
+    // matched by the expression, independently of the page returned in `features`.
     const matchingFeaturesQuery = this.buildExpressionTreeMatchingFeaturesQuery(
       knex,
       anchorFeatureType,
       expressionFeatureIds,
       systemUserId
     );
+
+    // Normalize all indexed typed-property tables to the two columns needed for presence checks.
+    // Typed rows represent non-null values. Keeping the matching-feature join outside this
+    // UNION means PostgreSQL consumes `matching_features` once instead of once per property table.
     const typedPropertyRowsQuery = knex.unionAll(
       this.typedPropertyTableNames.map((tableName) =>
-        knex(`${tableName} as p`)
-          .select('p.feature_type_property_id')
-          .whereIn('p.submission_feature_id', knex('matching_features').select('submission_feature_id'))
+        knex(`${tableName} as p`).select('p.submission_feature_id', 'p.feature_type_property_id')
       ),
       true
     );
+
+    // Retain property ids that occur on at least one matched feature. The feature-type join mirrors
+    // row hydration and rejects stale or unrelated property rows attached to a feature id. Grouping
+    // here reduces an arbitrarily large value set to the small set of distinct property ids before
+    // descriptive metadata is joined.
+    const presentPropertyIdsQuery = knex('typed_property_rows as tpr')
+      .select('tpr.feature_type_property_id')
+      .join('matching_features as mf', 'tpr.submission_feature_id', 'mf.submission_feature_id')
+      .join('feature_type_property as matching_ftp', (join) => {
+        join
+          .on('tpr.feature_type_property_id', '=', 'matching_ftp.feature_type_property_id')
+          .andOn('mf.feature_type_id', '=', 'matching_ftp.feature_type_id');
+      })
+      .whereNull('matching_ftp.record_end_date')
+      .groupBy('tpr.feature_type_property_id');
+
+    // Assemble the three stages as single-use CTEs, then hydrate only the active metadata records
+    // for property ids proven to have a non-null value in the full expression result.
     const query = knex
       .with('matching_features', matchingFeaturesQuery)
       .with('typed_property_rows', typedPropertyRowsQuery)
-      .from('typed_property_rows as tpr')
+      .with('present_property_ids', presentPropertyIdsQuery)
+      .from('present_property_ids as ppi')
       .select(
         'ftp.feature_type_property_id',
         'fp.feature_property_id',
@@ -199,35 +229,24 @@ export class SearchFeatureRepository extends BaseRepository {
         'fp.calculated_value',
         'ftp.allow_multiple'
       )
-      .join('feature_type_property as ftp', 'tpr.feature_type_property_id', 'ftp.feature_type_property_id')
+      .join('feature_type_property as ftp', 'ppi.feature_type_property_id', 'ftp.feature_type_property_id')
       .join('feature_property as fp', 'ftp.feature_property_id', 'fp.feature_property_id')
       .join('feature_property_type as fpt', 'fp.feature_property_type_id', 'fpt.feature_property_type_id')
       .whereNull('ftp.record_end_date')
       .whereNull('fp.record_end_date')
       .whereNull('fpt.record_end_date')
-      .groupBy(
-        'ftp.feature_type_property_id',
-        'fp.feature_property_id',
-        'fpt.feature_property_type_id',
-        'fp.name',
-        'fp.display_name',
-        'fp.description',
-        'fpt.name',
-        'ftp.required_value',
-        'fp.calculated_value',
-        'ftp.allow_multiple',
-        'ftp.sort'
-      )
       .orderByRaw('ftp.sort ASC NULLS LAST')
       .orderBy('fp.display_name', 'asc');
 
+    // Only the compact metadata result crosses the database/application boundary; matching feature
+    // ids and typed value rows remain inside PostgreSQL.
     const response = await this.connection.knex(query, FeatureTypeProperty);
 
     return response.rows;
   }
 
   /**
-   * Builds the filtered set of matching submission_feature ids without result hydration.
+   * Builds the filtered set of matching submission features without result hydration.
    *
    * Used by count and property-metadata queries so they do not pay the cost of building
    * row-level properties JSON that they never read.
@@ -236,7 +255,7 @@ export class SearchFeatureRepository extends BaseRepository {
    * @param {string} anchorFeatureType - Route anchor/result feature type
    * @param {Knex.QueryBuilder | null} expressionFeatureIds - Optional expression-tree matches
    * @param {number | null} [systemUserId] - Security context
-   * @return {Knex.QueryBuilder} Query returning submission_feature_id rows
+   * @return {Knex.QueryBuilder} Query returning submission_feature_id and feature_type_id rows
    */
   private buildExpressionTreeMatchingFeaturesQuery(
     knex: Knex,
@@ -245,7 +264,7 @@ export class SearchFeatureRepository extends BaseRepository {
     systemUserId?: number | null
   ): Knex.QueryBuilder {
     const query = knex('submission_feature as sf')
-      .select('sf.submission_feature_id')
+      .select('sf.submission_feature_id', 'sf.feature_type_id')
       .join('feature_type as ft', 'sf.feature_type_id', 'ft.feature_type_id')
       .where('ft.name', anchorFeatureType)
       .whereRaw(isSubmissionFeatureActive('sf'));
@@ -339,7 +358,7 @@ export class SearchFeatureRepository extends BaseRepository {
   }
 
   /**
-   * Builds a lateral join that hydrates the public `properties` JSON object from canonical
+   * Builds a lateral join that hydrates the public `properties` JSON object from indexed
    * typed property tables. Multiple rows for the same property, or properties configured
    * as allow_multiple, are surfaced as JSON arrays.
    *

--- a/database/src/migrations/20260713140000_submission_feature_property_presence_indexes.ts
+++ b/database/src/migrations/20260713140000_submission_feature_property_presence_indexes.ts
@@ -1,0 +1,54 @@
+import type { Knex } from 'knex';
+
+/**
+ * Add covering indexes for property-presence queries keyed by matching feature id.
+ *
+ * @param {Knex} knex
+ * @return {Promise<void>}
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    CREATE INDEX submission_feature_property_string_presence_idx
+      ON submission_feature_property_string (submission_feature_id, feature_type_property_id);
+
+    CREATE INDEX submission_feature_property_number_presence_idx
+      ON submission_feature_property_number (submission_feature_id, feature_type_property_id);
+
+    CREATE INDEX submission_feature_property_boolean_presence_idx
+      ON submission_feature_property_boolean (submission_feature_id, feature_type_property_id);
+
+    CREATE INDEX submission_feature_property_timestamp_presence_idx
+      ON submission_feature_property_timestamp (submission_feature_id, feature_type_property_id);
+
+    CREATE INDEX submission_feature_property_geometry_presence_idx
+      ON submission_feature_property_geometry (submission_feature_id, feature_type_property_id);
+
+    CREATE INDEX submission_feature_property_code_presence_idx
+      ON submission_feature_property_code (submission_feature_id, feature_type_property_id);
+
+    CREATE INDEX submission_feature_property_taxon_presence_idx
+      ON submission_feature_property_taxon (submission_feature_id, feature_type_property_id);
+  `);
+}
+
+/**
+ * Remove the property-presence covering indexes.
+ *
+ * @param {Knex} knex
+ * @return {Promise<void>}
+ */
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`--sql
+    SET SEARCH_PATH = biohub, public;
+
+    DROP INDEX IF EXISTS submission_feature_property_string_presence_idx;
+    DROP INDEX IF EXISTS submission_feature_property_number_presence_idx;
+    DROP INDEX IF EXISTS submission_feature_property_boolean_presence_idx;
+    DROP INDEX IF EXISTS submission_feature_property_timestamp_presence_idx;
+    DROP INDEX IF EXISTS submission_feature_property_geometry_presence_idx;
+    DROP INDEX IF EXISTS submission_feature_property_code_presence_idx;
+    DROP INDEX IF EXISTS submission_feature_property_taxon_presence_idx;
+  `);
+}


### PR DESCRIPTION
## Links to Jira Tickets

- https://apps.nrs.gov.bc.ca/int/jira/browse/SIMSBIOHUB-1096

## Description of Changes

- Returns only properties with values in the full search result.
- Excludes unused or unrelated properties.
- Keeps property results independent of pagination.
- Improves performance and memory efficiency for large searches.
- Adds database indexes to accelerate property lookups.

## Testing Notes

- Run the application locally with the seed data loaded.
- Apply search filters to narrow the result set for a feature type (eg. observations).
- Verify that the properties table excludes properties with no values across the filtered results.